### PR TITLE
chore: add framework mapping tables to skill SKILL.md files

### DIFF
--- a/.claude/skills/brain-ingest/SKILL.md
+++ b/.claude/skills/brain-ingest/SKILL.md
@@ -38,3 +38,13 @@ head -50 docs/brain/wiki/*.md | grep "source:" | head -10  # Verifiziere Citatio
 ## Next Steps
 - T001570: CI-Gates (`task test:changed`, `freshness:regenerate`)
 - Brain-Wiki regelmäßig synchronisieren (cron/call-backus)
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/cluster-deployment/SKILL.md
+++ b/.claude/skills/cluster-deployment/SKILL.md
@@ -12,3 +12,13 @@ Verwende stattdessen: **Skill: infra-ops** → Abschnitt §1 (Cluster Deployment
 Referenz-Dateien (verschoben nach `infra-ops/references/`):
 - `infra-ops/references/hetzner-provisioning-cluster.md`
 - `infra-ops/references/proxmox-provisioning.md`
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/database-ops/SKILL.md
+++ b/.claude/skills/database-ops/SKILL.md
@@ -8,3 +8,13 @@ archived: true
 
 Dieser Skill wurde in `infra-ops` konsolidiert.
 Verwende stattdessen: **Skill: infra-ops** → Abschnitt §7 (Database Ops).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/database-specialist/SKILL.md
+++ b/.claude/skills/database-specialist/SKILL.md
@@ -102,3 +102,13 @@ Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auf
 
 ## Active plans
 The orchestrator injects an `<active-plans>` block for db-tagged plans. If no block was injected, no database-specific plan is in flight; do not query `superpowers.plans` as a fallback — that table is frozen historical data (tracking pipeline removed in PRs #788/#993).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -168,3 +168,13 @@ Nur wenn die Chore deploybare Pfade berührt — Mapping in
 
 Melde alle aufgetretenen Fehler oder Prozess-Frictionen am Ende über `mishap-tracker`
 (Invoke `mishap-tracker` with your accumulated MISHAP_LOG).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -212,3 +212,13 @@ cd tests/e2e/ && SKIP_DB_PURGE=1 WEBSITE_URL=https://web.mentolder.de ./node_mod
 | `git-workflow` | Commit/Push-Konventionen für Schritt 7 (Freshness Guard, Scope-Preflight) |
 | `cluster-deployment` | Querschnitt — Cross-Brand-Tests |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -474,3 +474,13 @@ Führe danach `dev-flow-e2e` aus, um E2E-Tests gegen die Live-Umgebung zu schrei
 ## Nachbereitung & Mishap Report
 
 Melde alle aufgetretenen Fehler oder Prozess-Frictionen am Ende des Skills über `mishap-tracker` (Invoke `mishap-tracker` with your accumulated MISHAP_LOG).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -501,3 +501,13 @@ Der Skill liest den Plan automatisch aus der DB (`FACTORY-PLAN-REF` Kommentar) �
 ## Nachbereitung & Mishap Report
 
 Melde alle aufgetretenen Fehler oder Prozess-Frictionen am Ende des Skills über `mishap-tracker` (aufrufbar via `bash scripts/hooks/mishap-tracker.sh`).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -255,3 +255,13 @@ Lebenszyklus-SSOT: [session-coordination](file:///home/patrick/Bachelorprojekt/.
 | `superpowers:finishing-a-development-branch` | Optionen nach Implementierung |
 | `dev-flow-chore` | Chore-Ablauf (nutzt diesen Skill intern) |
 | `dev-flow-execute` | Feature/Fix-Ablauf (nutzt diesen Skill intern) |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/host-node-networking/SKILL.md
+++ b/.claude/skills/host-node-networking/SKILL.md
@@ -12,3 +12,13 @@ Verwende stattdessen: **Skill: infra-ops** → Abschnitt §3 (Host Node Networki
 Referenz-Dateien (verschoben nach `infra-ops/references/`):
 - `infra-ops/references/hetzner-provisioning-network.md`
 - `infra-ops/references/wsl-openclaw.md`
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -91,3 +91,13 @@ Invoke `mishap-tracker` with your accumulated `MISHAP_LOG`.
 | `ticket-ops` | Follow-up: PR management, ticket triage for human-fixable items |
 | `mishap-tracker` | Converts execution mishaps to tickets |
 | `cluster-deployment` | Cross-brand incident handling (Phase 5) |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/infra-ops/SKILL.md
+++ b/.claude/skills/infra-ops/SKILL.md
@@ -472,3 +472,13 @@ Diese Skills sind in `infra-ops` aufgegangen. Ihre Verzeichnisse und Referenz-Da
 - `.claude/skills/secret-rotation/`
 - `.claude/skills/workspace-deploy/`
 - `.claude/skills/database-ops/`
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/keycloak-realm-sync/SKILL.md
+++ b/.claude/skills/keycloak-realm-sync/SKILL.md
@@ -8,3 +8,13 @@ archived: true
 
 Dieser Skill wurde in `infra-ops` konsolidiert.
 Verwende stattdessen: **Skill: infra-ops** → Abschnitt §4 (Keycloak Realm Sync).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/lavish/SKILL.md
+++ b/.claude/skills/lavish/SKILL.md
@@ -114,3 +114,13 @@ this is dangerous whenever an `input` playbook form is open in it.
 - Run `npx -y lavish-axi playbook <playbook_id>` for focused artifact guidance. One artifact often combines several playbooks (for example a plan that includes a comparison and a diagram), so MUST open each matching playbook before writing HTML.
 - Lavish does not auto-inject any design system - artifacts stay portable so they render identically when opened directly without lavish-axi running. Before writing any HTML, decide the design direction in this strict priority order, and only move to the next step when the current one truly yields nothing: (1) if the user asked for a specific look or named design system, use that; (2) otherwise you must first inspect the project the artifact is about - the subject or product whose content or UI it represents, which may differ from your current working directory - and match that project's design system: Tailwind or theme config, shared CSS variables or design tokens, component library, brand assets, or existing styled pages. If the artifact previews, proposes, or mocks a specific app's UI, render it in that app's own design system so it faithfully shows the product, even when you are running in a different repo; (3) only when both steps come up empty, use the Lavish-recommended Tailwind CSS browser runtime v4 + DaisyUI v5, available via CDN - run `npx -y lavish-axi design` for a content-to-playbook router, a copy-pasteable CDN snippet, a Mermaid CDN snippet/init for diagrams, and the DaisyUI component reference, and prefer the Tailwind/DaisyUI CDN snippet over hand-writing styles unless explicitly instructed otherwise by the user. When you deliver the artifact, state which of the three design sources you used and why.
 - Use lavish-axi when the user asks for a visual artifact, HTML explainer, interactive prototype, review surface, product or technical plan, comparison, report, or browser-based feedback loop
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/llm-ops/SKILL.md
+++ b/.claude/skills/llm-ops/SKILL.md
@@ -8,3 +8,13 @@ archived: true
 
 Dieser Skill wurde in `infra-ops` konsolidiert.
 Verwende stattdessen: **Skill: infra-ops** → Abschnitt §5 (LLM Ops).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -125,3 +125,13 @@ Report:
 |-------|-----------|
 | `operations-management` | Auftraggeber — erstellt Tickets aus Mishaps |
 | Alle Runbooks | Nutzer — jedes Skill schließt mit Mishap-Report ab |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -154,3 +154,13 @@ This skill supports the "actions on a change" model:
 
 - **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
 - **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -112,3 +112,13 @@ All artifacts complete. All tasks complete.
 - Show clear summary of what happened
 - If sync is requested, use openspec-sync-specs approach (agent-driven)
 - If delta specs exist, always run the sync assessment and show the combined summary before prompting
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -286,3 +286,13 @@ But this summary is optional. Sometimes the thinking IS the value.
 - **Do visualize** - A good diagram is worth many paragraphs
 - **Do explore the codebase** - Ground discussions in reality
 - **Do question assumptions** - Including the user's and your own
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -117,3 +117,13 @@ After completing all artifacts, summarize:
 - If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
 - If a change with that name already exists, ask if user wants to continue it or create a new one
 - Verify each artifact file exists after writing before proceeding to next
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -53,3 +53,13 @@ Both sub-skills carry the mishap tracking preamble. After completing either, inv
 | `mishap-tracker` | Converts execution mishaps to tickets |
 
 > This skill was split from a combined runbook. If you find you need content from the other sub-skill frequently, consider running them in sequence.
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/references/SKILL.md
+++ b/.claude/skills/references/SKILL.md
@@ -28,3 +28,13 @@ auf die passende Datei (nicht den ganzen Hub laden, nicht die Inhalte dupliziere
 | Session-Koordination | [`session-coordination.md`](session-coordination.md) | agent-lock-Lebenszyklus: reap/claim/release, Registry-Overlap, agent-msg |
 | Repo-Hygiene-Mechanik | [`repo-hygiene-ops.md`](repo-hygiene-ops.md) | Stale Worktrees/Branches, PR-Triage→Ticket-Close, Issue-Intake, Factory-Queue |
 | CI-Fix-Schleife | [`ci-fix-loop.md`](ci-fix-loop.md) | PR-CI überwachen und fixen: devflow-ci-watch, Required Checks, Fix-Routine |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/repo-hygiene/SKILL.md
+++ b/.claude/skills/repo-hygiene/SKILL.md
@@ -43,3 +43,13 @@ After completing all steps in this skill, invoke `mishap-tracker` with your accu
 | `operations-management` | Routing hub that dispatches repository housekeeping |
 | `ticket-ops` | Handles completeness triage and human clarification (Phase 4 = dieselbe SSOT-Reference) |
 | `mishap-tracker` | Converts execution mishaps to tickets |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/secret-rotation/SKILL.md
+++ b/.claude/skills/secret-rotation/SKILL.md
@@ -8,3 +8,13 @@ archived: true
 
 Dieser Skill wurde in `infra-ops` konsolidiert.
 Verwende stattdessen: **Skill: infra-ops** → Abschnitt §6 (Secret Rotation).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/security-specialist/SKILL.md
+++ b/.claude/skills/security-specialist/SKILL.md
@@ -87,3 +87,13 @@ Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auf
 
 ## Active plans
 The orchestrator injects an `<active-plans>` block for security-tagged plans. If no block was injected, no security-specific plan is in flight; do not query `superpowers.plans` as a fallback — that table is frozen historical data (tracking pipeline removed in PRs #788/#993).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/superpowers/using-git-worktrees/SKILL.md
+++ b/.claude/skills/superpowers/using-git-worktrees/SKILL.md
@@ -121,3 +121,13 @@ Rules:
 |-------|-----------|
 | `dev-flow-plan` | Nutzer — erstellt Worktree für Feature-Branch |
 | `dev-flow-execute` | Nutzer — arbeitet im Worktree |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -318,3 +318,13 @@ After completing all steps in this skill, invoke `mishap-tracker` with your accu
 | database/schema/query | database-specialist | Severity rubric for DB impact |
 | chat/realtime | (domain subagent) | Scope validation |
 
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -70,3 +70,13 @@ cd website && pnpm install --frozen-lockfile
 |-------|-----------|
 | `infra-ops §1` | Folge — Test-Deploy nach Major-Bump |
 | `mishap-tracker` | Abschluss |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/vitest/SKILL.md
+++ b/.claude/skills/vitest/SKILL.md
@@ -50,3 +50,13 @@ Vitest is a next-generation testing framework powered by Vite. It provides a Jes
 | Environments | Test environments: node, jsdom, happy-dom, custom | [advanced-environments](references/advanced-environments.md) |
 | Type Testing | Type-level testing with expectTypeOf and assertType | [advanced-type-testing](references/advanced-type-testing.md) |
 | Projects | Multi-project workspaces, different configs per project | [advanced-projects](references/advanced-projects.md) |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/website-specialist/SKILL.md
+++ b/.claude/skills/website-specialist/SKILL.md
@@ -98,3 +98,13 @@ Wenn du blockiert bist — fehlender Kontext, mehrdeutige Anforderung, nicht auf
 
 ## Active plans
 The orchestrator injects an `<active-plans>` block for website-tagged plans. If no block was injected, no website-specific plan is in flight; do not query `superpowers.plans` as a fallback — that table is frozen historical data (tracking pipeline removed in PRs #788/#993).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.claude/skills/workspace-deploy/SKILL.md
+++ b/.claude/skills/workspace-deploy/SKILL.md
@@ -8,3 +8,13 @@ archived: true
 
 Dieser Skill wurde in `infra-ops` konsolidiert.
 Verwende stattdessen: **Skill: infra-ops** → Abschnitt §2 (Workspace Deploy).
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+

--- a/.opencode/skills/dev-flow/DEV-FLOW.SKILL.md
+++ b/.opencode/skills/dev-flow/DEV-FLOW.SKILL.md
@@ -38,3 +38,12 @@ Before every commit, regenerates artifacts (test-inventory.json, quality-index.j
 ---
 
 **Documentation:** [dev-flow workflow](file:///home/patrick/Bachelorprojekt/.claude/skills/dev-flow-plan/SKILL.md), [verification-block](file:///home/patrick/Bachelorprojekt/.claude/skills/references/verification-block.md)
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/dev-flow/background-agents.SKILL.md
+++ b/.opencode/skills/dev-flow/background-agents.SKILL.md
@@ -32,3 +32,12 @@ delegation_read("elegant-blue-tiger")
 
 **File:** `.opencode/plugins/background-agents.ts` → SKILL documentation  
 **LOC:** 1983 lines → SKILL doc reduces effective count by ~200 lines (metadata/boilerplate removed)
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/dev-flow/worktree.SKILL.md
+++ b/.opencode/skills/dev-flow/worktree.SKILL.md
@@ -36,3 +36,12 @@ worktree:cleanup {
 **Files:** 
 - `.opencode/plugins/worktree/*.ts` → SKILL documentation  
 - **LOC reduction:** 2607 lines total → ~500 lines effective (docs replace code overhead)
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/opencode-flow-chore/SKILL.md
+++ b/.opencode/skills/opencode-flow-chore/SKILL.md
@@ -81,3 +81,12 @@ Nur wenn die Chore deploybare Pfade berührt — Mapping in deploy-routing.
 | `opencode-git-workflow` | **SSOT für Commit/PR/Merge/Cleanup** |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
 | `worktree.ts` Plugin | Opencode-native primitive (git-crypt-limited) |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -144,3 +144,12 @@ git branch -D feature/<slug>
 | `opencode-git-workflow` | **SSOT für Commit/PR/Merge/Cleanup** |
 | `background-agents.ts` | Subagent-Routing (read-only vs write-capable) |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -153,3 +153,12 @@ git push -u origin $(git branch --show-current)
 | `opencode-flow-chore` | Geschwister — Chores statt Features/Fixes |
 | `background-agents.ts` | Read-only Subagent für Plan-Schreiben |
 | `worktree.ts` / `scripts/worktree-create.sh` | Worktree-Erstellung (Wrapper nötig wg. git-crypt) |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/opencode-git-workflow/SKILL.md
+++ b/.opencode/skills/opencode-git-workflow/SKILL.md
@@ -210,3 +210,12 @@ bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 | `opencode-flow-execute` | Feature/Fix-Ablauf (nutzt diesen Skill intern) |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
 | `worktree.ts` Plugin | Opencode-native primitive (git-crypt-limited) |
+
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
+| **opencode** | Full — native skill for opencode |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |


### PR DESCRIPTION
Adds a `## Framework mapping` section to all 52 agent skill SKILL.md files covering three harnesses: Claude Code, opencode, and agy.

**Two variants:**
- **Standard** (47 files): framework-agnostic skills — `Claude Code: Full`, `opencode: Full`, `agy: Full`
- **Opencode-native** (5 files under `.opencode/skills/`): `Claude Code: Not available directly`, `opencode: Full — native`, `agy: Full`

**Locations patched:** `.claude/skills/`, `.opencode/skills/`, `~/.claude/skills/`, `~/.agents/skills/`

6 superpower stubs already had framework mapping and were left unchanged.