### PR TITLE
fix(scripts): preflight-pr-scope.sh detached-HEAD + broken .worktrees/ glob [T001723]

### DIFF
--- a/docs/code-quality/loc-budget.json
+++ b/docs/code-quality/loc-budget.json
@@ -1,8 +1,8 @@
 {
-  "total_lines": 543566,
+  "total_lines": 543594,
   "file_count": 4120,
-  "commit": "c1263efc",
-  "measured_at": "2026-07-09T16:46:42.368Z",
+  "commit": "f3468b509",
+  "measured_at": "2026-07-09T16:49:59.331Z",
   "thresholds": {
     "warn_pct": 5,
     "fail_pct": 15,

--- a/scripts/preflight-pr-scope.sh
+++ b/scripts/preflight-pr-scope.sh
@@ -53,7 +53,7 @@ fi
 
 # Enforce worktree usage for feature/* and fix/* branches
 if [[ "$CURRENT_BRANCH" =~ ^(feature|fix)/ ]]; then
-  if [[ "$CURRENT_WORKTREE" != *"/worktrees/"* ]] && [[ "$CURRENT_WORKTREE" != *"\.worktrees/"* ]]; then
+  if [[ "$CURRENT_WORKTREE" != *"/worktrees/"* ]] && [[ "$CURRENT_WORKTREE" != *"/.worktrees/"* ]]; then
     echo "preflight-pr-scope: FATAL: PRs for feature/fix branches must be created from an isolated worktree under '.worktrees/'" >&2
     echo "  Current worktree path: $CURRENT_WORKTREE" >&2
     exit 1

--- a/tests/unit/preflight-pr-scope.bats
+++ b/tests/unit/preflight-pr-scope.bats
@@ -82,3 +82,18 @@ teardown() { rm -rf "$TMP"; }
   run bash "$HELPER" "feat(db)!: breaking schema" "$FIXTURE"
   [ "$status" -eq 0 ]
 }
+
+@test "preflight: fix/* branch under a real .worktrees/ path is accepted [T001723]" {
+  # Regression: the T001592 worktree-enforcement check used the broken glob
+  # `*"\.worktrees/"*` (a literal backslash-dot inside a quoted pattern never
+  # matches), so it silently fell through to `*"/worktrees/"*` — which does
+  # NOT match a real `.worktrees/foo` path (leading dot). Every real worktree
+  # created by scripts/worktree-create.sh (the repo-mandated convention) was
+  # rejected with a FATAL.
+  WTREE="$TMP/.worktrees/fix-example"
+  mkdir -p "$WTREE"
+  git -C "$TMP" worktree add -q -b fix/example "$WTREE" test-fixture
+  cd "$WTREE"
+  run bash "$HELPER" "fix(ops): example" "$FIXTURE"
+  [ "$status" -eq 0 ]
+}

--- a/tests/unit/preflight-pr-scope.bats
+++ b/tests/unit/preflight-pr-scope.bats
@@ -33,6 +33,19 @@ jobs:
             factory
           subjectPattern: ^.{1,200}$
 EOF
+
+  # Isolated git fixture [T001723]: the script's branch/worktree guards
+  # ([T001592]) call `git symbolic-ref --short HEAD`, which is meaningless
+  # against the *ambient* checkout — a CI `pull_request` run checks out a
+  # detached HEAD, so running the script straight from $BATS_TEST_DIRNAME's
+  # repo made every test here FATAL in CI while passing locally. Give the
+  # script its own throwaway repo with a real branch (not main/master, not
+  # feature/*|fix/*) checked out so these tests exercise scope-parsing only.
+  git -C "$TMP" init -q -b test-fixture
+  git -C "$TMP" config user.email "test@example.invalid"
+  git -C "$TMP" config user.name "Test Fixture"
+  git -C "$TMP" commit -q --allow-empty -m "fixture"
+  cd "$TMP"
 }
 
 teardown() { rm -rf "$TMP"; }


### PR DESCRIPTION
## Summary
Two bugs in `scripts/preflight-pr-scope.sh`, both introduced by the T001592 branch/worktree validation added earlier today (commit `bc32681bd`):

1. **Detached-HEAD FATAL breaks every PR's CI.** The script calls `git symbolic-ref --short HEAD` and exits 1 ("Not on any branch") when that's empty. `pull_request`-triggered CI runs check out a detached HEAD (no `ref:` override in `ci.yml`), so `tests/unit/preflight-pr-scope.bats` FATALed on all 6 cases in CI while passing locally. Fixed by isolating the bats test in its own throwaway git repo with a real branch checked out, instead of running the script against the ambient (possibly detached) checkout.
2. **Broken `.worktrees/` glob rejects every real worktree.** The worktree-enforcement fallback pattern was `*"\.worktrees/"*` — inside double quotes, `\.` is a literal two-char sequence (backslash + dot), not an escaped dot, so it can never match a real `.worktrees/foo` path. Every worktree created via the repo-mandated `scripts/worktree-create.sh` convention was rejected with a FATAL. Discovered live: this exact bug blocked creating this PR. Fixed to `*"/.worktrees/"*` and added a regression test.

## Test Plan
- [x] `tests/unit/preflight-pr-scope.bats` — 7/7 (added 1 regression test for bug 2)
- [x] Reproduced bug 1 via isolated clone + `git checkout --detach HEAD` before the fix, confirmed fixed after
- [x] Reproduced bug 2 by temporarily reverting the one-line fix — new test 7 correctly fails
- [x] `task freshness:check`, `task test:code-quality` (incl. `loc:check`) — green
- [x] `bash scripts/preflight-pr-scope.sh` against this PR's own title, from this PR's own `.worktrees/` worktree — passes (previously would have FATALed on bug 2)

Ticket: T001723