### PR TITLE
fix(factory): disable Qwen3.5 thinking mode for structured-output calls [T001763]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -45,6 +45,7 @@
       "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwen3.5-9B (IQ4_XS weights, unsloth/Qwen3.5-9B-GGUF) on LM Studio - serves up to 4 parallel subagents, ~65k ctx recommended per call (260k total). Try this before qwythos/q4_k_m/q4_k_xl variants.",
       "mode": "subagent",
       "model": "lmstudio/qwen3.5-9b@iq4_xs",
+      "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#0EA5E9",
       "temperature": 0.7,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
@@ -53,6 +54,7 @@
       "description": "Single-session implementation/planning agent: Qwen3-14B (Q4_K_M, lmstudio-community/Qwen3-14B-GGUF) on LM Studio",
       "mode": "subagent",
       "model": "lmstudio/qwen3-14b@q4_k_m",
+      "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
       "temperature": 0.7,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
@@ -61,6 +63,7 @@
       "description": "Subagent using Qwen3.5-9B (Q4_K_M weights) on LM Studio - use when 3 parallel subagents are loaded (48k ctx each)",
       "mode": "subagent",
       "model": "lmstudio/qwen3.5-9b@q4_k_m",
+      "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#22C55E",
       "temperature": 0.7,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
@@ -69,6 +72,7 @@
       "description": "Subagent using Qwen3.5-9B (UD-Q4_K_XL weights, higher fidelity, 140k ctx) on LM Studio - single session, serialized (no parallel dispatch), use when max per-call context matters more than concurrency",
       "mode": "subagent",
       "model": "lmstudio/qwen3.5-9b@q4_k_xl",
+      "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#16A34A",
       "temperature": 0.7,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }

--- a/.opencode/prompts/local-subagent.md
+++ b/.opencode/prompts/local-subagent.md
@@ -1,0 +1,9 @@
+You are a local subagent (Qwen3.5-9B, running on-device via LM Studio) delegated a narrow, well-defined task by an orchestrator. You are one of several parallel subagents sharing this GPU — keep responses short and get straight to the deliverable.
+
+Rules:
+- Do not narrate your reasoning, do not write "Let me think about this" or similar preambles, do not restate the task before answering.
+- If the caller asked for JSON, output ONLY the JSON object — no markdown code fence, no leading/trailing prose, no explanation after it.
+- If the caller asked for a specific format (a file, a diff, a list), match that format exactly and nothing else.
+- If a schema or set of allowed values was given, comply exactly — do not invent fields or values outside it.
+- If something is genuinely ambiguous, make the most reasonable choice and proceed rather than asking a follow-up — there is no further turn.
+- Keep answers as short as the task allows. Verbosity is a cost here, not a feature.

--- a/scripts/factory/auto-triage.sh
+++ b/scripts/factory/auto-triage.sh
@@ -198,11 +198,40 @@ PROMPT
   # cleanup at function exit
   trap "rm -f $tmp_req $tmp_resp 2>/dev/null" RETURN
 
-  # Build request body
+  # Build request body. For Qwen3-family hybrid reasoners, force
+  # enable_thinking=false (hard switch via chat_template_kwargs, not the
+  # soft "/no_think" prompt convention) so the model doesn't burn max_tokens
+  # on a <think> trace before ever emitting the JSON turn — the same failure
+  # mode documented for factory_ask in scripts/factory/mcp-go/main.go.
+  # response_format uses json_schema (not json_object) so llama.cpp/LM
+  # Studio constrain decoding to the enum-valid schema at the sampler level,
+  # instead of only validating after the fact in validate_triage().
+  local schema
+  schema=$(jq -n --argjson enums "$enums" '{
+    name: "ticket_triage",
+    strict: true,
+    schema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["type","priority","severity","areas","component","assignee_suggested","rationale"],
+      properties: {
+        type: { type: "string", enum: ["bug","feature","task","project"] },
+        priority: { type: "string", enum: ["hoch","mittel","niedrig"] },
+        severity: { type: "string", enum: ["critical","major","minor","trivial"] },
+        areas: { type: "array", items: { type: "string", enum: $enums.areas }, minItems: 1, maxItems: 3 },
+        component: { type: ["string","null"], enum: ($enums.components + [null]) },
+        assignee_suggested: { type: "string", enum: $enums.assignees },
+        rationale: { type: "string" }
+      }
+    }
+  }')
+
   jq -n \
     --arg model "$model" \
     --arg sys "$system_prompt" \
     --arg user "$user_prompt" \
+    --argjson schema "$schema" \
+    --argjson thinking_off "$([[ "$model" == *qwen* ]] && echo true || echo false)" \
     '{
       model: $model,
       messages: [
@@ -211,8 +240,9 @@ PROMPT
       ],
       temperature: 0.2,
       max_tokens: 512,
-      response_format: {type: "json_object"}
-    }' > "$tmp_req"
+      response_format: {type: "json_schema", json_schema: $schema}
+    }
+    + (if $thinking_off then {chat_template_kwargs: {enable_thinking: false}} else {} end)' > "$tmp_req"
 
   local curl_args=(-s -S --max-time 60)
   if [[ -n "$api_key" ]]; then

--- a/scripts/factory/mcp-go/main.go
+++ b/scripts/factory/mcp-go/main.go
@@ -43,6 +43,13 @@ func llmModel() string {
 	return envOr("FACTORY_LLM_MODEL", "hermes-3-llama-3.1-8b")
 }
 func llmKey() string { return envOr("FACTORY_LLM_API_KEY", "lmstudio") }
+
+// isQwenReasoningModel reports whether model is a Qwen3-family hybrid
+// reasoner, which needs enable_thinking:false to avoid burning max_tokens
+// on the reasoning_content trace before ever emitting a final answer.
+func isQwenReasoningModel(model string) bool {
+	return strings.Contains(strings.ToLower(model), "qwen")
+}
 func openspecURL() string {
 	return envOr("OPENSPEC_SEARCH_URL", "http://website.website.svc.cluster.local:4321")
 }
@@ -92,7 +99,7 @@ type mcpTool struct {
 
 type mcpToolResult struct {
 	Content []map[string]any `json:"content"`
-	IsError bool            `json:"isError,omitempty"`
+	IsError bool             `json:"isError,omitempty"`
 }
 
 type toolCallParams struct {
@@ -290,9 +297,9 @@ func runTool(name string, args json.RawMessage) (string, bool, error) {
 		return toolFactoryRecent(a.Limit)
 	case "openspec_find_similar":
 		var a struct {
-			Query  string `json:"query"`
+			Query  string          `json:"query"`
 			Limit  json.RawMessage `json:"limit"`
-			Status string `json:"status"`
+			Status string          `json:"status"`
 		}
 		_ = json.Unmarshal(args, &a)
 		return toolOpenspecSimilar(a.Query, a.Limit, a.Status)
@@ -337,8 +344,8 @@ func toolFactoryStatus() (string, bool, error) {
 	backlog := psqlJSON("SELECT count(*) FROM tickets.tickets WHERE status='backlog'")
 	planStaged := psqlJSON("SELECT count(*) FROM tickets.tickets WHERE status='plan_staged'")
 	out := map[string]any{
-		"backlog":     backlog,
-		"plan_staged": planStaged,
+		"backlog":      backlog,
+		"plan_staged":  planStaged,
 		"tick_running": lockHeld == "true",
 	}
 	b, _ := json.MarshalIndent(out, "", "  ")
@@ -435,14 +442,23 @@ func toolFactoryAsk(question string) (string, bool, error) {
 	if q == "" {
 		return "", true, fmt.Errorf("question is required")
 	}
+	model := llmModel()
 	body := map[string]any{
-		"model": llmModel(),
+		"model": model,
 		"messages": []map[string]string{
 			{"role": "system", "content": factorySystemPrompt},
 			{"role": "user", "content": q},
 		},
 		"temperature": 0.2,
 		"max_tokens":  1500,
+	}
+	if isQwenReasoningModel(model) {
+		// Hard switch (not the soft "/no_think" prompt convention): forces
+		// the Jinja chat template to skip the <think> turn entirely, so the
+		// full max_tokens budget goes to the visible answer. Without this,
+		// Qwen3.5 frequently exhausts max_tokens mid-reasoning and returns
+		// an empty content field (see extractAnswerFromReasoning fallback).
+		body["chat_template_kwargs"] = map[string]any{"enable_thinking": false}
 	}
 	bb, _ := json.Marshal(body)
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)


### PR DESCRIPTION
## Summary
- Qwen3.5-9B ist ein Hybrid-Reasoning-Modell; ohne `enable_thinking=false` verbrennt es bei den lokalen Structured-Output-Calls oft das `max_tokens`-Budget im `reasoning_content`-Trace, bevor der finale JSON-Turn beginnt -> leerer `content`, 60s+ Latenz (dokumentiertes Symptom in `scripts/factory/mcp-go/README.md`).
- `mcp-go` (`factory_ask`) und `auto-triage.sh` (`ticket-triage`) senden jetzt `chat_template_kwargs: {enable_thinking: false}`, wenn das gewaehlte Modell "qwen" im Namen traegt.
- `auto-triage.sh` nutzt zusaetzlich `response_format: json_schema` (strict) statt `json_object` — das Enum-Schema wird aus der bestehenden `triage-enums.json` kompiliert, damit ungueltige `type`/`priority`/`areas`/`component`/`assignee_suggested`-Werte bereits beim Sampling ausgeschlossen sind statt erst nachtraeglich in `validate_triage()` erkannt zu werden.
- Fuer die opencode-Subagenten (`qwen35-iq4`, `qwen35`, `qwen35-hq`, `qwythos`, `qwythos-hq`) gibt es keinen verifizierten Weg, `chat_template_kwargs` ueber die opencode-Agent-Config bis zum `@ai-sdk/openai-compatible`-Provider durchzureichen (dessen `providerOptions`-Zod-Schema kennt nur `user`/`reasoningEffort`/`textVerbosity` und verwirft unbekannte Felder). Stattdessen bekommen diese Subagenten jetzt einen dedizierten Systemprompt (`.opencode/prompts/local-subagent.md`), der Reasoning-Preamble und Markdown-Wrapping um JSON-Antworten explizit verbietet.

## Test Plan
- [x] `go build` in `scripts/factory/mcp-go` (sauber, `gofmt` clean)
- [x] `bash -n scripts/factory/auto-triage.sh`
- [x] jq-Request-Body isoliert getestet (`chat_template_kwargs` + `response_format.json_schema` korrekt gemergt)
- [x] `.opencode/agent-models.jsonc` als valides JSON geprueft
- [ ] Manueller Livetest gegen die LM-Studio-Instanz (lokaler GPU-Host, ausserhalb CI)

[T001763]