### PR TITLE
chore(plans): archive t001749-admin-tickets-e2e-seed [T001760]

### DIFF
--- a/openspec/changes/t001749-admin-tickets-e2e-seed/proposal.md
+++ b/openspec/changes/t001749-admin-tickets-e2e-seed/proposal.md
@@ -2,7 +2,7 @@
 title: "t001749-admin-tickets-e2e-seed — DB-Level E2E Seed Helper"
 ticket_id: T001749
 domains: [e2e, tests, database]
-status: plan_staged
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/t001749-admin-tickets-e2e-seed/tasks.md
+++ b/openspec/changes/t001749-admin-tickets-e2e-seed/tasks.md
@@ -2,7 +2,7 @@
 title: "t001749-admin-tickets-e2e-seed — Implementation Plan"
 ticket_id: T001749
 domains: [e2e, tests, database]
-status: plan_staged
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null


### PR DESCRIPTION
## Summary

Archives the t001749-admin-tickets-e2e-seed OpenSpec change. The implementation was already merged to main (commit ac44039f0) as part of T001748. This PR finalizes the formal OpenSpec record so the change can be archived and the dependency chain (T001749 → T001754) resolved.

## Verification

- ✅ e2e-seed.ts helper exists with all 5 exports
- ✅ fa-admin-tickets.spec.ts uses new helpers, no legacy createTestBugReport refs
- ✅ TypeScript typecheck (tests/e2e/) — exit 0
- ✅ Vitest regression (transition.test.ts) — 7/7 passing
- ✅ freshness:regenerate — no changes needed

Closes T001760