### PR TITLE
fix(health-goal): update image exclusions [T001781]

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "brett": "0.36.0",
   "k3d/docs-content": "0.5.0",
-  "website": "1.176.0"
+  "website": "1.177.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ task feature:deploy  # fan-out to both brands
 - **`scripts/task-oracle.sh` is DEPRECATED.** Use `bash scripts/vda.sh oracle` instead. The old script is a thin shim.
 - **Adding `${VAR}` to a manifest?** Register in `environments/schema.yaml` AND `envsubst` list in every Taskfile task that builds that manifest.
 - **Never SELECT * from `tickets.ticket_plans`** — `content` column is multi-MB markdown.
-- **Website, Brett, Docs, Videovault, Mediaviewer-Widget images use `:latest` intentionally** — CI warns, do not "fix" to digests.
+- **Website, Brett, Docs, Videovault, Mediaviewer-Widget, Mentolder-Web, Downloads, Brain, Studio, and Talk-Transcriber images use `:latest` intentionally** — CI warns, do not "fix" to digests.
 - **`env:generate ENV=<target>` must run before `env:seal`** — talk-hpb-setup.sh aborts on placeholder values.
 - **Cluster reset order**: sealed-secrets:install → env:fetch-cert → env:seal → cert:install → cert:secret → workspace:deploy.
 - **`docs:sync` does NOT work** — container rootfs is read-only. Deploy via `task docs:deploy`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,9 @@ The following components intentionally use `:latest` images and are excluded fro
 - Mediaviewer-Widget
 - Mentolder-Web
 - Downloads
+- Brain
+- Studio
+- Talk-Transcriber
 
 This ensures that the Infrastructure and Dev workflows correctly identify these as "live" targets that do not require manual digest pinning.
 

--- a/openspec/changes/health-goal-latest-image-exclusions/plan.md
+++ b/openspec/changes/health-goal-latest-image-exclusions/plan.md
@@ -1,0 +1,23 @@
+# Plan: Health-Goal: Unvollständige :latest-Image Exclusions in CLAUDE.md
+
+## Objectives
+Ensure that the exclusion list for `:latest` images in `CLAUDE.md` and `AGENTS.md` is complete. This prevents AI agents from attempting to pin images that are intentionally designed to be rebuilt and re-imported on every release.
+
+## Tasks
+1. **Update CLAUDE.md**
+   - Locate the `Image Exclusions` section (approx line 158).
+   - Add `Brain`, `Studio`, and `Talk-Transcriber` to the list.
+   - Current list: Website, Brett, Docs, Videovault, Mediaviewer-Widget, Mentolder-Web, Downloads.
+
+2. **Update AGENTS.md**
+   - Locate the `Image-Pins` section (approx line 96).
+   - Add `Mentolder-Web`, `Downloads`, `Brain`, `Studio`, and `Talk-Transcriber` to the exclusion list.
+   - Current list: Website, Brett, Docs, Videovault, Mediaviewer-Widget.
+
+3. **Verification**
+   - Verify that the new entries match the manifests in `k3d/` (e.g., `k3d/brain.yaml`, `k3d/studio.yaml`, and `Taskfile.yml` for talk-transcriber).
+   - Run `task workspace:validate` to ensure no manifest syntax errors were introduced.
+
+4. **Deployment**
+   - Commit changes with a conventional commit message.
+   - Create a PR and merge into `main`.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+This PR adds the intentionally `:latest` image exclusions to the `CLAUDE.md` file to ensure that the infrastructure and dev workflows correctly identify these as 'live' targets that do not require manual digest pinning.
+
+Ticket: T001775
+Fixes: T001775

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.177.0](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.176.0...website-v1.177.0) (2026-07-10)
+
+
+### Features
+
+* **infra:** update image exclusions in CLAUDE.md [T001775] ([#2738](https://github.com/Paddione/Bachelorprojekt/issues/2738)) ([db2c6bc](https://github.com/Paddione/Bachelorprojekt/commit/db2c6bc64301a58552d34398787966d67024bc27))
+
 ## [1.176.0](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.175.0...website-v1.176.0) (2026-07-10)
 
 

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
     "node": ">=22.13.0"
   },
   "type": "module",
-  "version": "1.176.0",
+  "version": "1.177.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Update CLAUDE.md and AGENTS.md to include Brain, Studio, and Talk-Transcriber in the :latest image exclusions list. This ensures that these components are correctly identified as "live" targets and not pinned to specific digests.