### PR TITLE
fix(factory): wire resolveAgentModel guard into pipeline.js call sites

### DIFF
--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -150,7 +150,7 @@ if (A.batch_mode === true && Array.isArray(A.sub_features)) {
        After implementing: cd ${WORK_WT} && task workspace:validate && task test:all && task freshness:regenerate
        Then commit: cd ${WORK_WT} && git add -A && git commit -m ${JSON.stringify(`feat(${slug}): ${sf.id} [batch-factory]`)}
        Return a summary of the diff and local test result.` + consumeInjections('implement'),
-      { label: `batch:${sf.id}`, phase: 'Implement', model: sfRoute.modelId },
+      { label: `batch:${sf.id}`, phase: 'Implement', model: BL.resolveAgentModel(sfRoute, routerTier(sfProv.model), log) },
     )
   }))
 
@@ -302,7 +302,7 @@ if (!isSimple) {
 
      Return JSON { tasks: [...], plan_path: "<absolute path>" }` + consumeInjections('plan'),
     {
-      model: planRoute.modelId,
+      model: BL.resolveAgentModel(planRoute, routerTier(planProv.model), log),
       label: 'plan:decompose',
       phase: 'Plan',
       schema: { type: 'object', required: ['tasks', 'plan_path'], properties: { plan_path: { type: 'string' }, tasks: { type: 'array', items: { type: 'object', required: ['id', 'target_files', 'acceptance_criteria'], properties: { id: { type: 'string' }, target_files: { type: 'array', items: { type: 'string' } }, acceptance_criteria: { type: 'array', items: { type: 'string' } } } } } } },
@@ -418,7 +418,7 @@ if (tasks.length && !A.batch_mode) {
          After implementing: cd ${WORK_WT} && task workspace:validate && task test:all && task freshness:regenerate
          Then commit: cd ${WORK_WT} && git add -A && git commit -m ${JSON.stringify(`feat(${slug}): ${t.id} [factory]`)}
          Return a summary of the diff and local test result (pass/fail).` + consumeInjections('implement'),
-        { label: `impl:${t.id}`, phase: 'Implement', model: route.modelId },
+        { label: `impl:${t.id}`, phase: 'Implement', model: BL.resolveAgentModel(route, routerTier(prov.model), log) },
       )
       releaseSlotSync(route.slotId, impl != null, route.ctx)
     } catch (err) {
@@ -494,7 +494,7 @@ if (!cleanDiff || !String(cleanDiff).trim()) {
     return agent(
       `/goal Perform verification review lens: ${l.key}.
        Liveness: \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`. Then review at ${REPO}/${l.file} against: git -C ${WORK_WT} diff origin/main...HEAD. Return findings as JSON per the prompt's schema.` + consumeInjections('verify'),
-      { label: `review:${l.key}`, phase: 'Verify', ...(l.key === 'agents-md' ? {} : { schema: REVIEW_SCHEMA }), model: route.modelId },
+      { label: `review:${l.key}`, phase: 'Verify', ...(l.key === 'agents-md' ? {} : { schema: REVIEW_SCHEMA }), model: BL.resolveAgentModel(route, 'opus', log) },
     )
   }))).filter(Boolean)
   log(`Verify: ${reviews.length}/${lenses.length} lenses done, tier=${tier}`)
@@ -542,7 +542,7 @@ if (!cleanDiff || !String(cleanDiff).trim()) {
     const coordRoute = routeProviderSync('factory-review', 'opus', 'verify')
     const coord = await agent(
       `Read ${REPO}/scripts/factory/review-coordinator.prompt.md and apply to these lens findings. Return ONE consolidated JSON with "verdict" field.\n${xml}`,
-      { label: 'review:coordinator', phase: 'Verify', schema: COORDINATOR_SCHEMA, model: coordRoute.modelId },
+      { label: 'review:coordinator', phase: 'Verify', schema: COORDINATOR_SCHEMA, model: BL.resolveAgentModel(coordRoute, 'opus', log) },
     )
     if (coord && coord.verdict) {
       coordinatorVerdict = coord.verdict

--- a/scripts/migrations/2026-07-03-local-qwen35-seed.sql
+++ b/scripts/migrations/2026-07-03-local-qwen35-seed.sql
@@ -5,6 +5,10 @@
 -- priority-2+ rows). Idempotent (ON CONFLICT DO UPDATE + provider<>'local-qwen35' demotion
 -- guard). Depends on 2026-07-03-context-budget.sql.
 --
+-- Scope-corrected 2026-07-09 (T001681): factory-scout/factory-plan/lavish-artifact removed —
+-- they call the harness agent() primitive, which has no baseUrl support; only ticket-triage
+-- uses its own baseURL-aware SDK client (website/src/lib/ticket-triage.ts) and benefits from this row.
+--
 -- Apply to BOTH brands (separate per-brand DBs):
 --   BRAND=mentolder bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-07-03-local-qwen35-seed.sql'
 --   BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-07-03-local-qwen35-seed.sql'
@@ -20,7 +24,7 @@ BEGIN;
 WITH targets AS (
   SELECT id, source, tier
     FROM tickets.provider_config
-   WHERE source IN ('factory-scout','factory-plan','ticket-triage','lavish-artifact')
+   WHERE source IN ('ticket-triage')
      AND priority = 1
      AND provider <> 'local-qwen35'
 ),
@@ -40,10 +44,7 @@ UPDATE tickets.provider_config pc
 INSERT INTO tickets.provider_config
   (source, tier, priority, provider, model_id, base_url, context_window, context_budget, enabled)
 VALUES
-  ('factory-scout',   'sonnet', 1, 'local-qwen35', 'qwen3.5-9b@iq4_xs', 'http://100.102.71.114:1234/v1', 60000, 180000, true),
-  ('factory-plan',    'sonnet', 1, 'local-qwen35', 'qwen3.5-9b@iq4_xs', 'http://100.102.71.114:1234/v1', 60000, 180000, true),
-  ('ticket-triage',   'haiku',  1, 'local-qwen35', 'qwen3.5-9b@iq4_xs', 'http://100.102.71.114:1234/v1', 60000, 180000, true),
-  ('lavish-artifact', 'sonnet', 1, 'local-qwen35', 'qwen3.5-9b@iq4_xs', 'http://100.102.71.114:1234/v1', 60000, 180000, true)
+  ('ticket-triage',   'haiku',  1, 'local-qwen35', 'qwen3.5-9b@iq4_xs', 'http://100.102.71.114:1234/v1', 60000, 180000, true)
 ON CONFLICT (source, tier, priority) DO UPDATE
   SET provider       = EXCLUDED.provider,
       model_id       = EXCLUDED.model_id,


### PR DESCRIPTION
## Summary
- T001681 was closed `done` after PR #2671 merged, but that PR only shipped Task 1 (the `resolveAgentModel` helper in `build-loop.cjs`) — the plan's Task 2 (wiring the 5 `pipeline.js` `agent()` call sites) and Task 3 (narrowing the `local-qwen35` seed migration) never landed.
- This PR completes the remaining work per the still-open plan at `openspec/changes/factory-provider-baseurl-routing/tasks.md`: all 5 `pipeline.js` call sites (batch, plan-decompose, implement, review lenses, review coordinator) now route through `BL.resolveAgentModel`, and the seed migration is narrowed to `ticket-triage` only (the only source with its own baseURL-aware SDK client).
- Filed as new bug ticket T001796 per the repo's bug-triage convention (no silent fix commit without a ticket).

## Test plan
- [x] `node --test scripts/factory/build-loop.test.cjs` — 23/23 pass
- [x] `node --check scripts/factory/pipeline.js scripts/factory/build-loop.cjs` — exit 0
- [x] `grep -n "model: .*\.modelId" scripts/factory/pipeline.js` — no output (all call sites guarded)
- [x] `task test:changed` — 52/52 pass
- [x] `task freshness:regenerate` — no drift

Closes T001796

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC6x6y3eKhu78viPoN5Z4q