### PR TITLE
fix(website): restore --brass-deep fallback for portal avatar gradient [T001797]

### DIFF
--- a/website/src/components/admin/ui/AdminBadge.svelte
+++ b/website/src/components/admin/ui/AdminBadge.svelte
@@ -30,7 +30,7 @@
 
 <style>
   /* T001433 — variant mapping: warning→Brass, success→Sage, error→Danger, info→Brass.
-     Resolved through the --admin-* alias layer (factory-tokens.css), not literals. */
+     Resolved through the --admin-* alias layer (global.css), not literals. */
 
   .badge {
     display: inline-flex;

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -144,6 +144,7 @@
   --brass: var(--color-brass);
   --brass-2: var(--color-brass-2);
   --brass-d: var(--color-brass-d);
+  --brass-deep: #4a3814; /* used via var(--brass-deep, ...) fallback in PortalLayout.astro */
   --sage: var(--color-sage);
   --danger: var(--color-danger);
   --line: var(--color-line);


### PR DESCRIPTION
## Summary
- Follow-up to T001787 (PR #2752, admin-token-consolidation), which merged before a code-review finding was applied.
- `--brass-deep` was classified as a dead token (0 bare `var(--brass-deep)` consumers) and dropped when `factory-tokens.css` was dissolved into `global.css`. It's actually consumed via the fallback form `var(--brass-deep, #8a6a2a)` in `website/src/layouts/PortalLayout.astro:145,162` (portal avatar gradient) — a plain grep for the bare token name missed this usage pattern.
- Without the declaration, the CSS fallback (`#8a6a2a`) rendered instead of the original `#4a3814`, a visible color regression.
- Re-adds `--brass-deep: #4a3814;` to `global.css` and fixes a stale `factory-tokens.css` comment reference in `AdminBadge.svelte`.

## Test plan
- [x] `cd website && npx vitest run src/lib/__tests__/admin-token-alias.test.ts` — 17/17 pass
- [x] `task test:changed` — 52/52 pass
- [x] `task freshness:regenerate` && `task freshness:check` — pass, no stale artifacts

Ticket: T001797 (bug, filed per Bug-Triage-Konvention since the regression already shipped to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)