### PR TITLE
fix(infra): sync pocket_id DB password in workspace:sync-db-passwords

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2965,7 +2965,7 @@ tasks:
         echo "Syncing DB passwords from ${NS}/workspace-secrets → shared-db ({{.ENV}})..."
 
         nc_needs_restart=0
-        for user in keycloak nextcloud vaultwarden website docuseal; do
+        for user in pocket_id nextcloud vaultwarden website docuseal; do
           key="${user^^}_DB_PASSWORD"
           pw=$(kubectl $context_flag get secret workspace-secrets -n "$NS" \
             -o jsonpath="{.data.${key}}" 2>/dev/null | base64 -d)


### PR DESCRIPTION
## Summary
- `workspace:sync-db-passwords` synced DB passwords for `keycloak nextcloud vaultwarden website docuseal` — `keycloak` is a leftover from before the Welle-3 pocket-id migration and `pocket_id` was never added.
- Result: `POCKET_ID_DB_PASSWORD` rotations in `workspace-secrets` never propagated to the actual postgres role, so the secret and the DB drifted apart. Mentolder's `pocket-id` pod was in CrashLoopBackOff for 18h+ (224 restarts) with `password authentication failed for user "pocket_id"` over the `shared-db` Service (scram-sha-256 auth). `localhost` connections use `trust` auth in `pg_hba.conf`, which masked the drift during initial diagnosis.
- Fix: swap `keycloak` → `pocket_id` in the sync loop.

## Live remediation (already applied on both brands)
- `ALTER ROLE pocket_id` synced to the current `workspace-secrets` value via `task workspace:sync-db-passwords` (corrected version) on `mentolder` and `korczewski`.
- Mentolder `pocket-id` pod restarted, now `1/1 Running`, 0 restarts.
- Both brands' `nextcloud` DB passwords/`config.php` were also found drifted (same underlying gap, `nextcloud` was already in the loop but this run picked up an existing drift) and were resynced as a side effect; `nextcloud` deployment rolled out cleanly.
- Both brands' `pocket-id-client-seed` Jobs were `Failed` (downstream of pocket-id being unreachable for 18h) — deleted for GC; will re-run cleanly on next deploy now that pocket-id is healthy.

Tracked in T001798.

## Test plan
- [x] Live-verified: `kubectl --context fleet get pods -n workspace -l app=pocket-id` → `1/1 Running`
- [x] Live-verified: `kubectl --context fleet logs -n workspace -l app=pocket-id` → clean startup, `200` on `/.well-known/openid-configuration`
- [x] `task workspace:sync-db-passwords ENV=mentolder` and `ENV=korczewski` ran cleanly end-to-end (idempotent re-run)
- [ ] CI (BATS/manifest structure) — no manifest/behavior change beyond the task's user list, existing tests should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfUJHsSiMbkz7GN8g3rtKz