### PR TITLE
fix(tickets): align child_of in DB constraint + get_ticket_links output [T001793]

### DIFF
--- a/scripts/lib/ticket-links.sh
+++ b/scripts/lib/ticket-links.sh
@@ -94,7 +94,7 @@ EOF
 }
 
 # cmd_get_ticket_links --id <ext_id>
-# Returns JSON: {"blocks": [...], "blocked_by": [...], "relates": [...]}
+# Returns JSON: {"blocks": [...], "blocked_by": [...], "relates": [...], "child_of": [...]}
 # Refuses offline reads (exits 9 with TICKET_OFFLINE=1).
 cmd_get_ticket_links() {
   local id=""
@@ -139,6 +139,13 @@ SELECT jsonb_build_object(
     END
     WHERE tl.kind = 'relates'
       AND (tl.from_id = self.id OR tl.to_id = self.id)
+  ), '[]'::jsonb),
+  'child_of', COALESCE((
+    SELECT jsonb_agg(t2.external_id ORDER BY t2.external_id)
+    FROM tickets.ticket_links tl
+    JOIN tickets.tickets t2 ON t2.id = tl.to_id
+    WHERE tl.from_id = (SELECT id FROM tickets.tickets WHERE external_id = :'ext_id')
+      AND tl.kind = 'child_of'
   ), '[]'::jsonb)
 ) AS links;
 EOF

--- a/scripts/ticket-mcp/go/internal/tools/links.go
+++ b/scripts/ticket-mcp/go/internal/tools/links.go
@@ -62,7 +62,7 @@ func RegisterLinkTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("get_ticket_links",
-			mcp.WithDescription("Gibt alle Dependency-Links eines Tickets zurück: blocks (von diesem Ticket ausgehend), blocked_by (auf dieses Ticket zeigend), relates (symmetrisch)."),
+			mcp.WithDescription("Gibt alle Dependency-Links eines Tickets zurück: blocks (von diesem Ticket ausgehend), blocked_by (auf dieses Ticket zeigend), relates (symmetrisch), child_of (Elternticket)."),
 			mcp.WithString("id", mcp.Description("external_id z.B. T000123"), mcp.Required()),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)")),
 		),


### PR DESCRIPTION
## T001793 — Mishap-Bundle: ticket-mcp, website

Fixes 2 mishaps:
1. **ticket-mcp child_of schema-DB drift** — Applied CHECK constraint migration, added child_of to get_ticket_links SQL output
2. **coaching-studio heredoc leak** — Already fixed in PR #2743

Branch: fix/t001793-mishap-bundle