### PR TITLE
fix: ignore locally installed market-cli skills [T001783]

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -51,7 +51,9 @@
       // ── UI/design (not primary workflow) ─────────────────────────────
       "ui-ux-pro-max": "deny",
       "react-bits": "deny",
-      "references": "deny"
+      "references": "deny",
+      // ── market-cli installed (not project-relevant, avoid context bloat) ─
+      "lavish": "deny"
     }
   },
   "lsp": true,


### PR DESCRIPTION
## T001783 — Ignore locally installed market-cli skills

Added `lavish` to the permission.skill deny list in .opencode/opencode.jsonc. All other market-cli skills were already denied.

Branch: fix/t001783-market-cli-ignore