### PR TITLE
fix(security): add POCKET_ID_TERMINAL_SECRET to schema + secrets [T001801]

### DIFF
--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -881,6 +881,12 @@ secrets:
     length: 64
     description: "OIDC client secret for the session-hub oauth2-proxy (Pocket ID confidential client `session-hub`). Pocket ID has no groups — gating moves to --authenticated-emails-file."
 
+  - name: POCKET_ID_TERMINAL_SECRET
+    required: false
+    generate: true
+    length: 40
+    description: "OIDC client secret for the `terminal-sidekick` Pocket ID client (terminal oauth2-proxy)."
+
   - name: SESSIONS_CRON_TOKEN
     required: false
     sealed: true

--- a/k3d/clean-seed.yaml
+++ b/k3d/clean-seed.yaml
@@ -146,6 +146,8 @@ spec:
               valueFrom: { secretKeyRef: { name: workspace-secrets, key: POCKET_ID_RUSTDESK_WEB_SECRET, optional: true } }
             - name: SECRET_brain
               valueFrom: { secretKeyRef: { name: workspace-secrets, key: POCKET_ID_BRAIN_SECRET, optional: true } }
+            - name: SECRET_terminal
+              valueFrom: { secretKeyRef: { name: workspace-secrets, key: POCKET_ID_TERMINAL_SECRET, optional: true } }
           command:
             - /bin/sh
             - -ec
@@ -189,6 +191,7 @@ spec:
                website|SECRET_website|POCKET_ID_WEBSITE_SECRET|${SCHEME}://web.${SUFFIX}/api/auth/callback
                rustdesk-web|SECRET_rustdeskweb|POCKET_ID_RUSTDESK_WEB_SECRET|${SCHEME}://remote.${SUFFIX}/oauth2/callback
                brain|SECRET_brain|POCKET_ID_BRAIN_SECRET|${SCHEME}://brain.${SUFFIX}/oauth2/callback
+               terminal-sidekick|SECRET_terminal|POCKET_ID_TERMINAL_SECRET|${SCHEME}://terminal.${SUFFIX}/oauth2/callback
               "
 
               # Resolve a client's REAL pocket-id id by NAME. pocket-id:v2.9.0

--- a/k3d/secrets.yaml
+++ b/k3d/secrets.yaml
@@ -94,6 +94,7 @@ stringData:
   POCKET_ID_SESSION_HUB_SECRET: "devsessionhubpocketidsecret123"
   POCKET_ID_BRAINSTORM_SECRET: "devbrainstormpocketidsecret123"
   POCKET_ID_NEXTCLOUD_SECRET: "devnextcloudpocketidsecret1234"
+  POCKET_ID_TERMINAL_SECRET: "devterminalpocketidsecret12"
 
   # Tracking DB URL (legacy, tracking pipeline fully removed)
   TRACKING_DB_URL: ""

--- a/k3d/seed.yaml
+++ b/k3d/seed.yaml
@@ -146,6 +146,8 @@ spec:
               valueFrom: { secretKeyRef: { name: workspace-secrets, key: POCKET_ID_RUSTDESK_WEB_SECRET, optional: true } }
             - name: SECRET_brain
               valueFrom: { secretKeyRef: { name: workspace-secrets, key: POCKET_ID_BRAIN_SECRET, optional: true } }
+            - name: SECRET_terminal
+              valueFrom: { secretKeyRef: { name: workspace-secrets, key: POCKET_ID_TERMINAL_SECRET, optional: true } }
           command:
             - /bin/sh
             - -ec
@@ -189,6 +191,7 @@ spec:
                website|SECRET_website|POCKET_ID_WEBSITE_SECRET|${SCHEME}://web.${SUFFIX}/api/auth/callback
                rustdesk-web|SECRET_rustdeskweb|POCKET_ID_RUSTDESK_WEB_SECRET|${SCHEME}://remote.${SUFFIX}/oauth2/callback
                brain|SECRET_brain|POCKET_ID_BRAIN_SECRET|${SCHEME}://brain.${SUFFIX}/oauth2/callback
+               terminal-sidekick|SECRET_terminal|POCKET_ID_TERMINAL_SECRET|${SCHEME}://terminal.${SUFFIX}/oauth2/callback
               "
 
               # Resolve a client's REAL pocket-id id by NAME. pocket-id:v2.9.0

--- a/openspec/changes/pocket-id-terminal-secret/proposal.md
+++ b/openspec/changes/pocket-id-terminal-secret/proposal.md
@@ -1,0 +1,21 @@
+# Proposal: pocket-id-terminal-secret
+
+## Why
+
+Der `oauth2-proxy-terminal` Pod schlägt mit `CreateContainerConfigError` fehl, weil der
+Key `POCKET_ID_TERMINAL_SECRET` im Kubernetes Secret `workspace-secrets` fehlt. Der Pod
+referenziert diesen Key als `secretKeyRef` (k3d/oauth2-proxy-terminal.yaml:93), aber er
+wurde nie in die Secret-Definition aufgenommen. Der aktive Pocket-ID-Seed-Job
+(`pocket-id-client-seed.yaml`) handhabt den Terminal-Client korrekt inklusive Writeback,
+aber `env:seal` kann den Key nicht generieren/sealen, weil `environments/schema.yaml`
+keinen Eintrag für `POCKET_ID_TERMINAL_SECRET` enthält. Für Dev fehlt zudem der
+Platzhalter in `k3d/secrets.yaml`.
+
+## What
+
+Füge `POCKET_ID_TERMINAL_SECRET` an allen drei Stellen hinzu:
+1. `environments/schema.yaml` — Schema-Eintrag (required: false, generate: true, length: 40)
+2. `k3d/secrets.yaml` — Dev-Platzhalter
+3. `k3d/seed.yaml` + `k3d/clean-seed.yaml` — Legacy-Seed-Jobs aktualisieren (optional, für Konsistenz)
+
+_Ticket: T001801_

--- a/openspec/changes/pocket-id-terminal-secret/specs/pocket-id-terminal-secret.md
+++ b/openspec/changes/pocket-id-terminal-secret/specs/pocket-id-terminal-secret.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: POCKET_ID_TERMINAL_SECRET in schema and secrets
+
+The `POCKET_ID_TERMINAL_SECRET` key SHALL be present in `environments/schema.yaml` with
+`generate: true` so that `env:seal` can generate and seal it into `workspace-secrets`. A
+dev placeholder SHALL exist in `k3d/secrets.yaml` so the dev cluster deploy succeeds.
+The `pocket-id-client-seed` Job and the `oauth2-proxy-terminal` Deployment both reference
+this key via `secretKeyRef`.
+
+#### Scenario: schema declares POCKET_ID_TERMINAL_SECRET
+
+- **GIVEN** `environments/schema.yaml` is read by `env:seal`
+- **WHEN** the schema entry for `POCKET_ID_TERMINAL_SECRET` is evaluated
+- **THEN** it has `generate: true`, `required: false`, and `length: 40`
+
+#### Scenario: dev secret contains placeholder
+
+- **GIVEN** `k3d/secrets.yaml` is rendered for the dev cluster
+- **WHEN** the `workspace-secrets` Secret is created
+- **THEN** it contains a `POCKET_ID_TERMINAL_SECRET` key with a valid placeholder value
+
+#### Scenario: oauth2-proxy-terminal pod starts successfully
+
+- **GIVEN** the `oauth2-proxy-terminal` Deployment references `POCKET_ID_TERMINAL_SECRET` as a `secretKeyRef`
+- **WHEN** the pod is created in the `workspace` namespace
+- **THEN** the container starts without `CreateContainerConfigError`

--- a/openspec/changes/pocket-id-terminal-secret/tasks.md
+++ b/openspec/changes/pocket-id-terminal-secret/tasks.md
@@ -1,0 +1,35 @@
+---
+title: "pocket-id-terminal-secret — Implementation Plan"
+ticket_id: T001801
+domains: [security, infra]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# pocket-id-terminal-secret — Implementation Plan
+
+## Tasks
+
+### Task 1: Schema-Eintrag hinzufügen
+- Datei: `environments/schema.yaml`
+- Füge `POCKET_ID_TERMINAL_SECRET` nach `POCKET_ID_SESSION_HUB_SECRET` (Zeile 882) ein
+- Pattern wie `POCKET_ID_BRAINSTORM_SECRET` (Zeile 872): required: false, generate: true, length: 40
+- Description: "OIDC client secret for the `terminal-sidekick` Pocket ID client (terminal oauth2-proxy)."
+
+### Task 2: Dev-Platzhalter hinzufügen
+- Datei: `k3d/secrets.yaml`
+- Füge `POCKET_ID_TERMINAL_SECRET: "devterminalpocketidsecret12"` nach `POCKET_ID_NEXTCLOUD_SECRET` (Zeile 96) ein
+
+### Task 3: Legacy-Seed-Jobs aktualisieren (optional)
+- Datei: `k3d/seed.yaml`
+  - Env-Var: `SECRET_terminal` mit `secretKeyRef: POCKET_ID_TERMINAL_SECRET` (nach Zeile 148, brain)
+  - ROWS: `terminal-sidekick|SECRET_terminal|POCKET_ID_TERMINAL_SECRET|${SCHEME}://terminal.${SUFFIX}/oauth2/callback`
+- Datei: `k3d/clean-seed.yaml` — gleiche Änderungen
+
+### Task 4: Validierung
+- `task workspace:validate` — Kustomize Dry-Run
+- Prüfe ob `env:seal` den neuen Key erkennt: `bash scripts/env-resolve.sh` ( sourced )


### PR DESCRIPTION
## Summary
- Add `POCKET_ID_TERMINAL_SECRET` to `environments/schema.yaml` so `env:seal` can generate and seal it
- Add dev placeholder to `k3d/secrets.yaml`
- Add env var + ROW to legacy seed jobs (`k3d/seed.yaml`, `k3d/clean-seed.yaml`) for consistency
- The active `pocket-id-client-seed.yaml` already handles terminal-sidekick correctly

Root cause: `oauth2-proxy-terminal` fails with `CreateContainerConfigError` because `POCKET_ID_TERMINAL_SECRET` is missing from `workspace-secrets`. The key was never registered in the schema, so `env:seal` couldn't generate it.

## Test Plan
- [x] `task workspace:validate` passes
- [ ] `task workspace:deploy ENV=mentolder` — verify pod starts without CreateContainerConfigError
- [ ] Re-seal secrets: `task env:seal ENV=mentolder`

🤖 T001801