### PR TITLE
fix(factory): SIGPIPE in factory-prep watchdog step [T001806]

### DIFF
--- a/scripts/vda/factory-prep.sh
+++ b/scripts/vda/factory-prep.sh
@@ -59,9 +59,14 @@ run_prep() {
       continue
     fi
 
-    # Watchdog
+    # Watchdog — stdout muss von einer stdin-lesenden Schleife konsumiert werden:
+    # log() liest kein stdin; ein direktes `| log` beendet die rechte Seite sofort
+    # und der Watchdog stirbt an SIGPIPE (rc 141 unter pipefail). Best-effort:
+    # ein Watchdog-Fehler bricht den PREP nicht ab (T001806).
     log "Watchdog ${brand}..."
-    BRAND="${brand}" bash "${REPO}/scripts/factory/watchdog.sh" 2>&1 | log
+    BRAND="${brand}" bash "${REPO}/scripts/factory/watchdog.sh" 2>&1 \
+      | while IFS= read -r _wdline; do log "${_wdline}"; done \
+      || log "Watchdog ${brand} failed (non-fatal)"
 
     # Schedule
     log "Schedule ${brand}..."

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3139,3 +3139,12 @@ STUB
   grep -q "tickets.factory_model_slots" scripts/factory/route-provider.sh
   grep -Eq "PHASE=" scripts/factory/route-provider.sh
 }
+
+@test "T001806: factory-prep.sh must not pipe watchdog into the non-reading log() function" {
+  # log() ignores stdin and exits immediately -> SIGPIPE (rc 141) kills PREP under pipefail.
+  run bash -c "grep -E 'watchdog\.sh.*\| *log$' scripts/vda/factory-prep.sh"
+  [ "$status" -ne 0 ]
+  # stdout muss von einer stdin-lesenden Konstruktion konsumiert werden (Folgezeile der Pipe)
+  run bash -c "grep -A2 'watchdog\.sh' scripts/vda/factory-prep.sh | grep -E 'while IFS= read'"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- `run_prep()` piped `watchdog.sh 2>&1 | log`, but `log()` never reads stdin — the right side exits instantly and the watchdog dies with SIGPIPE (rc 141) under `set -euo pipefail`, aborting the whole PREP.
- Latent since the prep consolidation; masked because a duplicate global kill-switch row (`on`, T000474 pattern) short-circuited every brand before the watchdog step. After deduplicating the kill-switch rows the bug fired on every tick: dispatcher PREP returned null, nothing ever left `backlog`.
- Fix: consume watchdog output with a stdin-reading `while IFS= read` loop; watchdog failure is logged non-fatally.

## Test plan
- [x] Red→green BATS `T001806` in `tests/spec/software-factory.bats`
- [x] `bash scripts/vda.sh factory-prep` now completes (rc 0) and claims the queued ticket
- [x] `task test:changed`, `task freshness:regenerate`, `task freshness:check`, `task test:inventory` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aCpg6TWLCcepVLEh5GJdp