### PR TITLE
fix(test): admin-nav test vs removed coaching studio route [T001807]

### DIFF
--- a/tests/unit/admin-nav.bats
+++ b/tests/unit/admin-nav.bats
@@ -80,14 +80,13 @@ EINSTELLUNGEN_TABS="$PROJECT_DIR/website/src/components/AdminEinstellungenTabs.a
   refute_output "0"
 }
 
-@test "coaching/sessions/index.astro: Sessions + Studio tabs present (post-T001649)" {
-  # T001649 / PR #2624 removed the Projekte tab; the page now exposes
-  # Sessions-Liste (href /admin/coaching/sessions) and Sessions
-  # (href /admin/coaching/studio, the renamed Studio tab). Verify the
-  # new tab state instead of the removed Projekte one.
-  run grep -c 'href="/admin/coaching/sessions"' "$PROJECT_DIR/website/src/pages/admin/coaching/sessions/index.astro"
-  refute_output "0"
+@test "coaching/sessions/index.astro: kein Studio-Link mehr, Breadcrumb vorhanden (post-T001792)" {
+  # T001792 / PR #2767 removed the dead coaching studio route and its tab
+  # links; the sessions page keeps only the Admin breadcrumb. Assert the
+  # removed route is not referenced anymore and the breadcrumb survives.
   run grep -c 'href="/admin/coaching/studio"' "$PROJECT_DIR/website/src/pages/admin/coaching/sessions/index.astro"
+  assert_output "0"
+  run grep -c 'href="/admin"' "$PROJECT_DIR/website/src/pages/admin/coaching/sessions/index.astro"
   refute_output "0"
 }
 


### PR DESCRIPTION
## Summary
- `tests/unit/admin-nav.bats` still asserted the coaching-studio tab links that PR #2767 (T001792) removed — red on `main` since that merge, blocking unrelated PRs (e.g. #2774) whose `test:changed` runs the unit suite.
- Rewrites the assertion to the post-T001792 state: the removed route is no longer referenced, the Admin breadcrumb survives.

## Test plan
- [x] `bats tests/unit/admin-nav.bats` — 18/18 green
- [x] `task test:inventory` / `freshness:regenerate` — keine Artefakt-Änderung

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aCpg6TWLCcepVLEh5GJdp