### PR TITLE
fix(test): studio-sessions spec suites vs removed coaching studio route [T001807]

### DIFF
--- a/tests/spec/coaching-sessions-polish-guide.bats
+++ b/tests/spec/coaching-sessions-polish-guide.bats
@@ -9,15 +9,15 @@ setup() {
 }
 
 @test "sidebar has a Sessions nav item in Geschäft section" {
-  # T001649: Sessions label now points to /admin/coaching/studio (Studio was renamed to Sessions;
-  # the separate /admin/coaching/sessions sidebar link was removed).
+  # T001792 / PR #2767: the dead studio route was removed; the Sessions label
+  # points to /admin/coaching/sessions again (T001807).
   # Use -E to handle variable whitespace between object properties.
-  run grep -qE "href: '/admin/coaching/studio'.*label: 'Sessions'" "$WEB/components/admin/AdminSidebarNav.astro"
+  run grep -qE "href: '/admin/coaching/sessions'.*label: 'Sessions'" "$WEB/components/admin/AdminSidebarNav.astro"
   [ "$status" -eq 0 ]
 }
 
-@test "Studio nav item no longer matches the sessions path" {
-  run grep -qF "matches: ['/admin/coaching/studio', '/admin/fragebogen']" "$WEB/components/admin/AdminSidebarNav.astro"
+@test "Sessions nav item matches sessions and fragebogen paths" {
+  run grep -qF "matches: ['/admin/coaching/sessions', '/admin/fragebogen']" "$WEB/components/admin/AdminSidebarNav.astro"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/spec/studio-sessions-reorganize.bats
+++ b/tests/spec/studio-sessions-reorganize.bats
@@ -2,29 +2,30 @@
 # tests/spec/studio-sessions-reorganize.bats
 # SSOT: docs/superpowers/specs/2026-07-08-studio-sessions-reorganize-design.md
 # Verification for reorganizing Studio and Sessions views.
+# Post-T001792 (PR #2767): the dead coaching studio route was removed entirely;
+# /admin/coaching/sessions is the canonical Sessions surface. The assertions
+# below verify the post-removal state (T001807).
 
 setup() {
   REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   WEB="$REPO_ROOT/website/src"
 }
 
-@test "sidebar has Studio item renamed to Sessions and matches studio and fragebogen" {
-  run grep -qF "href: '/admin/coaching/studio',     label: 'Sessions',     icon: 'clipboard', matches: ['/admin/coaching/studio', '/admin/fragebogen']" "$WEB/components/admin/AdminSidebarNav.astro"
+@test "sidebar Sessions item points to coaching/sessions and matches sessions and fragebogen" {
+  run grep -qF "href: '/admin/coaching/sessions',   label: 'Sessions',     icon: 'clipboard', matches: ['/admin/coaching/sessions', '/admin/fragebogen']" "$WEB/components/admin/AdminSidebarNav.astro"
   [ "$status" -eq 0 ]
 }
 
-@test "sidebar does not contain separate coaching sessions nav item" {
-  run grep -qF "href: '/admin/coaching/sessions'" "$WEB/components/admin/AdminSidebarNav.astro"
+@test "sidebar does not reference the removed coaching studio route" {
+  run grep -qF "href: '/admin/coaching/studio'" "$WEB/components/admin/AdminSidebarNav.astro"
   [ "$status" -ne 0 ]
 }
 
-@test "sessions index page removes projects tab and has sessions-liste tab and sessions tab" {
+@test "sessions index page references neither projects tab nor removed studio route" {
   run grep -qF "/admin/coaching/projekte" "$WEB/pages/admin/coaching/sessions/index.astro"
   [ "$status" -ne 0 ]
-  run grep -qF "href=\"/admin/coaching/sessions\"" "$WEB/pages/admin/coaching/sessions/index.astro"
-  [ "$status" -eq 0 ]
   run grep -qF "href=\"/admin/coaching/studio\"" "$WEB/pages/admin/coaching/sessions/index.astro"
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
 }
 
 @test "sessions overview does not contain Neue Session link" {
@@ -32,9 +33,8 @@ setup() {
   [ "$status" -ne 0 ]
 }
 
-@test "coaching studio page wrapper has Coaching Sessions title" {
-  run grep -qF "<AdminLayout title=\"Coaching Sessions\">" "$WEB/pages/admin/coaching/studio.astro"
-  [ "$status" -eq 0 ]
+@test "coaching studio page wrapper was removed with the dead route" {
+  [ ! -f "$WEB/pages/admin/coaching/studio.astro" ]
 }
 
 @test "coaching studio app.jsx has brand-sub set to Coaching Sessions" {


### PR DESCRIPTION
## Summary
- Part 2 of T001807: after PR #2767 (T001792) removed the dead coaching studio route, six tests across `tests/spec/studio-sessions-reorganize.bats` and `tests/spec/coaching-sessions-polish-guide.bats` still asserted the studio-canonical sidebar/tab state — red on `main`, blocking unrelated PRs (e.g. #2774).
- Rewrites the assertions to the post-removal state: `/admin/coaching/sessions` is canonical, no `/admin/coaching/studio` references remain, `studio.astro` is gone.

## Test plan
- [x] Both suites: 23/23 green
- [x] `task test:changed` (52 tests, 0 fail), `task freshness:regenerate` + `check`, `task test:inventory` unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aCpg6TWLCcepVLEh5GJdp