### PR TITLE
fix(factory): deterministic PREP handoff via args.prep [T001808]

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -52,12 +52,21 @@ async function main() {
   // - ticket.sh get (fetch details for launch)
   // - scripts/factory/guards.sh (kill-switch via guard_killswitch_on, daily cap via guard_daily_cap_reached)
   phase('Prep')
-  const prep = await agent(
-    `Run the unified Software Factory prep script from ${REPO} and return its JSON output:
-       FACTORY_DAILY_DEPLOY_CAP=${A.FACTORY_DAILY_DEPLOY_CAP ?? '5'} FACTORY_GLOBAL_CAP=3 bash ${REPO}/scripts/vda.sh factory-prep
-     Return the exact JSON output from this script and nothing else.`,
-    { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
-  )
+  // T001808: prefer the deterministic prep JSON precomputed by wakeup.sh (args.prep) —
+  // small local models fail the PREP subagent's StructuredOutput contract; the agent
+  // call below survives only as fallback for invocations without a precomputed prep.
+  let prep
+  if (A.prep && typeof A.prep === 'object' && Array.isArray(A.prep.launch)) {
+    log('Dispatcher: using precomputed prep from args (deterministic wakeup handoff)')
+    prep = A.prep
+  } else {
+    prep = await agent(
+      `Run the unified Software Factory prep script from ${REPO} and return its JSON output:
+         FACTORY_DAILY_DEPLOY_CAP=${A.FACTORY_DAILY_DEPLOY_CAP ?? '5'} FACTORY_GLOBAL_CAP=3 bash ${REPO}/scripts/vda.sh factory-prep
+       Return the exact JSON output from this script and nothing else.`,
+      { label: 'prep', phase: 'Prep', schema: PLAN_SCHEMA },
+    )
+  }
 
   // Guard: PREP agent returned null (API error, model config mismatch, or subagent failure).
   // Fail-closed — record the outage and exit cleanly so the /loop can retry next tick.

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -91,8 +91,19 @@ TICK=0
 while true; do
   TICK=$(( TICK + 1 ))
   TIMESTAMP="$(date -u +%FT%TZ)"
+  # T001808: PREP deterministisch vorberechnen und als args.prep durchreichen.
+  # Kleine lokale Modelle scheitern am StructuredOutput-Kontrakt des PREP-Subagenten;
+  # factory-prep ist reines Bash — der LLM-Schritt ist hier unnötig. Bei leerem/
+  # ungültigem JSON fällt dispatcher.js auf den PREP-Agenten zurück.
+  PREP_JSON="$(FACTORY_DAILY_DEPLOY_CAP="${FACTORY_DAILY_DEPLOY_CAP:-5}" FACTORY_GLOBAL_CAP="${FACTORY_GLOBAL_CAP:-3}" \
+    bash "${REPO}/scripts/vda.sh" factory-prep 2>/dev/null | jq -c . 2>/dev/null || true)"
+  PREP_ARG=""
+  if [[ -n "${PREP_JSON}" ]]; then
+    PREP_ARG=", prep: ${PREP_JSON}"
+  fi
   PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
-scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN} }. \
+scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN}${PREP_ARG} }. \
+Pass the prep value through verbatim — do not alter, re-run, or improvise it. \
 The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step. \
 Report only the dispatcher's final JSON result. Do not improvise scheduling."
 

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3148,3 +3148,17 @@ STUB
   run bash -c "grep -A2 'watchdog\.sh' scripts/vda/factory-prep.sh | grep -E 'while IFS= read'"
   [ "$status" -eq 0 ]
 }
+
+@test "T001808: wakeup.sh precomputes factory-prep JSON and passes it as args.prep" {
+  run grep -E 'vda\.sh.? factory-prep' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+  run grep -F 'prep: ${PREP_JSON}' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "T001808: dispatcher.js prefers precomputed args.prep over the PREP subagent" {
+  run grep -F 'A.prep' scripts/factory/dispatcher.js
+  [ "$status" -eq 0 ]
+  run grep -F 'Array.isArray(A.prep.launch)' scripts/factory/dispatcher.js
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- With a local LM Studio model as dispatcher, the PREP subagent in `dispatcher.js` reliably fails the StructuredOutput contract (returns prose or hallucinated JSON) → `prep=null` guard → queue never dispatched.
- `scripts/vda.sh factory-prep` is pure bash, so `wakeup.sh` now precomputes its JSON and passes it verbatim as `args.prep` into the Workflow invocation; `dispatcher.js` prefers `args.prep` (validated shape) and keeps the PREP agent only as a fallback for invocations without it.
- Removes one LLM step per tick regardless of model — cheaper and deterministic.

## Test plan
- [x] New BATS contracts (T001808) in `tests/spec/software-factory.bats`
- [x] Existing wakeup contract suites (FA-SF-41/47): 29/29 green
- [x] `bash -n` / ESM syntax check, `task test:changed` (52/0), freshness gates, inventory unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aCpg6TWLCcepVLEh5GJdp