### PR TITLE
fix(admin): cockpit Aktiv-Filter zeigt keine Tickets via Store-Pfad

### DIFF
--- a/website/src/components/admin/CockpitTable.svelte
+++ b/website/src/components/admin/CockpitTable.svelte
@@ -48,7 +48,9 @@
 
     let matchStatus = true;
     if (storeFilter && storeFilter.status && storeFilter.status.length > 0) {
-      matchStatus = storeFilter.status.includes(t.status);
+      const statuses = storeFilter.status;
+      matchStatus = statuses.includes(t.status) ||
+        (statuses.includes('active') && !isTerminal(t.status));
     } else {
       matchStatus =
         statusFilter === '' ? true :


### PR DESCRIPTION
## Summary
- Fix Aktiv-Filter in CockpitTable: Klick auf 'Aktiv' Chip zeigt keine Tickets
- Ursache: Store-Filter-Pfad prüft `storeFilter.status.includes(t.status)` — der Pseudo-Status 'active' matcht nie
- Fix: 'active' im Store-Branch auf `!isTerminal()` expandieren

## Test Plan
- [x] 35 Cockpit-Tests bestanden (vitest)
- [x] TypeScript Check bestanden (tsc --noEmit)