### PR TITLE
fix(factory): deterministic budget-guard + sentinel handoff [T001809]

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -56,9 +56,11 @@ async function main() {
   // small local models fail the PREP subagent's StructuredOutput contract; the agent
   // call below survives only as fallback for invocations without a precomputed prep.
   let prep
+  let prepPrecomputed = false
   if (A.prep && typeof A.prep === 'object' && Array.isArray(A.prep.launch)) {
     log('Dispatcher: using precomputed prep from args (deterministic wakeup handoff)')
     prep = A.prep
+    prepPrecomputed = true
   } else {
     prep = await agent(
       `Run the unified Software Factory prep script from ${REPO} and return its JSON output:
@@ -96,7 +98,18 @@ async function main() {
     },
   }
 
-  const budgetResult = await agent(
+  // T001809: with a precomputed prep the budget guard already ran deterministically
+  // in wakeup.sh (blocked features were cleaned up and filtered out of prep.launch) —
+  // skip the LLM step; small local models fail its StructuredOutput contract.
+  let budgetResult
+  if (prepPrecomputed) {
+    log('Dispatcher: budget-guard precomputed in wakeup — prep.launch is pre-filtered')
+    budgetResult = {
+      ok: prep.launch.map((f) => ({ external_id: f.external_id, brand: f.brand })),
+      blocked: [],
+    }
+  } else {
+  budgetResult = await agent(
     `/goal Guard the Software Factory budget and estimate feature costs.
      You are the Software Factory budget guard. Process ONLY the features listed below.
      REPO=${REPO}
@@ -124,6 +137,7 @@ async function main() {
      Return JSON: { ok: [{external_id, brand}, ...], blocked: [{external_id, brand, reason}, ...], estimates: [...] }`,
     { label: 'budget-guard', phase: 'Launch', schema: BUDGET_RESULT_SCHEMA },
   )
+  }
 
   const okIds = new Set((budgetResult?.ok ?? []).map(f => f.external_id))
   const launches = (prep.launch ?? []).filter(f => okIds.has(f.external_id))
@@ -141,13 +155,19 @@ async function main() {
     required: ['interactive_worker_active'],
     properties: { interactive_worker_active: { type: 'boolean' } },
   }
-  const sentinel = await agent(
-    `Run this and report the result as JSON ONLY:
-       bash ${REPO}/scripts/agent-lock.sh list | grep -q interactive-worker && echo found || echo none
-     If output is "found": return {"interactive_worker_active": true}
-     If output is "none":  return {"interactive_worker_active": false}`,
-    { label: 'sentinel-check', phase: 'Launch', schema: SENTINEL_SCHEMA },
-  )
+  // T001809: prefer the sentinel state precomputed by wakeup.sh (args.interactive_worker).
+  let sentinel
+  if (typeof A.interactive_worker === 'boolean') {
+    sentinel = { interactive_worker_active: A.interactive_worker }
+  } else {
+    sentinel = await agent(
+      `Run this and report the result as JSON ONLY:
+         bash ${REPO}/scripts/agent-lock.sh list | grep -q interactive-worker && echo found || echo none
+       If output is "found": return {"interactive_worker_active": true}
+       If output is "none":  return {"interactive_worker_active": false}`,
+      { label: 'sentinel-check', phase: 'Launch', schema: SENTINEL_SCHEMA },
+    )
+  }
 
   let maxParallel = launches.length
   if (sentinel && sentinel.interactive_worker_active) {

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -99,7 +99,28 @@ while true; do
     bash "${REPO}/scripts/vda.sh" factory-prep 2>/dev/null | jq -c . 2>/dev/null || true)"
   PREP_ARG=""
   if [[ -n "${PREP_JSON}" ]]; then
-    PREP_ARG=", prep: ${PREP_JSON}"
+    # T001809: Budget-Guard + Blocked-Cleanup + Sentinel ebenfalls deterministisch —
+    # reine Bash-Orchestrierung; die LLM-Agent-Schritte in dispatcher.js scheitern mit
+    # kleinen lokalen Modellen am StructuredOutput-Kontrakt und hinterlassen den
+    # PREP-Claim als Zombie (in_progress ohne Pipeline).
+    _ok_ids='[]'
+    while IFS=$'\t' read -r _ext _brand; do
+      [[ -z "${_ext}" ]] && continue
+      if BRAND="${_brand}" bash "${REPO}/scripts/factory/budget-guard.sh" "${_brand}" >/dev/null 2>&1; then
+        BRAND="${_brand}" bash "${REPO}/scripts/factory/budget-estimate.sh" "${_ext}" "${_brand}" >/dev/null 2>&1 || true
+        _ok_ids="$(jq -c --arg e "${_ext}" '. + [$e]' <<<"${_ok_ids}")"
+      else
+        echo "wakeup.sh: budget-guard blocked ${_ext} (${_brand})" >&2
+        BRAND="${_brand}" bash "${REPO}/scripts/ticket.sh" update-status --id "${_ext}" --status blocked >/dev/null 2>&1 || true
+        BRAND="${_brand}" bash "${REPO}/scripts/ticket.sh" phase "${_ext}" scout blocked --detail 'daily budget exceeded' >/dev/null 2>&1 || true
+        BRAND="${_brand}" bash "${REPO}/scripts/ticket.sh" release-slot --id "${_ext}" >/dev/null 2>&1 || true
+      fi
+    done < <(jq -r '.launch[]? | [.external_id, .brand] | @tsv' <<<"${PREP_JSON}" 2>/dev/null)
+    PREP_JSON="$(jq -c --argjson ok "${_ok_ids}" \
+      '.launch = [.launch[]? | select(.external_id as $e | $ok | index($e) != null)]' <<<"${PREP_JSON}")"
+    _iw=false
+    bash "${REPO}/scripts/agent-lock.sh" list 2>/dev/null | grep -q interactive-worker && _iw=true
+    PREP_ARG=", prep: ${PREP_JSON}, interactive_worker: ${_iw}"
   fi
   PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
 scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN}${PREP_ARG} }. \
@@ -135,7 +156,7 @@ Report only the dispatcher's final JSON result. Do not improvise scheduling."
       | sed "s/^/[auto-triage:${_t_brand}] /" >&2 || true
   done
   "${CLAUDE_BIN}" -p "${PROMPT}" \
-    --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),ToolSearch,PushNotification" \
+    --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),Bash(bash scripts/vda.sh*),ToolSearch,PushNotification" \
     --permission-mode acceptEdits
   TICK_EXIT=$?
 

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3162,3 +3162,22 @@ STUB
   run grep -F 'Array.isArray(A.prep.launch)' scripts/factory/dispatcher.js
   [ "$status" -eq 0 ]
 }
+
+@test "T001809: wakeup.sh runs budget-guard deterministically and passes interactive_worker" {
+  run grep -F 'budget-guard.sh' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+  run grep -F 'interactive_worker: ${_iw}' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "T001809: dispatcher.js skips budget/sentinel agents on precomputed handoff" {
+  run grep -F 'prepPrecomputed' scripts/factory/dispatcher.js
+  [ "$status" -eq 0 ]
+  run grep -F "typeof A.interactive_worker === 'boolean'" scripts/factory/dispatcher.js
+  [ "$status" -eq 0 ]
+}
+
+@test "T001809: dispatcher allowedTools covers vda.sh for the PREP fallback agent" {
+  run grep -F 'Bash(bash scripts/vda.sh*)' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Follow-up to #2777 (T001808): after the deterministic PREP claim, `dispatcher.js` still ran two LLM agent steps (budget-guard with `BUDGET_RESULT_SCHEMA`, sentinel-check) before launching pipelines. Local models fail their StructuredOutput contract → `okIds` empty → no launch → the claimed ticket rots as an `in_progress` zombie without a pipeline or worktree (observed live with T001805).
- `wakeup.sh` now runs budget-guard (incl. blocked-feature cleanup and best-effort estimates) and the interactive-worker sentinel deterministically, passes the pre-filtered `prep.launch` and `interactive_worker` via Workflow args; `dispatcher.js` skips both agents when the precomputed values are present (agents remain as fallback).
- Adds `Bash(bash scripts/vda.sh*)` to the dispatcher `allowedTools` — the PREP fallback agent was permission-blocked ("command requires Claude Code approval").

## Test plan
- [x] New BATS contracts (T001809), wakeup suites FA-SF-41/47: 29/29
- [x] `bash -n` + ESM syntax check, `task test:changed` (52/0), freshness gates, inventory unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aCpg6TWLCcepVLEh5GJdp