### PR TITLE
chore(infra): document intentional :latest image usage [T001790]

### DIFF
--- a/openspec/changes/e2e-hydration-timeout/proposal.md
+++ b/openspec/changes/e2e-hydration-timeout/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: e2e-hydration-timeout
+
+## Why
+
+FA-10 T5/T6 (Kontaktformular) scheitern konsistent mit `waitForHydration()`-Timeout
+auf `web.mentolder.de`. Das Problem wurde in **T001748 (#2715)** testseitig adressiert
+(Tablist-basierter Wait statt globalem `astro-island[ssr]`-Wait, Timeouts von 8 s
+auf 15 s erhöht) — dennoch treten die Failures weiterhin auf, reproduziert in PR #2737
+(Run 29104527737) **und** im nightly e2e.yml (Run 29100595050, 2026-07-10T14:38) der
+kein Code-Changes enthält. Das bestätigt: es ist ein **pre-existing Live-Site-Problem**
+mit der Astro-Hydration, kein Test-Flake und kein PR-spezifischer Regression.
+
+Die Seite `/kontakt` enthält vier `client:load`-Inseln (Navigation, CookieConsent,
+PortalSidekick, ContactHub). Der PortalSidekick öffnet WebSocket-/log-bus-Abhängigkeiten
+und die `agent-guide-harness` Patches — wenn eine dieser Inseln auf dem Live-Server
+nicht hydratet (fehlerhaftes JS-Bundle, 404 auf Chunk, Syntax-Error in prod-Build),
+liegt `astro-island[ssr]` ewig im DOM.
+
+**Laut T001785-Beschreibung:** Site selbst liefert HTTP 200 in <1 s, das Problem
+liegt im Client-JS. Discord-Console-Logs vom Live-Server (via `agent-guide-harness`)
+sind nötig, um zu sehen, ob ein Chunk 404'd, ein Import scheitert oder ein
+Runtime-Error in einer Insel die gesamte Hydration blockiert.
+
+## What
+
+1. **Diagnose Phase:** Via Browser-Konsole (Playwright) oder `agent-guide-harness`
+   die clientseitigen Console-/Network-Errors auf `web.mentolder.de/kontakt` erfassen.
+   Ziel: feststellen, WELCHE Insel nicht hydratet und WARUM.
+2. **Fix Phase (abhängig von Diagnose):**
+   - Option A: Fehlerhaftes JS-Bundle → Astro-Build-Konfiguration prüfen, Chunk-Splitting
+     anpassen, fehlende Importe ergänzen.
+   - Option B: Runtime-Error in einer shared Dependency (Sidekick, agent-guide-harness) →
+     isolieren und fixen.
+   - Option C: CSP/Network-Restriktion blockiert JS-Chunk → Helmet-Header/CSP anpassen.
+   - Option D: Astro-Island SSR-Attribut wird nie entfernt, weil eine Insel vor der
+     Hydration crasht → Error-Boundary in die Insel einbauen.
+3. **Verifikation:** 10×-Stabilitätslauf von T5/T6 gegen `web.mentolder.de` nach Fix.
+4. **Regression:** T1–T4, T7 müssen weiterhin grün bleiben.
+
+**Out of scope:**
+- Umbau von `client:load` auf `client:idle`/`client:visible` (eigenständige Optimierung)
+- Entfernen oder Deaktivieren der Tests
+- Korczewski-Brand (separater Follow-up falls nötig)
+
+## Impact
+
+- **Test-Datei (geändert):** `tests/e2e/specs/fa-10-website.spec.ts` — ggf. Debug-Ausgaben
+  oder resilienteren Wait.
+- **Website-Dateien (möglicherweise):** `website/src/layouts/Layout.astro`,
+  `website/src/components/PortalSidekick.svelte`, `website/src/components/ContactHub.svelte`,
+  Astro-Build-Config oder agent-guide-harness — abhängig von Diagnose.
+- **CI-Workflows:** keine Änderung an `.github/workflows/e2e-pr.yml` oder `e2e.yml`.

--- a/openspec/changes/e2e-hydration-timeout/specs/e2e-hydration-timeout.md
+++ b/openspec/changes/e2e-hydration-timeout/specs/e2e-hydration-timeout.md
@@ -1,0 +1,16 @@
+# e2e-hydration-timeout — Delta-Spec
+
+## Purpose
+
+Dokumentiert das pre-existing Live-Site-Problem mit waitForHydration-Timeouts in FA-10 T5/T6 und definiert den Scope der Test-Fixes.
+
+## ADDED Requirements
+
+### Requirement: E2E-001 — Hydration-Timeouts werden toleriert
+
+E2E-Tests müssen mit instabilen Hydration-Zeiten auf der Live-Site umgehen können.
+
+**Scenarios:**
+
+- GIVEN a page with slow hydration THEN the test MUST NOT fail with a waitForHydration timeout
+- GIVEN a pre-existing live-site issue THEN the test MUST document the known issue

--- a/openspec/changes/e2e-hydration-timeout/tasks.md
+++ b/openspec/changes/e2e-hydration-timeout/tasks.md
@@ -1,0 +1,262 @@
+---
+title: "E2E T5/T6 fa-10-website: hydration wait times out against web.mentolder.de"
+ticket_id: T001785
+domains: [website, tests]
+status: active
+file_locks: [tests/e2e/specs/fa-10-website.spec.ts, website/src/layouts/Layout.astro]
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: [t001748-e2e-page-load-fix]
+---
+
+# e2e-hydration-timeout — Implementation Plan
+
+**Ticket:** T001785  
+**Branch:** `fix/t001785-e2e-hydration-timeout`  
+**Vorgänger:** T001748 (#2715) — testseitiger Fix war unzureichend, Root-Cause liegt im Live-Site-JS
+
+## File Structure
+
+```
+openspec/changes/e2e-hydration-timeout/proposal.md   (neu)
+openspec/changes/e2e-hydration-timeout/tasks.md      (neu, dieses File)
+tests/e2e/specs/fa-10-website.spec.ts                (geändert) — resilienterer Wait + Console-Capture
+website/src/layouts/Layout.astro                     (möglicherweise) — abhängig von Diagnose
+website/src/components/PortalSidekick.svelte          (möglicherweise) — abhängig von Diagnose
+```
+
+---
+
+## Task 1 — Diagnose: Welche Astro-Insel scheitert an der Hydration?
+
+**expected: FAIL** — im aktuellen Zustand schlägt `waitForHydration()` fehl, weil
+`astro-island[ssr]` auf der Live-Seite nie verschwindet.
+
+**Diagnose-Schritt 1a: Playwright-Konsolen-Capture-Diagnose**
+
+Baue einen temporären Diagnose-Test, der auf `web.mentolder.de/kontakt` navigiert,
+`page.on('console')` und `page.on('pageerror')` aufzeichnet und nach 20 s ein
+Screenshot + Console-Dump ausgibt — OHNE auf Hydration zu warten:
+
+```ts
+test('DIAG: Kontaktseite Console-Errors erfassen', async ({ page }) => {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+    if (msg.type() === 'warning') warnings.push(msg.text());
+  });
+  page.on('pageerror', (err) => errors.push(err.message));
+  await page.goto(`${BASE}/kontakt`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(20_000);
+  console.log('=== CONSOLE ERRORS ===');
+  errors.forEach((e) => console.log(`  ERROR: ${e}`));
+  console.log('=== CONSOLE WARNINGS ===');
+  warnings.forEach((w) => console.log(`  WARN: ${w}`));
+  // SSR-Inseln zählen, die noch nicht hydratet sind
+  const unhydrated = await page.evaluate(() =>
+    document.querySelectorAll('astro-island[ssr]').length
+  );
+  console.log(`=== UNHYDRATED ISLANDS: ${unhydrated} ===`);
+  // Namen der unhydrated Inseln (component-name Attribut)
+  const names = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('astro-island[ssr]'))
+      .map((el) => el.getAttribute('component-name') || el.getAttribute('component-export') || '(unknown)')
+  );
+  console.log(`Unhydrated components: ${names.join(', ')}`);
+  await page.screenshot({ path: 'diag-kontakt.png', fullPage: true });
+});
+```
+
+**Lokaler Run:**
+```bash
+cd /home/patrick/Bachelorprojekt
+WEBSITE_URL=https://web.mentolder.de npx playwright test \
+  --project=website -g "DIAG: Kontaktseite Console-Errors erfassen" \
+  tests/e2e/specs/fa-10-website.spec.ts \
+  --reporter=list
+```
+
+Das Ergebnis zeigt:
+1. Welche Komponenten noch `astro-island[ssr]` tragen
+2. Welche JS-Fehler in der Console auftauchen (Missing Chunk? TypeError? CSP-Block?)
+3. Welche Network-Requests fehlschlagen (Chunk 404?)
+
+**Diagnose-Schritt 1b: Network-Tab-Capture (nur Chunk-Fehler)**
+
+Erweitere den DIAG-Test um Network-Response-Capture für fehlgeschlagene JS-Chunks:
+
+```ts
+page.on('response', (resp) => {
+  if (!resp.ok() && resp.url().includes('/_astro/')) {
+    console.log(`FAILED CHUNK: ${resp.status()} ${resp.url()}`);
+  }
+});
+```
+
+**Erwartete Diagnose-Ergebnisse (Hypothese):**
+
+Basierend auf dem Befund aus T001785 und T001748:
+- **Hypothese A:** Ein JS-Chunk fehlt (404) im prod-Build von `web.mentolder.de` —
+  z.B. ein dynamischer Import aus `agent-guide-harness`, den der Build nicht
+  mitkompiliert hat.
+- **Hypothese B:** Ein Runtime-Error in einer shared Dependency (PortalSidekick,
+  central-logging) crasht die gesamte Hydration-Kette — Astro bricht ab und
+  markiert die Insel nicht als hydratet.
+- **Hypothese C:** Die Seite lädt ein veraltetes Service-Worker-Cache-Bundle,
+  das gegen den neuen Build inkonsistent ist.
+- **Hypothese D:** CSP-Header auf `web.mentolder.de` blockieren ein benötigtes
+  Inline-Script oder einen dynamischen Import.
+
+**Entscheidungsmatrix nach Diagnose:**
+
+| Befund | Fix |
+|--------|-----|
+| Chunk 404 | Task 2a — Astro-Build / Rollup-Config prüfen |
+| Runtime-Error in Sidekick | Task 2b — Fehler isolieren + Error-Boundary |
+| CSP-Block | Task 2c — CSP-Header anpassen |
+| Alle Inseln hydraten (Test-Stabilität) | Task 2d — Playwright-Wait robuster machen |
+
+---
+
+## Task 2 — Fix abhängig von Diagnose-Ergebnis
+
+Nur EINER der folgenden Subtasks wird aktiv — je nachdem, was Task 1 ergibt:
+
+### Task 2a — Fehlenden JS-Chunk fixen (Hypothese A)
+
+**Wenn:** Ein `/_astro/*.js`-Chunk 404 liefert (`response.ok() === false`).
+
+Dann:
+1. Prüfen, ob der fehlende Chunk in `website/dist/` existiert (lokal `task website:build`).
+2. Prüfen, ob `website/astro.config.mjs` ein `rollupOptions.external` oder
+   `vite.ssr.noExternal` den Import ausschließt.
+3. Fix: `astro.config.mjs` ergänzen — entweder `vite.ssr.noExternal` um das
+   fehlende Package erweitern, oder `rollupOptions.output.inlineDynamicImports`
+   für kleine Bundles setzen.
+4. Build-Test: `task website:build` + Check `dist/_astro/` auf den Chunk.
+5. Nach Deploy: erneuter DIAG-Test-Lauf → erwartet: alle Inseln hydratet,
+   keine Chunk-404.
+
+```
+website/astro.config.mjs                    (geändert)
+```
+
+**Datei-Länge Check:**
+```bash
+wc -l website/astro.config.mjs
+# Baseline prüfen:
+jq -r '."S1:website/astro.config.mjs".metric // "nicht-baselined"' docs/code-quality/baseline.json
+```
+
+### Task 2b — Runtime-Error in Komponente isolieren + fixen (Hypothese B)
+
+**Wenn:** Ein `pageerror` oder console.error zeigt einen TypeError/ReferenceError
+in `PortalSidekick.svelte`, `central-logging`, `agent-guide-harness` oder einer
+anderen gebündelten Dependency.
+
+Dann:
+1. Root-Cause im Quellcode der betroffenen Komponente identifizieren.
+2. Fix anwenden (Type-Guard, Null-Check, fehlenden Import ergänzen).
+3. **Error-Boundary:** Erwäge `client:load`-Inseln mit einem Error-Boundary-Wrapper
+   zu versehen, damit ein Crash in einer Insel die anderen nicht blockiert.
+   Astro unterstützt kein natives Error-Boundary — stattdessen einen Svelte
+   `<ErrorBoundary>` um die Insel-Komponente legen.
+4. Lokal testen: `task website:build && task website:dev` + Debug-Konsole prüfen.
+
+```
+website/src/components/PortalSidekick.svelte    (möglicherweise)
+website/src/components/ErrorBoundary.svelte     (neu — falls Error-Boundary-Ansatz)
+```
+
+### Task 2c — CSP-Header anpassen (Hypothese D)
+
+**Wenn:** Console zeigt CSP-Verletzungen (`Refused to load the script` für
+einen `/_astro/`-Chunk).
+
+Dann: CSP-Header im Deployment-Manifest oder in der Traefik-Middleware anpassen,
+sodass `script-src` (oder `worker-src`) den Chunk-Pfad erlaubt.
+
+```
+k3d/configmap-domains.yaml                     (möglicherweise)
+k3d/middleware-csp.yaml                         (möglicherweise)
+prod-fleet/mentolder/middleware-csp.yaml        (möglicherweise)
+```
+
+### Task 2d — Playwright-Wait robuster machen (Hypothese A+B+D ausgeschlossen)
+
+**Wenn:** Die Diagnose ergibt, dass ALLE Inseln hydraten, aber der Playwright-Wait
+trotzdem sporadisch timeoutet. Dann:
+
+1. `waitForHydration()` in `tests/e2e/specs/fa-10-website.spec.ts` gegen einen
+   hybriden Ansatz austauschen: warte auf Tablist ODER warte max 20 s auf
+   `astro-island[ssr]`-Verschwinden — je nachdem, was zuerst eintritt.
+2. Zusätzlich `page.waitForLoadState('networkidle')` vor dem Hydration-Wait
+   einfügen, damit lazy-chunked Dependencies nicht die Hydration blockieren.
+
+```ts
+async function waitForHydration(page: Page) {
+  await page.waitForLoadState('networkidle');
+  await Promise.race([
+    page.getByRole('tablist', { name: /wie möchten sie kontakt aufnehmen/i })
+      .waitFor({ state: 'visible', timeout: 20_000 }),
+    page.waitForFunction(
+      () => document.querySelectorAll('astro-island[ssr]').length === 0,
+      { timeout: 20_000 }
+    ),
+  ]);
+}
+```
+
+3. Timeout für T5/T6 von 45 s auf 60 s erhöhen, um der verlängerten
+   `networkidle`-Phase Rechnung zu tragen.
+
+```
+tests/e2e/specs/fa-10-website.spec.ts           (geändert)
+```
+
+---
+
+## Task 3 — 10×-Stabilitätsprobe gegen `web.mentolder.de`
+
+Nach dem Fix (welcher Task 2-Pfad auch immer aktiv war):
+
+```bash
+cd /home/patrick/Bachelorprojekt
+set -a; source tests/e2e/.env; set +a
+for i in $(seq 1 10); do
+  echo "=== Run $i ==="
+  WEBSITE_URL=https://web.mentolder.de npx playwright test \
+    --project=website tests/e2e/specs/fa-10-website.spec.ts \
+    --reporter=line 2>&1 | tail -5
+done
+```
+
+**expected:** 10/10 Runs enden mit "7 passed" — kein T5/T6-Hydration-Timeout.
+Ein einzelner Failure ist akzeptabel (Runner-Latenz), zwei oder mehr bedeuten:
+der Fix ist unzureichend, zurücksetzen und Diagnose vertiefen.
+
+---
+
+## Task 4 — Final Verification (CI-Gates)
+
+```bash
+task test:changed
+# Erwartet: alle FA-10-relevanten Tests grün
+
+task freshness:regenerate
+task freshness:check
+# Erwartet: keine Drift
+
+task workspace:validate
+# Erwartet: kustomize dry-run grün (falls Manifeste geändert)
+```
+
+Vor dem PR-Open:
+```bash
+git status
+git diff --stat
+```
+
+PR-Titel: `fix(e2e): [T001785] resolve hydration timeout on web.mentolder.de/kontakt`

--- a/openspec/changes/unpinned-latest-images/proposal.md
+++ b/openspec/changes/unpinned-latest-images/proposal.md
@@ -1,0 +1,56 @@
+---
+title: "Pin unpinned :latest images"
+ticket_id: "T001790"
+domains: [infra]
+status: proposed
+---
+
+# unpinned-latest-images — Maintenance: Document intentional :latest usage
+
+## Purpose
+
+A maintenance scan on 2026-07-10 found `:latest` image tags across `k3d/` manifests. This change documents the findings and ensures every `:latest` usage has an explicit inline comment explaining why it is intentional — improving clarity for future maintainers and automated audits.
+
+## Findings
+
+### External images — already pinned ✅
+All third-party images use pinned version + digest:
+- `vaultwarden/server:1.35.3-alpine@sha256:...`
+- `busybox:1.38.0@sha256:...`
+- `nats:2.10-alpine@sha256:...`
+- `postgres:16-alpine@sha256:...`
+- `bitnami/sealed-secrets-controller:0.27.3@sha256:...`
+- `axllent/mailpit:v1.29@sha256:...`
+
+### Project-internal images — intentionally :latest ✅
+Per AGENTS.md (`Critical Footguns`): *Website, Brett, Docs, Brain, Studio, and Talk-Transcriber images use `:latest` intentionally* — CI warns, do not "fix" to digests.
+
+| Image | File | Has explicit comment? |
+|-------|------|----------------------|
+| `ghcr.io/paddione/${WEBSITE_IMAGE}:latest` | k3d/website.yaml | ✅ yes (line 181) |
+| `ghcr.io/paddione/workspace-brett:latest` | k3d/brett.yaml | ❌ **missing** |
+| `ghcr.io/paddione/workspace-docs:latest` | k3d/docs.yaml | ❌ **missing** |
+| `ghcr.io/paddione/brain-site:latest` | k3d/brain.yaml | ✅ yes (line 2) |
+| `ghcr.io/paddione/videovault:latest` | k3d/videovault.yaml | ✅ yes (line 33) |
+| `ghcr.io/paddione/mediaviewer-widget:latest` | k3d/mediaviewer-widget.yaml | ✅ yes (line 29) |
+| `ghcr.io/paddione/downloads-content:latest` | k3d/downloads.yaml | ✅ yes (line 20) |
+| `ghcr.io/paddione/mentolder-web:latest` | k3d/mentolder-web.yaml | ✅ yes (line 31) |
+| `studio-server:latest` | k3d/configmap-domains.yaml | ❌ **missing** (local dev image) |
+
+### kube-prometheus-stack-rendered.yaml — false positives
+The monitoring manifest references `:latest` in descriptive text only (Kubernetes API descriptions), not as actual image tags. No action needed.
+
+## Recommendation
+
+No images need to be pinned. The two missing comments (brett, docs) and the configmap reference (studio-server) should receive explicit `# :latest is intentional` comments to match the convention used by the other manifests.
+
+## Scenarios
+
+### GIVEN a deployment manifest uses `:latest` for a project-internal image
+WHEN the manifest is deployed to the cluster
+THEN the image is pulled from GHCR on every deploy (CI builds push `:latest` on merge)
+AND the comment explains why pinning is not appropriate
+
+### GIVEN a deployment manifest uses an external image
+WHEN the manifest is deployed to the cluster
+THEN the image is pinned to a specific version + digest for reproducibility

--- a/openspec/changes/unpinned-latest-images/specs/unpinned-latest-images.md
+++ b/openspec/changes/unpinned-latest-images/specs/unpinned-latest-images.md
@@ -1,0 +1,16 @@
+# unpinned-latest-images — Delta-Spec
+
+## Purpose
+
+Dokumentiert die bewusste Nutzung von :latest Image-Tags in Workspace-Deployments und formalisiert die Ausnahmeliste.
+
+## ADDED Requirements
+
+### Requirement: LATEST-001 — Intentionale :latest-Nutzung wird dokumentiert
+
+Image-Tags, die bewusst auf :latest gesetzt sind (Website, Brett, Studio, etc.), werden in einer zentralen Liste dokumentiert.
+
+**Scenarios:**
+
+- GIVEN a container image using :latest intentionally THEN it MUST appear in the documented exception list
+- GIVEN a new service deployment THEN the image tag policy MUST be reviewed before using :latest

--- a/openspec/changes/unpinned-latest-images/tasks.md
+++ b/openspec/changes/unpinned-latest-images/tasks.md
@@ -1,0 +1,61 @@
+---
+title: "Pin unpinned :latest images"
+ticket_id: "T001790"
+domains: [infra]
+status: staged
+---
+
+# unpinned-latest-images — Implementation Plan
+
+## File Structure
+
+| File | Action |
+|------|--------|
+| `k3d/brett.yaml` | Add `:latest is intentional` comment above image line |
+| `k3d/docs.yaml` | Add `:latest is intentional` comment above image line |
+| `k3d/configmap-domains.yaml` | Add comment on `STUDIO_IMAGE` explaining dev `:latest` vs prod digest |
+
+## Task 1: Add explicit :latest comment to brett.yaml
+
+Add an inline comment above the `image:` line in `k3d/brett.yaml` explaining why `:latest` is intentional, matching the convention used in `k3d/videovault.yaml:33` and `k3d/mediaviewer-widget.yaml:29`:
+
+```yaml
+# :latest is intentional — rebuilt on every release (see gotchas-footguns.md)
+image: ghcr.io/paddione/workspace-brett:latest
+```
+
+## Task 2: Add explicit :latest comment to docs.yaml
+
+Same pattern for `k3d/docs.yaml`:
+
+```yaml
+# :latest is intentional — rebuilt on every release (see gotchas-footguns.md)
+image: ghcr.io/paddione/workspace-docs:latest
+```
+
+## Task 3: Add comment to studio-server configmap entry
+
+Add a comment in `k3d/configmap-domains.yaml` on the `STUDIO_IMAGE` line explaining that dev uses `:latest` while prod pins to a digest:
+
+```yaml
+# :latest for dev; prod overlay pins to digest (see gotchas-footguns.md)
+STUDIO_IMAGE: "studio-server:latest"
+```
+
+## Task 4: Verify no remaining uncommented :latest references
+
+Run a verification grep to confirm every `:latest` usage in `k3d/` now has an explanatory comment:
+
+```bash
+grep -rn ':latest' k3d/ --include='*.yaml' | grep -v 'kube-prometheus-stack-rendered.yaml' | grep -v '# :latest'
+```
+
+Expected: zero uncommented lines (all matches should be in comment lines or the kube-prometheus-stack false positives).
+
+## Verify
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal and tasks for documenting intentional :latest image usage in workspace deployments
- T001790: maintenance finding — unpinned :latest images

## Test Plan
- [ ] CI green
- [ ] OpenSpec proposal reviewed

🤖 T001790