### PR TITLE
chore(openspec): add ignore-market-cli-skills proposal [T001783]

### DIFF
--- a/openspec/changes/ignore-market-cli-skills/proposal.md
+++ b/openspec/changes/ignore-market-cli-skills/proposal.md
@@ -1,0 +1,35 @@
+---
+title: "Ignore locally installed market-cli skills"
+ticket_id: "T001783"
+status: planning
+---
+
+# ignore-market-cli-skills — Proposal
+
+## Problem
+
+Lokal via lobehub market-cli installierte Skills (Drittanbieter, nicht geprüft, nicht team-geteilt)
+landen im Git-Index und können versehentlich committed werden. Der bisherige `.gitignore`-Eintrag
+(`.claude/skills/haniakrim21-*/`) deckt nur einen PREFIX ab — andere market-cli Skills
+(`gguf-quantization`, `llama-cpp`, `ui-ux-pro-max`, `unsloth`, `speculative-decoding`, `whisper`)
+sind bereits im Repo getrackt und können nicht mehr einfach ignoriert werden (Git ignoriert
+getrackte Dateien nicht automatisch).
+
+## Ziel
+
+Alle market-cli Skills werden vollständig aus dem Git-Index entfernt und zukünftig
+systematisch ignoriert — unabhängig vom Installations-Prefix.
+
+## Non-Goals
+
+- Team-eigene Skills (`dev-flow-*`, `git-workflow`, `infra-ops`, etc.) bleiben getrackt.
+- Keine Änderung am Skill-Loading-Verhalten (Skills bleiben lokal verfügbar).
+
+## Lösungsansatz
+
+1. **`.gitignore` erweitern:** Ein generisches Muster ergänzen, das alle known market-cli
+   Skill-Verzeichnisse unter `.claude/skills/` abdeckt — plus ein Kommentar mit der
+   Konvention für zukünftige market-cli Installationen.
+2. **Bereits getrackte Dateien entfernen:** `git rm --cached` für alle betroffenen
+   Skill-Verzeichnisse — löscht die Dateien nur aus dem Index, nicht vom Dateisystem.
+3. **Verifikation:** Prüfen, dass `git status` keine markierten market-cli Skills mehr zeigt.

--- a/openspec/changes/ignore-market-cli-skills/specs/ignore-market-cli-skills.md
+++ b/openspec/changes/ignore-market-cli-skills/specs/ignore-market-cli-skills.md
@@ -1,0 +1,24 @@
+# ignore-market-cli-skills — Delta-Spec
+
+## Purpose
+
+Markiert alle market-cli Skills als ungetrackt und erweitert die .gitignore um ein generisches Muster, das zukünftige market-cli Installationen abdeckt.
+
+## ADDED Requirements
+
+### Requirement: GITIGNORE-001 — Market-cli Skills werden ignoriert
+
+Alle unter `.claude/skills/` installierten market-cli Skills (Drittanbieter) werden über ein generisches .gitignore-Muster ignoriert.
+
+**Scenarios:**
+
+- GIVEN a locally installed market-cli skill THEN it MUST NOT appear in `git status` as untracked
+- GIVEN a tracked market-cli skill THEN `git rm --cached` MUST remove it from the index without deleting the files
+
+### Requirement: GITIGNORE-002 — Team-eigene Skills bleiben getrackt
+
+Eigene Skills (`dev-flow-*`, `git-workflow`, `infra-ops`, etc.) werden von der Ignore-Regel nicht betroffen.
+
+**Scenarios:**
+
+- GIVEN a team-owned skill THEN it MUST remain tracked in git

--- a/openspec/changes/ignore-market-cli-skills/tasks.md
+++ b/openspec/changes/ignore-market-cli-skills/tasks.md
@@ -1,0 +1,77 @@
+---
+title: "Ignore locally installed market-cli skills"
+ticket_id: "T001783"
+domains: [infra]
+status: planning
+---
+
+# ignore-market-cli-skills — Implementation Plan
+
+## File Structure
+
+- `.gitignore` — erweitern um Known-Market-Cli-Skills + Comment-Konvention
+- `openspec/changes/ignore-market-cli-skills/proposal.md` — Problemstellung
+- `openspec/changes/ignore-market-cli-skills/tasks.md` — diese Datei
+
+## Task 1: .gitignore erweitern
+
+**File:** `.gitignore`
+
+Bereits vorhandener Eintrag (Zeile 199-200):
+```
+# ── lobehub market-cli — locally installed skills (not vetted/shared) ──
+.claude/skills/haniakrim21-*/
+```
+
+Ersetzen durch eine vollständige Liste known-market-cli Skills:
+```
+# ── lobehub market-cli — locally installed skills (not vetted/shared) ──
+# Prefix-gestützt (neue market-cli Skills):  .claude/skills/<prefix>-*/
+# Bekannt installiert (Orchestra Research / nextlevelbuilder / haniakrim21):
+.claude/skills/haniakrim21-*/
+.claude/skills/gguf-quantization/
+.claude/skills/llama-cpp/
+.claude/skills/speculative-decoding/
+.claude/skills/unsloth/
+.claude/skills/ui-ux-pro-max/
+.claude/skills/whisper/
+```
+
+**AC:** Jede Zeile exakt wie oben — kein Regex, kein Glob, keine Platzhalter.
+
+## Task 2: Market-cli Skills aus Git-Index entfernen
+
+```bash
+git rm --cached -r \
+  .claude/skills/gguf-quantization/ \
+  .claude/skills/llama-cpp/ \
+  .claude/skills/speculative-decoding/ \
+  .claude/skills/unsloth/ \
+  .claude/skills/ui-ux-pro-max/ \
+  .claude/skills/whisper/
+```
+
+Dateien bleiben lokal erhalten — nur der Index-Eintrag wird entfernt.
+
+**AC:** `git status` zeigt die Dateien als `deleted` (aus dem Index), nicht als untracked.
+
+## Task 3: Commit & Push
+
+```bash
+git add .gitignore
+git commit -m "chore: ignore locally installed market-cli skills [T001783]"
+git push -u origin fix/t001783-ignore-market-cli-skills
+```
+
+**AC:** Commit enthält `.gitignore` + die `git rm --cached`-Änderungen.
+
+## Task 4: Ticket-Status setzen
+
+Ticket T001783 auf `plan_staged` setzen mit Branch- und Plan-Referenz.
+
+## Verify
+
+```bash
+git status    # keine untracked market-cli Skills, keine verschwindenden team-Skills
+grep -c 'market-cli\|haniakrim\|gguf-quant\|llama-cpp\|speculative-decod\|ui-ux-pro-max\|unsloth\|whisper' .gitignore
+```


### PR DESCRIPTION
## Summary
- Add OpenSpec proposal and tasks for ignoring locally installed market-cli skills
- T001783: prevent market-cli skills from interfering with the factory

## Test Plan
- [ ] CI green
- [ ] OpenSpec proposal reviewed

🤖 T001783