### PR TITLE
fix(factory): repair invalid sed regex in auto-close-merged.sh [T001811]

### DIFF
--- a/scripts/factory/auto-close-merged.sh
+++ b/scripts/factory/auto-close-merged.sh
@@ -51,7 +51,7 @@ fi
 # `[T-NNNNNN]` (literal `[T` + 6 digits + `]`, e.g. [T123456] or [T001415]).
 echo "$PRS" | while IFS=$'\t' read -r pr_num title branch; do
   # Skip if no ticket tag in title
-  ticket=$(printf '%s' "$title" | sed -n 's/.*\[(T[0-9]\{6\})\].*/\1/p' | head -1)
+  ticket=$(printf '%s' "$title" | sed -n 's/.*\[\(T[0-9]\{6\}\)\].*/\1/p' | head -1)
   [[ -z "$ticket" ]] && continue
 
   # T001580 FIX: Skip plan-only PRs (chore/archive, openspec branches)

--- a/tests/spec/t001415-mishap-bundle.bats
+++ b/tests/spec/t001415-mishap-bundle.bats
@@ -115,6 +115,25 @@ setup() {
   grep -EqE '\[T[0-9]{6}\]|sed.*T[0-9]\{6\}' "$REPO/scripts/factory/auto-close-merged.sh"
 }
 
+@test "T001811: auto-close-merged.sh sed pattern actually extracts the ticket ID (regression)" {
+  # T001811: the pattern previously had unescaped capture-group parens
+  # ('\[(T...)\]' instead of '\[\(T...\)\]'), which made sed abort with
+  # "invalid reference \1" on every PR title — auto-close silently never
+  # matched anything for either brand. Run the exact sed line from the
+  # script (not a re-typed copy) so a future regression here fails loudly.
+  sed_cmd=$(grep -m1 '^\s*ticket=\$(printf' "$REPO/scripts/factory/auto-close-merged.sh" \
+    | sed -n "s/.*printf '%s' \"\$title\" | \(sed -n '[^']*'\).*/\1/p")
+  [ -n "$sed_cmd" ]
+
+  run bash -c "printf '%s' 'fix(admin): cockpit foo [T001655]' | $sed_cmd | head -1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "T001655" ]
+
+  run bash -c "printf '%s' 'chore: no ticket tag here' | $sed_cmd | head -1"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 @test "T001415-M3: auto-close-merged.sh transitions non-terminal tickets via ticket.sh update-status" {
   [ -f "$REPO/scripts/factory/auto-close-merged.sh" ]
   grep -Eq 'ticket\.sh[[:space:]]+update-status.*--status[[:space:]]+done' "$REPO/scripts/factory/auto-close-merged.sh"


### PR DESCRIPTION
## Summary
- `auto-close-merged.sh`'s ticket-tag extraction used an invalid BRE pattern (`\[(T...)\]` — unescaped capture-group parens instead of `\[\(T...\)\]`), which made every `sed` invocation abort with `invalid reference \1 on 's' command's RHS`.
- Effect: auto-close silently matched **zero** tickets on every factory tick, for both brands — confirmed in the `factory.service` systemd journal (2026-07-14 16:20:53, both `mentolder` and `korczewski`).
- Fixed the escaping; added a regression test that actually executes the sed pattern (the existing M3 tests only grep the script's source text, so they didn't catch this).

## Test plan
- [x] `tests/unit/lib/bats-core/bin/bats tests/spec/t001415-mishap-bundle.bats` — 10/10 green
- [x] Confirmed the new regression test fails against the pre-fix pattern (reverted locally, reran, saw `not ok`, restored fix)
- [x] `task freshness:regenerate` — no diff, inventory already current

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VunrMVvettRM5Bi8x1LgKo