### PR TITLE
ci(infra): parallelize dual-brand deploys + cache Playwright browsers

### DIFF
--- a/.github/workflows/build-brett.yml
+++ b/.github/workflows/build-brett.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      sha_tag: ${{ steps.version.outputs.sha }}
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
@@ -59,6 +61,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=min
 
+  deploy-mentolder:
+    name: Deploy Brett (mentolder)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
       - name: Deploy to mentolder
         env:
           KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
@@ -70,6 +82,16 @@ jobs:
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/brett -n workspace
           kubectl rollout status deployment/brett -n workspace --timeout=120s
+
+  deploy-korczewski:
+    name: Deploy Brett (korczewski)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Deploy to korczewski
         env:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,6 +20,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      sha_tag: ${{ steps.version.outputs.sha }}
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
@@ -70,6 +72,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=min
 
+  deploy-mentolder:
+    name: Deploy Docs (mentolder)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
       - name: Deploy to mentolder
         env:
           KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
@@ -81,6 +93,16 @@ jobs:
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/docs -n workspace
           kubectl rollout status deployment/docs -n workspace --timeout=120s
+
+  deploy-korczewski:
+    name: Deploy Docs (korczewski)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Deploy to korczewski
         env:

--- a/.github/workflows/build-mediaviewer-widget.yml
+++ b/.github/workflows/build-mediaviewer-widget.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      sha_tag: ${{ steps.version.outputs.sha }}
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
@@ -62,6 +64,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=min
 
+  deploy-mentolder:
+    name: Deploy Mediaviewer Widget (mentolder)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
       - name: Deploy to mentolder
         env:
           KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
@@ -73,6 +85,16 @@ jobs:
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/mediaviewer-widget -n workspace
           kubectl rollout status deployment/mediaviewer-widget -n workspace --timeout=120s
+
+  deploy-korczewski:
+    name: Deploy Mediaviewer Widget (korczewski)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Deploy to korczewski
         env:

--- a/.github/workflows/build-videovault.yml
+++ b/.github/workflows/build-videovault.yml
@@ -13,12 +13,16 @@ env:
   OPENSPEC_TELEMETRY: '0'
 
 jobs:
-  build-and-deploy:
-    name: Build & Deploy VideoVault (both brands)
+  build:
+    name: Build & push VideoVault image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      image: ${{ steps.compute-tags.outputs.image }}
+      sha_tag: ${{ steps.compute-tags.outputs.sha_tag }}
+
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
@@ -54,11 +58,12 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Compute image + tags
+        id: compute-tags
         run: |
           IMAGE="ghcr.io/paddione/videovault"
           SHA_TAG="sha-$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
-          echo "IMAGE=${IMAGE}" >> "$GITHUB_ENV"
-          echo "SHA_TAG=${SHA_TAG}" >> "$GITHUB_ENV"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${SHA_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build & push Docker image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
@@ -67,21 +72,55 @@ jobs:
           file: VideoVault/Dockerfile
           push: true
           tags: |
-            ${{ env.IMAGE }}:${{ env.SHA_TAG }}
-            ${{ env.IMAGE }}:latest
+            ${{ steps.compute-tags.outputs.image }}:${{ steps.compute-tags.outputs.sha_tag }}
+            ${{ steps.compute-tags.outputs.image }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Deploy to both brands
+  deploy-mentolder:
+    name: Deploy VideoVault (mentolder)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Deploy to mentolder
         env:
           KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          SHA_TAG: ${{ needs.build.outputs.sha_tag }}
         run: |
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
-          for NS in workspace workspace-korczewski; do
-            kubectl set image deployment/videovault videovault="${IMAGE}:${SHA_TAG}" -n "$NS"
-            kubectl rollout status deployment/videovault -n "$NS" --timeout=180s
-          done
+          kubectl set image deployment/videovault videovault="${IMAGE}:${SHA_TAG}" -n workspace
+          kubectl rollout status deployment/videovault -n workspace --timeout=180s
+
+  deploy-korczewski:
+    name: Deploy VideoVault (korczewski)
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+
+      - name: Deploy to korczewski
+        env:
+          KUBECONFIG_DATA: ${{ secrets.FLEET_KUBECONFIG }}
+          IMAGE: ${{ needs.build.outputs.image }}
+          SHA_TAG: ${{ needs.build.outputs.sha_tag }}
+        run: |
+          curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
+            -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          mkdir -p ~/.kube
+          echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+          kubectl set image deployment/videovault videovault="${IMAGE}:${SHA_TAG}" -n workspace-korczewski
+          kubectl rollout status deployment/videovault -n workspace-korczewski --timeout=180s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,11 @@ jobs:
           echo "Total line coverage: ${COV}%"
           awk -v cov="$COV" 'BEGIN { if (cov + 0 < 60) { print "::error::Coverage gate failed: " cov "% < 60%"; exit 1 } else { print "::notice::Coverage gate passed: " cov "% >= 60%" } }'
 
+      - name: Astro TypeScript check
+        run: |
+          cd website
+          pnpm run astro:check
+
       - name: Knip dead-code report (advisory)
         continue-on-error: true
         run: |
@@ -288,29 +293,6 @@ jobs:
           name: website-dist
           path: website/dist
           retention-days: 1
-
-  astro-check:
-    name: Astro TypeScript Check
-    if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: website
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
-        with:
-          version: 10
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
-        with:
-          node-version: '22'
-          cache: pnpm
-          cache-dependency-path: website/pnpm-lock.yaml
-      - run: pnpm install --frozen-lockfile
-      - name: Run astro check
-        run: pnpm run astro:check
-        continue-on-error: false
 
   bundle-budget:
     name: Client-JS Bundle Budget

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -84,8 +84,16 @@ jobs:
         working-directory: tests/e2e
         run: npm ci
 
-      - name: Install Playwright browsers (chromium only)
+      - name: Cache Playwright browsers
         if: steps.filter.outputs.run_e2e == 'true'
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers (chromium only)
+        if: steps.filter.outputs.run_e2e == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: tests/e2e
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,8 +79,16 @@ jobs:
         working-directory: tests/e2e
         run: npm ci
 
-      - name: Install Playwright browsers
+      - name: Cache Playwright browsers
         if: steps.gate.outputs.skip != 'true'
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('tests/e2e/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.gate.outputs.skip != 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: tests/e2e
         run: npx playwright install --with-deps chromium webkit
 


### PR DESCRIPTION
## Summary
- Merge `vitest-website` + `astro-check` in `ci.yml` — eliminates redundant pnpm install (~1.5min saved per PR)
- Split sequential mentolder/korczewski deploys into parallel jobs in `build-brett.yml`, `build-docs.yml`, `build-mediaviewer-widget.yml`, `build-videovault.yml` (~1-2min saved per deploy)
- Cache Playwright browsers in `e2e-pr.yml` and `e2e.yml` (~2-3min saved on cache hit)

## Test Plan
- [ ] CI passes on this PR (all required checks green)
- [ ] Verify `Vitest (website)` required check still reports (job name preserved)
- [ ] Verify `bundle-budget` still picks up `website-dist` artifact
- [ ] Post-merge: confirm both brands deploy in parallel on a real service change

🤖 CI performance optimization — no behavior change