### PR TITLE
fix(factory): move factory-prep back to wakeup.sh, hand dispatcher.js a file path [T001812]

### DIFF
--- a/scripts/factory/dispatcher.js
+++ b/scripts/factory/dispatcher.js
@@ -19,27 +19,24 @@ async function main() {
   // - ticket.sh get (fetch details for launch)
   // - scripts/factory/guards.sh (kill-switch via guard_killswitch_on, daily cap via guard_daily_cap_reached)
   phase('Prep')
-  // T001810: run the deterministic prep directly via child_process — Workflow scripts
-  // CAN exec (pipeline.js does it throughout; the old "cannot execFileSync" note was
-  // stale). Passing prep JSON through the top-level model (T001808/T001809 handoff)
-  // proved lossy: small models drop fields like branch/plan_path → REUSE=false → the
-  // pipeline re-designs instead of executing the staged plan.
+  // T001812: factory-prep now runs in wakeup.sh (plain bash, before this Workflow
+  // call), which writes the result to args.prep_file. Reading a file here is a
+  // fast, synchronous op, unlike the T001810 approach of running factory-prep
+  // (up to 300s worst case: watchdog sweep + schedule poll, both brands) via
+  // child_process.execFileSync INSIDE this Workflow call — that made the call
+  // slow enough to flip into the harness's async "launched in background" mode,
+  // which a one-shot `claude -p` session never survives to see the notification
+  // for (orphaned runs, no transcript ever written). Passing prep as a file path
+  // instead of inline JSON also keeps T001809's original fix intact (small local
+  // models drop fields like branch/plan_path when relaying a large JSON blob
+  // verbatim through the prompt).
   const cp = require('child_process')
+  const fs = require('fs')
   let prep = null
   try {
-    const out = cp.execFileSync('bash', [`${REPO}/scripts/vda.sh`, 'factory-prep'], {
-      encoding: 'utf8',
-      timeout: 300000,
-      env: {
-        ...process.env,
-        FACTORY_DAILY_DEPLOY_CAP: String(A.FACTORY_DAILY_DEPLOY_CAP ?? '5'),
-        FACTORY_GLOBAL_CAP: String(A.FACTORY_GLOBAL_CAP ?? '3'),
-      },
-    })
-    // Defensiv: alles vor dem ersten '{' abschneiden — einzelne Helper (z. B.
-    // agent-lock.sh check) haben historisch stdout-Zeilen vor dem JSON geleakt.
-    const jsonStart = out.indexOf('{')
-    prep = JSON.parse(jsonStart >= 0 ? out.slice(jsonStart) : out)
+    if (!A.prep_file) throw new Error('args.prep_file missing — wakeup.sh must precompute it')
+    const raw = fs.readFileSync(A.prep_file, 'utf8')
+    prep = JSON.parse(raw)
   } catch (e) {
     log(
       `Dispatcher: factory-prep failed (${String(e && e.message ? e.message : e).slice(0, 300)}). ` +

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -91,12 +91,26 @@ TICK=0
 while true; do
   TICK=$(( TICK + 1 ))
   TIMESTAMP="$(date -u +%FT%TZ)"
-  # T001810: Kein Precompute/args-Durchreichen mehr (lossy durch kleine Modelle) —
-  # der Dispatcher führt prep/budget/sentinel selbst deterministisch via
-  # child_process aus. Das Modell übergibt nur noch timestamp + dry_run.
+  # T001812: factory-prep (watchdog sweep + schedule poll, up to 300s worst case)
+  # runs here in plain bash again — synchronous, no LLM/Workflow overhead. T001810
+  # moved it into dispatcher.js's Workflow call via child_process.execFileSync to
+  # avoid small models dropping fields when relaying prep JSON through the prompt
+  # (T001808/T001809 handoff), but that made the Workflow call itself slow enough
+  # to flip into the harness's async "launched in background" mode — and a
+  # one-shot `claude -p` session doesn't survive to receive that notification
+  # (observed: orphaned Workflow runs, no transcript dir ever created, weak local
+  # models retry + hallucinate an unrelated failure reason). Writing the result to
+  # a file and passing only the path keeps BOTH properties: no lossy JSON-in-prompt
+  # relay, and a fast/synchronous Workflow call (dispatcher.js just reads the file).
+  PREP_FILE="/tmp/factory-prep-tick${TICK}-$$.json"
+  FACTORY_DAILY_DEPLOY_CAP="${FACTORY_DAILY_DEPLOY_CAP:-5}" FACTORY_GLOBAL_CAP="${FACTORY_GLOBAL_CAP:-3}" \
+    bash "${REPO}/scripts/vda.sh" factory-prep 2>/dev/null | jq -c . > "${PREP_FILE}" 2>/dev/null || echo 'null' > "${PREP_FILE}"
+
   PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
-scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN} }. \
-The dispatcher runs all guards (kill-switch, daily-cap, dry-run-first) deterministically inside its PREP step. \
+scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN}, prep_file: '${PREP_FILE}' }. \
+Pass prep_file through verbatim — do not alter, re-run, or improvise it. \
+The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step \
+(already evaluated into prep_file by this wrapper). \
 Report only the dispatcher's final JSON result. Do not improvise scheduling."
 
   echo "wakeup.sh: starting tick #${TICK} at ${TIMESTAMP}" >&2
@@ -130,6 +144,7 @@ Report only the dispatcher's final JSON result. Do not improvise scheduling."
     --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),Bash(bash scripts/vda.sh*),ToolSearch,PushNotification" \
     --permission-mode acceptEdits
   TICK_EXIT=$?
+  rm -f "${PREP_FILE}"
 
   if [[ ${TICK_EXIT} -ne 0 ]]; then
     echo "wakeup.sh: tick #${TICK} exited with code ${TICK_EXIT} — stopping loop" >&2

--- a/tests/local/FA-SF-30-dispatcher-contract.bats
+++ b/tests/local/FA-SF-30-dispatcher-contract.bats
@@ -38,15 +38,30 @@ setup() { load 'test_helper.bash'; }
 }
 
 @test "FA-SF-30: PREP gate reads hard guards fresh per tick via guards.sh" {
-  run grep -q "scripts/factory/guards.sh" "$SCRIPT"; [ "$status" -eq 0 ]
-  run grep -q "guard_killswitch_on" "$SCRIPT"; [ "$status" -eq 0 ]
-  run grep -q "guard_daily_cap_reached" "$SCRIPT"; [ "$status" -eq 0 ]
+  # T001812: factory-prep (which sources guards.sh) now runs in wakeup.sh, once
+  # per while-loop tick, BEFORE the Workflow call — not inside dispatcher.js
+  # anymore (see FA-SF-30: dispatcher reads prep from a file, below). "Fresh per
+  # tick" holds because wakeup.sh recomputes prep_file on every loop iteration.
+  WAKEUP="scripts/factory/wakeup.sh"
+  run grep -q "scripts/factory/guards.sh\|factory-prep" "$WAKEUP"; [ "$status" -eq 0 ]
+}
+
+@test "FA-SF-30: dispatcher reads prep from a file, not via child_process (T001812)" {
+  # T001810 ran factory-prep via child_process.execFileSync INSIDE the Workflow
+  # call (up to 300s worst case), which was slow enough to flip the call into the
+  # harness's async "launched in background" mode — a one-shot `claude -p`
+  # session never survives to see that notification (orphaned runs observed,
+  # no transcript dir ever written). T001812 moved factory-prep back to
+  # wakeup.sh (synchronous bash) and hands the result to dispatcher.js as a file
+  # path, keeping the Workflow call itself fast/synchronous.
+  run grep -q "args.prep_file\|A.prep_file" "$SCRIPT"; [ "$status" -eq 0 ]
+  run grep -q "readFileSync" "$SCRIPT"; [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-30: PREP gate is fail-closed (drops the brand from launch on guard trip / read error)" {
-  # T001810: PREP gate now runs via child_process.execFileSync — fail-closed by
-  # JavaScript exception (non-zero exit propagates, no brands launched).
-  run grep -Eq "execFile|child_process" "$SCRIPT"; [ "$status" -eq 0 ]
+  # T001812: fail-closed via JS exception on missing/invalid prep_file — same
+  # early-return-with-no-launches contract as before, different trigger.
+  run grep -Eq "prep_file missing|JSON.parse\(raw\)" "$SCRIPT"; [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-30: captures the parallel() launch result (not discarded)" {

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -836,15 +836,15 @@ DISPATCHER_SCRIPT="scripts/factory/dispatcher.js"
 }
 
 @test "FA-SF-30: PREP gate reads hard guards fresh per tick via guards.sh" {
-  run grep -q "scripts/factory/guards.sh" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
-  run grep -q "guard_killswitch_on" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
-  run grep -q "guard_daily_cap_reached" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  # T001812: factory-prep (which sources guards.sh) now runs in wakeup.sh, once
+  # per while-loop tick, before the Workflow call — not inside dispatcher.js.
+  run grep -q "scripts/factory/guards.sh\|factory-prep" scripts/factory/wakeup.sh; [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-30: PREP gate is fail-closed (drops the brand from launch on guard trip / read error)" {
-  # T001810: PREP gate now runs via child_process.execFileSync — fail-closed by
-  # JavaScript exception (non-zero exit propagates, no brands launched).
-  run grep -Eq "execFile|child_process" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
+  # T001812: fail-closed via JS exception on missing/invalid prep_file — same
+  # early-return-with-no-launches contract as before, different trigger.
+  run grep -Eq "prep_file missing|JSON.parse\(raw\)" "$DISPATCHER_SCRIPT"; [ "$status" -eq 0 ]
 }
 
 @test "FA-SF-30: captures the parallel() launch result (not discarded)" {
@@ -3152,12 +3152,19 @@ STUB
   [ "$status" -eq 0 ]
 }
 
-@test "T001810: dispatcher.js runs factory-prep deterministically via child_process" {
-  # T001808/T001809 routed prep through wakeup args — lossy through small models
-  # (branch/plan_path dropped). Superseded by direct execFileSync in the dispatcher.
-  run grep -F "require('child_process')" scripts/factory/dispatcher.js
+@test "T001812: dispatcher.js reads factory-prep from a file precomputed by wakeup.sh" {
+  # T001810 ran factory-prep via child_process.execFileSync INSIDE the Workflow
+  # call (up to 300s worst case) to avoid T001808/T001809's lossiness (small
+  # models dropped fields like branch/plan_path when relaying prep JSON through
+  # the prompt) — but that made the call slow enough to flip into the harness's
+  # async "launched in background" mode, which a one-shot `claude -p` session
+  # never survives to see the notification for (orphaned Workflow runs observed,
+  # no transcript dir ever written). T001812 moved factory-prep back to
+  # wakeup.sh (fast, synchronous bash) and hands dispatcher.js a file path
+  # instead — no lossy JSON-in-prompt relay, and a fast/synchronous Workflow call.
+  run grep -F "args.prep_file" scripts/factory/dispatcher.js
   [ "$status" -eq 0 ]
-  run bash -c "grep -A2 'execFileSync' scripts/factory/dispatcher.js | grep -F 'vda.sh'"
+  run grep -F "readFileSync" scripts/factory/dispatcher.js
   [ "$status" -eq 0 ]
 }
 
@@ -3171,10 +3178,17 @@ STUB
   [ "$status" -ne 0 ]
 }
 
-@test "T001810: wakeup.sh passes only timestamp and dry_run — no prep JSON through the model" {
+@test "T001812: wakeup.sh precomputes factory-prep and passes a file path, not inline JSON" {
+  # Neither the T001810 args-blob (no prep object relayed verbatim) nor a
+  # T001808/T001809-style giant inline JSON string — just a short path the
+  # model passes through untouched.
   run grep -F 'PREP_JSON' scripts/factory/wakeup.sh
   [ "$status" -ne 0 ]
-  run grep -F "args { timestamp: '\${TIMESTAMP}', dry_run: \${DRY_RUN} }" scripts/factory/wakeup.sh
+  run grep -F 'PREP_FILE=' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+  run grep -F 'factory-prep' scripts/factory/wakeup.sh
+  [ "$status" -eq 0 ]
+  run grep -F "prep_file: '\${PREP_FILE}'" scripts/factory/wakeup.sh
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary
- T001810 ran `factory-prep` (up to 300s worst case) + budget-guard/sentinel via `child_process.execFileSync` **inside** the `dispatcher.js` Workflow call, to avoid small local models dropping fields when relaying prep JSON through the prompt.
- That made the Workflow call slow enough to flip into the harness's async "launched in background" mode — a one-shot `claude -p` session (as `wakeup.sh` uses) never survives to see that notification.
- Observed in the systemd journal: the same Workflow call relaunched 3x with distinct task IDs in one session; none of their transcript directories were ever created (orphaned runs). The local model (Qwythos-9B-v2) eventually gave up and hallucinated an unrelated failure reason ("require() unsupported") that never appeared in any real tool result.
- Fix: `factory-prep` runs in `wakeup.sh` again (synchronous bash, before the Workflow call), writes its result to a file; `dispatcher.js` does a plain `fs.readFileSync` instead. Keeps T001809's original fix intact (no giant JSON blob relayed verbatim through the prompt — model only passes a short file path) while restoring a fast, synchronous Workflow call. `budget-guard`/sentinel stay in `dispatcher.js` unchanged (bounded per-feature timeouts, not the dominant cost).

## Test plan
- [x] `node --check scripts/factory/dispatcher.js`, `bash -n scripts/factory/wakeup.sh`
- [x] `tests/local/FA-SF-30-dispatcher-contract.bats` — 12/12 green
- [x] `tests/spec/software-factory.bats` (FA-SF-30/T001809/T001810/T001812 filter) — 15/15 green
- [x] `task test:all` — full offline gate, 0 failures
- [x] `task freshness:regenerate` — no diff

Ticket: T001812

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VunrMVvettRM5Bi8x1LgKo