### PR TITLE
chore(admin): remove remaining 3 redirect-map stub pages [T001789]

### DIFF
--- a/website/src/pages/admin/dora.astro
+++ b/website/src/pages/admin/dora.astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect('/admin/pipeline?tab=analytics', 301);
----

--- a/website/src/pages/admin/factory-budget.astro
+++ b/website/src/pages/admin/factory-budget.astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect('/admin/pipeline?tab=kosten', 301);
----

--- a/website/src/pages/admin/factory-observability.astro
+++ b/website/src/pages/admin/factory-observability.astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect('/admin/pipeline?tab=kosten', 301);
----


### PR DESCRIPTION
## Summary

Removes the last 3 redirect-map stub pages from the admin area. These were placeholder .astro files that redirected to real implementations — the real implementations now exist on main, so the stubs are dead code.

**Deleted files:**
- website/src/pages/admin/dora.astro
- website/src/pages/admin/factory-budget.astro
- website/src/pages/admin/factory-observability.astro

## Verification
- ✅ vitest 24/24 tests pass (redirect-map.test.ts)
- ✅ astro:check 0 errors
- ✅ eslint 0 errors

**Ticket:** T001789