### PR TITLE
chore(dev-flow): fix plan-lint doc drift for STRUCT2/B1a/B1b

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -263,13 +263,26 @@ Statt deinen eigenen Kontext zurückzusetzen (das ließe dich den Faden verliere
         `## File Structure`, die die geänderten/neuen Dateien auflistet.
       - **STRUCT2 Failing-Test-Step:** Mindestens ein Task enthält einen
         rot→grün-Failing-Test-Step mit der wortwörtlichen Phrase
-        `expected: FAIL` (regex tolerant: `expected:? *fail`).
+        `expected: FAIL` (regex tolerant: `expected:? *fail`) — **UND** einen
+        echten Testrunner-Aufruf (`bats`/`vitest`/`pytest`/`jest`/`mocha`/
+        `go test`/`playwright test`) im selben oder einem anderen Task. Die
+        Phrase allein reicht NICHT (billig zu faken, vom `openspec propose`-
+        Skeleton vorgeseedet); der finale `task test:*`-Verify-Task (STRUCT3)
+        zählt NICHT als dieser Failing-Test-Step (T001791 #2).
       - **STRUCT3 Verify-Task:** Der letzte Task listet die drei mandatory
         Verify-Commands: `task test:changed`, `task freshness:regenerate`,
         `task freshness:check` (regex `task[[:space:]]+<cmd>`).
       - **P1 Placeholder-Verbot:** In Prosa (außerhalb von ```-Fences und
         `inline code`) dürfen die Tokens `TBD`, `TODO`, `FIXME`, `???`,
         `<ausfüllen>` und `similar to Task <N>` NICHT vorkommen.
+      - **B1a Budget-Integrität:** Jeder im Plan behauptete Budget-Wert für
+        eine bereits im Repo existierende Datei muss exakt dem vom Linter
+        berechneten effektiven Budget entsprechen (Baseline vs. Limit) —
+        sonst Hard-Fail.
+      - **B1b Split/Shrink bei Budget ≤ 0:** Ist das effektive Budget einer
+        referenzierten Datei ≤ 0, MUSS der Plan einen Split-/Shrink-Schritt
+        enthalten (Stichwörter: `split`, `extract`, `verkleiner`, `shrink`,
+        `aufteil`) — sonst Warnung (kosmetisches Zusammenziehen reicht nicht).
       - **Auftrag:** „**PFLICHT — Worktree-Isolation:** Beginne deinen Prompt mit `cd .worktrees/<slug>` — der Subagent hat keinen impliziten CWD-Kontext und schreibt sonst ins Haupt-Checkout. Alle folgenden Dateipfade sind relativ zu diesem Worktree.
      Dann: Lies die Spec UND `.claude/skills/references/plan-quality-gates.md`. Rufe `superpowers:writing-plans` auf und schreibe den Implementierungsplan **ausschließlich** nach `openspec/changes/<slug>/tasks.md` (OpenSpec-Format: H2-Operationsheader im Delta, H3-Requirement, H4-Scenario im `specs/<capability>.md`). Der finale Verifikations-Task des Plans MUSS `task test:changed`, `task freshness:regenerate` und `task freshness:check` als Steps enthalten (CI-Äquivalent inkl. S1–S4-Ratchet); nach Test-Änderungen zusätzlich `task test:inventory` + Commit des Inventars. Vor dem Commit: `task test:openspec` (oder `bash scripts/openspec.sh validate`) — muss grün sein. **Test-Assertion-Konsistenz:** Verifiziere vor Finalisierung, dass jede im Plan-Task vorgegebene Test-Regex/Erwartung tatsächlich die im selben Task referenzierten Implementierungs-Snippets matchen kann — bei Diskrepanz wähle eine semantisch äquivalente Assertion-Form, die zum Snippet passt. Starte KEINE Implementierung (nur Plan schreiben, dann STOPP). Gib den Plan-Pfad (`openspec/changes/<slug>/tasks.md`) und eine 3-Zeilen-Zusammenfassung zurück."
 ### Schritt 3.8: Plan-Qualitäts-Gate (deterministischer Linter + advisory LLM-QA)

--- a/.claude/skills/references/plan-quality-gates.md
+++ b/.claude/skills/references/plan-quality-gates.md
@@ -105,12 +105,27 @@ lesen diese Datei statt einer Kopie im Skill-Prompt):
   `# <slug> — Implementation Plan` als H1, gefolgt von einer H2-Sektion `## File Structure`
   mit den geänderten/neuen Dateien.
 - **STRUCT2 Failing-Test-Step:** Mindestens ein Task enthält einen rot→grün-Failing-Test-Step
-  mit der wortwörtlichen Phrase `expected: FAIL` (regex tolerant: `expected:? *fail`).
+  mit der wortwörtlichen Phrase `expected: FAIL` (regex tolerant: `expected:? *fail`) —
+  UND einen echten Testrunner-Aufruf (`bats`, `vitest`, `pytest`, `jest`, `mocha`, `go test`
+  oder `playwright test`). Die Phrase allein reicht NICHT: sie ist billig zu faken und wird
+  bereits vom `openspec propose`-Skeleton vorgeseedet. Der finale `task test:*`-Verify-Task
+  (STRUCT3) zählt NICHT als dieser Failing-Test-Step — es muss ein eigener, expliziter
+  Testrunner-Befehl im selben oder einem anderen Task stehen (T001791 #2).
 - **STRUCT3 Verify-Task:** Der letzte Task listet die drei mandatory Verify-Commands:
   `task test:changed`, `task freshness:regenerate`, `task freshness:check`
   (regex `task[[:space:]]+<cmd>`).
 - **P1 Placeholder-Verbot:** In Prosa (außerhalb von ```-Fences und `inline code`) dürfen
   `TBD`, `TODO`, `FIXME`, `???`, `<ausfüllen>` und `similar to Task <N>` NICHT vorkommen.
+- **B1a Budget-Integrität:** Für jede im Plan referenzierte Datei (`` `path` `` als 3-Spalten-
+  Tabellenzeile `| \`path\` | <ist> | <budget> |` oder als Prosa `` `path` … (Budget|Restbudget|
+  budget) <N> ``), die bereits im Repo existiert, muss der behauptete Budget-Wert exakt dem
+  vom Linter berechneten effektiven Budget (Baseline vs. Limit, siehe oben) entsprechen —
+  sonst Hard-Fail. Nicht als Zahl behauptete Budgets werden nicht geprüft.
+- **B1b Split/Shrink bei Budget ≤ 0 (Warn, nicht Hard-Fail):** Ist das berechnete effektive
+  Budget einer referenzierten Datei ≤ 0 und der Plan enthält keinen Split-/Shrink-Schritt
+  (Stichwörter: `split`, `extract`, `verkleiner`, `shrink`, `aufteil`), gibt der Linter eine
+  Warnung aus — kosmetisches Zusammenziehen reicht bei Budget≈0 nicht (siehe Schritt 3.7/4
+  im Skill).
 
 ### Weitere CI-Gates (Pflicht im finalen Verifikations-Task jedes Plans)
 


### PR DESCRIPTION
## Summary
- `plan-quality-gates.md` (SSOT) and `dev-flow-plan/SKILL.md` documented STRUCT2 as satisfied by the literal `expected: FAIL` phrase alone, but `scripts/plan-lint.sh` (T001791 #2) also hard-fails without an accompanying real test-runner invocation (bats/vitest/pytest/jest/mocha/go test/playwright test).
- B1a (per-file budget-integrity check) and B1b (split/shrink requirement when residual budget ≤ 0) exist in `plan-lint.sh` but were entirely undocumented in both files.
- Both docs now match the linter, so plan-writing subagents following the SSOT/Kurzfassung text no longer risk an unexpected hard-fail loop.

Found during an audit of `dev-flow-plan` (does it still reference real scripts, does it correctly drive branch/worktree/openspec creation) — all script/reference paths checked out fine except this doc/lint drift.

## Test plan
- [x] `task test:changed` — 52/52 pass
- [x] `task freshness:regenerate` — no artifact drift
- [x] `task freshness:check` — green
- Doc-only change, no runtime code touched

Ticket: T001818

🤖 Generated with [Claude Code](https://claude.com/claude-code)
