### PR TITLE
chore(test): remove stale T001433 redirect tests for pages deleted in #2790 [T001819]

### DIFF
--- a/tests/spec/dora-dashboard.bats
+++ b/tests/spec/dora-dashboard.bats
@@ -6,18 +6,11 @@
 # Convention: one .bats file per OpenSpec SSOT spec.
 
 # ── File-level variables ──────────────────────────────────────────────────────
-DORA_PAGE="$BATS_TEST_DIRNAME/../../website/src/pages/admin/dora.astro"
 DORA_DASHBOARD="$BATS_TEST_DIRNAME/../../website/src/components/admin/DoraDashboard.svelte"
 DORA_METRICS_LIB="$BATS_TEST_DIRNAME/../../website/src/lib/dora-metrics.ts"
 DORA_API="$BATS_TEST_DIRNAME/../../website/src/pages/api/admin/dora-metrics.ts"
 
 # ── T001433: DORA removal ─────────────────────────────────────────────────────
-@test "T001433 dora: /admin/dora redirects to /admin/pipeline?tab=analytics" {
-  [ -f "$DORA_PAGE" ]
-  run grep -F "Astro.redirect('/admin/pipeline?tab=analytics', 301)" "$DORA_PAGE"
-  [ "$status" -eq 0 ]
-}
-
 @test "T001433 dora: DoraDashboard.svelte is removed" {
   [ ! -f "$DORA_DASHBOARD" ]
 }

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -2972,8 +2972,6 @@ REG="scripts/factory/service-registry.sh"
 # ── T001433 admin-redesign: Pipeline move + Kosten tab + chart-color SSOT ────
 PIPELINE_PAGE="$BATS_TEST_DIRNAME/../../website/src/pages/admin/pipeline.astro"
 DEV_STATUS_PAGE="$BATS_TEST_DIRNAME/../../website/src/pages/dev-status.astro"
-FACTORY_OBSERVABILITY_PAGE="$BATS_TEST_DIRNAME/../../website/src/pages/admin/factory-observability.astro"
-FACTORY_BUDGET_PAGE="$BATS_TEST_DIRNAME/../../website/src/pages/admin/factory-budget.astro"
 FACTORY_OBSERVABILITY_COMP="$BATS_TEST_DIRNAME/../../website/src/components/factory/FactoryObservability.svelte"
 FACTORY_CHART_COLORS="$BATS_TEST_DIRNAME/../../website/src/components/factory/factory-chart-colors.ts"
 
@@ -2985,16 +2983,6 @@ FACTORY_CHART_COLORS="$BATS_TEST_DIRNAME/../../website/src/components/factory/fa
 
 @test "T001433 pipeline: dev-status.astro is a 301 redirect to /admin/pipeline" {
   run grep -F "Astro.redirect(\`/admin/pipeline" "$DEV_STATUS_PAGE"
-  [ "$status" -eq 0 ]
-}
-
-@test "T001433 pipeline: factory-observability.astro redirects to /admin/pipeline?tab=kosten" {
-  run grep -F "Astro.redirect('/admin/pipeline?tab=kosten', 301)" "$FACTORY_OBSERVABILITY_PAGE"
-  [ "$status" -eq 0 ]
-}
-
-@test "T001433 pipeline: factory-budget.astro redirects to /admin/pipeline?tab=kosten" {
-  run grep -F "Astro.redirect('/admin/pipeline?tab=kosten', 301)" "$FACTORY_BUDGET_PAGE"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary
- PR #2790 (T001789) deleted `website/src/pages/admin/{factory-observability,factory-budget,dora}.astro` but left 3 BATS tests asserting those files exist and redirect — breaking the required "Offline Tests" CI check on `main` and every PR built on it.
- Removes the 3 now-obsolete tests. The pages were intentionally removed, not regressed — this is dead test weight, not a signal to restore anything.

## Test plan
- [x] `bats tests/spec/software-factory.bats --filter "T001433 pipeline"` — green
- [x] `bats tests/spec/dora-dashboard.bats` — green (remaining 3 "is removed" tests still pass)
- [x] `task test:changed` — exit 0, 0 failures
- [x] `task freshness:regenerate && task freshness:check` — clean, no diff

Closes T001819

https://claude.ai/code/session_01KwtjQ4pa7vPe27ZUcvM2cC