### PR TITLE
fix(test): update stale dora-dashboard test after redirect stub removal [T001433]

### DIFF
--- a/openspec/specs/dora-dashboard.md
+++ b/openspec/specs/dora-dashboard.md
@@ -22,5 +22,6 @@ through the CLI gate `vda.sh cfr` and direct `tickets.pr_events` queries.
 
 - **GIVEN** an authenticated admin on `/admin`
 - **WHEN** the sidebar or shortcuts render
-- **THEN** no link to `/admin/dora` is present, and the URL returns a 301
-  redirect to `/admin/pipeline?tab=analytics`
+- **THEN** no link to `/admin/dora` is present, the redirect stub page
+  (`website/src/pages/admin/dora.astro`) has been removed, and the URL
+  returns a 404

--- a/tests/spec/dora-dashboard.bats
+++ b/tests/spec/dora-dashboard.bats
@@ -12,10 +12,8 @@ DORA_METRICS_LIB="$BATS_TEST_DIRNAME/../../website/src/lib/dora-metrics.ts"
 DORA_API="$BATS_TEST_DIRNAME/../../website/src/pages/api/admin/dora-metrics.ts"
 
 # ── T001433: DORA removal ─────────────────────────────────────────────────────
-@test "T001433 dora: /admin/dora redirects to /admin/pipeline?tab=analytics" {
-  [ -f "$DORA_PAGE" ]
-  run grep -F "Astro.redirect('/admin/pipeline?tab=analytics', 301)" "$DORA_PAGE"
-  [ "$status" -eq 0 ]
+@test "T001433 dora: /admin/dora redirect stub is removed" {
+  [ ! -f "$DORA_PAGE" ]
 }
 
 @test "T001433 dora: DoraDashboard.svelte is removed" {


### PR DESCRIPTION
## Summary
- PR #2790 removed the `dora.astro` redirect stub, but `tests/spec/dora-dashboard.bats` test 915 still expected the file to exist with a redirect — causing a hard failure on every CI run.
- Updates the test to assert the file is **removed** (matching the other 3 assertions in the same file and the current state of the codebase).
- Updates `openspec/specs/dora-dashboard.md` scenario to reflect the URL now returns 404 instead of 301.

## Verification
- `bats tests/spec/dora-dashboard.bats` — all 4 tests pass locally
- `task freshness:regenerate` — no drift detected