### PR TITLE
chore(openspec): fix dora-dashboard spec redirect drift [T001820]

### DIFF
--- a/openspec/specs/dora-dashboard.md
+++ b/openspec/specs/dora-dashboard.md
@@ -24,4 +24,6 @@ through the CLI gate `vda.sh cfr` and direct `tickets.pr_events` queries.
 - **WHEN** the sidebar or shortcuts render
 - **THEN** no link to `/admin/dora` is present, the redirect stub page
   (`website/src/pages/admin/dora.astro`) has been removed, and the URL
-  returns a 404
+  returns a 301 redirect to `/admin/pipeline?tab=analytics` (handled by the
+  `redirectMiddleware` / `REDIRECT_MAP` in `website/src/middleware/redirect-map.ts`,
+  independent of the deleted stub page)


### PR DESCRIPTION
## Summary
- PR #2794 changed the `/admin/dora` scenario in `openspec/specs/dora-dashboard.md` to claim the URL returns a 404.
- That's incorrect: `redirectMiddleware` (`website/src/middleware.ts`) runs before routing and unconditionally 301-redirects `/admin/dora` → `/admin/pipeline?tab=analytics` via `REDIRECT_MAP` (`website/src/middleware/redirect-map.ts`), independent of whether the `dora.astro` stub file exists.
- This is already covered by `redirect-map.test.ts` (24/24 passing) and the existing Playwright test `FA-UNIF-12` (`tests/e2e/specs/dev-status-tabs.spec.ts`), and matches the original archived spec delta (`openspec/changes/archive/2026-07-02-admin-redesign/specs/dora-dashboard.md`).
- Spec-only correction — no code or test changes needed.

## Test plan
- [x] `bats tests/spec/dora-dashboard.bats` — 3/3 pass
- [x] `task openspec:validate` — pass
- [x] `task freshness:check` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rdnWcEQ5jTn9yoCiP9YaK