### PR TITLE
fix(factory): auto-detect FACTORY-PLAN-REF and move ticket creation earlier in opencode-flow-plan

### DIFF
--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -81,6 +81,19 @@ Starte strukturiertes Brainstorming mit dem User. Stelle Fragen als Plain-Text-F
 
 Übertrage Brainstorming-Output nach `openspec/changes/<slug>/proposal.md`. Der Implementierungsplan kommt in `openspec/changes/<slug>/tasks.md`.
 
+#### Schritt A.5: Ticket anlegen — VOR Plan-Schreibung ⚡
+
+Erstelle das Ticket **jetzt** (nach dem Propose, vor dem Plan-Schreiben), damit die
+Ticket-ID für den Rest des Flows verfügbar ist und `stage_plan` sofort nach der
+Plan-Erstellung ausgeführt werden kann (kein Fenster für Plan-Verlagerung):
+
+```
+ticket-mcp: create_ticket({ type: "task", brand: "mentolder", title: "<slug>", priority: "mittel", description: "Branch: feature/<slug>\nPlan: openspec/changes/<slug>/tasks.md\nSpec: docs/superpowers/specs/<date>-<slug>-design.md" })
+```
+
+Setze `TICKET_EXT_ID` (Feld 1) und `TICKET_UUID` (Feld 2) aus der Rückgabe.
+Claims: `agent-lock.sh claim ticket` + `claim branch` mit Label `opencode-flow-plan`.
+
 ### Phase B: Worktree anlegen + Artefakte übertragen
 #### Schritt B.1: Worktree anlegen
 
@@ -120,12 +133,13 @@ bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md
 bash scripts/openspec.sh validate
 ```
 
-#### Schritt 4: Plan prüfen & Ticket anlegen/verwenden
+#### Schritt 4: Plan stagen (Ticket existiert bereits aus Schritt A.5)
 
-Ticket anlegen (via ticket-mcp `create_ticket`), dann stagen:
+Ticket-ID muss aus Schritt A.5 im Kontext sein (`$TICKET_EXT_ID`).
+Plan stagen — `stage_plan` setzt automatisch `status=plan_staged` und die
+`FACTORY-PLAN-REF`-Comment:
 ```
 ticket-mcp: stage_plan({ id: "$TICKET_EXT_ID", branch: "feature/<slug>", plan: "openspec/changes/<slug>/tasks.md" })
-ticket-mcp: transition_status({ id: "$TICKET_EXT_ID", status: "plan_staged" })
 ```
 
 #### Schritt 5: Commit & Push — dann STOPP

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -97,9 +97,34 @@ function consumeInjections(ph) {
 }
 
 const DRY_RUN = A.dry_run === true || A.dry_run === 'true'
-const REUSE_BRANCH = A.branch || null
-const REUSE_PLAN   = A.plan_path || null
-const REUSE = !!(REUSE_BRANCH && REUSE_PLAN)
+let REUSE_BRANCH = A.branch || null
+let REUSE_PLAN   = A.plan_path || null
+let REUSE = !!(REUSE_BRANCH && REUSE_PLAN)
+
+// ── Auto-detect FACTORY-PLAN-REF when REUSE is not explicitly set ──
+// If dev-flow-plan staged a plan but the dispatcher didn't pass branch/plan_path,
+// the ticket still carries a FACTORY-PLAN-REF comment. Parse it to enable REUSE
+// and skip Scout/Design/Plan-creation — the human already did that work.
+if (!REUSE && A.ticket_id) {
+  try {
+    const cp2 = require('child_process')
+    const ticketJson = cp2.execFileSync('bash',
+      [`${REPO}/scripts/ticket.sh`, 'get', '--id', String(A.ticket_id)],
+      { encoding: 'utf8', timeout: 15000, env: { ...process.env, BRAND: brand } })
+    const planRef = JSON.parse(ticketJson).plan_ref || ''
+    const branchMatch = planRef.match(/branch=(\S+)/)
+    const planMatch   = planRef.match(/plan=(\S+)/)
+    if (branchMatch && planMatch) {
+      REUSE_BRANCH = branchMatch[1]
+      REUSE_PLAN   = planMatch[1]
+      REUSE = true
+      log(`Auto-detected FACTORY-PLAN-REF on ${A.ticket_id}: branch=${REUSE_BRANCH} plan=${REUSE_PLAN} — skipping Scout/Design/Plan-creation`)
+    }
+  } catch (e) {
+    log(`FACTORY-PLAN-REF auto-detect failed for ${A.ticket_id} (non-fatal): ${e.message}`)
+  }
+}
+
 const WORK_BRANCH = REUSE ? REUSE_BRANCH : `feature/${slug}`
 const WORK_WT = REUSE ? `${REPO}/.worktrees/${slug}-reuse` : WT
 


### PR DESCRIPTION
## Summary
- **Fix 1**: `pipeline.js` now auto-detects `FACTORY-PLAN-REF` on tickets when the dispatcher doesn't pass `branch`/`plan_path`. This means plans staged by `dev-flow-plan` or `opencode-flow-plan` are no longer silently ignored — Scout/Design/Plan-creation are skipped as expected.
- **Fix 2**: `opencode-flow-plan` now creates the ticket **before** plan writing (Step A.5) instead of after (Step 4). This eliminates the crash window where a plan exists but isn't linked to a ticket.

## Test Plan
- [ ] Run `factory:trigger` with a ticket that has a `FACTORY-PLAN-REF` comment but no explicit `--branch`/`--plan-path` args — pipeline should skip Scout/Design/Plan
- [ ] Run `opencode-flow-plan` end-to-end — ticket should be created before plan writing, `stage_plan` called immediately after quality gate