### PR TITLE
chore(openspec): fix stale plan_staged status on shipped changes

### DIFF
--- a/openspec/changes/agent-guide-harness-badge/tasks.md
+++ b/openspec/changes/agent-guide-harness-badge/tasks.md
@@ -2,7 +2,7 @@
 title: "agent-guide-harness-badge — Implementation Plan"
 ticket_id: T001612
 domains: [website, sidekick]
-status: plan_staged
+status: archived
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/agent-model-slots/tasks.md
+++ b/openspec/changes/agent-model-slots/tasks.md
@@ -2,7 +2,7 @@
 title: agent-model-slots
 ticket_id: T001733
 domains: [factory, website, database, tooling]
-status: plan_staged
+status: archived
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/hermes-agent-mcp-access/tasks.md
+++ b/openspec/changes/hermes-agent-mcp-access/tasks.md
@@ -2,7 +2,7 @@
 title: "hermes-agent-mcp-access — Implementation Plan"
 ticket_id: T001609
 domains: [infra, tooling, tests]
-status: plan_staged
+status: archived
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/t001556-size02-refactor/proposal.md
+++ b/openspec/changes/t001556-size02-refactor/proposal.md
@@ -1,7 +1,7 @@
 ---
 title: "G-SIZE02: Großdateien außerhalb Gate-Scope — Refactoring"
 ticket_id: T001556
-status: plan_staged
+status: archived
 created_at: 2026-07-08T14:30:00Z
 ---
 

--- a/openspec/changes/t001556-size02-refactor/tasks.md
+++ b/openspec/changes/t001556-size02-refactor/tasks.md
@@ -1,7 +1,7 @@
 ---
 title: "G-SIZE02: Großdateien außerhalb Gate-Scope — Refactoring (17 → ≤ 8)"
 ticket_id: T001556
-status: planning
+status: archived
 created_at: 2026-07-08
 domains: [ci, code-quality]
 ---

--- a/openspec/changes/t001748-e2e-page-load-fix/tasks.md
+++ b/openspec/changes/t001748-e2e-page-load-fix/tasks.md
@@ -2,7 +2,7 @@
 title: "t001748-e2e-page-load-fix — Implementation Plan"
 ticket_id: T001748
 domains: [tests, website]
-status: plan_staged
+status: archived
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/t001803-pocket-id-dns/tasks.md
+++ b/openspec/changes/t001803-pocket-id-dns/tasks.md
@@ -2,7 +2,7 @@
 title: "t001803-pocket-id-dns — Implementation Plan"
 ticket_id: T001803
 domains: [infra, auth]
-status: plan_staged
+status: archived
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/website-db-decouple/tasks.md
+++ b/openspec/changes/website-db-decouple/tasks.md
@@ -2,7 +2,7 @@
 title: "website-db-decouple — Implementation Plan"
 ticket_id: T001490
 domains: [website, infra]
-status: plan_staged
+status: archived
 file_locks:
   - Taskfile.yml
   - environments/schema.yaml


### PR DESCRIPTION
## Summary
- Sieben openspec-Changes zeigten noch `status: plan_staged`/`planning` in `tasks.md`/`proposal.md`, obwohl das jeweilige DB-Ticket bereits `archived` ist und der Code längst gemerged/deployed wurde (agent-guide-harness-badge [T001612], agent-model-slots [T001733], hermes-agent-mcp-access [T001609], t001556-size02-refactor [T001556], t001748-e2e-page-load-fix [T001748], t001803-pocket-id-dns [T001803], website-db-decouple [T001490]).
- Status-Frontmatter auf `archived` korrigiert, damit `scripts/plan-context.sh` sie nicht mehr fälschlich als aktive/staged Pläne meldet.
- Bewusst NICHT gemacht: Ordner nach `openspec/changes/archive/` verschieben + Deltas per `task openspec:archive` in die SSOT mergen — das Script verlangt Ticket-Status `done` (nicht `archived`) und hätte abgebrochen; ein Umgehen dieser Sperre hätte riskiert, Spec-Deltas doppelt zu mergen. Reiner Doku-Drift-Fix, keine Verhaltensänderung.

## Test Plan
- [x] `git diff origin/main` vor Commit geprüft — nur die 8 Status-Zeilen weichen ab
- [x] `task quality:check` lief beim Push (0 blocking violations)
- [ ] CI grün abwarten