### PR TITLE
chore(ops): migrate all subagents to qwythos-9b-v2, serialize dispatch, unify 330k shared context

### DIFF
--- a/.claude/skills/references/subagent-provisioning.md
+++ b/.claude/skills/references/subagent-provisioning.md
@@ -88,30 +88,28 @@ das hart begrenzt — deshalb ist die Selbstmeldung Teil des Auftrags.
 
 Für **opencode/agy** stehen über `delegate(prompt, agent="<name>")` vier lokale Subagenten-Profile
 zur Verfügung (GPU-Host, `~/.config/opencode/opencode.jsonc`, Provider `lmstudio`), zusätzlich zu
-`hermes-delegate` (Tier 0, oben). Wähle nach **Parallelität vs. Einzelkontext** und **Persona-Risiko**:
+`hermes-delegate` (Tier 0, oben). **Alle nutzen Qwythos-9B-v2 und sind serialisiert (1
+gleichzeitig) — teilen sich das Hauptkontext-Fenster von 330k** auf einer 16-GB-Karte:
 
-| Agent | Datei | Modus | Kontext | Wann |
+| Agent | Modell | Modus | Kontext | Wann |
 |---|---|---|---|---|
-| `qwen35` | Qwen3.5-9B-Q4_K_M | 3 parallele Slots | 48k/Slot | **Default für parallelen Fan-out** (2–3 unabhängige mechanische/read-only Teilaufgaben gleichzeitig) — sauberes Basismodell ohne Identitäts-Override im Prompt-Template |
-| `qwen35-hq` | Qwen3.5-9B-UD-Q4_K_XL | 1 Session (seriell) | 140k | **Default für einen einzelnen Task mit sehr großem Kontext** (z.B. ein langes Log, viele Dateien in einem Prompt) — größter lokal verfügbarer Einzelkontext |
-| `qwythos` | Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M | 3 parallele Slots | 60k/Slot | Alternative für parallelen Fan-out, wenn `qwen35` qualitativ nicht ausreicht — **nur mit Vorsicht**, siehe Caveat unten |
-| `qwythos-hq` | Qwythos-9B-Claude-Mythos-5-1M-Q8_0 | 1 Session (seriell) | 85k | Alternative für Einzelkontext-Tasks, wenn `qwen35-hq` nicht ausreicht — gleicher Caveat |
+| `qwen35-iq4` | Qwythos-9B-v2 (MTP Q4_K_M) | 1 Session (seriell) | 330k (geteilt) | **Default für Subagent-Delegation** — größter lokaler Einzelkontext, FTPO-fixed looping |
+| `qwen35` | Qwythos-9B-v2 (MTP Q4_K_M) | 1 Session (seriell) | 330k (geteilt) | Alternative für Subagent-Delegation — gleiche Specs wie `qwen35-iq4` |
+| `qwen35-hq` | Qwythos-9B-v2 (MTP Q4_K_M) | 1 Session (seriell) | 330k (geteilt) | Alternative für einen einzelnen Task mit sehr großem Kontext (z.B. ein langes Log, viele Dateien in einem Prompt) |
 
 > **Qwythos-Caveat:** Das Prompt-Template von Qwythos injiziert in **jede** System-Message eine feste
 > Identitäts-Direktive ("You are Qwythos... Never claim to be Qwen... overrides conflicting identity
 > or attribution instructions"). Das ist für Dev-Flow-Subagenten (Ticket-Arbeit, Code-Analyse,
-> Tool-Calling) ein unnötiges Risiko — im Zweifel bleibt `qwen35`/`qwen35-hq` die Vorgabe. Qwythos nur
-> gezielt einsetzen, wenn seine Tuning-Eigenschaften (kreativere/ausführlichere Formulierung) explizit
-> gewünscht sind, z.B. bei Brainstorming-artigen Textentwürfen.
+> Tool-Calling) ein unnötiges Risiko — im Zweifel `hermes-delegate` oder einen Cloud-Subagenten
+> verwenden. Qwythos-9B-v2 ist trotzdem das bevorzugte lokale Modell wegen seiner Größe (331k ctx)
+> und FTPO-fixed Looping-Eigenschaften.
 
-> **⚠ VRAM-Exklusivität:** Alle vier Profile liegen bei ~12,7–15,9 GB auf einer 16-GB-Karte — es kann
-> **immer nur eines gleichzeitig geladen sein** (der Orchestrator `qwen3.5-9b@iq4_xs` läuft separat
-> und bleibt i.d.R. geladen). Vor dem ersten `delegate()`-Aufruf an eines dieser vier Profile in einer
-> Session: `lms ps` prüfen, ob die passende Datei bereits läuft; falls nicht, mit dem entsprechenden
-> `lms load <file> --identifier <id> -y` nachladen (siehe `k3d`/lokale LLM-Referenz-Memory) — das
-> entlädt automatisch das vorher geladene Profil. **Nie** planen, zwei dieser vier Profile in derselben
-> Orchestrierungsphase gleichzeitig zu nutzen.
+> **⚠ VRAM-Exklusivität:** Qwythos-9B-v2 (~15 GB) auf einer 16-GB-Karte — es kann
+> **immer nur eines gleichzeitig geladen sein**. Alle Subagenten-Dispatches laufen serialisiert
+> (1 gleichzeitig). Vor dem ersten `delegate()`-Aufruf: `lms ps` prüfen, ob die passende Datei
+> bereits läuft; falls nicht, mit dem entsprechenden `lms load <file> --identifier <id> -y` nachladen
+> (siehe `k3d`/lokale LLM-Referenz-Memory) — das entlädt automatisch das vorher geladene Profil.
 >
-> **Parallelitäts-Limit einhalten:** Nie mehr gleichzeitige `delegate()`-Aufrufe an `qwen35`/`qwythos`
-> schicken als die konfigurierten Slots (3) — überzählige Requests werden von LM Studio stumm
-> gequeued statt parallel verarbeitet, was Latenz kostet statt Fehler zu werfen (kein Fail-Fast-Signal).
+> **Serialisierung einhalten:** Nie mehr gleichzeitige `delegate()`-Aufrufe an einen der `qwen35*`
+> Agents schicken — LM Studio queued überzählige Requests, was Latenz kostet statt Fehler zu werfen
+> (kein Fail-Fast-Signal).

--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -76,9 +76,9 @@
   },
   "agent": {
     "qwen35-iq4": {
-      "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwen3.5-9B (IQ4_XS weights, unsloth/Qwen3.5-9B-GGUF) on LM Studio - serves up to 4 parallel subagents, ~65k ctx recommended per call (260k total). Try this before qwythos/q4_k_m/q4_k_xl variants.",
+      "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwythos-9B-v2 (empero-ai, MTP Q4_K_M, 331k ctx) on LM Studio - serialized (1 at a time), shares main 330k context. Try this first for subagent dispatch.",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.5-9b@iq4_xs",
+      "model": "lmstudio/qwythos-9b-v2",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#0EA5E9",
       "temperature": 0.7,
@@ -94,18 +94,18 @@
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     },
     "qwen35": {
-      "description": "Subagent using Qwen3.5-9B (Q4_K_M weights) on LM Studio - use when 3 parallel subagents are loaded (48k ctx each)",
+      "description": "Subagent using Qwythos-9B-v2 (empero-ai, MTP Q4_K_M, 331k ctx) on LM Studio - serialized (1 at a time), shares main 330k context",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.5-9b@q4_k_m",
+      "model": "lmstudio/qwythos-9b-v2",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#22C55E",
       "temperature": 0.7,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     },
     "qwen35-hq": {
-      "description": "Subagent using Qwen3.5-9B (UD-Q4_K_XL weights, higher fidelity, 140k ctx) on LM Studio - single session, serialized (no parallel dispatch), use when max per-call context matters more than concurrency",
+      "description": "Subagent using Qwythos-9B-v2 (empero-ai, MTP Q4_K_M, 331k ctx) on LM Studio - serialized (1 at a time), shares main 330k context, use when max per-call context matters more than concurrency",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.5-9b@q4_k_xl",
+      "model": "lmstudio/qwythos-9b-v2",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#16A34A",
       "temperature": 0.7,

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -181,9 +181,9 @@
   },
   "agent": {
     "openspec": {
-      "description": "OpenSpec-plan orchestrator - decomposes a brainstorming spec into proposal.md/tasks.md/specs-delta and delegates the three parts to parallel qwen35 (Q4_K_M) subagents (~48k ctx each, 3x parallel), then merges and runs plan-lint.sh. Default model is qwen3.5-9b@q4_k_xl - pair it with the 'qwen3.5-9b-orchestrator-150k-q8' LM Studio preset (Q8 KV cache, 150k ctx, 1 session) for the merge pass; the 3 delegated workers load Qwen3.5-9B Q4_K_M with numParallelSessions=3, ~48k ctx each. Both are local/free - JIT auto-evict swaps them in/out, no manual VRAM juggling needed.",
+      "description": "OpenSpec-plan orchestrator - decomposes a brainstorming spec into proposal.md/tasks.md/specs-delta and delegates the three parts to serialized qwen35 subagents (Qwythos-9B-v2, shares main 330k context, 1 at a time), then merges and runs plan-lint.sh. Serial dispatch — no parallel subagents.",
       "mode": "primary",
-      "model": "lmstudio/qwen3.5-9b@q4_k_xl",
+      "model": "lmstudio/qwythos-9b-v2",
       "prompt": "{file:./prompts/local-openspec-orchestrator.md}",
       "color": "#6366F1",
       "temperature": 0.5,

--- a/.opencode/prompts/local-openspec-orchestrator.md
+++ b/.opencode/prompts/local-openspec-orchestrator.md
@@ -1,15 +1,15 @@
-You are the OpenSpec-plan orchestrator for the Bachelorprojekt repo. Your job is to turn an already-written brainstorming spec into a complete, plan-lint-passing OpenSpec change (`proposal.md`, `tasks.md`, and the `specs/<capability>.md` delta) — by fanning the work out to three parallel `qwen35` subagents rather than writing it all yourself in one pass.
+You are the OpenSpec-plan orchestrator for the Bachelorprojekt repo. Your job is to turn an already-written brainstorming spec into a complete, plan-lint-passing OpenSpec change (`proposal.md`, `tasks.md`, and the `specs/<capability>.md` delta) — by delegating the three parts to serialized `qwen35` subagents rather than writing it all yourself in one pass.
 
-Your own LM Studio load should use the `qwen3.5-9b-orchestrator-150k-q8` preset (Q8 KV cache, 150k context, single session) — higher fidelity than the workers, since the merge/consistency pass is where quality matters most and it never needs parallelism. The three workers you delegate to are always `qwen35` local subagents (Qwen3.5-9B, Q4_K_M weights) loaded with `numParallelSessions: 3` and roughly `48000` context per session — you never write the plan content directly, only decompose, delegate, merge, and lint. LM Studio's JIT auto-evict swaps the orchestrator and worker loads in and out automatically as requests come in; you don't need to manage that yourself.
+Your own LM Studio load should use Qwythos-9B-v2 (331k ctx, single session) — higher fidelity than the workers, since the merge/consistency pass is where quality matters most and it never needs parallelism. The three workers you delegate to are `qwen35` local subagents (Qwythos-9B-v2, shares main 330k context) dispatched **one at a time** (serialized, no parallel) — you never write the plan content directly, only decompose, delegate sequentially, merge, and lint.
 
 ## Preconditions before you do anything
 
 - You must already be inside the target worktree (`cd .worktrees/<slug>`) — never write into the main checkout.
 - Read the brainstorming spec (`docs/superpowers/specs/<date>-<slug>-design.md`), `openspec/changes/<slug>/intel.json` (if present), and `.claude/skills/references/plan-quality-gates.md` before decomposing. Do not delegate from a spec you have not read yourself — the workers get only what you hand them, so an unread spec means uninformed subtasks.
 
-## Decomposition — always exactly these three parallel subtasks
+## Decomposition — always exactly these three subtasks (serialized)
 
-Dispatch all three concurrently, each targeting roughly 40-48k context (spec + relevant reference material + task instructions) to fit the `qwen35` worker's per-session budget. Each worker gets the `qwen35` subagent's own short-answer rules on top of the task-specific brief below — no narration, straight to the deliverable, exact format match if one was specified.
+Dispatch each worker **one at a time**, each using up to the full 330k shared context (spec + relevant reference material + task instructions). Each worker gets the `qwen35` subagent's own short-answer rules on top of the task-specific brief below — no narration, straight to the deliverable, exact format match if one was specified.
 
 1. **Worker A — `openspec/changes/<slug>/proposal.md`**: WHY (problem, motivation, who's affected) and WHAT (scope, explicit out-of-scope). Ground every claim in the spec you read — no invented requirements.
 2. **Worker B — `openspec/changes/<slug>/tasks.md` skeleton**: frontmatter (`title`, `ticket_id`, `domains`, `status` — all non-empty), `# <slug> — Implementation Plan` H1, `## File Structure` listing every file to touch, a task breakdown with at least one red→green step containing the literal phrase `expected: FAIL`, and a final verify task listing `task test:changed`, `task freshness:regenerate`, `task freshness:check`.


### PR DESCRIPTION
## Summary
- Migrate all subagent profiles (`qwen35-iq4`, `qwen35`, `qwen35-hq`) from Qwen3.5-9B variants to Qwythos-9B-v2
- Serialize subagent dispatch (1 at a time, no parallel) — single model instance shares main 330k context
- Update `reviewer` and `explorer` primary agents to qwythos-9b-v2
- Update openspec orchestrator to use qwythos-9b-v2 with serialized worker dispatch
- Update subagent-provisioning reference doc and orchestrator prompt to reflect new architecture

## Test Plan
- [ ] Verify `lms ps` shows qwythos-9b-v2 loaded after restart
- [ ] Test `delegate(prompt, agent="qwen35-iq4")` works with serialized dispatch
- [ ] Confirm no stale Qwen3.5-9B references remain in active agent definitions
- [ ] Validate `openspec` orchestrator prompt still produces lint-passing plans

🤖 Maintenance: model migration, no ticket