### PR TITLE
fix(scripts): move MAIN_ROOT assignment before submodule fallback [T001815]

### DIFF
--- a/openspec/changes/worktree-main-root-unbound/tasks.md
+++ b/openspec/changes/worktree-main-root-unbound/tasks.md
@@ -1,0 +1,62 @@
+---
+title: "worktree-create.sh: MAIN_ROOT unbound variable im Submodule-Fallback"
+ticket: T001815
+status: plan_staged
+---
+
+# Fix: MAIN_ROOT unbound variable in submodule fallback
+
+## Problem
+
+`scripts/worktree-create.sh` uses `$MAIN_ROOT` in the submodule copy fallback loop (line 157),
+but `MAIN_ROOT` is not defined until line 171. When `git submodule update` fails and the fallback
+runs, the script crashes under `set -u` with `MAIN_ROOT: unbound variable` and rolls back the
+worktree.
+
+## Root Cause
+
+`MAIN_ROOT="$(dirname "$COMMON_DIR")"` is defined at line 171, inside the node_modules symlink
+block (section 3). The submodule fallback (section 2, lines 154-162) references `$MAIN_ROOT` at
+line 157 — before it is assigned.
+
+## Fix
+
+Move `MAIN_ROOT="$(dirname "$COMMON_DIR")"` to immediately before the submodule block (before
+line 153). `COMMON_DIR` is already defined at line 69, so this is safe.
+
+### Before (lines ~153-171)
+
+```bash
+# 2) Init submodules
+git -C "$WT_PATH" submodule update --init --recursive --quiet || {
+    echo "worktree-create: submodule update failed — ..." >&2
+    for sm in tests/unit/lib/bats-core ...; do
+        if [ -d "$MAIN_ROOT/$sm" ]; then   # ← MAIN_ROOT unbound here
+            ...
+        fi
+    done
+}
+
+# 3) node_modules
+MAIN_ROOT="$(dirname "$COMMON_DIR")"        # ← defined too late
+```
+
+### After
+
+```bash
+# Pre-compute MAIN_ROOT (needed by submodule fallback and node_modules symlink)
+MAIN_ROOT="$(dirname "$COMMON_DIR")"
+
+# 2) Init submodules
+git -C "$WT_PATH" submodule update --init --recursive --quiet || {
+    ...  # MAIN_ROOT is now in scope
+}
+
+# 3) node_modules
+if [ -d "$MAIN_ROOT/node_modules" ] ...
+```
+
+## Testing
+
+- Run `task test:changed` (or `bash scripts/worktree-create.sh` with a failing submodule) to verify the fix.
+- No new BATS test needed — the fix is a one-line move.

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -150,6 +150,9 @@ if [ "$BRANCH_EXISTS" -eq 1 ] && [ -f "$KEY_SRC" ]; then
   fi
 fi
 
+# Pre-compute MAIN_ROOT (needed by submodule fallback and node_modules symlink).
+MAIN_ROOT="$(dirname "$COMMON_DIR")"
+
 # 2) Init submodules (git worktree add does NOT; the BATS runner lives in one).
 git -C "$WT_PATH" submodule update --init --recursive --quiet || {
     echo "worktree-create: submodule update failed — attempting local copy fallback" >&2
@@ -168,7 +171,6 @@ git -C "$WT_PATH" submodule update --init --recursive --quiet || {
 #    worktree resolves deps instantly — no 536M reinstall, and the Taskfile's
 #    `[ -d node_modules ] || npm ci` guards short-circuit (avoiding their race
 #    under concurrent test:all). Skipped cleanly if the base has none. [T000526]
-MAIN_ROOT="$(dirname "$COMMON_DIR")"
 if [ -d "$MAIN_ROOT/node_modules" ] && [ ! -e "$WT_PATH/node_modules" ]; then
     ln -s "$MAIN_ROOT/node_modules" "$WT_PATH/node_modules"
     echo "worktree-create: linked node_modules → $MAIN_ROOT/node_modules" >&2


### PR DESCRIPTION
## Problem\n\n`scripts/worktree-create.sh` uses `$MAIN_ROOT` in the submodule copy fallback loop (line 157), but `MAIN_ROOT` is not defined until line 171. When `git submodule update` fails and the fallback runs, the script crashes under `set -u` with `MAIN_ROOT: unbound variable` and rolls back the worktree.\n\n## Fix\n\nMove `MAIN_ROOT="$(dirname "$COMMON_DIR")"` from line 171 to immediately before the submodule block (before line 153). `COMMON_DIR` is already defined at line 69, so this is safe.\n\n## Testing\n\n- `bash -n scripts/worktree-create.sh` — syntax OK\n- `task test:changed` — all tests pass