### PR TITLE
chore(ops): use qwythos-9b-v2 for all TUI agents in opencode [T001827]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -70,6 +70,13 @@
             "context": 150000,
             "output": 8192
           }
+        },
+        "qwythos-9b-v2": {
+          "name": "Qwythos-9B-v2 (empero-ai, MTP Q4_K_M, vision-capable via mmproj, loaded at 331k ctx in LM Studio) — FTPO-fixed looping (6.7%→0%), MTP head restored, replaces qwythos-9b-claude-mythos-5-1m — CAVEAT (T001733): still injects a fixed identity directive into every system message, unverified whether v2 fixed this vs. v1; use with care for tool-calling-heavy work",
+          "limit": {
+            "context": 330000,
+            "output": 8192
+          }
         }
       }
     }
@@ -85,9 +92,9 @@
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     },
     "qwen3-14b": {
-      "description": "Single-session implementation/planning agent: Qwen3-14B (Q4_K_M, lmstudio-community/Qwen3-14B-GGUF) on LM Studio",
+      "description": "Single-session implementation/planning agent: Qwythos-9B-v2 (empero-ai, MTP Q4_K_M, 331k ctx) on LM Studio",
       "mode": "subagent",
-      "model": "lmstudio/qwen3-14b@q4_k_m",
+      "model": "lmstudio/qwythos-9b-v2",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
       "temperature": 0.7,

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "lmstudio/qwen3.5-9b@q4_k_m",
+  "model": "lmstudio/qwythos-9b-v2",
   "permission": {
     "read": "allow",
     "edit": "allow",


### PR DESCRIPTION
Close T001827. Updates opencode agent configurations to use qwythos-9b-v2 for all TUI agents.