### PR TITLE
fix(factory): exclude archive merges from scout drift, fix space-separated touched_files, log sets

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -149,6 +149,12 @@ jobs:
         run: |
           set -euo pipefail
           TICKET_ID="${{ steps.close.outputs.ticket_id }}"
+          # Only feature/fix merges produce meaningful drift — skip chore/docs/archive
+          COMMIT_TITLE="$(git log -1 --pretty=%s)"
+          case "$COMMIT_TITLE" in
+            feat:*|fix:*) ;;
+            *) echo "scout-drift: skipping — not a feature/fix merge ($COMMIT_TITLE)"; exit 0 ;;
+          esac
           mkdir -p "$HOME/.kube"
           echo "$FLEET_KUBECONFIG" | base64 -d > "$HOME/.kube/config"
           chmod 600 "$HOME/.kube/config"

--- a/scripts/factory/scout-drift.sh
+++ b/scripts/factory/scout-drift.sh
@@ -96,4 +96,7 @@ if awk "BEGIN {exit !($drift > $THRESHOLD)}" 2>/dev/null; then
     2>/dev/null || warn "drift warning comment failed (non-fatal)"
 fi
 
+A_joined="$(printf '%s\n' "$A_clean" | jq -r 'join(" ")' 2>/dev/null || echo '(empty)')"
 echo "scout-drift: drift=$drift persisted for $TICKET"
+echo "scout-drift: P=${P_rel[*]:-(empty)}"
+echo "scout-drift: A=$A_joined"

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -262,6 +262,8 @@ cmd_set_touched_files() {
     esac; done
   if [[ -z "$id" || -z "$files" ]]; then echo "ERROR: --id and --files are required." >&2; exit 2; fi
   if _ticket_offline_skip "set-touched-files" "--id" "$id"; then return 0; fi
+  # Normalize any whitespace to commas so both comma- and space-separated input works
+  files="$(printf '%s' "$files" | tr ',' '\n' | tr -s '[:space:]' '\n' | grep -v '^$' | paste -sd ',' -)"
   local pod; pod=$(_pgpod)
   _exec_sql "$pod" -v ext_id="$id" -v files="$files" <<'EOF' >/dev/null
 UPDATE tickets.tickets SET touched_files = string_to_array(:'files', ',') WHERE external_id = :'ext_id';


### PR DESCRIPTION
## Summary

Three fixes for the scout-drift measurement:

1. **post-merge.yml** — skip drift ratchet for chore/docs/archive merges; only `feat:` and `fix:` commits now trigger measurement. Prevents archive merges from overwriting meaningful drift scores with 1.0.

2. **ticket.sh** — `set_touched_files` normalizes whitespace to commas before the SQL `string_to_array`, so space-separated input (from MCP callers) no longer corrupts the DB array into a single element.

3. **scout-drift.sh** — logs the predicted (P) and actual (A) file sets alongside the drift score in workflow output for future debugging.

## Test Plan
- [x] `bash -n` for all 3 edited scripts
- [x] `task test:changed` — all tests pass
- [x] `tests/unit/factory-scout-drift.bats` — 11/11 pass
- [x] `tests/unit/factory-scout-quality.bats` — 5/5 pass