### PR TITLE
fix(factory): forbid Skill-tool hallucination in dispatcher/pipeline prompts [T001843]

### DIFF
--- a/scripts/factory/dispatcher-bridge.sh
+++ b/scripts/factory/dispatcher-bridge.sh
@@ -71,7 +71,10 @@ Invoke the Workflow tool with Workflow({scriptPath:\"scripts/factory/pipeline.js
 slug:\"${slug}\", timestamp:\"${TIMESTAMP}\", dry_run:${dry_run_val}, \
 branch:$(if [[ -n "$branch" ]]; then echo "\"${branch}\""; else echo 'null'; fi), \
 plan_path:$(if [[ -n "$plan_path" ]]; then echo "\"${plan_path}\""; else echo 'null'; fi)}). \
-Report only the pipeline's final JSON result."
+Report only the pipeline's final JSON result. \
+Do NOT call the Skill tool — there is no skill that runs the pipeline; \
+the ONLY correct way to run it is the Workflow tool call described above. \
+If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
 
   "${CLAUDE_BIN:-claude}" -p "$PIPELINE_PROMPT" \
     --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),Bash(bash scripts/vda.sh*),ToolSearch,PushNotification" \

--- a/scripts/factory/run-dispatcher.sh
+++ b/scripts/factory/run-dispatcher.sh
@@ -12,7 +12,10 @@ DRY_RUN="${2:-false}"
 PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
 scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN} }. \
 The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step. \
-Report only the dispatcher's final JSON result. Do not improvise scheduling."
+Report only the dispatcher's final JSON result. Do not improvise scheduling. \
+Do NOT call the Skill tool — there is no 'factory-dispatch' skill or any skill that runs the dispatcher; \
+the ONLY correct way to run it is the Workflow tool call described above. \
+If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
 exec claude -p "${PROMPT}" \
   --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),ToolSearch,PushNotification" \
   --dangerously-skip-permissions

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -113,7 +113,10 @@ scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}',
 Pass prep_file through verbatim — do not alter, re-run, or improvise it. \
 The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step \
 (already evaluated into prep_file by this wrapper). \
-Report only the dispatcher's final JSON result. Do not improvise scheduling."
+Report only the dispatcher's final JSON result. Do not improvise scheduling. \
+Do NOT call the Skill tool — there is no 'factory-dispatch' skill or any skill that runs the dispatcher; \
+the ONLY correct way to run it is the Workflow tool call described above. \
+If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
 
   echo "wakeup.sh: starting tick #${TICK} at ${TIMESTAMP}" >&2
 


### PR DESCRIPTION
## Summary
- `qwythos-9b-v2` (local LM Studio autopilot backend, T001837) was observed live hallucinating a nonexistent `factory-dispatch` skill instead of calling the `Workflow` tool as instructed, then retrying the identical failing call ~180 times before self-recovering via an improvised `eval()` workaround — confirmed via the LM Studio server log (2026-07-15 00:4x–00:55).
- `--allowedTools` did not hard-block the `Skill` call (it's not in the allowlist, but the model got `Unknown skill: factory-dispatch` back instead of a permission denial), so the reliable fix is an explicit prompt clause.
- Added to all three dispatcher/pipeline prompt-builders (`wakeup.sh`, `run-dispatcher.sh`, `dispatcher-bridge.sh`): forbid the `Skill` tool by name, and forbid retrying an identical failing tool call.

## Test plan
- [x] `task quality:check` — 0 new/worsened violations
- [ ] Next `factory.timer` tick runs clean (no `Unknown skill: factory-dispatch` in the LM Studio server log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqEjYM7YTcJGWRCBcTE9JL