### PR TITLE
fix(factory): reinforce Workflow/scriptPath prompt + retry-on-refusal [T001843]

### DIFF
--- a/scripts/factory/dispatcher-bridge.sh
+++ b/scripts/factory/dispatcher-bridge.sh
@@ -66,14 +66,17 @@ for row in $(echo "$prep" | jq -c '.launch[]' 2>/dev/null); do
   # only the Workflow() meta-tool was problematic.
   TIMESTAMP="$(date -u +%FT%TZ)"
   PIPELINE_PROMPT="Run the Software Factory pipeline for ticket ${ext_id} (${title}). \
-Invoke the Workflow tool with Workflow({scriptPath:\"scripts/factory/pipeline.js\"}, \
+Call the Workflow tool exactly like this — the scriptPath option IS supported and this is \
+the standard, working way to run it: \
+Workflow({scriptPath:\"scripts/factory/pipeline.js\"}, \
 {title:\"${title}\", ticket_id:\"${ext_id}\", brand:\"${brand}\", \
 slug:\"${slug}\", timestamp:\"${TIMESTAMP}\", dry_run:${dry_run_val}, \
 branch:$(if [[ -n "$branch" ]]; then echo "\"${branch}\""; else echo 'null'; fi), \
 plan_path:$(if [[ -n "$plan_path" ]]; then echo "\"${plan_path}\""; else echo 'null'; fi)}). \
 Report only the pipeline's final JSON result. \
 Do NOT call the Skill tool — there is no skill that runs the pipeline; \
-the ONLY correct way to run it is the Workflow tool call described above. \
+the ONLY correct way to run it is the exact Workflow tool call shown above. \
+Do NOT refuse or claim scriptPath is unsupported — it is supported; if you believe otherwise, call it anyway. \
 If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
 
   "${CLAUDE_BIN:-claude}" -p "$PIPELINE_PROMPT" \

--- a/scripts/factory/run-dispatcher.sh
+++ b/scripts/factory/run-dispatcher.sh
@@ -9,12 +9,15 @@ REPO="${FACTORY_REPO:-/home/patrick/Bachelorprojekt}"
 cd "${REPO}"
 TIMESTAMP="${1:-$(date -u +%FT%TZ)}"
 DRY_RUN="${2:-false}"
-PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
-scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN} }. \
+PROMPT="Run the Software Factory dispatcher now. Call the Workflow tool exactly like this — \
+the scriptPath option IS supported and this is the standard, working way to run it \
+(the same pattern is used successfully every tick for pipeline.js launches): \
+Workflow({scriptPath: 'scripts/factory/dispatcher.js'}, { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN} }). \
 The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step. \
 Report only the dispatcher's final JSON result. Do not improvise scheduling. \
 Do NOT call the Skill tool — there is no 'factory-dispatch' skill or any skill that runs the dispatcher; \
-the ONLY correct way to run it is the Workflow tool call described above. \
+the ONLY correct way to run it is the exact Workflow tool call shown above. \
+Do NOT refuse or claim scriptPath is unsupported — it is supported; if you believe otherwise, call it anyway. \
 If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
 exec claude -p "${PROMPT}" \
   --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),ToolSearch,PushNotification" \

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -108,14 +108,17 @@ while true; do
 
   DISPATCHER_BRIDGE="${REPO}/scripts/factory/dispatcher-bridge.sh"
 
-  PROMPT="Run the Software Factory dispatcher now. Invoke the Workflow tool with \
-scriptPath 'scripts/factory/dispatcher.js' and args { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN}, prep_file: '${PREP_FILE}' }. \
+  PROMPT="Run the Software Factory dispatcher now. Call the Workflow tool exactly like this — \
+the scriptPath option IS supported and this is the standard, working way to run it \
+(the same pattern is used successfully every tick for pipeline.js launches): \
+Workflow({scriptPath: 'scripts/factory/dispatcher.js'}, { timestamp: '${TIMESTAMP}', dry_run: ${DRY_RUN}, prep_file: '${PREP_FILE}' }). \
 Pass prep_file through verbatim — do not alter, re-run, or improvise it. \
 The dispatcher reads all guards (kill-switch, daily-cap, dry-run-first) fresh per brand inside its PREP step \
 (already evaluated into prep_file by this wrapper). \
 Report only the dispatcher's final JSON result. Do not improvise scheduling. \
 Do NOT call the Skill tool — there is no 'factory-dispatch' skill or any skill that runs the dispatcher; \
-the ONLY correct way to run it is the Workflow tool call described above. \
+the ONLY correct way to run it is the exact Workflow tool call shown above. \
+Do NOT refuse or claim scriptPath is unsupported — it is supported; if you believe otherwise, call it anyway. \
 If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
 
   echo "wakeup.sh: starting tick #${TICK} at ${TIMESTAMP}" >&2
@@ -162,11 +165,31 @@ If a tool call fails, do not retry the identical call — stop and report the er
   # T001805: PR-CI-Babysitter — repo-weit, brand-agnostisch, best-effort.
   bash "${REPO}/scripts/factory/babysit-prs.sh" 2>&1 \
     | sed 's/^/[babysit] /' >&2 || true
-  "${CLAUDE_BIN}" -p "${PROMPT}" \
-    --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),Bash(bash scripts/vda.sh*),ToolSearch,PushNotification" \
-    --permission-mode acceptEdits
-  TICK_EXIT=$?
-  rm -f "${PREP_FILE}"
+  # T001843 follow-up: weak local models occasionally refuse the Workflow/scriptPath
+  # call outright, wrongly claiming it's unsupported (exit 0, but nothing dispatched).
+  # Detect that refusal from the transcript and retry ONCE with a reinforced prompt
+  # instead of silently treating the no-op tick as success.
+  CLAUDE_OUT="$(mktemp /tmp/factory-tick-out.XXXXXX)"
+  REFUSAL_RETRIED=0
+  RUN_PROMPT="${PROMPT}"
+  while true; do
+    set +e
+    "${CLAUDE_BIN}" -p "${RUN_PROMPT}" \
+      --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),Bash(bash scripts/vda.sh*),ToolSearch,PushNotification" \
+      --permission-mode acceptEdits | tee "${CLAUDE_OUT}"
+    TICK_EXIT=${PIPESTATUS[0]}
+    set -e
+
+    if [[ ${TICK_EXIT} -eq 0 && ${REFUSAL_RETRIED} -eq 0 ]] \
+       && grep -qiE "cannot proceed|isn't possible|does(n't| not) support|unable to (invoke|call) the workflow|scriptPath is unsupported" "${CLAUDE_OUT}"; then
+      echo "wakeup.sh: tick #${TICK} refused the Workflow scriptPath call — retrying once with reinforced prompt" >&2
+      REFUSAL_RETRIED=1
+      RUN_PROMPT="${PROMPT} REMINDER: you already refused this exact call once claiming scriptPath is unsupported — that claim is false. Call Workflow({scriptPath: 'scripts/factory/dispatcher.js'}, ...) now; do not refuse again."
+      continue
+    fi
+    break
+  done
+  rm -f "${CLAUDE_OUT}" "${PREP_FILE}"
 
   if [[ ${TICK_EXIT} -ne 0 ]]; then
     echo "wakeup.sh: tick #${TICK} exited with code ${TICK_EXIT} — stopping loop" >&2


### PR DESCRIPTION
## Summary
- Follow-up to #2818 (Skill-hallucination loop fix). The very next live tick after that merge (2026-07-15 01:26 CEST) hit a **new** failure mode: `qwythos-9b-v2` outright **refused** to call `Workflow({scriptPath: ...})`, wrongly claiming `scriptPath` is unsupported, and exited 0 having dispatched nothing that tick.
- All three dispatcher/pipeline prompts (`wakeup.sh`, `run-dispatcher.sh`, `dispatcher-bridge.sh`) now show the **exact working call** as a concrete example (few-shot beats prose for this model) and explicitly assert `scriptPath` is supported and must not be refused.
- `wakeup.sh` now captures the `claude -p` transcript and greps for refusal phrasing. On a false-refusal with exit 0, it retries the **same tick once** with a reinforced prompt instead of silently treating a no-op tick as a successful one.

## Test plan
- [x] `bats tests/local/FA-SF-41-wakeup.bats` — 25/25
- [x] `bats tests/local/FA-SF-47-wakeup-reasoning-effort.bats` — 4/4
- [x] `bats tests/local/FA-SF-30-dispatcher-contract.bats` — 16/16
- [x] `task quality:check` — 0 new/worsened violations
- [ ] Next `factory.timer` tick actually dispatches (no refusal, no `Unknown skill`, in the LM Studio server log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqEjYM7YTcJGWRCBcTE9JL