### PR TITLE
fix(factory): watchdog resumes staged plans instead of restarting from triage [T001850]

### DIFF
--- a/docs/superpowers/specs/2026-07-15-dispatcher-bridge-pipeline-orphan-design.md
+++ b/docs/superpowers/specs/2026-07-15-dispatcher-bridge-pipeline-orphan-design.md
@@ -1,0 +1,71 @@
+---
+ticket_id: T001850
+plan_ref: null
+domains: [factory]
+status: draft
+---
+
+# dispatcher-bridge-pipeline-orphan — Root-Cause Spec
+
+## Problem / Root Cause
+
+Beobachtet 2026-07-15 an T001828/T001830/T001839 (G-GIT03/G-DB01/G-DB10): jedes Ticket
+durchlief zweimal denselben Zyklus — `dev-flow-plan` staged einen Plan (Commit
+`chore(plans): stage ...`, `FACTORY-PLAN-REF`-Kommentar), danach 30+ Minuten keine weitere
+Phase-Progress-Schreibung, dann `watchdog.sh`: *"pipeline stale > 30min ... Returned to queue
+(triage); slot released."* Anschließend re-staged `dev-flow-plan` denselben Plan erneut —
+Implement/Verify/Deploy wird nie erreicht.
+
+`pipeline.js` (Zeile ~108-123) hat bereits eine **Resume-Erkennung**: fehlt `A.branch`/
+`A.plan_path`, liest es das `FACTORY-PLAN-REF` vom Ticket, setzt `REUSE=true` und überspringt
+Scout/Design/Plan — genau das Verhalten, das ein hängengebliebenes Ticket bräuchte, um direkt
+bei Implement fortzusetzen.
+
+**Der eigentliche Bug liegt nicht in `pipeline.js`, sondern in `watchdog.sh`:** Es setzt JEDE
+stale `in_progress`-Ticket unbedingt auf `status='triage'` zurück (`watchdog.sh:19`) —
+unabhängig davon, ob bereits ein `FACTORY-PLAN-REF`-Kommentar (= fertiger, committeter Plan)
+existiert. `triage` ist aber kein Status, den `dispatcher-bridge.sh`/`queue.sh` dispatcht
+(`queue.sh` verlangt `status='backlog'` für Features) — das Ticket verlässt die automatisierte
+Pipeline komplett und wird nur durch einen erneuten, manuellen/eigenständigen
+`dev-flow-plan`-Lauf wieder aufgegriffen, der bei Null neu plant statt `pipeline.js`s
+eingebaute Resume-Fähigkeit zu nutzen.
+
+(Die tiefere Frage, WARUM die Phase nach dem Plan-Stage-Commit überhaupt hängen bleibt —
+vermutlich derselbe Orphaned-Workflow-Effekt wie beim äußeren Dispatcher-Call, T001808-10,
+jetzt beim inneren `Workflow({scriptPath:'scripts/factory/pipeline.js'},...)`-Aufruf in
+`dispatcher-bridge.sh` — bleibt ungelöst, da sie im Closed-Source-Harness liegt und nicht
+deterministisch reproduzierbar ist. Dieser Fix behebt stattdessen die **Konsequenz**: die
+Watchdog-Reaktion darf schon vorhandene Planungsarbeit nicht wegwerfen.)
+
+## Fix-Ansatz
+
+`watchdog.sh` prüft vor dem Reset, ob `ticket.sh get --id <ext_id>` ein nicht-leeres
+`.plan_ref` liefert (identische Quelle wie `pipeline.js`s Auto-Detect: neuester
+`FACTORY-PLAN-REF %`-Kommentar):
+
+- **`plan_ref` vorhanden** (Plan bereits gestaged) → Reset-Ziel `status='backlog'` statt
+  `triage`. Für `type='feature'` erfüllt das direkt `queue.sh`s Gate (der Ticket war beim
+  ursprünglichen Dispatch bereits `lastenheft_locked=true`, das Flag bleibt unangetastet) —
+  der nächste Dispatcher-Tick claimed erneut einen Slot und `pipeline.js` erkennt
+  `FACTORY-PLAN-REF` automatisch, überspringt Scout/Design/Plan und fährt bei Implement fort.
+  Kommentar-Text ändert sich entsprechend ("plan already staged — resuming via backlog"
+  statt "Returned to queue (triage)").
+- **kein `plan_ref`** (noch nie geplant) → unverändertes Verhalten: `status='triage'`.
+
+Kein Eingriff in `pipeline.js` oder `dispatcher-bridge.sh` nötig — die Resume-Logik existiert
+bereits, sie wird nur nie erreicht, weil der Watchdog vorher den falschen Status setzt.
+
+## Betroffene Subsysteme
+
+- `scripts/factory/watchdog.sh` — Reset-Zielstatus konditional auf `plan_ref`.
+- `tests/local/FA-SF-26-watchdog.bats` — neuer Testfall: stale Ticket MIT `FACTORY-PLAN-REF`
+  landet auf `backlog`, nicht `triage`; bestehender Testfall (ohne Plan) bleibt `triage`.
+
+## Edge Cases
+
+- Ticket mit `FACTORY-PLAN-REF`, aber `lastenheft_locked` nie gesetzt (z. B. `type='task'`
+  ohne Lock-Konzept) → `type='task' AND status='plan_staged'` ist der bestehende Dispatch-Pfad
+  in `queue.sh`; für `task`-Tickets ist `plan_staged` (nicht `backlog`) das korrekte
+  Reset-Ziel bei vorhandenem `plan_ref`. Der Fix unterscheidet daher nach `type`.
+- Mehrere `FACTORY-PLAN-REF`-Kommentare (re-staged) → `ticket.sh get` nimmt bereits den
+  neuesten (`ORDER BY created_at DESC LIMIT 1` in `get.sh`), unverändert übernommen.

--- a/openspec/changes/dispatcher-bridge-pipeline-orphan/proposal.md
+++ b/openspec/changes/dispatcher-bridge-pipeline-orphan/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: dispatcher-bridge-pipeline-orphan
+
+## Why
+
+T001828/T001830/T001839 hingen 2026-07-15 zweimal hintereinander in derselben Schleife:
+`dev-flow-plan` staged einen Plan, danach 30+ Minuten kein Fortschritt, `watchdog.sh` setzt
+den Status unbedingt auf `triage` zurück, ein neuer `dev-flow-plan`-Lauf staged denselben
+Plan erneut — Implement/Verify/Deploy wird nie erreicht. `pipeline.js` hat bereits eine
+eingebaute Resume-Erkennung (`FACTORY-PLAN-REF`-Auto-Detect, Zeile ~111-123), die
+Scout/Design/Plan überspringt, sobald ein Plan schon existiert — sie wird aber nie erreicht,
+weil `watchdog.sh` das Ticket vorher aus dem Dispatch-fähigen Status (`backlog`/`plan_staged`)
+in `triage` wirft, wo es kein automatisierter Pfad mehr aufgreift.
+
+## What
+
+`watchdog.sh` prüft vor dem Reset eines stale `in_progress`-Tickets, ob bereits ein
+`FACTORY-PLAN-REF`-Kommentar existiert (`ticket.sh get --id <id> | jq -r '.plan_ref'`):
+
+- Kein Plan vorhanden → `status=triage` (unverändert).
+- Plan vorhanden, `type=feature` → `status=backlog` (re-qualifiziert sich sofort für
+  `queue.sh`s Dispatch-Gate; `lastenheft_locked` bleibt unangetastet).
+- Plan vorhanden, `type=task` → `status=plan_staged` (matcht `queue.sh`s bestehenden
+  Task-Pfad).
+
+Kein Eingriff in `pipeline.js` oder `dispatcher-bridge.sh` nötig — deren Resume-Logik
+existiert bereits und wird durch diesen Fix erstmals erreichbar.
+
+## Out of Scope
+
+- Die tiefere Ursache, warum die Pipeline nach dem Plan-Stage-Commit überhaupt hängen bleibt
+  (vermuteter Orphaned-Workflow-Effekt im Closed-Source-Harness, analog T001808-10, jetzt beim
+  inneren `Workflow(pipeline.js)`-Call in `dispatcher-bridge.sh`) — nicht deterministisch
+  reproduzierbar, daher kein Fix-Ziel dieses Changes. Dieser Change behebt die Konsequenz
+  (weggeworfene Planungsarbeit), nicht die harness-seitige Ursache.

--- a/openspec/changes/dispatcher-bridge-pipeline-orphan/specs/software-factory.md
+++ b/openspec/changes/dispatcher-bridge-pipeline-orphan/specs/software-factory.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Watchdog-Eskalation und Zombie-Cleanup
+
+The system SHALL pro Tick stale `in_progress`-Tickets (kein `updated_at`-Update seit
+`FACTORY_STALE_MIN` Minuten, Default 30) prüfen, ob bereits ein `FACTORY-PLAN-REF`-Kommentar
+(`plan_ref` via `ticket.sh get`) existiert, und den Slot in jedem Fall freigeben sowie den
+verwaisten Worktree entfernen:
+
+- Existiert **kein** `plan_ref` (noch nie geplant), setzt das System den Status auf `triage`
+  zurück (unverändertes Verhalten).
+- Existiert bereits ein `plan_ref` und `type='feature'`, setzt das System den Status auf
+  `backlog` zurück, statt die bereits geleistete Planungsarbeit über `triage` zu verwerfen —
+  das Ticket re-qualifiziert sich direkt für `queue.sh`s Dispatch-Gate (bleibt
+  `lastenheft_locked`) und `pipeline.js` erkennt `FACTORY-PLAN-REF` beim nächsten Dispatch
+  automatisch, überspringt Scout/Design/Plan und setzt bei Implement fort.
+- Existiert bereits ein `plan_ref` und `type='task'`, setzt das System den Status auf
+  `plan_staged` zurück (matcht `queue.sh`s bestehenden Task-Dispatch-Pfad).
+
+`awaiting_deploy`-Features ohne Deployment seit `FACTORY_AD_STALE_H` Stunden (Default 24)
+werden mit `attention_mode=needs_human` markiert und erhalten einen Warn-Kommentar
+(unverändert).
+
+#### Scenario: Hung Pipeline ohne gestagten Plan (kein Phase-Heartbeat)
+- **GIVEN** Ticket T000503 ist seit 35 Minuten `in_progress` ohne `ticket.sh touch`-Update
+  und ohne `FACTORY-PLAN-REF`-Kommentar
+- **WHEN** `watchdog.sh` ausgeführt wird (FACTORY_STALE_MIN=30)
+- **THEN** T000503 erhält `status=triage`; `pipeline_slot=NULL`; ein Kommentar wird hinzugefügt; der Worktree `/tmp/wt-sf-t000503` wird entfernt
+
+#### Scenario: Hung Pipeline MIT bereits gestagtem Plan (Feature)
+- **GIVEN** Ticket T001828 (`type=feature`) ist seit 50 Minuten `in_progress` ohne
+  `ticket.sh touch`-Update, trägt aber einen `FACTORY-PLAN-REF`-Kommentar von einem
+  abgeschlossenen `dev-flow-plan`-Lauf
+- **WHEN** `watchdog.sh` ausgeführt wird (FACTORY_STALE_MIN=30)
+- **THEN** T001828 erhält `status=backlog` (nicht `triage`); `pipeline_slot=NULL`; ein
+  Kommentar verweist auf den bereits vorhandenen Plan; der nächste Dispatcher-Tick claimed
+  erneut einen Slot und `pipeline.js` fährt bei Implement fort, statt Scout/Design/Plan zu
+  wiederholen
+
+#### Scenario: Stale awaiting_deploy
+- **GIVEN** Ticket T000504 ist seit 26 Stunden im Status `awaiting_deploy`
+- **WHEN** `watchdog.sh` ausgeführt wird (FACTORY_AD_STALE_H=24)
+- **THEN** T000504 erhält `attention_mode=needs_human` und einen Warn-Kommentar; der Status bleibt `awaiting_deploy`

--- a/openspec/changes/dispatcher-bridge-pipeline-orphan/tasks.md
+++ b/openspec/changes/dispatcher-bridge-pipeline-orphan/tasks.md
@@ -1,0 +1,77 @@
+---
+title: dispatcher-bridge-pipeline-orphan
+ticket_id: T001850
+domains: [factory]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# dispatcher-bridge-pipeline-orphan — Implementation Plan
+
+## File Structure
+
+- `scripts/factory/watchdog.sh` (51 lines, nicht-baselined — no S1 budget constraint)
+  — modified: conditional reset target based on `plan_ref`.
+- `tests/local/FA-SF-26-watchdog.bats` — modified: new failing test case (already added
+  in the plan-stage commit), asserts `status='backlog'` for a stale ticket that already
+  carries a `FACTORY-PLAN-REF` comment.
+
+## Task 1 — Reproduce: failing test confirms the bug (already committed)
+
+`tests/local/FA-SF-26-watchdog.bats` now contains
+`"FA-SF-26: a stale in_progress feature WITH a staged plan (FACTORY-PLAN-REF) is returned to
+backlog, not triage [T001850]"`. Against current `watchdog.sh` (unconditional
+`status='triage'` reset at line 19) this fails: `st=$(... | jq -r '.status')` reads `triage`,
+the assertion `[ "$st" = "backlog" ]` fails.
+
+- expected: FAIL
+- Run: `bats tests/local/FA-SF-26-watchdog.bats -f "WITH a staged plan"` (requires
+  `FACTORY_CTX` pointed at a dev cluster; skips otherwise — see `[ -n "${FACTORY_CTX:-}" ] ||
+  skip` in the test file).
+
+## Task 2 — Fix `watchdog.sh`: resume instead of restart when a plan already exists
+
+In the per-ticket loop of `scripts/factory/watchdog.sh` (currently: unconditional
+`bash "$HERE/../ticket.sh" update-status --id "$ext_id" --status triage`), before choosing
+the reset status:
+
+1. Read `plan_ref` the same way `pipeline.js`'s auto-detect does (scripts/factory/pipeline.js
+   ~line 111-123): `plan_ref=$(BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash
+   "$HERE/../ticket.sh" get --id "$ext_id" | jq -r '.plan_ref // empty')` and also capture
+   `ticket_type=$(... | jq -r '.type')` (or read both from a single `ticket.sh get` call to
+   avoid a second round-trip).
+2. Choose the reset target:
+   - `plan_ref` non-empty AND `ticket_type == 'feature'` → `--status backlog` (matches
+     `queue.sh`'s `type='feature' AND status='backlog' AND lastenheft_locked=true` gate; the
+     ticket was already locked before its original dispatch, so it re-qualifies immediately).
+   - `plan_ref` non-empty AND `ticket_type == 'task'` → `--status plan_staged` (matches
+     `queue.sh`'s `type='task' AND status='plan_staged'` gate).
+   - `plan_ref` empty (no plan was ever staged) → `--status triage` (existing behaviour,
+     unchanged).
+3. Adjust the `add-comment` body to reflect which branch was taken, e.g. for the
+   plan-exists case: `"Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write).
+   Plan already staged (${plan_ref}) — resuming via ${target_status} instead of restarting
+   from Scout."` — for the no-plan case, keep the current wording verbatim.
+4. Do not touch `readiness`/`lastenheft_locked` — the lock is forward-only per the
+   Pflichtenheft→Lastenheft design (`docs/superpowers/specs/2026-06-17-ticket-pflichtenheft-lastenheft-design.md`)
+   and must survive the reset untouched.
+5. Zombie-worktree cleanup (existing lines after the status/slot/comment calls) stays
+   unconditional — a stale worktree gets removed either way; `pipeline.js`'s
+   `REUSE`/`WORK_WT = ${slug}-reuse` path re-clones from the pushed branch on the next
+   dispatch, so removing the local worktree is safe even in the resume case.
+
+## Task 3 — Verify
+
+Run the reproduction test again to confirm it now passes (green), then the full
+mandatory verification block:
+
+- `bats tests/local/FA-SF-26-watchdog.bats` (both the new and the pre-existing
+  `FA-SF-26` cases must pass; `FACTORY_CTX` required — skip is acceptable in CI if no dev
+  cluster is configured, but must be run manually against `k3d-mentolder-dev` before merge)
+- `task test:changed`
+- `task freshness:regenerate`
+- `task freshness:check`

--- a/scripts/factory/watchdog.sh
+++ b/scripts/factory/watchdog.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # scripts/factory/watchdog.sh — escalate stale in-flight features for a brand.
 #   BRAND=<brand> FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
-# A feature in_progress whose updated_at is older than the threshold is treated
-# as a hung/crashed pipeline: status → triage (back to queue), slot released, and
-# a comment recorded. updated_at is auto-bumped by fn_lifecycle_ts on every row
-# write; pipeline.js writes a `ticket.sh touch` at each phase boundary, so a
-# healthy long phase is not mistaken for stale. JSON array of escalated ext_ids.
+# A feature/task in_progress whose updated_at is older than the threshold is
+# treated as a hung/crashed pipeline: slot released, a comment recorded, and
+# status reset. If a FACTORY-PLAN-REF already exists (dev-flow-plan staged a
+# plan before the pipeline hung), the reset target is 'backlog' (feature) or
+# 'plan_staged' (task) instead of 'triage' — pipeline.js auto-detects
+# FACTORY-PLAN-REF and resumes at Implement, skipping Scout/Design/Plan, so a
+# ticket with a staged plan must land back in a status queue.sh dispatches
+# (triage is not dispatched, which forced a wasteful full re-plan) [T001850].
+# updated_at is auto-bumped by fn_lifecycle_ts on every row write; pipeline.js
+# writes a `ticket.sh touch` at each phase boundary, so a healthy long phase
+# is not mistaken for stale. JSON array of escalated ext_ids.
 set -euo pipefail
 HERE="$(dirname "${BASH_SOURCE[0]}")"
 source "$HERE/lib.sh"
@@ -14,15 +20,29 @@ factory_resolve
 [[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
 STALE_MIN="${FACTORY_STALE_MIN:-30}"
 
-mapfile -t stale < <(printf "SELECT external_id FROM tickets.tickets WHERE type IN ('feature','task') AND status='in_progress' AND updated_at < now() - make_interval(mins => %s);" "$STALE_MIN" | factory_psql)
+mapfile -t stale < <(printf "SELECT external_id, type FROM tickets.tickets WHERE type IN ('feature','task') AND status='in_progress' AND updated_at < now() - make_interval(mins => %s);" "$STALE_MIN" | factory_psql)
 
 escalated='[]'
-for ext_id in "${stale[@]}"; do
-  [[ -z "$ext_id" ]] && continue
-  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" update-status --id "$ext_id" --status triage >/dev/null
+for row in "${stale[@]}"; do
+  [[ -z "$row" ]] && continue
+  ext_id="${row%%|*}"
+  ticket_type="${row##*|}"
+  ticket_json="$(BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" get --id "$ext_id")"
+  plan_ref="$(echo "$ticket_json" | jq -r '.plan_ref // empty')"
+  if [[ -n "$plan_ref" && "$ticket_type" == "feature" ]]; then
+    reset_status="backlog"
+    reset_msg="Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Plan already staged (${plan_ref}) — resuming via backlog instead of restarting from Scout."
+  elif [[ -n "$plan_ref" && "$ticket_type" == "task" ]]; then
+    reset_status="plan_staged"
+    reset_msg="Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Plan already staged (${plan_ref}) — resuming via plan_staged instead of restarting from Scout."
+  else
+    reset_status="triage"
+    reset_msg="Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Returned to queue (triage); slot released."
+  fi
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" update-status --id "$ext_id" --status "$reset_status" >/dev/null
   BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" release-slot --id "$ext_id" >/dev/null
   BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$ext_id" \
-    --body "Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write). Returned to queue (triage); slot released." >/dev/null
+    --body "$reset_msg" >/dev/null
   # Zombie-Worktree-Cleanup: a hung pipeline leaves .worktrees/sf-* behind. Remove the
   # worktree whose branch matches this ticket (idempotent; never fails the loop).
   ext_lc="$(printf '%s' "$ext_id" | tr '[:upper:]' '[:lower:]')"

--- a/tests/local/FA-SF-26-watchdog.bats
+++ b/tests/local/FA-SF-26-watchdog.bats
@@ -26,4 +26,27 @@ setup() { load 'test_helper.bash'; source 'tests/lib/factory-test-fixtures.sh'; 
   [ "$st" = "triage" ]
 }
 
+@test "FA-SF-26: a stale in_progress feature WITH a staged plan (FACTORY-PLAN-REF) is returned to backlog, not triage [T001850]" {
+  # expected: FAIL until watchdog.sh checks plan_ref before choosing the reset target.
+  [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
+  local brand="${TEST_BRAND:-korczewski}"
+  ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-wd-$$-b.txt")
+  env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1 >/dev/null
+  # Simulate dev-flow-plan already having staged a plan for this ticket.
+  BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh add-comment --id "$ext" \
+    --body "FACTORY-PLAN-REF branch=feature/sf-test-wd-$$ plan=openspec/changes/sf-test-wd-$$/tasks.md" >/dev/null
+  local ns; case "$brand" in mentolder) ns=workspace ;; korczewski) ns=workspace-korczewski ;; esac
+  # Backdate updated_at by 40 minutes to simulate a hung pipeline.
+  pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name | head -1)
+  kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET updated_at = now() - interval '40 minutes' WHERE external_id='$ext';"
+  run env BRAND="$brand" FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e --arg e "$ext" 'any(.[]; . == $e)'
+  # A plan already exists — the watchdog must not throw that work away by sending
+  # the ticket back to triage (which forces a full Scout/Design/Plan restart).
+  st=$(BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh get --id "$ext" | jq -r '.status')
+  [ "$st" = "backlog" ]
+}
+
 teardown() { [ -n "${FACTORY_CTX:-}" ] && purge_factory_test_data "${TEST_BRAND:-korczewski}" || true; }


### PR DESCRIPTION
## Summary
- `watchdog.sh` unconditionally reset every stale `in_progress` ticket to `triage` — a status `queue.sh` never dispatches — throwing away an already-staged plan and forcing a full Scout/Design/Plan restart, even though `pipeline.js` already auto-detects `FACTORY-PLAN-REF` and resumes straight at Implement.
- T001828/T001830/T001839 got stuck in exactly this loop twice in a row (observed 2026-07-15).
- Fix: check `plan_ref` before choosing the reset target — feature tickets with a staged plan go to `backlog`, task tickets to `plan_staged`; no-plan tickets keep the unchanged `triage` behavior.

## Test plan
- [x] `bats tests/local/FA-SF-26-watchdog.bats -f "dry-resolve"` — green
- [x] `task test:changed` — green except pre-existing unrelated `FA-SF-70: provider-config.sh set rejects tier=opus` failure (confirmed present on `main` before this change too)
- [x] `task freshness:regenerate` + `task freshness:check` — clean, no drift
- [ ] Cluster-based `FA-SF-26` assertions (`backlog` reset path) — **deferred**: local `k3d-mentolder-dev` is currently down in this environment, could not exercise against a live DB. New test case added (`tests/local/FA-SF-26-watchdog.bats`) and passes plan-lint/logic review; recommend running `FACTORY_CTX=k3d-mentolder-dev bats tests/local/FA-SF-26-watchdog.bats` once the dev cluster is back up, before/shortly after merge.

Closes T001850

https://claude.ai/code/session_01LJLSmSpMxFKfnDWEkarJrA