### PR TITLE
fix: correct invalid --allowed-groups flag to --allowed-group [T001851]

### DIFF
--- a/prod/patch-oauth2-proxy-brain-deployment.yaml
+++ b/prod/patch-oauth2-proxy-brain-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - "--oidc-extra-audience=brain"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_BRAIN_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-brett-deployment.yaml
+++ b/prod/patch-oauth2-proxy-brett-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             - "--oidc-extra-audience=brett"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_BRETT_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-comfy-deployment.yaml
+++ b/prod/patch-oauth2-proxy-comfy-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - "--oidc-extra-audience=comfy"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_COMFY_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-docs-deployment.yaml
+++ b/prod/patch-oauth2-proxy-docs-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - "--oidc-extra-audience=docs"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_DOCS_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-downloads-deployment.yaml
+++ b/prod/patch-oauth2-proxy-downloads-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - "--oidc-extra-audience=downloads"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_DOWNLOADS_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-mediaviewer-deployment.yaml
+++ b/prod/patch-oauth2-proxy-mediaviewer-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - "--oidc-extra-audience=mediaviewer-widget"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_MEDIAVIEWER_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-rustdesk-web-deployment.yaml
+++ b/prod/patch-oauth2-proxy-rustdesk-web-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - "--oidc-extra-audience=rustdesk-web"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_RUSTDESK_WEB_SECRET
               valueFrom:

--- a/prod/patch-oauth2-proxy-videovault-deployment.yaml
+++ b/prod/patch-oauth2-proxy-videovault-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - "--oidc-extra-audience=videovault"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
-            - "--allowed-groups=workspace-users"
+            - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_VIDEOVAULT_SECRET
               valueFrom:


### PR DESCRIPTION
## Summary
- `oauth2-proxy` v7.9.0 has no `--allowed-groups` flag (only `--allowed-group`, singular, repeatable). All 8 gated `prod/patch-oauth2-proxy-*-deployment.yaml` overlays passed the invalid plural form.
- Every affected Deployment's new ReplicaSet crash-looped on `unknown flag: --allowed-groups` and never became Ready. Kubernetes' RollingUpdate strategy then kept the **old** pre-cutover pod (running the unpatched k3d/dev args, pointing at `auth.localhost`/`pocket-id:1411`) alive indefinitely — masking the outage since the Deployment still reported `1/1 Ready`.
- External users could not complete OIDC login on: brain, mediaviewer, rustdesk-web, videovault, downloads, comfy, docs, brett — some stuck since deploy (docs/comfy/brett: 45 days).
- Incident ticket: T001851.

## Test plan
- [x] `task workspace:validate` — manifests valid (dry-run apply clean)
- [ ] After merge: `task workspace:deploy ENV=mentolder` then `kubectl rollout restart deploy/oauth2-proxy-<svc>` for all 8 services; confirm new pods become Ready and `curl -I https://brain.mentolder.de` redirects to `https://auth.mentolder.de`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJLSmSpMxFKfnDWEkarJrA