### PR TITLE
fix: restore --email-domain=* dropped by prod args replacement [T001851]

### DIFF
--- a/prod/patch-oauth2-proxy-brain-deployment.yaml
+++ b/prod/patch-oauth2-proxy-brain-deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - "--oidc-extra-audience=brain"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_BRAIN_SECRET

--- a/prod/patch-oauth2-proxy-brett-deployment.yaml
+++ b/prod/patch-oauth2-proxy-brett-deployment.yaml
@@ -32,6 +32,7 @@ spec:
             - "--oidc-extra-audience=brett"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_BRETT_SECRET

--- a/prod/patch-oauth2-proxy-comfy-deployment.yaml
+++ b/prod/patch-oauth2-proxy-comfy-deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - "--oidc-extra-audience=comfy"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_COMFY_SECRET

--- a/prod/patch-oauth2-proxy-docs-deployment.yaml
+++ b/prod/patch-oauth2-proxy-docs-deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - "--oidc-extra-audience=docs"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_DOCS_SECRET

--- a/prod/patch-oauth2-proxy-downloads-deployment.yaml
+++ b/prod/patch-oauth2-proxy-downloads-deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - "--oidc-extra-audience=downloads"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_DOWNLOADS_SECRET

--- a/prod/patch-oauth2-proxy-mediaviewer-deployment.yaml
+++ b/prod/patch-oauth2-proxy-mediaviewer-deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - "--oidc-extra-audience=mediaviewer-widget"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_MEDIAVIEWER_SECRET

--- a/prod/patch-oauth2-proxy-rustdesk-web-deployment.yaml
+++ b/prod/patch-oauth2-proxy-rustdesk-web-deployment.yaml
@@ -33,6 +33,7 @@ spec:
             - "--oidc-extra-audience=rustdesk-web"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_RUSTDESK_WEB_SECRET

--- a/prod/patch-oauth2-proxy-videovault-deployment.yaml
+++ b/prod/patch-oauth2-proxy-videovault-deployment.yaml
@@ -33,6 +33,7 @@ spec:
             - "--oidc-extra-audience=videovault"
             - "--scope=openid email profile groups"
             - "--oidc-groups-claim=groups"
+            - "--email-domain=*"
             - "--allowed-group=workspace-users"
           env:
             - name: POCKET_ID_VIDEOVAULT_SECRET


### PR DESCRIPTION
## Summary
- Follow-up to #2837. The prod overlay's `args` list fully replaces (not merges) the `k3d/` base, which dropped `--email-domain=*` in the process.
- oauth2-proxy v7.9.0 hard-fails at startup without `--email-domain` or `--authenticated-emails-file`, even when `--allowed-group` already restricts authorization. After #2837 fixed the flag name, the new pods still crash-looped with "missing setting for email validation".
- Incident ticket: T001851.

## Test plan
- [x] `task workspace:validate`
- [x] Applied live on fleet (emergency mitigation ahead of merge, incident in progress): all 8 services (brain, mediaviewer, rustdesk-web, videovault, downloads, comfy, docs, brett) rolled out cleanly
- [x] Verified full chain: `curl -I https://brain.mentolder.de` → 302 to `https://auth.mentolder.de/authorize` → 200 Pocket-ID login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJLSmSpMxFKfnDWEkarJrA