### PR TITLE
fix(brain): scope worklist to curated groups + parallelize ingest [T001608]

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -42,6 +42,5 @@ jobs:
         # SHA-gepinnt (Supply-Chain: Action erhaelt OPENCODE_API_KEY). v1.17.18 (2026-07-09).
         # Bump via Review/Dependabot; nie @latest fuer secret-tragende Third-Party-Actions.
         uses: anomalyco/opencode/github@b1fc8113948b518835c2a39ece49553cffe9b30c
-        env:
         with:
           model: llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2821,7 +2821,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 509,
+      "file_count": 510,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -2895,6 +2895,7 @@
         "scripts/brain-auto-memory-scan.sh",
         "scripts/brain-bootstrap.sh",
         "scripts/brain-gekko-inbox.sh",
+        "scripts/brain-group-match.sh",
         "scripts/brain-ingest-transform.sh",
         "scripts/brain-ingest-worklist.sh",
         "scripts/brain-ingest.sh",

--- a/scripts/brain-group-match.sh
+++ b/scripts/brain-group-match.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# brain-group-match.sh — shared group/pattern matcher for the brain ingest
+# pipeline. Parses the `groups:` section of a brain ingest manifest in either
+# shape:
+#   - map style (production manifest, scripts/brain/ingest-sources.yaml):
+#     "name: glob(s)" or "name: |" followed by an indented multiline glob list
+#   - list style (BATS test fixtures): "- group: name" blocks with a nested
+#     "include:" glob list
+#
+# Sourced by scripts/brain-ingest.sh and scripts/brain-ingest-worklist.sh —
+# do not duplicate this matching logic in either script; both must stay in
+# sync on what "belongs to a group" means.
+#
+# Perf note: brain_group_for() runs once per candidate file (thousands of
+# calls before group-filtering narrows things down), so it and its helpers
+# avoid spawning subprocesses (no awk/sed/echo) — pure bash string ops and
+# global output vars instead of command substitution.
+
+# Extracts the `groups:` section once. Call this ONE time per manifest and
+# reuse the result across all brain_group_for() calls — re-parsing the
+# manifest per file turns an O(files) walk into O(files * manifest-size)
+# worth of subprocess forks.
+brain_group_section_for_manifest() {
+  local manifest="$1" line in_section=0
+  _BRAIN_GROUP_SECTION=""
+  while IFS= read -r line; do
+    if [[ "$in_section" -eq 0 ]]; then
+      [[ "$line" == "groups:" ]] && in_section=1
+      continue
+    fi
+    if [[ "$line" =~ ^[a-zA-Z] ]]; then
+      break
+    fi
+    _BRAIN_GROUP_SECTION+="$line"$'\n'
+  done < "$manifest"
+}
+
+# Sets _BRAIN_REGEX_OUT. No subshell/subprocess — pure parameter expansion.
+_brain_glob_to_regex() {
+  local pattern="$1"
+  # "**/"  -> optional path prefix (globstar directory wildcard)
+  # "**"   -> any characters incl. "/"
+  # "*"    -> any characters excl. "/" (single path segment)
+  pattern="${pattern//\*\*\//@@GLOBSTAR_SLASH@@}"
+  pattern="${pattern//\*\*/.*}"
+  pattern="${pattern//\*/[^\/]*}"
+  pattern="${pattern//\?/.}"
+  _BRAIN_REGEX_OUT="${pattern//@@GLOBSTAR_SLASH@@/(.*\/)?}"
+}
+
+# brain_group_for <relative-path> <groups-section-text>
+# Sets _BRAIN_GROUP_OUT and returns 0 on match; returns 1 on no match.
+# <groups-section-text> comes from brain_group_section_for_manifest(),
+# called ONCE by the caller, not per file.
+brain_group_for() {
+  local rel="$1" groups_section="$2"
+  local group_name="" pattern="" in_multiline=0 in_include=0 value
+  # $- holds current shopt/set flags as a string — checking it is a pure
+  # bash builtin op. `set -o | grep noglob | head -1` (the previous approach)
+  # forks two external processes per call, which dominates runtime when this
+  # function runs thousands of times during worklist generation.
+  local restore_glob=0
+  [[ "$-" != *f* ]] && restore_glob=1
+  set -f  # disable glob expansion while matching literal patterns
+  _BRAIN_GROUP_OUT=""
+
+  while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+    # --- list style: "  - group: <name>" opens a new group block ---
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+group:[[:space:]]*(.+)$ ]]; then
+      group_name="${BASH_REMATCH[1]}"
+      in_multiline=0
+      in_include=0
+      continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]*include:[[:space:]]*$ ]]; then
+      in_include=1
+      continue
+    fi
+    if [[ "$in_include" -eq 1 ]]; then
+      if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+\"?([^\"]+)\"?[[:space:]]*$ ]]; then
+        pattern="${BASH_REMATCH[1]}"
+        _brain_glob_to_regex "$pattern"
+        if [[ "$rel" =~ ^${_BRAIN_REGEX_OUT}$ ]]; then
+          [[ "$restore_glob" -eq 1 ]] && set +f
+          _BRAIN_GROUP_OUT="$group_name"
+          return 0
+        fi
+        continue
+      else
+        in_include=0
+      fi
+    fi
+
+    # --- map style: "  name: |" (multiline block) or "  name: value(s)" ---
+    if [[ "$line" =~ ^[[:space:]]{2}([a-zA-Z_-]+):\|[[:space:]]*$ ]]; then
+      group_name="${BASH_REMATCH[1]}"
+      in_multiline=1
+      continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]{2}([a-zA-Z_-]+):[[:space:]]+(.+)$ ]]; then
+      group_name="${BASH_REMATCH[1]}"
+      value="${BASH_REMATCH[2]}"
+      in_multiline=0
+      if [[ "$value" == "|" ]]; then
+        in_multiline=1
+        continue
+      fi
+      for pattern in $value; do
+        [[ -z "$pattern" ]] && continue
+        _brain_glob_to_regex "$pattern"
+        if [[ "$rel" =~ ^${_BRAIN_REGEX_OUT}$ ]]; then
+          [[ "$restore_glob" -eq 1 ]] && set +f
+          _BRAIN_GROUP_OUT="$group_name"
+          return 0
+        fi
+      done
+      group_name=""
+      continue
+    fi
+    if [[ "$in_multiline" -eq 1 ]] && [[ "$line" =~ ^[[:space:]]{4}(.+)$ ]]; then
+      pattern="${BASH_REMATCH[1]}"
+      # trim leading/trailing whitespace (pure bash, no sed)
+      pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+      pattern="${pattern%"${pattern##*[![:space:]]}"}"
+      [[ -z "$pattern" ]] && continue
+      _brain_glob_to_regex "$pattern"
+      if [[ "$rel" =~ ^${_BRAIN_REGEX_OUT}$ ]]; then
+        [[ "$restore_glob" -eq 1 ]] && set +f
+        _BRAIN_GROUP_OUT="$group_name"
+        return 0
+      fi
+    fi
+  done <<< "$groups_section"
+
+  [[ "$restore_glob" -eq 1 ]] && set +f
+  return 1
+}

--- a/scripts/brain-ingest-transform.sh
+++ b/scripts/brain-ingest-transform.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # brain-ingest-transform.sh — LLM-assisted transformation of source files
-# into brain wiki pages. Calls local LM Studio API (OpenAI-compatible).
+# into brain wiki pages. Calls a local llama-server ingest-pool endpoint
+# (OpenAI-compatible; standalone llama-server.exe, not LM Studio's own
+# server — see start-qwen36-ingest-pool.ps1, -np 6 concurrent slots).
 #
 # Usage: brain-ingest-transform.sh <source_file> <type> <slug> <slugs_json> <tag_defaults_json>
 #
@@ -12,7 +14,8 @@
 #   tag_defaults_json — JSON array of default tags for the group
 #
 # Env:
-#   LM_STUDIO_URL    — LM Studio API URL (default: http://localhost:1234)
+#   LM_STUDIO_URL    — ingest-pool API URL (default: http://localhost:8095;
+#                      var name kept for backward compat, it's not LM Studio)
 #   LM_MODEL         — Model to use (default: qwen3.6-14b-a3b-fablevibes)
 #   MAX_SOURCE_CHARS — Max source chars to send to LLM (default: 4000)
 #
@@ -26,7 +29,7 @@ SLUG="${3:?page slug required}"
 SLUGS_JSON="${4:?slugs json required}"
 TAG_DEFAULTS="${5:?tag defaults json required}"
 
-LM_URL="${LM_STUDIO_URL:-http://localhost:1234}"
+LM_URL="${LM_STUDIO_URL:-http://localhost:8095}"
 LM_MODEL="${LM_MODEL:-qwen3.6-14b-a3b-fablevibes}"
 MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-4000}"
 

--- a/scripts/brain-ingest-worklist.sh
+++ b/scripts/brain-ingest-worklist.sh
@@ -50,12 +50,20 @@ is_excluded() {
   return 1
 }
 
-# --- groups: either a map "name: glob(s)" (production manifest) or a list of
-# {group,priority,include} objects (test fixtures). Full glob-priority
-# resolution is out of scope here — every row is tagged with the default
-# group; downstream compilation reads the manifest directly for grouping.
+# shellcheck source=./brain-group-match.sh
+source "$(dirname "${BASH_SOURCE[0]}")/brain-group-match.sh"
+
+# Extracted once (not per file — see brain-group-match.sh perf note).
+brain_group_section_for_manifest "$MANIFEST"
+GROUPS_SECTION="$_BRAIN_GROUP_SECTION"
+
+# Files that don't match any group's patterns are not brain-wiki sources —
+# skip them rather than defaulting to a catch-all "docs" group (T001608:
+# defaulting swept in the whole repo tree, ~1921 unrelated files).
 group_for() {
-  echo "docs"
+  local rel="$1"
+  brain_group_for "$rel" "$GROUPS_SECTION" || return 1
+  echo "$_BRAIN_GROUP_OUT"
 }
 
 slugify() {
@@ -87,7 +95,8 @@ find "$ROOT" \
   -name '*.toml' \) -print 2>/dev/null | sort | while read -r file; do
   rel="${file#"$ROOT"/}"
   is_excluded "$rel" && continue
+  grp="$(group_for "$rel")" || true
+  [[ -z "$grp" ]] && continue
   slug="$(slugify "$rel")"
-  grp="$(group_for "$rel")"
   printf '%s\t%s\t%s\n' "$rel" "$slug" "$grp"
 done

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -6,8 +6,14 @@
 # Usage: brain-ingest.sh --brain-repo <path> [--pilot N] [--dry-run] [--state <path>] [--branch <name>]
 #
 # Env:
-#   LM_STUDIO_URL    — LM Studio API URL (default: http://localhost:1234)
+#   LM_STUDIO_URL    — llama-server ingest-pool API URL (default:
+#                      http://localhost:8095 — standalone llama-server.exe,
+#                      NOT LM Studio's :1234 despite the var name; kept for
+#                      backward compat with existing callers/CI config)
 #   LM_MODEL         — Model to use (default: qwen3.6-14b-a3b-fablevibes)
+#   MAX_PARALLEL     — Concurrent process_page() jobs (default: 6, matching
+#                      the ingest-pool server's -np slot count — raising this
+#                      above the server's slot count just queues requests)
 #   BRAIN_INGEST_STATE — State file path (default: ~/.brain-ingest-state.json)
 set -euo pipefail
 
@@ -17,14 +23,24 @@ MANIFEST="$REPO_ROOT/scripts/brain/ingest-sources.yaml"
 WORKLIST_SCRIPT="$REPO_ROOT/scripts/brain-ingest-worklist.sh"
 TRANSFORM_SCRIPT="$HERE/brain-ingest-transform.sh"
 
+# shellcheck source=./brain-group-match.sh
+source "$HERE/brain-group-match.sh"
+
 # --- Defaults ---
 BRAIN_REPO=""
 DRY_RUN=0
 PILOT=0
 STATE_FILE="${BRAIN_INGEST_STATE:-$HOME/.brain-ingest-state.json}"
 BRANCH="feature/brain-initial-ingest"
-LM_URL="${LM_STUDIO_URL:-http://localhost:1234}"
+LM_URL="${LM_STUDIO_URL:-http://localhost:8095}"
 LM_MODEL="${LM_MODEL:-qwen3.6-14b-a3b-fablevibes}"
+MAX_PARALLEL="${MAX_PARALLEL:-6}"
+# transform.sh runs as a child process per page — it needs its own copy of
+# these, not just brain-ingest.sh's local vars (was previously unset here,
+# so a caller who didn't export LM_STUDIO_URL got transform.sh's own
+# default, silently disagreeing with whatever brain-ingest.sh computed).
+export LM_STUDIO_URL="$LM_URL"
+export LM_MODEL
 
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
@@ -44,6 +60,10 @@ done
 [ -f "$MANIFEST" ] || { echo "error: manifest not found: $MANIFEST" >&2; exit 1; }
 [ -f "$WORKLIST_SCRIPT" ] || { echo "error: worklist script not found: $WORKLIST_SCRIPT" >&2; exit 1; }
 [ -f "$TRANSFORM_SCRIPT" ] || { echo "error: transform script not found: $TRANSFORM_SCRIPT" >&2; exit 1; }
+
+# Extracted once (not per file — see brain-group-match.sh perf note).
+brain_group_section_for_manifest "$MANIFEST"
+GROUPS_SECTION="$_BRAIN_GROUP_SECTION"
 
 # ============================================================
 # Phase 1: Preparation
@@ -99,72 +119,25 @@ SKIPPED=0
 FAILED=0
 CURRENT=0
 
-# Determine group from manifest by matching source path against group patterns
+# Determine group from manifest by matching source path against group
+# patterns. Delegates to the shared matcher (scripts/brain-group-match.sh) so
+# worklist generation and page processing never drift on what "belongs to a
+# group" means. Falls back to "docs" — unlike the worklist's group_for(),
+# every path reaching this function already passed the worklist's group
+# filter, so the fallback should be unreachable in practice; kept as a
+# defensive default for direct/test callers.
 determine_group() {
   local src_path="$1"
-  local group_name="" pattern="" regex="" in_multiline=0
-  local old_noglob; old_noglob="$(set -o | grep noglob | head -1)"
-  set -f  # Disable glob expansion for pattern matching
-
-  while IFS= read -r line; do
-    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-
-    # Detect group with block scalar indicator (multi-line)
-    if [[ "$line" =~ ^[[:space:]]{2}([a-zA-Z_-]+):\|[[:space:]]*$ ]]; then
-      group_name="${BASH_REMATCH[1]}"
-      in_multiline=1
-      continue
-    fi
-
-    # Detect group with inline value (e.g., "runbooks: docs/runbooks/*.md")
-    if [[ "$line" =~ ^[[:space:]]{2}([a-zA-Z_-]+):[[:space:]]+(.+)$ ]]; then
-      group_name="${BASH_REMATCH[1]}"
-      local value="${BASH_REMATCH[2]}"
-      in_multiline=0
-
-      # Check if value is just "|" (block scalar indicator)
-      if [[ "$value" == "|" ]]; then
-        in_multiline=1
-        continue
-      fi
-
-      # Match against space-separated patterns
-      for pattern in $value; do
-        [[ -z "$pattern" ]] && continue
-        regex="$(echo "$pattern" | sed 's/\*/.*/g; s/\?/./g')"
-        if [[ "$src_path" =~ ^${regex}$ ]]; then
-          eval "$old_noglob" 2>/dev/null || true
-          echo "$group_name"
-          return 0
-        fi
-      done
-      group_name=""
-      continue
-    fi
-
-    # Collect multi-line patterns (indented lines under a group)
-    if [[ "$in_multiline" -eq 1 ]] && [[ "$line" =~ ^[[:space:]]{4}(.+)$ ]]; then
-      pattern="${BASH_REMATCH[1]}"
-      pattern="$(echo "$pattern" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-      [[ -z "$pattern" ]] && continue
-      regex="$(echo "$pattern" | sed 's/\*/.*/g; s/\?/./g')"
-      if [[ "$src_path" =~ ^${regex}$ ]]; then
-        eval "$old_noglob" 2>/dev/null || true
-        echo "$group_name"
-        return 0
-      fi
-    fi
-  done < <(awk '/^groups:/{flag=1; next} /^[a-zA-Z]/{flag=0} flag{print}' "$MANIFEST")
-
-  eval "$old_noglob" 2>/dev/null || true
-  echo "docs"
+  brain_group_for "$src_path" "$GROUPS_SECTION" || { echo "docs"; return 0; }
+  echo "$_BRAIN_GROUP_OUT"
 }
 
-# Process a single page (extracted for reuse)
+# Process a single page (extracted for reuse). Safe to run concurrently —
+# the STATE_FILE read-modify-write is flock-protected since multiple
+# parallel jobs write to it.
 process_page() {
   local src_path="$1" slug="$2"
-  local src_file src_hash existing_hash type tag_defaults transformed group
+  local src_file src_hash existing_hash type tag_defaults transformed group tmp
 
   src_file="$REPO_ROOT/$src_path"
   [ -f "$src_file" ] || { echo "WARN: source not found: $src_path" >&2; return 1; }
@@ -202,33 +175,60 @@ process_page() {
 
   echo "$transformed" > "$BRAIN_REPO/wiki/$slug.md"
 
-  tmp="$(mktemp)"
-  jq --arg k "$src_path" --arg h "$src_hash" --arg s "$slug" --arg t "$type" \
-    '.[$k] = {hash:$h, slug:$s, type:$t, transformed_at:(now | todate)}' \
-    "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+  (
+    flock -x 200
+    tmp="$(mktemp)"
+    jq --arg k "$src_path" --arg h "$src_hash" --arg s "$slug" --arg t "$type" \
+      '.[$k] = {hash:$h, slug:$s, type:$t, transformed_at:(now | todate)}' \
+      "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+  ) 200>"$STATE_FILE.lock"
   return 0
 }
 
-# Sequential processing (LM Studio handles one request at a time)
+# Parallel processing — dispatches up to MAX_PARALLEL concurrent
+# process_page() jobs, matching the ingest-pool llama-server's slot count
+# (default 6, see scripts/brain-ingest-transform.sh header). Each job writes
+# its exit code to RESULTS_DIR so the parent can tally after `wait`, since
+# background subshells can't mutate the parent's PROCESSED/SKIPPED/FAILED
+# counters directly.
+RESULTS_DIR="$(mktemp -d)"
+trap 'rm -f "$WORKLIST" "$SLUGS_JSON"; rm -rf "$RESULTS_DIR"' EXIT
+
 while IFS=$'\t' read -r src_path slug _worklist_group; do
   [ -n "$src_path" ] || continue
   CURRENT=$((CURRENT + 1))
 
-  printf "\r[%d/%d] %s " "$CURRENT" "$TOTAL" "$src_path"
+  while (( $(jobs -rp | wc -l) >= MAX_PARALLEL )); do
+    wait -n
+  done
 
-  process_page "$src_path" "$slug"
-  exit_code=$?
-  case $exit_code in
+  (
+    # `|| rc=$?` (not a bare call + separate `$?` capture) — under this
+    # script's `set -e`, a non-zero exit from process_page as a bare
+    # top-level command would kill the subshell immediately, skipping the
+    # result-file write below and silently dropping the job from every
+    # PROCESSED/SKIPPED/FAILED count instead of counting it as failed.
+    rc=0
+    process_page "$src_path" "$slug" || rc=$?
+    echo "$rc" > "$RESULTS_DIR/$CURRENT"
+  ) &
+  printf "\r[%d/%d] dispatched: %s " "$CURRENT" "$TOTAL" "$src_path"
+done < "$WORKLIST"
+
+wait
+
+for result_file in "$RESULTS_DIR"/*; do
+  [ -f "$result_file" ] || continue
+  case "$(cat "$result_file")" in
     0) PROCESSED=$((PROCESSED + 1)) ;;
     2) SKIPPED=$((SKIPPED + 1)) ;;
     *) FAILED=$((FAILED + 1)) ;;
   esac
-
-done < "$WORKLIST"
+done
 
 echo ""
 echo ""
-echo "Phase 2 complete: Processed=$PROCESSED, Skipped=$SKIPPED, Failed=$FAILED"
+echo "Phase 2 complete: Processed=$PROCESSED, Skipped=$SKIPPED, Failed=$FAILED (parallel, MAX_PARALLEL=$MAX_PARALLEL)"
 
 # ============================================================
 # Phase 2b: MOC Generation

--- a/tests/spec/brain-initial-ingest.bats
+++ b/tests/spec/brain-initial-ingest.bats
@@ -133,12 +133,27 @@ YAML
 }
 
 @test "worklist does not exclude a legitimately-named dir that merely contains 'build' or 'coverage' as a substring" {
+  # Uses a broad-include test manifest, not $MANIFEST — the real manifest's
+  # groups: scope to curated doc paths only (T001608: group_for() now
+  # actually enforces group membership instead of defaulting everything to
+  # "docs"), so these openspec/changes/ fixtures wouldn't match any group
+  # there for reasons unrelated to what this test checks (the is_excluded()
+  # substring-collision bug, not group scoping).
   mkdir -p "$WORK/repo/openspec/changes/mentolder-react-rebuild" \
            "$WORK/repo/openspec/changes/vitest-coverage"
   printf -- '# rebuild notes\n' > "$WORK/repo/openspec/changes/mentolder-react-rebuild/proposal.md"
   printf -- '# coverage notes\n' > "$WORK/repo/openspec/changes/vitest-coverage/proposal.md"
+  cat > "$WORK/manifest.yaml" <<YAML
+exclude:
+  - drafts/
+groups:
+  - group: notes
+    priority: 1
+    include:
+      - "**/*.md"
+YAML
 
-  run bash "$WL" --root "$WORK/repo" --manifest "$MANIFEST"
+  run bash "$WL" --root "$WORK/repo" --manifest "$WORK/manifest.yaml"
   [ "$status" -eq 0 ] || { echo "FAIL: worklist exited with $status"; return 1; }
   [[ "$output" == *"mentolder-react-rebuild"* ]] || { echo "FAIL: *-rebuild/ dir wrongly excluded"; return 1; }
   [[ "$output" == *"vitest-coverage"* ]] || { echo "FAIL: *-coverage/ dir wrongly excluded"; return 1; }


### PR DESCRIPTION
## Summary
- `group_for()` in `scripts/brain-ingest-worklist.sh` was a stub that tagged every file "docs" — the worklist walked the whole repo tree (1921 files) instead of the manifest's curated ~30-glob scope. The per-request slug list alone hit 30k+ tokens.
- Extracted the real glob-priority matcher into `scripts/brain-group-match.sh`, shared by `brain-ingest.sh`'s `determine_group()` and the worklist's `group_for()` — supports both the production map-style manifest and the BATS list-style test fixtures. Perf-tuned to avoid per-file subprocess forks (was ~117ms/file → ~6ms/file).
- Parallelizes `brain-ingest.sh` Phase 2 to match the new ingest-pool llama-server profile (6 concurrent slots): dispatches up to `MAX_PARALLEL` `process_page()` jobs, flock-protects the state-file read-modify-write, and fixes a `set -e` footgun where a failed job silently vanished from the PROCESSED/SKIPPED/FAILED tally instead of counting as failed.
- Default `LM_STUDIO_URL` moves from `:1234` (LM Studio) to `:8095` (standalone llama-server ingest-pool); var name kept for backward compat.

## Validated
- Ran the full pipeline against the real corpus: worklist correctly narrows to 11 curated files (was 1921), slug list 114 tokens (was 30,562).
- Delivered a real pilot PR against Paddione/brain with the corrected scope: https://github.com/Paddione/brain/pull/2

## Test plan
- [x] `tests/spec/brain-initial-ingest.bats` — 10/10 passing (1 test updated: it exercised the exclude-substring bug, not group scoping, now uses a broad-include test manifest instead of the real curated one)
- [x] `tests/spec/brain-ingest.bats` — 13/13 passing
- [x] Manual pipeline dry-run + real delivery run against Paddione/brain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
