### PR TITLE
feat(dev-flow): add fablevibes 262k concurrent model reference for opencode TUI

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -77,6 +77,20 @@
             "context": 330000,
             "output": 8192
           }
+        },
+        "qwen3.6-14b-a3b-fablevibes": {
+          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 32k ctx, 4 parallel slots)",
+          "limit": {
+            "context": 32768,
+            "output": 8192
+          }
+        },
+        "qwen3.6-14b-a3b-fablevibes@262k": {
+          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx, concurrent/single-session)",
+          "limit": {
+            "context": 262000,
+            "output": 8192
+          }
         }
       }
     }

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -71,6 +71,22 @@
           "name": "Gemma 4 12B QAT (Q4_K_XL) + MTP"
         }
       }
+    },
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "qwen3.6-14b-a3b-fablevibes@262k": {
+          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx, concurrent)",
+          "limit": {
+            "context": 262000,
+            "output": 8192
+          }
+        }
+      }
     }
   },
   "mcp": {


### PR DESCRIPTION
## Summary\n- Add `qwen3.6-14b-a3b-fablevibes` (32k, 4 parallel slots) and `qwen3.6-14b-a3b-fablevibes@262k` (concurrent/single-session) model entries in `.opencode/agent-models.jsonc`\n- Add `lmstudio` provider section in `.opencode/opencode.jsonc` with the 262k variant so it appears in the opencode TUI model picker\n\n## Test Plan\n- [ ] TUI model picker shows `LM Studio (local) → Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx, concurrent)`