### PR TITLE
test(e2e): target ContactHub island specifically in hydration wait [T001881]

### DIFF
--- a/tests/e2e/specs/fa-10-website.spec.ts
+++ b/tests/e2e/specs/fa-10-website.spec.ts
@@ -7,33 +7,30 @@ const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
 const HYDRATION_TIMEOUT = parseInt(process.env.E2E_HYDRATION_TIMEOUT || '20000', 10);
 
 /**
- * Wait for Astro islands to finish hydration by polling the removal of the
- * `ssr` attribute.  Some non-critical islands (e.g. PortalSidekick) may
- * never hydrate in certain environments, so we wait for the *count* of
- * `astro-island[ssr]` elements to **stabilise** (stop decreasing) rather
- * than requiring it to reach exactly zero.
+ * Wait for the ContactHub Astro island to finish hydration.
  *
- * The function polls every 200 ms.  Once the count has been unchanged for
- * three consecutive polls (≈ 600 ms of stability) the function returns
- * successfully.  If the overall timeout is exceeded the caller's test
- * fails with a clear message.
+ * Previous implementation polled the *count* of `astro-island[ssr]`
+ * elements and returned once it stabilised.  That fails when other
+ * islands (e.g. PortalSidekick) never hydrate — the count stabilises
+ * above zero *before* the ContactHub island is interactive, so the
+ * tab click does nothing and the form never renders.
+ *
+ * This version specifically waits for the `astro-island[ssr]` that
+ * contains the `tab-nachricht` element to lose its `ssr` attribute,
+ * guaranteeing the Svelte component is interactive when we click.
  */
 async function waitForHydration(page: Page) {
   await page.waitForFunction(
     () => {
-      // Expose a stable polling counter on the window object.
-      const w = window as any;
-      const current = document.querySelectorAll('astro-island[ssr]').length;
-      if (w.__ssrLast === undefined || w.__ssrLast !== current) {
-        // Count changed – reset the stability counter.
-        w.__ssrLast = current;
-        w.__ssrStablePolls = 0;
-        return false;
+      const islands = Array.from(document.querySelectorAll('astro-island[ssr]'));
+      for (const island of islands) {
+        if (island.querySelector('[data-testid="tab-nachricht"]')) {
+          return false; // ContactHub island still SSR – keep waiting
+        }
       }
-      // Count unchanged – increment stability counter.
-      w.__ssrStablePolls = (w.__ssrStablePolls || 0) + 1;
-      // Consider hydrated once stable for 3 polls (≈ 600 ms) or count hit 0.
-      return current === 0 || w.__ssrStablePolls >= 3;
+      // No SSR island with tab-nachricht found → ContactHub is hydrated
+      // (or no SSR islands remain at all).
+      return true;
     },
     { timeout: HYDRATION_TIMEOUT },
   );


### PR DESCRIPTION
## Summary
- Fix FA-10 T5/T6 e2e tests timing out on `getByLabel(/name/i)` after clicking the contact form tab
- The old `waitForHydration` polled the total count of `astro-island[ssr]` elements and returned once that count stabilised. When other islands (e.g. PortalSidekick) never hydrate, the count stabilises above zero *before* the ContactHub island is interactive, so the tab click does nothing and the form never renders
- Replace with a targeted check that specifically waits for the `astro-island[ssr]` containing the `tab-nachricht` element to lose its `ssr` attribute, guaranteeing the Svelte component is interactive before the test clicks the tab

## Test Plan
- [ ] `task test:changed` passes (fa-10-website.spec.ts T5/T6 green)
- [ ] Nightly e2e.yml no longer flakes on contact form hydration

🤖 T001881