### PR TITLE
fix(test): update stale provider-config opus test + harden e2e-marker regex [T001868]

### DIFF
--- a/tests/local/FA-SF-70-provider-router.bats
+++ b/tests/local/FA-SF-70-provider-router.bats
@@ -8,10 +8,15 @@ setup() { load 'test_helper.bash'; }
   [[ "$output" == *"Usage"* ]]
 }
 
-@test "FA-SF-70: provider-config.sh set rejects tier=opus" {
+@test "FA-SF-70: provider-config.sh set does not reject tier=opus at validation, warns instead" {
+  # DB-touching: this file is offline (no cluster), so the write itself may
+  # still fail downstream (factory_psql needs a live shared-db pod) — only
+  # assert the pre-DB validation behavior: opus passes argument validation
+  # and emits a warning, instead of being hard-rejected like before.
   run bash scripts/factory/provider-config.sh set --source x --tier opus --priority 1 --provider anthropic --model m
-  [ "$status" -ne 0 ]
+  [[ "$output" == *"WARNING"* ]]
   [[ "$output" == *"opus"* ]]
+  [[ "$output" != *"Usage:"* ]]
 }
 
 @test "FA-SF-70: provider-config.sh set requires all mandatory flags" {

--- a/website/tests/e2e-marker-hygiene.test.ts
+++ b/website/tests/e2e-marker-hygiene.test.ts
@@ -15,9 +15,6 @@
 // offline in the website `node` vitest project (no server / DB needed), so the
 // guard is part of `task test:all` / CI rather than only catching the leak in
 // production after the fact.
-//
-// RED today: tests/e2e/specs/fa-admin-tickets.spec.ts POSTs to /api/bug-report
-// with no marker. GREEN once that seed goes through the shared marker helper.
 
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
@@ -44,9 +41,17 @@ function collectSpecFiles(dir: string): string[] {
 
 /**
  * A spec that creates a bug report must carry the E2E marker — either inline
- * (`X-E2E-Test`) or via the shared helper (`createTestBugReport`). Detection is
- * intentionally conservative: it only flags files that POST to /api/bug-report.
+ * (`X-E2E-Test`) or via the shared helper (`createTestBugReport`).
+ *
+ * Detection matches an actual `.post(...)` call site whose URL argument
+ * contains `/api/bug-report` via regex, rather than two independent substring
+ * checks — the old approach flagged any file that merely *mentioned*
+ * '/api/bug-report' (e.g. in a comment) alongside an unrelated `.post(` call
+ * elsewhere in the same file. The URL argument may be a template literal with
+ * a variable prefix (`` `${BASE}/api/bug-report` ``), so the match spans from
+ * the opening quote to the path rather than requiring it immediately after.
  */
+const BUG_REPORT_POST_RE = /\.post\(\s*[`'"][^`'"]*\/api\/bug-report/;
 const MARKER_TOKENS = ['X-E2E-Test', 'createTestBugReport', 'bugReportMarkerHeaders', 'markerHeaders', 'markerAvailable'];
 
 describe('E2E marker hygiene (T000862/T000863)', () => {
@@ -60,7 +65,7 @@ describe('E2E marker hygiene (T000862/T000863)', () => {
     const violators: string[] = [];
     for (const file of specs) {
       const src = readFileSync(file, 'utf8');
-      const createsBugReport = src.includes('/api/bug-report') && src.includes('.post(');
+      const createsBugReport = BUG_REPORT_POST_RE.test(src);
       if (!createsBugReport) continue;
       const hasMarker = MARKER_TOKENS.some((t) => src.includes(t));
       if (!hasMarker) {


### PR DESCRIPTION
## Summary
- `tests/local/FA-SF-70-provider-router.bats`: the `set rejects tier=opus` test expected a hard rejection, but `scripts/factory/provider-config.sh` now accepts `tier=opus` with a `WARNING` (a recent model-routing change) instead of exiting non-zero. Updated the test to match the actual (intended) behavior — verified against the live script output.
- `website/tests/e2e-marker-hygiene.test.ts`: hardened the bug-report POST detection from two independent substring checks (`includes('/api/bug-report')` + `includes('.post(')`, matched anywhere in the file independently) to a single regex anchored on the actual call site — the old approach could false-positive on a file that merely mentions `/api/bug-report` (e.g. in a comment) near an unrelated `.post()` call elsewhere. The new regex still matches template literals with a variable URL prefix (`` `${BASE}/api/bug-report` ``, the real-world usage in `fa-26-bug-report-form.spec.ts`) — verified with a standalone node sanity check. Also dropped a stale "RED today" code comment referencing `fa-admin-tickets.spec.ts`, which no longer POSTs to `/api/bug-report` at all since T001749.
- `website/src/lib/__tests__/factory-model-slots.test.ts` and the `scout.sh` empty-slug bats test (both listed in the mishap plan `openspec/changes/mishap-t001868`) were already passing on main — no change needed.
- Closes T001868 (mishap bundle).

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/local/FA-SF-70-provider-router.bats` — 7/7 pass
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats` — 393/393 pass (full suite, not just the changed test)
- [x] `npx vitest run tests/e2e-marker-hygiene.test.ts src/lib/__tests__/factory-model-slots.test.ts` (website/) — 6/6 pass
- [x] Regex sanity check against real template-literal usage + a synthetic false-positive case
- [x] `task test:openspec` — 11/11 pass
