### PR TITLE
chore(test): speed up local checks + harden test tmpdir isolation

### DIFF
--- a/scripts/brain-ingest-worklist.sh
+++ b/scripts/brain-ingest-worklist.sh
@@ -88,7 +88,21 @@ find "$ROOT" \
      -o -name generated \
      -o -name archive \
      -o -name legacy-html \
-     -o -name drift-reports \) -prune \
+     -o -name drift-reports \
+     -o -name .worktrees \
+     -o -name website \
+     -o -name mentolder-web \
+     -o -name brett \
+     -o -name tui \
+     -o -name tests \
+     -o -name scripts \
+     -o -name k3d \
+     -o -name packages \
+     -o -name VideoVault \
+     -o -name art-library \
+     -o -name studio-server \
+     -o -name mediaviewer-widget \
+     -o -name design-system \) -prune \
   -o -type f \( \
   -name '*.md' -o -name '*.yaml' -o -name '*.yml' -o \
   -name '*.sh' -o -name '*.bats' -o -name '*.json' -o \

--- a/scripts/code-quality/gates/s4-orphans.mjs
+++ b/scripts/code-quality/gates/s4-orphans.mjs
@@ -17,21 +17,6 @@ export function findOrphans(candidates, corpus) {
   return orphans;
 }
 
-/** Concatenate the text of every source file, excluding the candidate itself. */
-function corpusExcluding(repoRoot, sourceFiles, candidate) {
-  const parts = [];
-  for (const f of sourceFiles) {
-    if (f === candidate) continue;
-    try { parts.push(readFileSync(join(repoRoot, f), 'utf8')); }
-    catch (err) {
-      // Keep the skip (git-tracked source; a read failure is a rare race), but
-      // be loud so a systemic corpus-read failure is never silent.
-      process.stderr.write(`S4: unreadable corpus source ${f}: ${err?.message}\n`);
-    }
-  }
-  return parts.join('\n');
-}
-
 /** Run S4 over the tracked tree. Returns the gate contract object. */
 export function runS4(repoRoot, gates) {
   const s4 = gates?.s4 ?? {};
@@ -45,9 +30,23 @@ export function runS4(repoRoot, gates) {
   );
   const sourceFiles = tracked.filter((f) => srcGlobs.some((g) => matchGlob(f, g)));
 
+  const loadedSources = sourceFiles.map((f) => {
+    try {
+      return { path: f, content: readFileSync(join(repoRoot, f), 'utf8') };
+    } catch (err) {
+      process.stderr.write(`S4: unreadable corpus source ${f}: ${err?.message}\n`);
+      return { path: f, content: '' };
+    }
+  });
+
   const violations = [];
   for (const c of candidates) {
-    const corpus = corpusExcluding(repoRoot, sourceFiles, c);
+    const parts = [];
+    for (const s of loadedSources) {
+      if (s.path === c) continue;
+      parts.push(s.content);
+    }
+    const corpus = parts.join('\n');
     if (!corpus.includes(basename(c))) {
       violations.push({
         key: `S4:${c}`,

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -275,7 +275,7 @@ row target G-SIZE03 "$( [ -f website/src/lib/website-db.ts ] && wc -l < website/
 # .codebase-memory/graph.db.zst (16.7MB, ehem. PR #2281) ist seit T001717 nicht mehr getrackt
 # (lokal via `task codebase:index` regeneriert, .gitignore) — die frühere Scope-Ausschluss-Policy
 # T001348 ist damit gegenstandslos, da kein >1MB-Binärartefakt mehr im Tree liegt.
-row target G-GIT03 "$(git ls-files -z 2>/dev/null | xargs -0 -I{} sh -c 'test -f "{}" && wc -c "{}"' 2>/dev/null | awk '$1>1048576{c++} END{print c+0}')" le 6 "Dateien >1MB (kein LFS)"
+row target G-GIT03 "$(git ls-files -z 2>/dev/null | xargs -0 wc -c 2>/dev/null | grep -v ' total$' | awk '$1>1048576{c++} END{print c+0}')" le 6 "Dateien >1MB (kein LFS)"
 row target G-IMG01 "$(grep -rhE '^[[:space:]]*-?[[:space:]]*image:[[:space:]]+["'"'"']?[A-Za-z0-9$]' --include='*.yaml' --include='*.yml' k3d/ prod*/ 2>/dev/null | grep -v '@sha256' | grep -vE '^[[:space:]]*#' | grep -vE 'website|brett|videovault|mediaviewer-widget|mentolder-web|WEBSITE_IMAGE|STUDIO_IMAGE|STAGING_IMAGE|paddione' | sed -E 's/.*image:[[:space:]]*//; s/["'"'"']//g; s/[[:space:]]*#.*//' | sort -u | wc -l | tr -d ' ')" le 0 "ungepinnte Fremd-Images"
 row target G-DOC02 "$(wc -l < CLAUDE.md | tr -d ' ')" le 200 "CLAUDE.md Zeilen"
 row target G-AGENTIC01 "$(
@@ -322,26 +322,28 @@ row target G-DB10 "$(db_scalar "SELECT count(*) FROM pg_stat_user_indexes WHERE 
 
 # ── CI-TARGETS ──
 row target G-CI03 "$(
-  gh_ok=0; out=$(gh-axi run list --workflow ci.yml --branch main --limit 20 --json createdAt,updatedAt 2>/dev/null) || gh_ok=1
-  if [ "$gh_ok" = 1 ] || [ -z "$out" ]; then echo "-"; else
-    echo "$out" | python3 -c "
+  if [ "$FAST" = 1 ]; then echo "-"; else
+    gh_ok=0; out=$(gh-axi run list --workflow ci.yml --branch main --limit 20 --json createdAt,updatedAt 2>/dev/null) || gh_ok=1
+    if [ "$gh_ok" = 1 ] || [ -z "$out" ]; then echo "-"; else
+      echo "$out" | python3 -c "
 import json,sys
 runs=json.load(sys.stdin)
 durations=[(r['updatedAt']-r['createdAt']).total_seconds()/60 for r in runs if 'updatedAt' in r]
 durations.sort(); p95=durations[int(len(durations)*0.95)] if durations else 0; print(f'{p95:.0f}')
 " 2>/dev/null || echo "-"
+    fi
   fi
 )" le 12 "CI Pipeline p95 Duration (min, letzte 20 Runs auf main)"
 
 # ── SEC-TARGETS ──
-if command -v kubectl >/dev/null 2>&1 && command -v trivy >/dev/null 2>&1; then
-  row target G-SEC06 "$(trivy image --severity HIGH,CRITICAL --exit-code 0 --format json $(kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.spec.containers[*].image}{"\n"}{end}' 2>/dev/null | sort -u | tr '\n' ' ') 2>/dev/null | jq '[.Results[].Vulnerabilities[] | select(.Severity=="HIGH" or .Severity=="CRITICAL")] | length' 2>/dev/null || echo "-")" le 0 "Container Images mit High/Critical CVEs (via Trivy)"
+if [ "$FAST" = 0 ] && command -v kubectl >/dev/null 2>&1 && command -v trivy >/dev/null 2>&1; then
+  row target G-SEC06 "$(trivy image --severity HIGH,CRITICAL --exit-code 0 --format json $(kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.spec.containers[*].image}{\"\n\"}{end}' 2>/dev/null | sort -u | tr '\n' ' ') 2>/dev/null | jq '[.Results[].Vulnerabilities[] | select(.Severity=="HIGH" or .Severity=="CRITICAL")] | length' 2>/dev/null || echo "-")" le 0 "Container Images mit High/Critical CVEs (via Trivy)"
 else
   row target G-SEC06 "-" le 0 "Container CVEs (erfordert kubectl + Trivy — nicht messbar)"
 fi
 
 # ── FE-TARGETS ──
-if command -v npx >/dev/null 2>&1 && npx --yes @lhci/cli --version >/dev/null 2>&1; then
+if [ "$FAST" = 0 ] && command -v npx >/dev/null 2>&1 && npx --yes @lhci/cli --version >/dev/null 2>&1; then
   row target G-FE05 "$(
     score=$(npx @lhci/cli autorun --no-lighthouserc --collect.url=https://web.mentolder.de --collect.settings.chromeFlags='--headless --no-sandbox' --assert.preset=none 2>/dev/null | grep -oP 'Performance: \K[0-9]+' | head -1)
     echo "${score:--}"

--- a/tests/spec/auth-sso.bats
+++ b/tests/spec/auth-sso.bats
@@ -5,14 +5,21 @@
 # Render pattern follows tests/spec/brain-quartz-deploy.bats.
 load 'test_helper'
 
+setup_file() {
+  export RENDERED_MENTOLDER="${BATS_FILE_TMPDIR}/rendered-mentolder.yaml"
+  export RENDERED_KORCZEWSKI="${BATS_FILE_TMPDIR}/rendered-korczewski.yaml"
+  
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  kubectl kustomize "${repo_root}/prod-fleet/mentolder" --load-restrictor=LoadRestrictionsNone > "$RENDERED_MENTOLDER" 2>/dev/null
+  kubectl kustomize "${repo_root}/prod-fleet/korczewski" --load-restrictor=LoadRestrictionsNone > "$RENDERED_KORCZEWSKI" 2>/dev/null
+}
+
 _render_mentolder() {
-  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
-  kubectl kustomize "$REPO_ROOT/prod-fleet/mentolder" --load-restrictor=LoadRestrictionsNone 2>/dev/null
+  cat "$RENDERED_MENTOLDER"
 }
 
 _render_korczewski() {
-  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
-  kubectl kustomize "$REPO_ROOT/prod-fleet/korczewski" --load-restrictor=LoadRestrictionsNone 2>/dev/null
+  cat "$RENDERED_KORCZEWSKI"
 }
 
 @test "prod render (mentolder): no --ssl-insecure-skip-verify anywhere" {

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -43,7 +43,7 @@ setup() {
   if [ ! -x "$REPO_ROOT/website/node_modules/.bin/eslint" ]; then
     skip "website deps not installed in this context — enforced by CI vitest-website job"
   fi
-  run bash -c "cd '$REPO_ROOT/website' && ./node_modules/.bin/eslint . --max-warnings 0"
+  run bash -c "cd '$REPO_ROOT/website' && ./node_modules/.bin/eslint . --max-warnings 0 --cache"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/spec/secret-rotation-exposure.bats
+++ b/tests/spec/secret-rotation-exposure.bats
@@ -15,6 +15,10 @@ make_kubeseal_stub() {
   local stub_dir="$1"
   cat > "${stub_dir}/kubeseal" <<'STUB'
 #!/usr/bin/env bash
+if [[ "$*" == *"--fetch-cert"* ]]; then
+  echo "STUB_CERTIFICATE"
+  exit 0
+fi
 cat
 cat <<'ENVELOPE'
 ---

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -82,7 +82,7 @@ setup() {
   TMPLOG="$(mktemp)"
 
   # FA-SF-57/58/59: temp directory with all needed subdirs
-  TEST_TMP_DIR="$BATS_TMPDIR/sf-tests-$$"
+  TEST_TMP_DIR="$BATS_TEST_TMPDIR/sf-tests-$$"
   mkdir -p "$TEST_TMP_DIR/fixtures/T000725" "$TEST_TMP_DIR/out"
 
   # FA-SF-63: scout.sh deterministic tests
@@ -3307,7 +3307,7 @@ STUB
 # guard_killswitch_on resolves offline (no live cluster) — same override
 # pattern as the FA-SF-44 guard_killswitch_on tests above.
 _stub_gh_prs() {
-  BIN_DIR="${BATS_TMPDIR}/babysit-gh-stubs"
+  BIN_DIR="${BATS_TEST_TMPDIR}/babysit-gh-stubs"
   rm -rf "$BIN_DIR"; mkdir -p "$BIN_DIR"
   ARGV_LOG="$BIN_DIR/argv.log"; : > "$ARGV_LOG"
   echo '{"comments":[]}' > "$BIN_DIR/comments.json"
@@ -3327,7 +3327,7 @@ GHSTUB
   chmod +x "$BIN_DIR/gh"
   export PATH="$BIN_DIR:$PATH"
 
-  GUARDS_REPO_DIR="${BATS_TMPDIR}/babysit-guards-repo"
+  GUARDS_REPO_DIR="${BATS_TEST_TMPDIR}/babysit-guards-repo"
   rm -rf "$GUARDS_REPO_DIR"; mkdir -p "$GUARDS_REPO_DIR/scripts"
   cat > "$GUARDS_REPO_DIR/scripts/ticket.sh" <<'TSTUB'
 #!/usr/bin/env bash
@@ -3337,7 +3337,7 @@ TSTUB
   chmod +x "$GUARDS_REPO_DIR/scripts/ticket.sh"
   export GUARDS_REPO="$GUARDS_REPO_DIR"
 
-  AGENT_LOCK_DIR="${BATS_TMPDIR}/babysit-agent-locks"
+  AGENT_LOCK_DIR="${BATS_TEST_TMPDIR}/babysit-agent-locks"
   rm -rf "$AGENT_LOCK_DIR"; mkdir -p "$AGENT_LOCK_DIR"
   export AGENT_LOCK_DIR
 }
@@ -3468,7 +3468,7 @@ QA_LENS="${BATS_TEST_DIRNAME}/../../scripts/factory/qa-lens.mjs"
 
 @test "FA-SF-QA: qa-lens.mjs exists and prints REVIEW_SCHEMA-shaped JSON in degraded mode" {
   [ -f "$QA_LENS" ]
-  local wt="${BATS_TMPDIR}/qa-lens-nonexistent-wt"
+  local wt="${BATS_TEST_TMPDIR}/qa-lens-nonexistent-wt"
   rm -rf "$wt"
   FACTORY_SANDBOX=off FACTORY_QA_SKIP_STAGING=1 run node "$QA_LENS" --worktree "$wt" --branch fake/branch --ticket T000000 --diff-range origin/main...HEAD
   [ "$status" -eq 0 ]
@@ -3477,7 +3477,7 @@ QA_LENS="${BATS_TEST_DIRNAME}/../../scripts/factory/qa-lens.mjs"
 }
 
 @test "FA-SF-QA: qa-lens degradation emits a single medium finding, never high, when staging is skipped" {
-  local wt="${BATS_TMPDIR}/qa-lens-nonexistent-wt2"
+  local wt="${BATS_TEST_TMPDIR}/qa-lens-nonexistent-wt2"
   rm -rf "$wt"
   FACTORY_SANDBOX=off FACTORY_QA_SKIP_STAGING=1 run node "$QA_LENS" --worktree "$wt" --branch fake/branch --ticket T000000 --diff-range origin/main...HEAD
   [ "$status" -eq 0 ]

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -8,6 +8,9 @@
 /coverage/
 /test-results/
 
+# ESLint --cache (tests/spec/ci-cd.bats runs eslint --cache)
+/.eslintcache
+
 # Lockfiles
 /package-lock.json
 


### PR DESCRIPTION
## Summary
Bundle of independent, already-complete local-dev/CI speed and reliability fixes found sitting uncommitted on `main`:

- `scripts/health-goals-check.sh`: gate G-CI03/G-SEC06/G-FE05 (network/Trivy/Lighthouse calls) behind `--fast` like the other expensive checks; switch G-GIT03's >1MB file count from a per-file `xargs -I{} sh -c` subshell spawn to a single batched `xargs wc -c`.
- `scripts/code-quality/gates/s4-orphans.mjs`: pre-load every source file's content once instead of re-reading the whole corpus from disk for every candidate (was O(n²) file reads).
- `scripts/brain-ingest-worklist.sh`: prune more non-doc directories (`.worktrees`, `website`, `scripts`, `tests`, `k3d`, and other code/asset-heavy trees) from the brain-ingest worklist scan.
- `tests/spec/auth-sso.bats`: render both brands' kustomize output once in `setup_file()` instead of on every individual `@test`.
- `tests/spec/ci-cd.bats`: run eslint with `--cache`.
- `tests/spec/secret-rotation-exposure.bats`: stub `kubeseal --fetch-cert` (was falling through to the generic `cat` stub).
- `tests/spec/software-factory.bats`: `BATS_TMPDIR` -> `BATS_TEST_TMPDIR` in three helper functions — `BATS_TMPDIR` is shared across the whole bats run, `BATS_TEST_TMPDIR` is per-test and auto-cleaned, avoiding cross-test state collisions.
- `website/.gitignore`: ignore the `.eslintcache` the `--cache` flag above now produces.

No behavior change to production code paths — test/tooling speed and isolation only.

## Test plan
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/auth-sso.bats` — 10/10 pass
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd.bats` — 32/32 pass
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/secret-rotation-exposure.bats` — 2/2 pass
- [x] `./tests/unit/lib/bats-core/bin/bats tests/spec/software-factory.bats` — 393/393 pass (full suite)
- [x] `bash scripts/health-goals-check.sh --fast --only=G-CI03,G-SEC06,G-FE05,G-GIT03` — verified `--fast` correctly skips the network checks
- [x] Syntax-checked `s4-orphans.mjs` / `brain-ingest-worklist.sh` / `health-goals-check.sh`
- [x] `task test:openspec` — 11/11 pass
