### PR TITLE
fix(test): isolate plan-context.bats fixtures in a temp repo root [T001895]

### DIFF
--- a/tests/spec/plan-context.bats
+++ b/tests/spec/plan-context.bats
@@ -6,21 +6,35 @@
 #   60 stale changes incl. the two proposals this file used to hardcode by
 #   name, and dropped the active-changes count below the old >=30 floor —
 #   breaking these tests without any change to plan-context.sh itself).
+# T001895 — fixtures moved out of the real $REPO/openspec/changes/ into a
+#   throwaway git repo under $BATS_TEST_TMPDIR. plan-context.sh anchors its
+#   CHANGES_DIR via `git rev-parse --show-toplevel`, so writing fixtures
+#   straight into the real repo tree raced against openspec-workflow.bats's
+#   "T001452: validator ignores specs under openspec/specs/archive/" test
+#   (both files run in parallel in the CI "Spec BATS" job, `bats -j $(nproc)
+#   --no-parallelize-within-files`). That test calls
+#   `validateTree('openspec')` against the real repo mid-test; if it ran
+#   while a fixture dir was present (fixtures intentionally have no specs/
+#   delta dir), validateTree failed with "<slug>: missing specs/ delta dir".
+#   Anchoring plan-context.sh at an isolated temp repo means it never reads
+#   or writes $REPO/openspec/changes/, so the two files can no longer race.
 #
 # Failing-test contract: these cases MUST fail on the pre-fix
 # `fix/t001387-plan-context-role-filter` branch (the current script
 # returns ALL proposals regardless of <role>) and MUST pass after the
 # fix lands in scripts/plan-context.sh.
 #
-# Test strategy: we run the script against the *real* repo (the script
-# uses `git rev-parse --show-toplevel` to anchor `CHANGES_DIR`; an
-# OPENSPEC_ROOT override is intentionally NOT used so we test the
-# production code path). To stay independent of the ever-changing set of
-# real active OpenSpec changes (proposals get archived over time), the
-# role-filter inclusion/exclusion cases use dedicated fixture proposals
-# created in setup() and removed in teardown(). Anchor cases that assert
-# "all non-archived proposals" compare against the real on-disk count
-# computed at test time, not a hardcoded floor.
+# Test strategy: run the script against a throwaway git repo built fresh in
+# setup() (see TMP_ROOT below), not the real repo — CHANGES_DIR resolution
+# via `git rev-parse --show-toplevel` inside plan-context.sh then anchors at
+# TMP_ROOT and never touches $REPO/openspec/changes/. The fixture set is
+# self-contained: exactly 3 non-archived proposals (ops/website/ci) plus one
+# proposal parked directly under a slug literally named "archive" (to
+# exercise the `slug == archive` skip in plan-context.sh — the real repo's
+# archive/ only ever holds nested sub-dirs, so that skip is otherwise
+# untested), so the "returns all non-archived proposals" / "archive is
+# always excluded" anchor assertions stay meaningful without depending on
+# the real repo's ever-changing openspec/changes/ contents.
 #
 # Cases 3, 5, 7 are anchor cases (PASS pre- and post-fix) that lock in
 # the existing semantics (archive exclusion, mandatory-arg error) so
@@ -31,10 +45,21 @@ setup() {
   SCRIPT="$REPO/scripts/plan-context.sh"
   [[ -x "$SCRIPT" ]] || chmod +x "$SCRIPT"
 
-  CHANGES_DIR="$REPO/openspec/changes"
+  # Throwaway git repo so `git rev-parse --show-toplevel` inside
+  # plan-context.sh anchors CHANGES_DIR here, never at $REPO. Each bats test
+  # gets its own unique $BATS_TEST_TMPDIR, so parallel test files/processes
+  # never share this directory.
+  TMP_ROOT="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$TMP_ROOT"
+  git init -q "$TMP_ROOT"
+  git -C "$TMP_ROOT" config user.email "pcf-test@example.invalid"
+  git -C "$TMP_ROOT" config user.name "PCF Test"
+
+  CHANGES_DIR="$TMP_ROOT/openspec/changes"
   FIXTURE_OPS_SLUG="zz-test-pcf-fixture-ops"
   FIXTURE_WEBSITE_SLUG="zz-test-pcf-fixture-website"
   FIXTURE_CI_SLUG="zz-test-pcf-fixture-ci"
+  FIXTURE_ARCHIVE_SLUG="archive"
 
   _make_fixture() {
     local slug="$1" domains="$2"
@@ -42,9 +67,12 @@ setup() {
     cat > "$CHANGES_DIR/$slug/proposal.md" <<EOF
 ---
 title: "Proposal: $slug"
+---
+
+# Proposal: $slug
+
+test fixture, safe to ignore.
 EOF
-    printf -- '---\n' >> "$CHANGES_DIR/$slug/proposal.md"
-    printf '\n# Proposal: %s\n\ntest fixture, safe to ignore.\n' "$slug" >> "$CHANGES_DIR/$slug/proposal.md"
     cat > "$CHANGES_DIR/$slug/tasks.md" <<EOF
 ---
 title: "Tasks: $slug"
@@ -61,22 +89,29 @@ EOF
   _make_fixture "$FIXTURE_OPS_SLUG" "ops"
   _make_fixture "$FIXTURE_WEBSITE_SLUG" "website"
   _make_fixture "$FIXTURE_CI_SLUG" "ci"
-}
+  # A proposal parked directly at .../archive/proposal.md (unlike the real
+  # repo, where archive/ only ever holds nested archive/<slug>/proposal.md
+  # dirs) so the `[[ "$slug" == "archive" ]] && continue` skip in
+  # plan-context.sh actually gets exercised by these tests.
+  _make_fixture "$FIXTURE_ARCHIVE_SLUG" "ops"
 
-teardown() {
-  rm -rf "$CHANGES_DIR/$FIXTURE_OPS_SLUG" "$CHANGES_DIR/$FIXTURE_WEBSITE_SLUG" "$CHANGES_DIR/$FIXTURE_CI_SLUG"
+  # Invoke plan-context.sh with CWD inside the throwaway repo so its
+  # `git rev-parse --show-toplevel` resolves to TMP_ROOT.
+  _run_pcf() {
+    (cd "$TMP_ROOT" && bash "$SCRIPT" "$@")
+  }
 }
 
 # ── (1) role=ops must include ops-tagged proposals and exclude website-only ──
 
 @test "PCF: role=bachelorprojekt-ops includes ops-tagged proposal (fixture)" {
-  out="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null || true)"
+  out="$(_run_pcf bachelorprojekt-ops 2>/dev/null || true)"
   echo "$out" | grep -q "### Active proposal: $FIXTURE_OPS_SLUG" \
     || { echo "MISSING: $FIXTURE_OPS_SLUG (domains: [ops]) should be included for ops"; return 1; }
 }
 
 @test "PCF: role=bachelorprojekt-ops excludes website-only proposal (fixture)" {
-  out="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null || true)"
+  out="$(_run_pcf bachelorprojekt-ops 2>/dev/null || true)"
   if echo "$out" | grep -q "### Active proposal: $FIXTURE_WEBSITE_SLUG"; then
     echo "REGRESSION: $FIXTURE_WEBSITE_SLUG (domains: [website]) leaked into ops output — filter not active"
     return 1
@@ -84,7 +119,7 @@ teardown() {
 }
 
 @test "PCF: role=bachelorprojekt-ops excludes non-ops/non-infra proposal (fixture)" {
-  out="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null || true)"
+  out="$(_run_pcf bachelorprojekt-ops 2>/dev/null || true)"
   if echo "$out" | grep -q "### Active proposal: $FIXTURE_CI_SLUG"; then
     echo "REGRESSION: $FIXTURE_CI_SLUG (domains: [ci]) leaked into ops output — filter not active"
     return 1
@@ -94,13 +129,13 @@ teardown() {
 # ── (2) role=website must include website-tagged and exclude pure-test ──
 
 @test "PCF: role=bachelorprojekt-website includes website-tagged proposal (fixture)" {
-  out="$(bash "$SCRIPT" bachelorprojekt-website 2>/dev/null || true)"
+  out="$(_run_pcf bachelorprojekt-website 2>/dev/null || true)"
   echo "$out" | grep -q "### Active proposal: $FIXTURE_WEBSITE_SLUG" \
     || { echo "MISSING: $FIXTURE_WEBSITE_SLUG (domains: [website]) should be included for website"; return 1; }
 }
 
 @test "PCF: role=bachelorprojekt-website excludes non-website proposal (fixture)" {
-  out="$(bash "$SCRIPT" bachelorprojekt-website 2>/dev/null || true)"
+  out="$(_run_pcf bachelorprojekt-website 2>/dev/null || true)"
   if echo "$out" | grep -q "### Active proposal: $FIXTURE_OPS_SLUG"; then
     echo "REGRESSION: $FIXTURE_OPS_SLUG (domains: [ops]) leaked into website output"
     return 1
@@ -118,7 +153,7 @@ teardown() {
     expected=$((expected+1))
   done
 
-  out="$(bash "$SCRIPT" orchestrator 2>/dev/null || true)"
+  out="$(_run_pcf orchestrator 2>/dev/null || true)"
   count=$(echo "$out" | grep -c '^### Active proposal:' || true)
   [ "$count" -eq "$expected" ] \
     || { echo "orchestrator should return all $expected non-archived proposals (got $count)"; return 1; }
@@ -127,7 +162,7 @@ teardown() {
 # ── (4) role=foobar (unknown) emits stderr WARN and returns all proposals ──
 
 @test "PCF: unknown role emits WARN: unknown role on stderr" {
-  err="$(bash "$SCRIPT" foobar 2>&1 >/dev/null || true)"
+  err="$(_run_pcf foobar 2>&1 >/dev/null || true)"
   echo "$err" | grep -Eq 'WARN: *unknown role' \
     || { echo "MISSING stderr WARN for unknown role (got: $err)"; return 1; }
 }
@@ -141,7 +176,7 @@ teardown() {
     expected=$((expected+1))
   done
 
-  out="$(bash "$SCRIPT" foobar 2>/dev/null || true)"
+  out="$(_run_pcf foobar 2>/dev/null || true)"
   count=$(echo "$out" | grep -c '^### Active proposal:' || true)
   [ "$count" -eq "$expected" ] \
     || { echo "unknown role should return all $expected proposals as fail-soft (got $count)"; return 1; }
@@ -151,10 +186,9 @@ teardown() {
 
 @test "PCF: archive/* proposals never appear in any role output (anchor)" {
   for role in bachelorprojekt-website bachelorprojekt-ops orchestrator; do
-    out="$(bash "$SCRIPT" "$role" 2>/dev/null || true)"
-    # If any archive/ slug leaks in, its header would be present.
-    if echo "$out" | grep -qE '^### Active proposal: (openspec-archive-fallback|template-change|legacy-import)'; then
-      echo "REGRESSION: archive/* proposal leaked into output for role=$role"
+    out="$(_run_pcf "$role" 2>/dev/null || true)"
+    if echo "$out" | grep -qE "^### Active proposal: $FIXTURE_ARCHIVE_SLUG\$"; then
+      echo "REGRESSION: $FIXTURE_ARCHIVE_SLUG proposal leaked into output for role=$role"
       return 1
     fi
   done
@@ -163,14 +197,13 @@ teardown() {
 # ── (6) Filter actually reduces output volume (the bug's main symptom) ──
 
 @test "PCF: filtered output is substantially smaller than orchestrator output" {
-  all="$(bash "$SCRIPT" orchestrator 2>/dev/null | grep -c '^### Active proposal:' || true)"
-  ops="$(bash "$SCRIPT" bachelorprojekt-ops 2>/dev/null | grep -c '^### Active proposal:' || true)"
-  website="$(bash "$SCRIPT" bachelorprojekt-website 2>/dev/null | grep -c '^### Active proposal:' || true)"
+  all="$(_run_pcf orchestrator 2>/dev/null | grep -c '^### Active proposal:' || true)"
+  ops="$(_run_pcf bachelorprojekt-ops 2>/dev/null | grep -c '^### Active proposal:' || true)"
+  website="$(_run_pcf bachelorprojekt-website 2>/dev/null | grep -c '^### Active proposal:' || true)"
   # A correctly filtered ops/website output should be strictly less than
   # the unfiltered orchestrator count (the script today returns the same
-  # entries for all three — the bug). The three fixture proposals plus at
-  # least one non-matching real proposal (fixture-ci is domains:[ci],
-  # excluded from both) guarantee a real reduction.
+  # entries for all three — the bug). The fixture set (ops/website/ci)
+  # guarantees a real reduction.
   [ "$ops" -lt "$all" ] \
     || { echo "BUG STILL ACTIVE: ops count ($ops) >= orchestrator count ($all) — filter does nothing"; return 1; }
   [ "$website" -lt "$all" ] \


### PR DESCRIPTION
## Summary

- Fixes a CI flake in the "Spec BATS" job (`bats -j $(nproc) --no-parallelize-within-files tests/spec/*.bats`): `tests/spec/plan-context.bats` wrote its ops/website/ci fixture proposals directly into the real `$REPO/openspec/changes/` (intentionally without a `specs/` delta dir). When that overlapped with `tests/spec/openspec-workflow.bats`'s "T001452: validator ignores specs under openspec/specs/archive/" test — which calls `validateTree('openspec')` against the real repo — the validator could observe a fixture dir mid-flight and fail with `"<slug>: missing specs/ delta dir"`, turning `main` red and blocking PR #2870 (Required Check, 3x red, run 29432040774).
- Root cause: `scripts/plan-context.sh` anchors `CHANGES_DIR` via `git rev-parse --show-toplevel`, so any fixtures written under the real repo tree are visible to concurrent processes scanning `openspec/changes/`.
- Fix: `setup()` in `tests/spec/plan-context.bats` now builds a throwaway git repo under `$BATS_TEST_TMPDIR` and runs `plan-context.sh` with CWD inside it, so `git rev-parse --show-toplevel` anchors at the temp repo instead of the real one. The fixture set is self-contained (3 non-archived proposals + one parked under a literal `archive` slug, to actually exercise the `slug == archive` skip in `plan-context.sh` — the real repo's `archive/` only ever holds nested sub-dirs, so that skip line was otherwise untested), keeping the anchor assertions ("all non-archived proposals", "archive is always excluded") meaningful without depending on the real repo's ever-changing `openspec/changes/` contents.
- `scripts/plan-context.sh` itself is unchanged — this is a test-isolation fix only.

## Repro (RED, pre-fix)

Created a fixture dir directly under the real `openspec/changes/` (mirroring the old `plan-context.bats` behavior) and ran the same `validateTree` call the T001452 test uses:

```
$ npx tsx -e "import {validateTree} from './scripts/openspec-validate.ts'; const r=validateTree('openspec'); console.log(JSON.stringify(r)); process.exit(r.ok?0:1)"
{"ok":false,"errors":["zz-test-pcf-fixture-ops: missing specs/ delta dir"], ...}
exit code: 1
```

This is exactly the failure mode from the CI run.

## Test plan

- [x] `bats tests/spec/plan-context.bats` — 11/11 green
- [x] `for i in 1 2 3; do bats -j 4 --no-parallelize-within-files tests/spec/plan-context.bats tests/spec/openspec-workflow.bats; done` — all 3 rounds green
- [x] Confirmed no `zz-test-*` dir appears in the real `openspec/changes/` while the suite runs (watch loop during the run)
- [x] `task test:changed`, `task freshness:regenerate`, `task freshness:check` — all green, no unrelated drift
- [x] Audited `tests/spec/*.bats` for other writers into the real `openspec/` tree (`grep -n 'REPO.*openspec' tests/spec/*.bats`) — none found; all other files either read committed files or already isolate via `$BATS_TEST_TMPDIR` / `OPENSPEC_ROOT`

Closes T001895

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
https://claude.ai/code/session_01DUw6y3PpWG8Dx49eYWP3fr