### PR TITLE
chore(dev-flow): set opencode doom_loop permission to deny [T001897]

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -15,7 +15,7 @@
     "webfetch": "allow",
     "websearch": "allow",
     "lsp": "allow",
-    "doom_loop": "allow",
+    "doom_loop": "deny",
     "skill": {
       "*": "allow",
       // ── Claude Code stubs (opencode has native equivalents) ──────────


### PR DESCRIPTION
## Summary
- `opencode`'s built-in loop-detection permission gate (`doom_loop`: `ask`|`allow`|`deny`) was set to `allow` in `.opencode/opencode.jsonc`, silently auto-approving loop continuation instead of interrupting it.
- A `build`-agent session ran unattended for **2h42min** (17:28–20:10) against the local LM Studio model `qwen3.6-14b-a3b-fablevibes`, growing its own conversation indefinitely without ever stopping — burning GPU/CPU with no circuit breaker in place.
- Traced to commit `ae8ab279f` (#2746), where a prior blanket `"permission": "allow"` was refactored into a granular permission object and every key — including the newly-introduced `doom_loop` gate — was carried over as `allow` without a deliberate decision about loop safety.
- Since this workspace runs unattended background subagents (no human present to answer an `"ask"` prompt), `"deny"` (fail-closed: auto-abort the loop) is the correct value, not `"ask"` (which would just deadlock waiting for a response nobody can give).
- The proximate trigger (a stale chat template causing empty/truncated completions) was already fixed separately; this chore adds the missing circuit breaker so a similar failure mode can't run unbounded again.
- Same fix already applied to the user's global `~/.config/opencode/opencode.jsonc` (not git-tracked, not part of this PR).

## Test plan
- [x] `git diff` confirms single-line value change (`doom_loop`: `allow` → `deny`), no other config drift
- [x] `task quality:check` — 0 new/worsened violations
- [x] `validate-commit-msg` — commit message passes Conventional Commit + scope validation
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128LBEfmWdUoSMzNuWUEeMt