### PR TITLE
fix(ci): preflight-pr-scope case-insensitive Ticket-ID matching [T001873]

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -74,6 +74,10 @@ cd .worktrees/<slug>
 bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label dev-flow-chore
 ```
 
+> Enthält `<slug>` eine wiederverwendete `TICKET_EXT_ID` (z.B. `T001869`), sollte deren Ticketnummer
+> im Slug vorkommen (z.B. `doc-cleanup-t001869`) — `preflight-pr-scope.sh` prüft das PR-Titel↔Branch-
+> Matching case-insensitiv (T001873), Groß-/Kleinschreibung im Slug spielt also keine Rolle.
+
 Claim-Semantik, main-checkout-Sonderfall (`claim main-checkout`) und Release:
 [session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md).
 

--- a/scripts/preflight-pr-scope.sh
+++ b/scripts/preflight-pr-scope.sh
@@ -29,8 +29,11 @@ fi
 # Matches [T123456] or T123456
 TICKET_ID="$(echo "$TITLE" | grep -oP '\[T\d{6}\]|T\d{6}' | tr -d '[]' | head -n 1 || true)"
 if [ -n "$TICKET_ID" ]; then
-  # Verify current branch contains the ticket ID
-  if [[ ! "$CURRENT_BRANCH" =~ $TICKET_ID ]]; then
+  # Case-insensitive Vergleich [T001873]: dev-flow-chore erzeugt chore/<slug>-Branches
+  # durchgehend in lowercase; die Ticket-ID im PR-Titel ist [T123456] (uppercase).
+  BRANCH_LC="$(echo "$CURRENT_BRANCH" | tr '[:upper:]' '[:lower:]')"
+  TICKET_LC="$(echo "$TICKET_ID" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$BRANCH_LC" != *"$TICKET_LC"* ]]; then
     echo "preflight-pr-scope: FATAL: PR title ticket ID '$TICKET_ID' does not match current branch name '$CURRENT_BRANCH'" >&2
     exit 1
   fi

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -291,3 +291,34 @@ assert not errors, f"YAML parse errors:\n" + "\n".join(errors)
 PY
   [ "$status" -eq 0 ]
 }
+
+# --- T001873: preflight-pr-scope lowercase-Branch-Regression (Mishap-Ticket) ---
+@test "T001873: preflight-pr-scope akzeptiert lowercase Ticket-ID im Branchnamen" {
+  local tmp
+  tmp="$(mktemp -d)"
+
+  # Fixture ci.yml mit 'docs' als bekanntem Scope (isoliert von echter ci.yml-Drift)
+  local fixture="$tmp/ci.yml"
+  cat > "$fixture" <<'EOF'
+jobs:
+  commit-lint:
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        with:
+          scopes: |
+            docs
+            test
+EOF
+
+  # Isoliertes Fixture-Repo direkt auf dem lowercase-Branch aus dem Mishap-Report,
+  # nicht main/master/feature/fix -> preflight-pr-scope's Branch-Guards greifen nicht ein.
+  git -C "$tmp" init -q -b chore/foo-t999901
+  git -C "$tmp" config user.email "test@example.invalid"
+  git -C "$tmp" config user.name "Test Fixture"
+  git -C "$tmp" commit -q --allow-empty -m "fixture"
+
+  run bash -c "cd '$tmp' && bash '$REPO_ROOT/scripts/preflight-pr-scope.sh' 'chore(docs): x [T999901]' '$fixture'"
+  rm -rf "$tmp"
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Make Ticket-ID ↔ branch name comparison case-insensitive in `preflight-pr-scope.sh`
- dev-flow-chore creates `chore/<slug>` branches in lowercase; ticket IDs in PR titles are `[T123456]` (uppercase)
- Add regression test in `tests/spec/ci-cd.bats`
- Add doc hint in `dev-flow-chore/SKILL.md`

## Test
- [x] New regression test passes (T001873)
- [x] All 7 existing preflight-pr-scope tests pass
- [x] Full ci-cd.bats suite (33/33) passes