### PR TITLE
chore(docs): mishap-lessons M1+M2 aus T001884-Session [T001899]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -293,6 +293,11 @@ Seit T001415 (Finding 2) beendet sich `devflow-ci-watch.sh` zusätzlich mit Exit
 
 ## Schritt 6: Auto-Merge wenn CI grün
 
+> **⚠️ M1-Lesson (T001899):** Auto-Merge **nicht** vor dem ersten Implementierungs-Push aktivieren.
+> Proposal-Commits auf Feature-Branches triggern den Auto-Merge-Flow und können das Ticket
+> vorzeitig schließen (Merge = Abschluss, T001092). Auto-Merge erst enable, wenn mindestens ein
+> Implementierungs-Commit auf dem Branch liegt.
+
 > **Hinweis:** `E2E PR` ist kein required check (T000722) — blockiert den Merge NICHT.
 > Die Required-Check-Liste lebt in [ci-fix-loop](file:///home/patrick/Bachelorprojekt/.claude/skills/references/ci-fix-loop.md).
 **Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge, KEIN `|| true`:**

--- a/.claude/skills/references/session-coordination.md
+++ b/.claude/skills/references/session-coordination.md
@@ -118,6 +118,10 @@ Der Reaper läuft automatisch in Step -1 der dev-flow-execute Pipeline und beim
 Session-Start (`bash scripts/agent-lock.sh reap`). Stale Locks werden gelöscht und
 ins `.reap.log` geschrieben (im Lock-Verzeichnis).
 
+> **⚠️ M2-Lesson (T001899):** Parallele Sessions können Claims löschen, die eine andere Session
+> noch aktiv nutzt. Nach jedem Reap-Fenster die eigenen Claims verifizieren:
+> `bash scripts/agent-lock.sh list` — fehlt ein Claim, neu setzten.
+
 ## Freigeben (nach Merge, VOR dem Worktree-Remove)
 
 ```bash


### PR DESCRIPTION
## Summary
Dokumentiert 2 Prozess-Lessings aus der T001884-Session (brain-ssot-consolidation):

- **M1 (Proposal-Race):** Auto-Merge-Warnung in dev-flow-execute — nicht vor Implementierungs-Push aktivieren
- **M2 (Verlorene Locks):** Reap-Verifikations-Hinweis in session-coordination

M3–M5 sind Prozess-/Transient-Findings ohne Code-Änderung (dokumentiert im Ticket).

## Test
- [x] Kein Code geändert, nur Doku-Hinweise