### PR TITLE
chore(brain): exclude .opencode/ from ingest-sources

### DIFF
--- a/scripts/brain/ingest-sources.yaml
+++ b/scripts/brain/ingest-sources.yaml
@@ -18,6 +18,7 @@ exclude:
   - .agy/
   - .antigravitycli/
   - .design-sync/
+  - .opencode/
   - dist/
   - tests/unit/lib/
   - .venv/


### PR DESCRIPTION
.opencode/ (package-lock.json, hooks, skill files) was getting ingested as wiki pages in the brain repo — 14 tool-state pages found and removed there (Paddione/brain#... wiki-restructure-phase1). Never a doc source; add to the same exclude list as .agy/, .antigravitycli/, .design-sync/.