### PR TITLE
chore(ci): wire GitHub token into Lighthouse audit for PR status checks [T001913]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,8 @@ jobs:
 
       - name: Run Lighthouse audit
         continue-on-error: true
+        env:
+          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
         run: |
           lhci autorun || true
 
@@ -481,7 +483,7 @@ jobs:
           echo "### Lighthouse Performance Audit" >> "$GITHUB_STEP_SUMMARY"
           echo "URL: https://web.mentolder.de" >> "$GITHUB_STEP_SUMMARY"
           echo "Budget: lighthouse-budget.json (Performance ≥ 90)" >> "$GITHUB_STEP_SUMMARY"
-          echo "Status: advisory only (does not block CI)" >> "$GITHUB_STEP_SUMMARY"
+          echo "Status: advisory only (does not block CI); GitHub status check posted via LHCI_GITHUB_TOKEN" >> "$GITHUB_STEP_SUMMARY"
 
   commit-lint:
     name: Conventional Commits


### PR DESCRIPTION
## Summary
- Adds `LHCI_GITHUB_TOKEN` repo secret (sourced from `GITHUB_PAT` in `environments/.secrets/mentolder.yaml`)
- Passes it as an env var to the `lhci autorun` step so the Lighthouse job posts a GitHub status check on PRs, not just a job-summary line

## Note
Used `LHCI_GITHUB_TOKEN` (not `LHCI_GITHUB_APP_TOKEN`) — the App-token integration requires a token issued by the installed "Lighthouse CI" GitHub App; a plain PAT maps to the `githubToken`/`LHCI_GITHUB_TOKEN` integration, which posts a basic commit status instead of the rich App check. Functionally equivalent for the goal (PR status visibility).

## Test plan
- [x] `.github/workflows/ci.yml` YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] `LHCI_GITHUB_TOKEN` secret confirmed present via `gh secret list`
- [ ] Confirm on this PR's own CI run that the Lighthouse job posts a status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVXVxH1rVv3m8iSniaArH