### PR TITLE
fix(infra): restore claude-code-agent ClusterRoleBinding default subject [T001918]

### DIFF
--- a/prod-fleet/platform/claude-code-agent-rbac.yaml
+++ b/prod-fleet/platform/claude-code-agent-rbac.yaml
@@ -1,0 +1,80 @@
+# fleet platform layer — cluster-scoped claude-code-agent RBAC, owned ONCE.
+#
+# Both brand overlays emit a byte-identical claude-code-agent ClusterRole and a
+# ClusterRoleBinding that already lists BOTH brand SAs (workspace +
+# workspace-korczewski). On a shared cluster that is a single logical singleton,
+# so the platform layer owns it and each brand's fleet-common component
+# $patch: deletes its copy — avoiding the cross-brand SharedResource conflict.
+# The per-namespace claude-code-agent ServiceAccount stays brand-owned (created
+# by each brand overlay in its own namespace); only the cluster-scoped CR/CRB
+# live here.
+#
+# T001914: re-added after PR #2052 (T001088, 2026-06-22) deleted this file
+# believing the in-cluster MCP monolith was fully decommissioned. In fact the
+# claude-code-mcp-monolith Deployment/Service (default ns) kept running —
+# deploys here are push-based with no GitOps reconciler, so removing a
+# manifest from git never tears down the live object. mcp-kubernetes
+# (localhost:18080, see mcp-tool-guide.md) still port-forwards to that pod and
+# needs `default/claude-code-agent` authorized, which the deleted file's
+# subjects list never covered even before the accidental removal — the SA was
+# added as a subject here so the still-running pod (and its NEW default-ns
+# ServiceAccount created 2026-06-01, not tracked here — brand-owned SAs are
+# workspace/workspace-korczewski only) actually resolves. The default-ns
+# Deployment/Service/SA themselves remain untracked orphans; only the RBAC
+# subject gap that broke mcp-kubernetes tool calls is fixed by this file.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: claude-code-agent
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - persistentvolumeclaims
+      - namespaces
+      - nodes
+      - events
+      - replicationcontrollers
+      - serviceaccounts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: claude-code-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: claude-code-agent
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: workspace
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: workspace-korczewski
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: default

--- a/prod-fleet/platform/kustomization.yaml
+++ b/prod-fleet/platform/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - cluster-issuer.yaml
   - ingressclass.yaml
   - reflector-rbac.yaml
+  - claude-code-agent-rbac.yaml


### PR DESCRIPTION
## Summary
- Restores `prod-fleet/platform/claude-code-agent-rbac.yaml`, deleted by PR #2052
  (T001088, 2026-06-22) under the assumption the in-cluster MCP monolith was
  fully decommissioned. The `claude-code-mcp-monolith` pod (`default` ns, fleet
  cluster) kept running regardless — deploys are push-based with no GitOps
  reconciler, so removing a manifest from git never tears down the live object.
- Adds `default/claude-code-agent` as a third subject on the ClusterRoleBinding,
  matching the live `kubectl patch` already applied to unblock `mcp-kubernetes`
  tool calls, which were failing with `403 Forbidden` for
  `system:serviceaccount:default:claude-code-agent`.
- `kustomize build` verified green for the platform layer and both brand
  overlays (no SharedResource conflict).

## Known limitation
`default/claude-code-agent` now shares the same ClusterRole as the brand SAs,
including cluster-wide `deployments patch/update` and `deployments/scale` —
broader than the read-only access `mcp-kubernetes` actually needs. Scoping it
down to a minimal, namespace-local Role is tracked separately rather than
bundled into this unblock.

## Test Plan
- [x] `kubectl auth can-i list pods -n workspace --as=system:serviceaccount:default:claude-code-agent` → yes
- [x] `kustomize build prod-fleet/platform/` — builds clean
- [x] `kustomize build prod-fleet/mentolder/` / `prod-fleet/korczewski/` — builds clean, no SharedResource conflict
- [ ] CI green

[T001918]