### PR TITLE
chore(dev-flow): dev-flow-chore Ticket-vor-Branch-Check gegen PR-Scope-Mishap [T001917]

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -49,6 +49,14 @@ einen Cron-Job ein. **STOPP hier.**
 
 ## Schritt 1: Worktree anlegen & claimen
 
+> **Ticket-vor-Branch-Check (T001917):** Bevor der Branch-Slug feststeht, prüfen ob für diese
+> Chore bereits ein Ticket existiert (`TICKET_EXT_ID` gesetzt oder in `./scripts/ticket.sh list`
+> auffindbar?). Existiert noch keines, **zuerst das Ticket anlegen** (Block in Schritt 1 unten)
+> und dessen ID sofort in den Branch-Slug aufnehmen (z.B. `chore/lighthouse-ci-token-t001913`
+> statt `chore/lighthouse-ci-token`) — nicht erst nach dem Worktree. Sonst schlägt
+> `preflight-pr-scope.sh` beim PR fehl (PR-Titel-Ticket-ID ≠ Branch-Name) und der Branch muss
+> nachträglich umbenannt werden (Zeitverlust, siehe T001913).
+
 > **Test-only-Kurzpfad (kein Worktree):** Berührt die Chore **ausschließlich** Testdateien
 > (`tests/**/*.bats`, `tests/spec/*.bats`, `website/**/*.test.ts`, Playwright-Specs) — z.B. "schreib
 > einen Test für X" — dann entfällt `.worktrees/*` als Standardfall. Ein eigener Worktree pro Testdatei


### PR DESCRIPTION
## Summary
- Mishap T001917 (skills/dev-flow-chore, Typ process): Worktree fuer T001913 wurde vor Ticket-Anlage erstellt; Branch enthielt keine Ticket-ID; `preflight-pr-scope.sh` schlug beim PR fehl (Titel-Ticket-ID != Branch-Name); Branch musste nachtraeglich umbenannt werden.
- Fix: `.claude/skills/dev-flow-chore/SKILL.md` Schritt 1 ("Worktree anlegen & claimen") um einen expliziten Vorab-Check erweitert — vor der Branch-Benennung pruefen, ob bereits ein Ticket existiert, und dessen ID sofort in den Branch-Slug aufnehmen.

## Test plan
- [x] Nur Dokumentationsaenderung an `.claude/skills/dev-flow-chore/SKILL.md` — keine Code-Pfade betroffen
- [x] `bash scripts/preflight-pr-scope.sh` gegen den PR-Titel gruen
- [x] CI (`task test:all` etc.) laeuft grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVXVxH1rVv3m8iSniaArH