### PR TITLE
chore(db): add missing FK-column indexes for G-DB01 [T001905]

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -76,8 +76,11 @@ find .claude/skills -name SKILL.md -exec wc -l {} + | awk '$2!="total"&&$1>500{c
 ## G-DB01 — FK-Spalten ohne Index: 4 → 0
 
 **Was:** Zählt FK-Spalten mit Single-Column-FK, die keinen passenden Index haben. Live-Wert 4
-(3 Tabellen mit je einem fehlenden Index, plus eine Wiederholung). Nur Messung verdrahtet,
-kein erzwungener Fix — die Indizes werden in einem Folge-Ticket nachgezogen.
+(3 Tabellen mit je einem fehlenden Index, plus eine Wiederholung): `public.onboarding_state.brand`,
+`sessions.templates.created_from_template_id`, `studio.sessions.client_id`,
+`studio.sessions.template_of`. Fix als Migration `website/src/db/migrations/20260717_add_missing_fk_indexes.sql`
+erstellt (T001905); wird beim nächsten `task workspace:deploy` (push-based) automatisch über
+`pnpm --dir website db:migrate` angewendet — Live-Wert aktualisiert sich erst nach Deploy.
 
 ```bash
 WITH fk AS (
@@ -88,7 +91,7 @@ idx AS (SELECT i.indrelid AS relid, i.indkey[0] AS col FROM pg_index i)
 SELECT count(*) FROM (SELECT relid,col FROM fk EXCEPT SELECT relid,col FROM idx) x;
 ```
 
-> **B · Baseline:** 4 · **Target:** 0 · **Aufwand:** gering (3 Indizes via Migration) · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T001905 (Nachfolger von T001739; Messung verdrahtet, Index-Fix ausstehend)
+> **B · Baseline:** 4 · **Target:** 0 · **Aufwand:** gering (4 Indizes via Migration) · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T001905 (Nachfolger von T001739; Migration erstellt, Anwendung erfolgt beim nächsten Deploy)
 
 ## G-DB03 — brand-Spalten ohne CHECK-Constraint: 44 → 0
 
@@ -344,7 +347,7 @@ bash scripts/health-goals-check.sh --only=G-RH01,G-CQ02
 | G-GIT03 | T001902 | offen (7 > Target 6; manuelle Entscheidung über 2 Nutzer-Assets — Nachfolger von T001717) |
 | G-SIZE02 | T001903 | offen (17 Großdateien; Nachfolger von T001556, das ohne Messwert-Fix archiviert wurde) |
 | G-AGENTIC09 | T001904 | offen (dev-flow-plan/SKILL.md 508 Zeilen; Nachfolger von T001559) |
-| G-DB01 | T001905 | offen (Messung verdrahtet; Index-Fix ausstehend — Nachfolger von T001739) |
+| G-DB01 | T001905 | Migration erstellt, Anwendung ausstehend (nächster Deploy) — Nachfolger von T001739 |
 | G-DB03 | T001906 | offen (Messung verdrahtet; CHECK-Constraints ausstehend — Nachfolger von T001739) |
 | G-DB09 | T001907 | offen (Slow Queries, erster Scan + Optimierung — Nachfolger von T001838) |
 | G-DB10 | T001908 | offen (Unused Indexes, Baseline fehlt — Nachfolger von T001839) |

--- a/website/src/db/migrations/20260717_add_missing_fk_indexes.sql
+++ b/website/src/db/migrations/20260717_add_missing_fk_indexes.sql
@@ -1,0 +1,35 @@
+-- Migration: add missing indexes on single-column FK constraints — T001905 (G-DB01).
+-- Applied automatically by website/src/db/migrate.ts (task workspace:deploy runs
+-- `pnpm --dir website db:migrate` against the target brand's `website` database).
+--
+-- Identified via the G-DB01 health-goal query (.claude/lib/goals.md#G-DB01):
+-- single-column FK constraints without a matching leading-column index.
+-- Baseline 4 → target 0 (T001739 wired the measurement; this migration is the fix).
+--
+-- Guarded with to_regclass() rather than bare CREATE INDEX IF NOT EXISTS: the
+-- `studio.*` and `sessions.*` schemas are mentolder-only (studio-server is
+-- "mentolder-only for MVP", see Taskfile.yml website:studio:rollout) and this
+-- migrations directory is shared by every brand's `db:migrate` run — an
+-- unguarded statement against a table that doesn't exist on another brand's
+-- database would abort that brand's entire migration run.
+
+DO $$
+BEGIN
+  IF to_regclass('public.onboarding_state') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_onboarding_state_brand
+      ON public.onboarding_state (brand);
+  END IF;
+
+  IF to_regclass('sessions.templates') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_sessions_templates_created_from_template_id
+      ON sessions.templates (created_from_template_id);
+  END IF;
+
+  IF to_regclass('studio.sessions') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_studio_sessions_client_id
+      ON studio.sessions (client_id);
+    CREATE INDEX IF NOT EXISTS idx_studio_sessions_template_of
+      ON studio.sessions (template_of);
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- Adds a migration for the 4 single-column FK columns without a matching index, identified by the G-DB01 health-goal query (measurement wired in T001739): `public.onboarding_state.brand`, `sessions.templates.created_from_template_id`, `studio.sessions.client_id`, `studio.sessions.template_of`.
- New file `website/src/db/migrations/20260717_add_missing_fk_indexes.sql`, applied automatically by `pnpm --dir website db:migrate` on the next `task workspace:deploy`. Guarded with `to_regclass()` per table since `studio.*`/`sessions.*` are mentolder-only (studio-server is mentolder-only for MVP) and this migrations directory is shared across brands.
- Updates `.claude/lib/goals.md#G-DB01` to reflect the migration status (created, pending deploy application).

## Test plan
- [x] `task test:all` — all offline tests green (52/52 node tests + BATS suites)
- [x] `task workspace:validate` — manifests valid
- [x] `bats tests/spec/db-quality-goals.bats` — 3/3 pass
- [x] SQL syntax verified against a live cluster (k3d-korczewski-dev shared-db, rolled back / errored only on a stale-cluster ownership permission quirk unrelated to the migration's correctness — guard logic confirmed working, skipping non-existent tables)
- [ ] Live index creation confirmed on next `task workspace:deploy` (decoupled, push-based deploy)

Ticket T001905 closes automatically on green merge (Merge = Abschluss convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVXVxH1rVv3m8iSniaArH