### PR TITLE
fix(tickets): default ticket.sh list to newest-first, not oldest-200 [T001916]

### DIFF
--- a/scripts/ticket-mcp/go/internal/tools/list.go
+++ b/scripts/ticket-mcp/go/internal/tools/list.go
@@ -22,7 +22,7 @@ func getArgs(req mcp.CallToolRequest) map[string]any {
 func RegisterListTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("list_tickets",
-			mcp.WithDescription("Listet Tickets gefiltert nach Status, Typ, Brand oder fehlender ID. Standard-Limit 200 Zeilen; mit --limit erhöhbar (max 1000)."),
+			mcp.WithDescription("Listet Tickets gefiltert nach Status, Typ, Brand oder fehlender ID. Standard-Limit 200 Zeilen, neueste zuerst (created_at DESC); mit --limit erhöhbar (max 1000)."),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)"),
 				mcp.Enum("mentolder", "korczewski")),
 			mcp.WithString("status", mcp.Description("z.B. triage, planning, plan_staged, backlog")),
@@ -94,7 +94,7 @@ func RegisterListTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("export_tickets",
-			mcp.WithDescription("Exportiert Tickets als JSON oder Markdown (gleiche Filter wie list_tickets). Default-Limit 200; max 1000. Ohne Filter empfiehlt sich ein Status-Filter, um den Kontextverbrauch gering zu halten."),
+			mcp.WithDescription("Exportiert Tickets als JSON oder Markdown (gleiche Filter wie list_tickets). Default-Limit 200, neueste zuerst (created_at DESC); max 1000. Ohne Filter empfiehlt sich ein Status-Filter, um den Kontextverbrauch gering zu halten."),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)"),
 				mcp.Enum("mentolder", "korczewski")),
 			mcp.WithString("status", mcp.Description("z.B. triage, planning, plan_staged, backlog")),

--- a/scripts/vda/ticket/list.sh
+++ b/scripts/vda/ticket/list.sh
@@ -2,7 +2,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/_ticket-core.sh"
 
 main() {
-  local brand="${BRAND:-mentolder}" status="" type="" attention_mode="" missing_id=false limit=200
+  local brand="${BRAND:-mentolder}" status="" type="" attention_mode="" missing_id=false limit=200 sort="desc"
 
   while [[ $# -gt 0 ]]; do case "$1" in
     --brand)          brand="$2"; shift 2 ;;
@@ -11,8 +11,16 @@ main() {
     --attention-mode) attention_mode="$2"; shift 2 ;;
     --missing-id)     missing_id=true; shift ;;
     --limit)          limit="$2"; shift 2 ;;
+    --sort)           sort="$2"; shift 2 ;;
     *)                echo "Unknown list option: $1" >&2; exit 2 ;;
   esac; done
+
+  case "$sort" in
+    asc|desc) : ;;
+    *) echo "Unknown --sort value: $sort (expected asc|desc)" >&2; exit 2 ;;
+  esac
+  local order_dir="DESC"
+  [[ "$sort" == "asc" ]] && order_dir="ASC"
 
   if [[ -n "${FACTORY_DRY_RESOLVE:-}" ]]; then
     echo "ticket list [DRY-RESOLVE]: brand=${brand}"
@@ -27,19 +35,23 @@ main() {
   [[ -n "$attention_mode" ]] && where+=" AND attention_mode = :'attn'"
   [[ "$missing_id" == "true" ]] && where+=" AND external_id IS NULL"
 
+  # T001916: default is now newest-first (created_at DESC). With more than
+  # `--limit` rows in the brand, an ASC default silently dropped the newest
+  # (and thus most relevant open) tickets from standard output. --sort asc
+  # restores the old oldest-first behavior for callers that need it.
   _exec_sql "$pod" \
     -v brand="$brand" \
     -v status="$status" \
     -v type="$type" \
     -v attn="$attention_mode" \
     -v lim="$limit" <<EOF
-SELECT COALESCE(json_agg(row ORDER BY row.created_at ASC), '[]')
+SELECT COALESCE(json_agg(row ORDER BY row.created_at ${order_dir}), '[]')
 FROM (
   SELECT external_id, title, status, type, priority, severity,
          attention_mode, created_at::date AS created_at
   FROM tickets.tickets
   WHERE $where
-  ORDER BY created_at ASC
+  ORDER BY created_at ${order_dir}
   LIMIT :'lim'::int
 ) row;
 EOF

--- a/tests/spec/ticket-mcp.bats
+++ b/tests/spec/ticket-mcp.bats
@@ -23,6 +23,21 @@ setup() {
   [ "$status" -eq 2 ]
 }
 
+@test "ticket.sh list accepts --sort desc (default) and asc" {
+  run bash "$REPO/scripts/ticket.sh" list --brand mentolder --sort desc
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "DRY-RESOLVE"
+
+  run bash "$REPO/scripts/ticket.sh" list --brand mentolder --sort asc
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "DRY-RESOLVE"
+}
+
+@test "ticket.sh list rejects unknown --sort value" {
+  run bash "$REPO/scripts/ticket.sh" list --brand mentolder --sort bogus
+  [ "$status" -eq 2 ]
+}
+
 @test "ticket.sh backfill-id --dry-resolve exits 0" {
   run bash "$REPO/scripts/ticket.sh" backfill-id --brand mentolder
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- `ticket.sh list` defaulted to `ORDER BY created_at ASC LIMIT 200`, so brands with more than 200 tickets silently dropped the newest (and usually most relevant/open) tickets from the standard listing output.
- Default sort is now `created_at DESC` (newest first); a new `--sort asc|desc` flag lets callers restore the old oldest-first behavior explicitly.
- Updated the `list_tickets` / `export_tickets` MCP tool descriptions to document the new default.
- Verified existing callers (`scripts/health-goals-update.sh --suggest-tickets` dedup check, `ticket-mcp` Go tools) are order-independent (they filter/parse JSON regardless of array order) so this is safe.

## Test plan
- [x] `bats tests/spec/ticket-mcp.bats` — 14/14 pass, incl. 2 new `--sort` tests
- [x] `bats tests/unit/vda-ticket-smoke.bats tests/local/FA-SF-48-ticket-phase-cli.bats tests/local/FA-SF-21-ticket-cli.bats` — all pass
- [x] `task test:all` — full offline suite green
- [x] `task test:inventory` — no diff (no new test IDs added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsVXVxH1rVv3m8iSniaArH