### PR TITLE
chore: t001911 fe05

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -187,7 +187,7 @@ npx @lhci/cli autorun \
   --assert.performance=0.9
 ```
 
-> **B · Baseline:** n/a → 0 (Lighthouse CI in CI + health-goals-check.sh integriert, erster Scan ausstehend) · **Target:** ≥ 90 · **Aufwand:** gering (Messung) · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T001911 (Nachfolger von T001842)
+> **B · Baseline:** n/a → 60 (erster Lauf 2026-07-17 gegen `https://web.mentolder.de`, 3× `npx @lhci/cli autorun`, Performance-Score konstant 60/100 über alle 3 Runs; FCP 6.0s, LCP 7.5s, TTI 7.5s — größter Hebel: fehlende Text-Compression, ~622 KiB Einsparpotenzial) · **Target:** ≥ 90 · **Aufwand:** gering (Messung) · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T001911 (Nachfolger von T001842) · **Follow-up:** T001922 (echte Performance-Optimierung, separates Ticket, kein Chore-Scope)
 
 ## G-BRAIN14 — Brain-Ingest-Backlog: 17 → 0
 
@@ -350,7 +350,7 @@ bash scripts/health-goals-check.sh --only=G-RH01,G-CQ02
 | G-DB10 | T001908 | offen (Unused Indexes, Baseline fehlt — Nachfolger von T001839) |
 | G-SEC06 | T001909 | offen (Container CVEs, erster Trivy-Scan ausstehend — Nachfolger von T001840) |
 | G-CI03 | T001910 | offen (CI p95, erster Messlauf ausstehend — Nachfolger von T001841) |
-| G-FE05 | T001911 | offen (Lighthouse, erster Lauf ausstehend — Nachfolger von T001842) |
+| G-FE05 | T001911 | **gemessen** (Baseline 60/100, Target 90 — Optimierung als Follow-up-Ticket ausgelagert) |
 | G-BRAIN14 | T001912 | offen (Ingest-Backlog 17/86; voller kuratierter Ingest = Follow-up zu PR #2851) |
 | G-DB04 | T001739 | gruen (1h, Target ≤26h — Root-Cause-Fix nicht verifiziert, Regressionswache bleibt täglich) |
 | G-DB06 | T001739 | gruen (Gate, halten) |
@@ -392,3 +392,9 @@ G-BRAIN15 Seed-Template-Lint Exit 0 (Gate) — alle drei in health-goals-check.s
 G-BRAIN14 Ingest-Backlog 17→0 (Prio B, T001912). Messwerte: G-CQ02 9→8, G-CQ05 1→0.
 Alle Alt-Tickets der offenen Ziele waren done/archived ohne Messwert-Fix — elf Nachfolge-Tickets
 T001902–T001912 angelegt und in den Meta-Zeilen referenziert.
+
+**Baseline-Update 2026-07-17 (T001911 — erster Lighthouse-Lauf):** G-FE05 n/a→60 (3× `npx @lhci/cli
+autorun` gegen `https://web.mentolder.de`, Performance-Score konstant 60/100; FCP 6.0s, LCP 7.5s,
+TTI 7.5s, TBT 0ms, CLS 0 — größte Opportunity: fehlende Text-Compression, ~622 KiB Einsparpotenzial,
+gefolgt von unused-javascript ~278 KiB und responsive Images ~146 KiB). Score liegt deutlich unter
+Target 90 — echte Optimierung ist bewusst nicht Teil dieses Chores; Follow-up-Ticket T001922 angelegt.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ presentation/
 .taskmaster/state.json
 vitest-junit-report/
 website-dist/
+.lighthouseci/
 
 # ── codebase-memory-mcp Graph/Embedding-Index (lokal via `task codebase:index`) ──
 # Nicht mehr committet (T001717) — wird pro Session/Checkout bei Bedarf lokal neu gebaut.

--- a/website/src/lib/goals-data.generated.json
+++ b/website/src/lib/goals-data.generated.json
@@ -141,7 +141,7 @@
     "priority": "B",
     "direction": "higher",
     "baseline": null,
-    "current": 0,
+    "current": 60,
     "target": 90,
     "unit": "",
     "status": "unknown",


### PR DESCRIPTION
## Summary
- Erster Lighthouse-CI-Lauf gegen `https://web.mentolder.de` (3× `npx @lhci/cli autorun`, konstant 60/100 Performance-Score)
- Baseline für G-FE05 in `.claude/lib/goals.md` dokumentiert: n/a → 60 (Target ≥ 90)
- Kernmetriken: FCP 6.0s, LCP 7.5s, TTI 7.5s, TBT 0ms, CLS 0 — größter Hebel: fehlende Text-Compression (~622 KiB Einsparpotenzial), gefolgt von unused-javascript (~278 KiB) und responsive Images (~146 KiB)
- Score liegt deutlich unter Target — echte Performance-Optimierung ist bewusst nicht Teil dieses Chores und wurde als Follow-up-Ticket **T001922** ausgelagert
- `.lighthouseci/` zu `.gitignore` ergänzt (lokales Scan-Artefakt)

## Test plan
- [x] `task freshness:regenerate` (goals-data.generated.json aktualisiert)
- [x] `task freshness:check` grün
- [x] 3× reproduzierter Lighthouse-Lauf (60/60/60) gegen die Live-URL

Ticket T001911 (offen für den Autopilot) schließt bei grünem Merge automatisch.

https://claude.ai/code/session_01CsVXVxH1rVv3m8iSniaArH