### PR TITLE
chore(goals): document health-goal commits use scope goals, not health [T001914]

### DIFF
--- a/.claude/skills/references/dev-flow-gotchas.md
+++ b/.claude/skills/references/dev-flow-gotchas.md
@@ -74,6 +74,21 @@ bash scripts/register-scope.sh <new-scope>
 This is advisory (the post-commit `preflight-pr-scope.sh` gate still exists as the hard backstop),
 but doing it pre-commit avoids the soft-reset/recommit cycle entirely.
 
+### [T001914] Health-goal commits use scope `goals`, not `health`
+**Context**: During T001901 (health-goals-refresh, PR #2881) a commit was written with
+`chore(health): ...`. `health` is not a registered scope in `commitlint.config.cjs`
+`NAMED_SCOPES` — only `goals` is. The `pre-push` hook blocked the push and the commit had to be
+amended to `chore(goals): ...` before it could land. The confusion is understandable: the repo
+health dashboard section is literally named `#health` (see `.claude/lib/goals.md` header) and
+`HEALTH_GOAL_SCOPE_RE` (`G-[A-Z][A-Z0-9]+`) matches individual goal IDs like `G-SIZE02` — neither
+of those is the same thing as a free-standing `health` scope.
+**Rule**: Commits touching `.claude/lib/goals.md`, health-goal baselines/measurements, or any
+`G-<ID>` gate belong to scope `goals` (established, used in 15+ prior commits) — or, if the
+commit is about one specific goal ID, use that goal ID itself as the scope (e.g.
+`fix(G-SIZE02): ...`), which `HEALTH_GOAL_SCOPE_RE` already allows. Do not introduce a new
+generic `health` scope for this — `goals` already owns the domain and splitting it would only
+create ambiguity about which of the two to use for future health-goal work.
+
 ### [T000344] Database row check before file deletion
 **Context**: Deleting plan markdown file before verifying database storage.
 **Rule**: Always verify that the plan exists in `tickets.ticket_plans` by checking that the row count is greater than 0 before running `rm` on the plan file.


### PR DESCRIPTION
## Summary
- T001914 mishap: `chore(health): ...` was rejected by the pre-push commit-lint hook during T001901 (PR #2881) because `health` is not a registered commit scope — only `goals` and per-goal-ID scopes (`G-<ID>`, via `HEALTH_GOAL_SCOPE_RE`) are valid for health-goal work.
- Investigated whether `health` should be added as a new named scope: rejected — `goals` already owns this domain (15+ prior commits), and introducing a parallel `health` scope would create ambiguity about which one to use going forward.
- Documented the resolution as a new gotcha entry (`[T001914]`) in `.claude/skills/references/dev-flow-gotchas.md`, right after the existing `[T001395]` "check scope SSOT before first commit" entry, so future health-goal-touching commits pick `goals` (or the specific `G-<ID>`) up front.

## Test plan
- [x] `bash scripts/validate-commit-msg.sh message <file>` confirms `chore(health): ...` is still rejected and `chore(goals): ...` is accepted (no scope-list change was made — `health` intentionally stays unregistered).
- [x] `bash scripts/validate-commit-msg.sh head` — HEAD commit OK.
- [x] `bash scripts/preflight-pr-scope.sh "<PR title>"` — scope `goals` ✓.
- [x] `task freshness:check` — green, no new/worsened violations.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C7B8sxCMVpKn5CSQwMSuYS