### PR TITLE
fix(dev-flow): preflight-pr-scope FATAL um Branch-Rename-Hinweis ergänzen [T001915]

### DIFF
--- a/scripts/preflight-pr-scope.sh
+++ b/scripts/preflight-pr-scope.sh
@@ -34,7 +34,12 @@ if [ -n "$TICKET_ID" ]; then
   BRANCH_LC="$(echo "$CURRENT_BRANCH" | tr '[:upper:]' '[:lower:]')"
   TICKET_LC="$(echo "$TICKET_ID" | tr '[:upper:]' '[:lower:]')"
   if [[ "$BRANCH_LC" != *"$TICKET_LC"* ]]; then
+    _suggested_branch="${CURRENT_BRANCH}-${TICKET_LC}"
     echo "preflight-pr-scope: FATAL: PR title ticket ID '$TICKET_ID' does not match current branch name '$CURRENT_BRANCH'" >&2
+    echo "  Fix: rename the branch to include the ticket ID, e.g.:" >&2
+    echo "    git branch -m '$CURRENT_BRANCH' '$_suggested_branch'" >&2
+    echo "  See T001917 (dev-flow-chore/SKILL.md, Schritt 1): create the ticket BEFORE" >&2
+    echo "  naming the branch/worktree slug so this never triggers in the first place." >&2
     exit 1
   fi
 fi

--- a/tests/unit/preflight-pr-scope.bats
+++ b/tests/unit/preflight-pr-scope.bats
@@ -83,6 +83,16 @@ teardown() { rm -rf "$TMP"; }
   [ "$status" -eq 0 ]
 }
 
+@test "preflight: ticket-ID/branch mismatch suggests a git branch -m fix [T001915]" {
+  # Mishap regression: FATAL alone left no clue how to recover. The error must
+  # now propose the concrete rename command and point at the T001917 process fix.
+  run bash "$HELPER" "chore(dev-flow): some chore [T001901]" "$FIXTURE"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "does not match current branch"
+  echo "$output" | grep -q "git branch -m"
+  echo "$output" | grep -q "T001917"
+}
+
 @test "preflight: fix/* branch under a real .worktrees/ path is accepted [T001723]" {
   # Regression: the T001592 worktree-enforcement check used the broken glob
   # `*"\.worktrees/"*` (a literal backslash-dot inside a quoted pattern never


### PR DESCRIPTION
## Zusammenfassung
- preflight-pr-scope bricht bei Ticket-ID/Branch-Mismatch nicht mehr nur mit FATAL ab, sondern schlägt das konkrete `git branch -m`-Rename-Kommando vor und verweist auf den T001917-Prozessfix (Ticket vor Branch-Slug anlegen).
- Regressionstest in `tests/unit/preflight-pr-scope.bats` ergänzt.

## Kontext
Übernahme verwaister, uncommitteter WIP aus `.worktrees/t001915-branchid` (Session abgebrochen). Ticket T001915 (Bug, major).

## Verifikation
- `bats tests/unit/preflight-pr-scope.bats` — 8/8 grün
- `task test:inventory` — kein Diff (279 Einträge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)