### PR TITLE
fix(infra): korczewski website Ingress unter Git-Tracking + compress-Middleware [T000251]

### DIFF
--- a/prod-fleet/website-korczewski/kustomization.yaml
+++ b/prod-fleet/website-korczewski/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
   # Security-headers middleware in this namespace (allowCrossNamespace disabled on korczewski)
   - ../website-common/domain-config.yaml
   - website-security-headers.yaml
+  # T000251: bisher untracked Cluster-Drift — dieses Ingress gewinnt das Routing
+  # gegen die IngressRoute, daher trägt es die compress/static-cache-Annotationen.
+  - website-ingress-web.yaml
 patches:
   # Fix HTTPS: add websecure entryPoint + wildcard TLS cert (T000144)
   # Also adds security-headers middleware to the route so SA-01 headers are present (T000171)

--- a/prod-fleet/website-korczewski/website-ingress-web.yaml
+++ b/prod-fleet/website-korczewski/website-ingress-web.yaml
@@ -1,0 +1,58 @@
+# T000251: Bringt das bisher nur manuell applizierte Ingress-Objekt unter Git-Tracking.
+# Dieses Ingress gewinnt das Traefik-Routing gegen die IngressRoute `website`
+# (längere Rule: Host && PathPrefix), daher MÜSSEN die Middlewares hier annotiert
+# sein — die middlewares-Patches in kustomization.yaml auf der IngressRoute greifen
+# für den Live-Traffic nicht.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: website-ingress-web
+  namespace: website-korczewski
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/router.middlewares: >-
+      website-korczewski-website-compress@kubernetescrd,website-korczewski-website-security-headers@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - web.${PROD_DOMAIN}
+      secretName: korczewski-tls
+  rules:
+    - host: web.${PROD_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: website
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: website-ingress-astro
+  namespace: website-korczewski
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/router.middlewares: >-
+      website-korczewski-website-compress@kubernetescrd,website-korczewski-website-static-cache@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - web.${PROD_DOMAIN}
+      secretName: korczewski-tls
+  rules:
+    - host: web.${PROD_DOMAIN}
+      http:
+        paths:
+          - path: /_astro/
+            pathType: Prefix
+            backend:
+              service:
+                name: website
+                port:
+                  number: 80


### PR DESCRIPTION
Nach-Merge-Befund zu T001922/PR #2899: web.korczewski.de lieferte weiterhin unkomprimiert, weil ein manuell appliziertes, untracked Ingress-Objekt website-ingress-web das Traefik-Routing gegen die gepatchte IngressRoute gewinnt (laengere Rule) und keine Middleware-Annotation trug.

- Ingress unter Git-Tracking gebracht (prod-fleet/website-korczewski/website-ingress-web.yaml, Spiegel des Live-Objekts)
- router.middlewares: website-compress + website-security-headers (Haupt-Route), zusaetzlicher /_astro/-Ingress mit compress + static-cache (immutable Cache)
- kustomization.yaml: Ressource registriert

Ticket: T000251 (Brand korczewski)

🤖 Generated with [Claude Code](https://claude.com/claude-code)