### PR TITLE
fix(website): avatarSrc Live-Quelle (Content-Bundle) auf gerald.webp [T001929]

### DIFF
--- a/tests/spec/website-core.bats
+++ b/tests/spec/website-core.bats
@@ -308,3 +308,9 @@ PERF_KORCZEWSKI_KUST="$BATS_TEST_DIRNAME/../../prod-fleet/website-korczewski/kus
 @test "T001922 perf: korczewski overlay binds website-compress to the IngressRoute" {
   run grep -q 'website-compress' "$PERF_KORCZEWSKI_KUST"; [ "$status" -eq 0 ]
 }
+
+@test "T001929 perf: mentolder content bundle avatarSrc references gerald.webp (live source)" {
+  HOMEPAGE_JSON="$BATS_TEST_DIRNAME/../../website/content/mentolder/homepage.json"
+  run grep -q '"avatarSrc": "/gerald.webp"' "$HOMEPAGE_JSON"; [ "$status" -eq 0 ]
+  run grep -q 'gerald.jpg' "$HOMEPAGE_JSON"; [ "$status" -ne 0 ]
+}

--- a/website/content/mentolder/homepage.json
+++ b/website/content/mentolder/homepage.json
@@ -22,7 +22,7 @@
     { "title": "Wie ich arbeite", "text": "Analytische Präzision mit Beziehungsarbeit." }
   ],
   "avatarType": "image",
-  "avatarSrc": "/gerald.jpg",
+  "avatarSrc": "/gerald.webp",
   "quote": "Ich stelle unbequeme Fragen – weil echte Lösungen manchmal unbequeme Wahrheiten brauchen.",
   "quoteName": "Gerald Korczewski",
   "processSteps": [

--- a/website/src/config/brands/mentolder.ts
+++ b/website/src/config/brands/mentolder.ts
@@ -82,7 +82,7 @@ export const mentolderConfig: BrandConfig = {
     quote: 'Ich stelle unbequeme Fragen – weil echte Lösungen manchmal unbequeme Wahrheiten brauchen.',
     quoteName: 'Gerald Korczewski',
     timeline: false,
-    identityImage: { src: '/gerald.jpg', alt: 'Gerald Korczewski' },
+    identityImage: { src: '/gerald.webp', alt: 'Gerald Korczewski' },
   },
   services: [
     {


### PR DESCRIPTION
Nach-Merge-Befund zu T001922/PR #2899: Das Live-HTML lieferte weiter /gerald.jpg (176 KB), weil avatarSrc zur Laufzeit aus website/content/mentolder/homepage.json kommt (getEffectiveHomepage → bundleHomepage), nicht aus config/brands/mentolder.ts.

- homepage.json avatarSrc → /gerald.webp (17 KB)
- mentolder.ts identityImage ebenfalls → .webp (Konsistenz)
- BATS-Regressionstest gegen die echte Content-Quelle

Ticket: T001929

🤖 Generated with [Claude Code](https://claude.com/claude-code)