### PR TITLE
fix(db): exclude backup COPY from G-DB09 slow query count [T001926]

### DIFF
--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -341,7 +341,7 @@ row target G-DB03 "$(db_scalar "SELECT
 row target G-DB08 "$(db_scalar "SELECT count(*) FROM pg_stat_user_tables
     WHERE n_live_tup>10000 AND seq_scan>0
       AND (seq_scan::numeric/NULLIF(seq_scan+idx_scan,0))>0.05;")" le 3 "Tabellen >10k Rows mit Seq-Scan-Anteil >5% (messen)"
-row target G-DB09 "$(db_scalar "SELECT count(*) FROM pg_stat_statements WHERE mean_exec_time > 1000")" le 0 "Slow Queries in pg_stat_statements (mean_exec_time > 1s)"
+row target G-DB09 "$(db_scalar "SELECT count(*) FROM pg_stat_statements WHERE mean_exec_time > 1000 AND query NOT ILIKE 'COPY %'")" le 0 "Slow Queries in pg_stat_statements (mean_exec_time > 1s, exkl. Backup-COPY T001926)"
 row target G-DB10 "$(db_scalar "SELECT count(*) FROM pg_stat_user_indexes WHERE idx_scan = 0 AND indisready AND NOT indisprimary AND indexrelid NOT IN (SELECT conindid FROM pg_constraint WHERE contype='u')")" le 0 "Unused Indexes (idx_scan=0, exkl. PK/Unique)"
 
 # ── CI-TARGETS ──


### PR DESCRIPTION
Excludes pg_dump COPY commands from G-DB09 slow query measurement.

Before: 1 false positive (COPY knowledge.chunks from nightly backup)
After: 0 (correctly filtered)

The COPY command is pg_dump-internal, not an app query. Backup I/O latency is expected behavior.