### PR TITLE
feat(infra): scope claude-code-agent RBAC to default namespace [T001919]

### DIFF
--- a/k3d/default/claude-code-agent-clusterrole.yaml
+++ b/k3d/default/claude-code-agent-clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: claude-code-agent
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "endpoints", "configmaps", "persistentvolumeclaims", "namespaces", "nodes", "events", "replicationcontrollers", "serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]

--- a/k3d/default/claude-code-agent-role.yaml
+++ b/k3d/default/claude-code-agent-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: claude-code-agent-deployments
+  namespace: default
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["patch", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "patch", "update"]

--- a/k3d/default/claude-code-agent-rolebinding.yaml
+++ b/k3d/default/claude-code-agent-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: claude-code-agent-deployments
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: claude-code-agent
+    namespace: default
+roleRef:
+  kind: Role
+  name: claude-code-agent-deployments
+  apiGroup: rbac.authorization.k8s.io

--- a/k3d/default/kustomization.yaml
+++ b/k3d/default/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 
 resources:
   - claude-code-agent-sa.yaml
+  - claude-code-agent-clusterrole.yaml
+  - claude-code-agent-role.yaml
+  - claude-code-agent-rolebinding.yaml
   - claude-code-mcp-monolith-deploy.yaml
   - claude-code-mcp-monolith-svc.yaml
 


### PR DESCRIPTION
Scopes deployments patch/update/scale from ClusterRole to namespace-scoped Role in default namespace.

Changes:
- ClusterRole: removed deployments patch/update/scale (read-only remains cluster-wide)
- New Role: claude-code-agent-deployments in default namespace (patch, update, scale)
- New RoleBinding: binds SA to Role in default namespace

This limits the agent to only manage deployments in the default namespace, not cluster-wide.