### PR TITLE
fix(brett): map OIDC env names to manifests, allow single-label DNS [T001932]

### DIFF
--- a/brett/src/server/auth.ts
+++ b/brett/src/server/auth.ts
@@ -5,25 +5,47 @@ import type { Role } from '../types/state';
 
 let oidcConfig: Configuration | null = null;
 
-export async function getOidcClient(): Promise<Configuration> {
-  if (oidcConfig) return oidcConfig;
-  const piUrl       = process.env.POCKET_ID_URL || 'http://pocket-id.workspace.svc.cluster.local:1411';
-  const piPublicUrl = process.env.POCKET_ID_FRONTEND_URL || '';
-  const clientId    = process.env.BRETT_KC_CLIENT_ID || 'brett-app';
-  const clientSecret = process.env.POCKET_ID_BRETT_SECRET || process.env.BRETT_OIDC_SECRET || '';
+export interface OidcEnv {
+  piUrl: string;
+  piPublicUrl: string;
+  clientId: string;
+  clientSecret: string;
+  internalUrl: URL;
+  issuerUrl: URL;
+  isClusterHttp: boolean;
+}
+
+export function resolveOidcEnv(env: NodeJS.ProcessEnv = process.env): OidcEnv {
+  const piUrl       = env.POCKET_ID_URL || 'http://pocket-id.workspace.svc.cluster.local:1411';
+  // Manifests (prod/patch-brett.yaml, k3d/brett.yaml) set POCKET_ID_PUBLIC_URL
+  // and BRETT_CLIENT_ID; the *_FRONTEND_URL / *_KC_* names predate the
+  // Pocket-ID migration and are kept as fallbacks.
+  const piPublicUrl = env.POCKET_ID_PUBLIC_URL || env.POCKET_ID_FRONTEND_URL || '';
+  const clientId    = env.BRETT_CLIENT_ID || env.BRETT_KC_CLIENT_ID || 'brett';
+  const clientSecret = env.POCKET_ID_BRETT_SECRET || env.BRETT_OIDC_SECRET || '';
 
   const internalUrl = new URL(piUrl);
-  // When POCKET_ID_FRONTEND_URL is set, openid-client validates the discovered
-  // issuer against the public URL while customFetch routes the actual request
-  // to the cluster-internal endpoint (avoids issuer mismatch with
-  // RFC-compliant v6).
+  // When the public URL is set, openid-client validates the discovered issuer
+  // against it while customFetch routes the actual request to the
+  // cluster-internal endpoint (avoids issuer mismatch with RFC-compliant v6).
   const issuerUrl = piPublicUrl ? new URL(piPublicUrl) : internalUrl;
 
+  // Single-label hostnames (no dot, e.g. "pocket-id") are same-namespace
+  // Kubernetes service DNS — the base manifest uses them so both brand
+  // namespaces (workspace / workspace-korczewski) resolve their own Pocket-ID.
   const isClusterHttp = internalUrl.protocol === 'http:' &&
-    (internalUrl.hostname === 'localhost' || internalUrl.hostname === '127.0.0.1' || internalUrl.hostname.endsWith('.svc.cluster.local'));
+    (internalUrl.hostname === 'localhost' || internalUrl.hostname === '127.0.0.1' ||
+      internalUrl.hostname.endsWith('.svc.cluster.local') || !internalUrl.hostname.includes('.'));
   if (internalUrl.protocol === 'http:' && !isClusterHttp) {
     throw new Error(`OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: ${internalUrl.hostname}`);
   }
+
+  return { piUrl, piPublicUrl, clientId, clientSecret, internalUrl, issuerUrl, isClusterHttp };
+}
+
+export async function getOidcClient(): Promise<Configuration> {
+  if (oidcConfig) return oidcConfig;
+  const { piUrl, piPublicUrl, clientId, clientSecret, internalUrl, issuerUrl, isClusterHttp } = resolveOidcEnv();
 
   const opts: Record<string | symbol, unknown> = {};
   if (isClusterHttp) opts.execute = [allowInsecureRequests];

--- a/brett/test/auth.test.ts
+++ b/brett/test/auth.test.ts
@@ -180,3 +180,48 @@ test('FA-BRT-B1d: requireLeiterOrAdmin honors the e2e secret bypass', () => {
   assert.equal(called, true);
   delete process.env.BRETT_OIDC_SECRET;
 });
+
+// T001932: env-name mismatch between manifests and code broke /auth/login in
+// prod ({"error":"internal_error"}). resolveOidcEnv must accept the names the
+// manifests actually set and treat single-label service DNS as cluster-internal.
+import { resolveOidcEnv } from '../src/server/auth';
+
+test('T001932-A1: bare service hostname (http://pocket-id:1411) is cluster-internal', () => {
+  const env = resolveOidcEnv({ POCKET_ID_URL: 'http://pocket-id:1411' } as NodeJS.ProcessEnv);
+  assert.equal(env.isClusterHttp, true);
+});
+
+test('T001932-A2: public http hostname is still rejected', () => {
+  assert.throws(
+    () => resolveOidcEnv({ POCKET_ID_URL: 'http://auth.example.com' } as NodeJS.ProcessEnv),
+    /must use HTTPS or a cluster-internal hostname/,
+  );
+});
+
+test('T001932-A3: POCKET_ID_PUBLIC_URL (manifest name) sets the issuer URL', () => {
+  const env = resolveOidcEnv({
+    POCKET_ID_URL: 'http://pocket-id:1411',
+    POCKET_ID_PUBLIC_URL: 'https://auth.mentolder.de',
+  } as NodeJS.ProcessEnv);
+  assert.equal(env.issuerUrl.href, 'https://auth.mentolder.de/');
+});
+
+test('T001932-A4: POCKET_ID_FRONTEND_URL still works as fallback', () => {
+  const env = resolveOidcEnv({
+    POCKET_ID_URL: 'http://pocket-id:1411',
+    POCKET_ID_FRONTEND_URL: 'https://auth.example.de',
+  } as NodeJS.ProcessEnv);
+  assert.equal(env.issuerUrl.href, 'https://auth.example.de/');
+});
+
+test('T001932-A5: BRETT_CLIENT_ID (manifest name) wins, default is brett', () => {
+  const base = { POCKET_ID_URL: 'http://pocket-id:1411' };
+  assert.equal(resolveOidcEnv({ ...base, BRETT_CLIENT_ID: 'brett' } as NodeJS.ProcessEnv).clientId, 'brett');
+  assert.equal(resolveOidcEnv({ ...base, BRETT_KC_CLIENT_ID: 'legacy' } as NodeJS.ProcessEnv).clientId, 'legacy');
+  assert.equal(resolveOidcEnv(base as NodeJS.ProcessEnv).clientId, 'brett');
+});
+
+test('T001932-A6: *.svc.cluster.local and localhost remain cluster-internal', () => {
+  assert.equal(resolveOidcEnv({ POCKET_ID_URL: 'http://pocket-id.workspace.svc.cluster.local:1411' } as NodeJS.ProcessEnv).isClusterHttp, true);
+  assert.equal(resolveOidcEnv({ POCKET_ID_URL: 'http://localhost:1411' } as NodeJS.ProcessEnv).isClusterHttp, true);
+});


### PR DESCRIPTION
## Summary
- Fixes {"error":"internal_error"} on https://brett.mentolder.de/auth/login — latent since the Pocket-ID migration (T001068, PRs #2042/#2057).
- Root cause: three env-name mismatches between code and manifests:
  1. `getOidcClient` rejected the base-manifest issuer `http://pocket-id:1411` — single-label service DNS was not on the cluster-internal whitelist (the actual crash).
  2. Code read `POCKET_ID_FRONTEND_URL`, prod patch sets `POCKET_ID_PUBLIC_URL`.
  3. Code read `BRETT_KC_CLIENT_ID` (default `brett-app`), manifests set `BRETT_CLIENT_ID=brett` — only client `brett` exists in Pocket-ID.
- Fix: extracted env resolution into pure `resolveOidcEnv()` (testable), accept manifest env names with legacy fallbacks, allow dot-less hostnames as cluster-internal (keeps the base manifest namespace-agnostic for both brands).

## Test Plan
- [x] 6 new unit tests T001932-A1…A6 in `brett/test/auth.test.ts` (whitelist, env fallbacks, client-id default)
- [x] `npm test` in brett/: 643 pass, `npm run typecheck` clean
- [ ] Post-merge: tag `brett-v*` build + rollout, then verify login on brett.mentolder.de

🤖 [T001932]