### PR TITLE
fix(brett): OIDC-Client-Init repariert — Session-Erstellung wieder möglich [T001933]

### DIFF
--- a/environments/dev.yaml
+++ b/environments/dev.yaml
@@ -28,7 +28,10 @@ env_vars:
   MEDIAVIEWER_HOST: mediaviewer.localhost
   VIDEOVAULT_DOMAIN: videovault.localhost
   POCKET_ID_FRONTEND_URL: "http://auth.localhost"
-  POCKET_ID_URL: "http://pocket-id:1411"
+  # FQDN statt Kurzname: brett/src/server/auth.ts akzeptiert http nur für
+  # localhost/*.svc.cluster.local (T001933) — Kurzname 'pocket-id' wirft beim
+  # OIDC-Client-Init.
+  POCKET_ID_URL: "http://pocket-id.workspace.svc.cluster.local:1411"
   NEXTCLOUD_DB_HOST: nextcloud-db.workspace.svc.cluster.local
   # CORS allowlist origin for the React SPA (dev)
   REACT_APP_ORIGIN: "http://react.localhost"

--- a/k3d/brett.yaml
+++ b/k3d/brett.yaml
@@ -53,7 +53,9 @@ spec:
             - name: DATABASE_URL
               value: "postgresql://website:$(WEBSITE_DB_PASSWORD)@shared-db:5432/website?sslmode=disable"
             - name: POCKET_ID_URL
-              value: "http://pocket-id:1411"
+              value: "${POCKET_ID_URL}"
+            - name: POCKET_ID_FRONTEND_URL
+              value: "${POCKET_ID_FRONTEND_URL}"
             - name: BRETT_CLIENT_ID
               value: "brett"
             - name: BRETT_OIDC_SECRET

--- a/prod/patch-brett.yaml
+++ b/prod/patch-brett.yaml
@@ -8,5 +8,8 @@ spec:
       containers:
         - name: brett
           env:
-            - name: POCKET_ID_PUBLIC_URL
+            # T001933: brett/src/server/auth.ts liest POCKET_ID_FRONTEND_URL —
+            # der alte Name POCKET_ID_PUBLIC_URL wurde nie gelesen (Issuer-
+            # Mismatch bei der Discovery → /auth/login 500 auf beiden Brands).
+            - name: POCKET_ID_FRONTEND_URL
               value: "https://auth.${PROD_DOMAIN}"


### PR DESCRIPTION
## Problem
Seit der Pocket-ID-Migration auf `auth.*` (#2057, 22.06.) konnte in Brett **niemand mehr eine Session starten** — auf beiden Brands. Brett's eigener OIDC-Login (`/auth/login`) warf 500, `/auth/me` blieb anon, und das Hauptmenü blendete den Button „Neue Session starten" aus (nur für authentifizierte User sichtbar).

## Root Cause (zweiteilig)
1. **mentolder**: `k3d/brett.yaml` setzte `POCKET_ID_URL=http://pocket-id:1411` (Kurzname). `brett/src/server/auth.ts` akzeptiert http nur für `localhost`/`*.svc.cluster.local` → Init wirft sofort (Pod-Log: `OIDC issuer URL must use HTTPS or a cluster-internal hostname, got: pocket-id`).
2. **korczewski**: FQDN war per Overlay gepatcht, aber `prod/patch-brett.yaml` setzte `POCKET_ID_PUBLIC_URL` — der Code liest `POCKET_ID_FRONTEND_URL`. Ohne Frontend-URL: Issuer-Mismatch bei der Discovery (Pocket ID advertised `https://auth.korczewski.de`, erwartet wurde die interne URL).

Verifiziert in-cluster: `/auth/login` → 500 auf beiden Brands; letzte erfolgreiche Session in `brett_rooms` vom 10.06. (vor der Migration).

## Fix
- `k3d/brett.yaml`: `POCKET_ID_URL`/`POCKET_ID_FRONTEND_URL` registry-getrieben als envsubst-Platzhalter (Muster wie `k3d/website.yaml` — dort funktioniert der Login).
- `prod/patch-brett.yaml`: Env auf den korrekten Namen `POCKET_ID_FRONTEND_URL` umbenannt.
- `environments/dev.yaml`: `POCKET_ID_URL` auf FQDN (Validator-kompatibel auch im k3d-Dev).

## Verifikation
- `task test:all` grün (52/52), `task freshness:check` grün, beide prod-fleet-Overlays bauen; gerenderte Env geprüft.
- Nach Merge + Deploy: Live-Verifikation Login → Menü → Session-Create auf beiden Brands.

Ticket: T001933

🤖 Generated with [Claude Code](https://claude.com/claude-code)