### PR TITLE
fix(infra): pocket-id-Seed — Mehrfach-Callbacks je Client, brett /auth/callback registriert [T001937]

### DIFF
--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -186,7 +186,7 @@ spec:
               docs|SECRET_docs|POCKET_ID_DOCS_SECRET|${SCHEME}://docs.${SUFFIX}/oauth2/callback
               downloads|SECRET_downloads|POCKET_ID_DOWNLOADS_SECRET|${SCHEME}://downloads.${SUFFIX}/oauth2/callback
               mailpit-admin|SECRET_mail|POCKET_ID_MAIL_SECRET|${SCHEME}://mail.${SUFFIX}/oauth2/callback
-              brett|SECRET_brett|POCKET_ID_BRETT_SECRET|${SCHEME}://brett.${SUFFIX}/oauth2/callback
+              brett|SECRET_brett|POCKET_ID_BRETT_SECRET|${SCHEME}://brett.${SUFFIX}/oauth2/callback,${SCHEME}://brett.${SUFFIX}/auth/callback
               comfy|SECRET_comfy|POCKET_ID_COMFY_SECRET|${SCHEME}://comfy.${SUFFIX}/oauth2/callback
               mediaviewer-widget|SECRET_mediaviewer|POCKET_ID_MEDIAVIEWER_SECRET|${SCHEME}://mediaviewer.${SUFFIX}/oauth2/callback
               videovault|SECRET_videovault|POCKET_ID_VIDEOVAULT_SECRET|${SCHEME}://videovault.${SUFFIX}/oauth2/callback
@@ -286,15 +286,19 @@ spec:
                 if [ -z "$secret" ]; then
                   echo "skip ${cid} (no secret configured)"; return 0
                 fi
+                # T001937: cb may be a comma-separated list (e.g. brett needs
+                # BOTH the oauth2-proxy callback AND its own /auth/callback for
+                # the app-level OIDC flow) — expand to a JSON string array.
+                cb_json=$(printf '%s' "$cb" | sed 's/,/","/g')
                 real_id=$(find_client_id "$cid")
                 if [ -n "$real_id" ]; then
                   curl -fsS $CURL_RETRY -X PUT -H "$AUTH" -H "$CT" \
-                    -d "$(printf '{"name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":[],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' "$cid" "$cb")" \
+                    -d "$(printf '{"name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":[],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' "$cid" "$cb_json")" \
                     "${API}/api/oidc/clients/${real_id}" </dev/null >/dev/null
                   echo "updated ${cid} (id=${real_id}), secret unchanged"
                 else
                   created=$(curl -fsS $CURL_RETRY -X POST -H "$AUTH" -H "$CT" \
-                    -d "$(printf '{"name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":[],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' "$cid" "$cb")" \
+                    -d "$(printf '{"name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":[],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' "$cid" "$cb_json")" \
                     "${API}/api/oidc/clients" </dev/null)
                   new_id=$(echo "$created" | sed -E 's/.*"id":"([^"]+)".*/\1/')
                   gen=$(curl -fsS $CURL_RETRY -X POST -H "$AUTH" -H "$CT" \


### PR DESCRIPTION
## Problem
Folgebefund aus T001933: Nach dem Env-Fix initialisiert Bretts OIDC-Client wieder, aber Pocket ID kennt für Client `brett` nur den oauth2-proxy-Callback (`/oauth2/callback`). Bretts eigener App-Login nutzt `/auth/callback` → invalid redirect_uri. Der Seed-Job (`k3d/pocket-id-client-seed.yaml`) konnte konstruktionsbedingt nur **eine** Callback-URL pro Client setzen und hätte jeden manuellen DB-Fix beim nächsten Deploy wieder überschrieben.

## Fix
- ROWS-Feld 4 akzeptiert eine kommaseparierte Callback-Liste
- `upsert()` expandiert sie per `sed` zu einem JSON-String-Array
- brett-Zeile registriert jetzt beide Callbacks

## Sofortmaßnahme (bereits erledigt)
`pocket_id.oidc_clients` auf mentolder direkt um den Callback ergänzt (hält bis zum nächsten Seed-Lauf — dieser PR macht es persistent). korczewski folgt nach dem laufenden Redeploy.

## Verifikation
`task test:all` grün (52/52), `task freshness:check` grün, `kustomize build k3d/` OK.

Ticket: T001937

🤖 Generated with [Claude Code](https://claude.com/claude-code)