### PR TITLE
chore(website): Neue-Session-Button in Coaching-Sessions-Übersicht [T001938]

### DIFF
--- a/tests/spec/studio-sessions-reorganize.bats
+++ b/tests/spec/studio-sessions-reorganize.bats
@@ -28,9 +28,9 @@ setup() {
   [ "$status" -ne 0 ]
 }
 
-@test "sessions overview does not contain Neue Session link" {
+@test "sessions overview contains Neue Session link (T001938: studio route is gone, sessions list is the only entry point)" {
   run grep -qF "+ Neue Session" "$WEB/components/admin/coaching/SessionsOverview.svelte"
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 0 ]
 }
 
 @test "coaching studio page wrapper was removed with the dead route" {

--- a/website/src/components/admin/coaching/SessionsOverview.svelte
+++ b/website/src/components/admin/coaching/SessionsOverview.svelte
@@ -121,6 +121,7 @@
       bind:value={q}
       oninput={onSearch}
     />
+    <a href="/admin/coaching/sessions/new" class="btn-primary">+ Neue Session</a>
     <a href="/admin/coaching/settings" class="btn-sm">⚙ Einstellungen</a>
   </div>
 


### PR DESCRIPTION
## Summary
- Coaching-Sessions-Übersicht (`/admin/coaching/sessions`) hatte keinen Weg, eine neue Session zu starten
- Die Zielseite `/admin/coaching/sessions/new` war bereits voll funktionsfähig, aber unverlinkt
- Toolbar-Link "+ Neue Session" ergänzt (bestehende `.btn-primary`-Styles, keine neue CSS)

## Test plan
- [x] `task test:changed` — 52/52 grün
- [x] `task freshness:regenerate` — keine Diffs
- [x] `task freshness:check` — grün (Ratchet, Baseline-Guard, Graph-Artefakte)
- [x] S1-Restbudget der Datei: 250 Zeilen (1 Zeile hinzugefügt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)