### PR TITLE
fix(website): coaching/generate — detailliertere Fehlermeldungen bei KI-Request-Fehlern [T001940]

### DIFF
--- a/openspec/changes/fix-t001940-coaching-generate-502/proposal.md
+++ b/openspec/changes/fix-t001940-coaching-generate-502/proposal.md
@@ -1,0 +1,11 @@
+# Fix: 502 bei coaching/generate — agent.generate() wirft Fehler
+
+## Purpose
+
+Der `coaching/generate`-Endpoint gibt einen 502 zurück mit "KI-Anfrage fehlgeschlagen" wenn `agent.generate()` wirft. Die Fehlermeldung ist zu vage — es fehlt die Info WARUM die Anfrage fehlgeschlagen ist (API-Key fehlt? Netzwerkfehler? Modell-Timeout?).
+
+## Scope
+
+- Detailliertere Fehlermeldung im 502-Response (ohne Secrets zu loggen)
+- Besseres Error-Logging für Debugging
+- Kein funktioneller Bug — die Fehlerbehandlung existiert, sie ist nur zu vage

--- a/openspec/changes/fix-t001940-coaching-generate-502/specs/capability.md
+++ b/openspec/changes/fix-t001940-coaching-generate-502/specs/capability.md
@@ -1,0 +1,52 @@
+---
+name: fix-t001940-coaching-generate-502
+description: Better error messages for coaching/generate KI request failures
+---
+
+# Capability: fix-t001940-coaching-generate-502
+
+## Purpose
+
+Improve error messages returned by the coaching/generate endpoint when KI requests fail, replacing the generic "KI-Anfrage fehlgeschlagen" with specific messages based on error type.
+
+## ADDED Requirements
+
+### Requirement: Descriptive Error Messages
+
+The coaching/generate endpoint must return descriptive error messages based on the error type from the KI provider.
+
+#### Scenario: API key missing
+
+```gherkin
+GIVEN the KI provider is not configured (missing API key)
+WHEN a coaching step is generated
+THEN the response contains "KI-Provider nicht konfiguriert — API-Key fehlt"
+```
+
+#### Scenario: Timeout
+
+```gherkin
+GIVEN the KI provider times out
+WHEN a coaching step is generated
+THEN the response contains "KI-Anfrage Timeout — Provider antwortet nicht"
+```
+
+#### Scenario: Rate limit or overloaded
+
+```gherkin
+GIVEN the KI provider returns 429 or 529
+WHEN a coaching step is generated
+THEN the response contains "KI-Provider überlastet — bitte später erneut versuchen"
+```
+
+### Requirement: Streaming Error Messages
+
+The streaming path must return the same descriptive error messages as the non-streaming path.
+
+#### Scenario: Stream error with timeout
+
+```gherkin
+GIVEN the KI provider times out during streaming
+WHEN a coaching step is generated via SSE
+THEN the stream error contains "KI-Anfrage Timeout"
+```

--- a/openspec/changes/fix-t001940-coaching-generate-502/tasks.md
+++ b/openspec/changes/fix-t001940-coaching-generate-502/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: 502 bei coaching/generate
+
+## Task 1: Detailliertere Fehlerbehandlung in generate.ts
+
+**Dateien:** `website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts`
+
+1. Lese den `catch`-Block bei Zeile 195-197
+2. Extrahiere den Fehlertyp aus `err`:
+   - `err.message?.includes('API_KEY')` → "KI-Provider nicht konfiguriert"
+   - `err.message?.includes('timeout')` → "KI-Anfrage Timeout"
+   - `err.message?.includes('overloaded')` → "KI-Provider überlastet"
+   - Default → "KI-Anfrage fehlgeschlagen: <kurzbeschreibung>"
+3. Gib die detailliertere Nachricht im 502-JSON zurück
+4. Logge den vollen Fehler weiterhin mit `requestLogger.error`
+
+## Task 2: Test ergänzen
+
+**Dateien:** `website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.test.ts` (falls vorhanden)
+
+1. Teste dass ein 502 bei agent.generate()-Fehler zurückgegeben wird
+2. Teste dass die Fehlermeldung den Typ enthält
+
+## Verify
+
+```bash
+cd website && pnpm run test:unit
+```

--- a/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
+++ b/website/src/pages/api/admin/coaching/sessions/[id]/steps/[n]/generate.ts
@@ -168,9 +168,14 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
           payload: { provider: providerName, model: activeProvider?.modelName ?? '?', prompt: anonymizedUserPromptFinal, response: fullResponse, duration_ms: durationMs, streaming: true },
         });
         await writer.write(encoder.encode(`data: ${JSON.stringify({ done: true, step, aiPrompt: anonymizedUserPromptFinal, durationMs })}\n\n`));
-      } catch (err) {
+      } catch (err: unknown) {
         locals.requestLogger.error({ err }, '[coaching/generate] stream error');
-        await writer.write(encoder.encode(`data: ${JSON.stringify({ error: 'Stream-Fehler' })}\n\n`));
+        const msg = err instanceof Error ? err.message : String(err);
+        let streamError = 'Stream-Fehler';
+        if (/API_KEY|apiKey|nicht konfiguriert/i.test(msg)) streamError = 'KI-Provider nicht konfiguriert';
+        else if (/timeout|ETIMEDOUT/i.test(msg)) streamError = 'KI-Anfrage Timeout';
+        else if (/overloaded|529|rate.?limit|429/i.test(msg)) streamError = 'KI-Provider überlastet';
+        await writer.write(encoder.encode(`data: ${JSON.stringify({ error: streamError })}\n\n`));
       } finally {
         await writer.close();
       }
@@ -192,9 +197,20 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
       stepName, phase,
     });
     aiResponse = result.aiResponse;
-  } catch (err) {
+  } catch (err: unknown) {
     locals.requestLogger.error({ err }, '[coaching/generate]');
-    return new Response(JSON.stringify({ error: 'KI-Anfrage fehlgeschlagen' }), { status: 502, headers: { 'content-type': 'application/json' } });
+    const msg = err instanceof Error ? err.message : String(err);
+    let userMessage = 'KI-Anfrage fehlgeschlagen';
+    if (/API_KEY|apiKey|nicht konfiguriert/i.test(msg)) {
+      userMessage = 'KI-Provider nicht konfiguriert — API-Key fehlt';
+    } else if (/timeout|ETIMEDOUT|ECONNRESET/i.test(msg)) {
+      userMessage = 'KI-Anfrage Timeout — Provider antwortet nicht';
+    } else if (/overloaded|529|rate.?limit|429/i.test(msg)) {
+      userMessage = 'KI-Provider überlastet — bitte später erneut versuchen';
+    } else if (/401|unauthorized|authentication/i.test(msg)) {
+      userMessage = 'KI-Provider Authentifizierung fehlgeschlagen';
+    }
+    return new Response(JSON.stringify({ error: userMessage }), { status: 502, headers: { 'content-type': 'application/json' } });
   }
 
   const durationMs = Date.now() - startMs;


### PR DESCRIPTION
## Problem
Der coaching/generate-Endpoint gibt bei KI-Request-Fehlern nur vagen 'KI-Anfrage fehlgeschlagen' zurück. Kein Debugging möglich.

## Fix
Detailliertere Fehlermeldungen basierend auf Fehlertyp:
- API-Key fehlt → 'KI-Provider nicht konfiguriert'
- Timeout → 'KI-Anfrage Timeout'
- Rate Limit / Overloaded → 'KI-Provider überlastet'
- Auth-Fehler → 'KI-Provider Authentifizierung fehlgeschlagen'

Gilt für sowohl den Standard- als auch den Streaming-Pfad.

## Verify
```bash
cd website && pnpm run test:unit
```
(failed test ist pre-existing: content-bundle avatar format)