### PR TITLE
fix: Mishap-Bundle — Agent-Toolnamen + Worktree-Pfad-Validierung [T001936]

### DIFF
--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -6,7 +6,7 @@ description: >
   (GPU host status, model management, Ollama/TEI/LiteLLM) on the Bachelorprojekt clusters.
   Triggers on: pod, logs, status, restart, crash, health, kubectl, "what's wrong",
   "why is X failing", "is X running", llm:, GPU, Ollama, model, LiveKit.
-tools: [run_shell_command, read_file, glob, grep_search, list_directory]
+tools: [Bash, Read, Glob, Grep]
 ---
 
 ## Library
@@ -23,7 +23,7 @@ You are an operations specialist for the Bachelorprojekt Kubernetes platform. Yo
 Your diagnoses are trusted downstream and acted on. A confident conclusion drawn from a broken shell is more dangerous than the broken shell itself — so verify the session before you believe anything it returns.
 
 1. **Probe before trusting the session.** As the first step of any investigation, run a trivial command with a known-shaped answer — `kubectl get nodes --context fleet` — and confirm you got real output (an actual node table) rather than the command echoed back at you.
-2. **Recognise corruption signals.** Treat the session as unreliable if `run_shell_command` echoes the input command instead of executing it, if a command returns a stale PTY buffer / stale prompt artifact (e.g. `date` returning a literal like the username instead of a timestamp), or if output is otherwise desynced from the command you ran.
+2. **Recognise corruption signals.** Treat the session as unreliable if `Bash` echoes the input command instead of executing it, if a command returns a stale PTY buffer / stale prompt artifact (e.g. `date` returning a literal like the username instead of a timestamp), or if output is otherwise desynced from the command you ran.
 3. **Fail loud — never fabricate.** If output looks echoed, stale, or suspicious, do NOT draw or narrate a diagnosis from it. Stop, and report the broken / unreliable environment to the orchestrator instead of producing a confident but unverified conclusion. A halted investigation with "the shell session is corrupted" is the correct, safe outcome.
 
 ## Cluster topology

--- a/openspec/changes/fix-t001936-mishap-bundle/proposal.md
+++ b/openspec/changes/fix-t001936-mishap-bundle/proposal.md
@@ -1,0 +1,10 @@
+# Fix: Mishap-Bundle — skills/agents, scripts/worktree
+
+## Purpose
+
+Mishap-Bundle mit 2 Einträgen betreffend `skills/agents` und `scripts/worktree`. Der Mishap-Buffer ist leer (evtl. bereits geflusht), daher müssen die betroffenen Dateien direkt analysiert werden.
+
+## Scope
+
+- Identifiziere die konkreten Probleme in `skills/agents` und `scripts/worktree`
+- Fixe die identifizierten Probleme

--- a/openspec/changes/fix-t001936-mishap-bundle/specs/capability.md
+++ b/openspec/changes/fix-t001936-mishap-bundle/specs/capability.md
@@ -1,0 +1,38 @@
+---
+name: fix-t001936-mishap-bundle
+description: Fixes two mishaps: agent tool names and worktree path validation
+---
+
+# Capability: fix-t001936-mishap-bundle
+
+## Purpose
+
+Fix two mishaps identified in the mishap bundle:
+1. Agent tool names in `bachelorprojekt-ops.md` use opencode names instead of Claude Code names
+2. Worktree path validation for feature/fix branches
+
+## ADDED Requirements
+
+### Requirement: Agent Tool Names
+
+The `bachelorprojekt-ops.md` agent file must use Claude Code tool names (`Bash`, `Read`, `Glob`, `Grep`) instead of opencode tool names (`run_shell_command`, `read_file`, `glob`, `grep_search`, `list_directory`).
+
+#### Scenario: Agent spawns with correct tools
+
+```gherkin
+GIVEN a Claude Code session
+WHEN spawning the bachelorprojekt-ops agent
+THEN the agent should have access to Bash, Read, Glob, and Grep tools
+```
+
+### Requirement: Worktree Path Validation
+
+The `worktree-create.sh` script must automatically redirect non-conformant paths (e.g., `tmp/`) to `.worktrees/` for feature/fix branches, preventing PR flow failures.
+
+#### Scenario: Worktree path auto-redirect
+
+```gherkin
+GIVEN a feature branch feature/test
+WHEN creating a worktree at tmp/test
+THEN the script should auto-redirect to .worktrees/test
+```

--- a/openspec/changes/fix-t001936-mishap-bundle/tasks.md
+++ b/openspec/changes/fix-t001936-mishap-bundle/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: Mishap-Bundle skills/agents, scripts/worktree
+
+## Task 1: Mishap-Einträge identifizieren
+
+1. Lies den Ticket-Description (1551 chars) um die konkreten Mishap-Einträge zu verstehen
+2. Analysiere die betroffenen Dateien in `skills/agents` und `scripts/worktree`
+3. Identifiziere die Root Causes
+
+## Task 2: Fixes anwenden
+
+1. Fixe die in Task 1 identifizierten Probleme
+2. Stelle sicher dass keine Regressionen entstehen
+
+## Task 3: Tests laufen lassen
+
+```bash
+task test:changed
+```

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -65,6 +65,21 @@ BRANCH="${1:?Usage: worktree-create.sh <branch> <path> [<base>]}"
 WT_PATH="${2:?Usage: worktree-create.sh <branch> <path> [<base>]}"
 BASE="${3:-origin/main}"
 
+# T001936: Enforce .worktrees/ path for feature/fix branches.
+# CLAUDE.local.md / Memory previously recommended tmp/ paths which conflict with
+# preflight-pr-scope.sh (lines 63-68). Auto-redirect non-conformant paths instead
+# of letting the PR flow fail with FATAL.
+# Skip in test mode (WT_PATH under /tmp or $TMP) — BATS tests create ephemeral
+# worktrees in temp dirs which are expected to be outside .worktrees/.
+if [[ "$BRANCH" =~ ^(feature|fix)/ ]] && [[ "$WT_PATH" != /tmp/* ]] && [[ "$WT_PATH" != "${TMP:-/nonexistent}"/* ]]; then
+  ABS_WT="$(cd "$(dirname "$WT_PATH")" 2>/dev/null && pwd)/$(basename "$WT_PATH")" 2>/dev/null || ABS_WT="$WT_PATH"
+  if [[ "$ABS_WT" != *"/worktrees/"* ]] && [[ "$ABS_WT" != *"/.worktrees/"* ]]; then
+    _wt_name="$(basename "$WT_PATH")"
+    WT_PATH=".worktrees/$_wt_name"
+    echo "worktree-create: T001936 — auto-redirected path to $WT_PATH (feature/fix branches require .worktrees/)" >&2
+  fi
+fi
+
 # Absolute path to the SHARED gitdir (.../.git), valid from main or a worktree.
 COMMON_DIR="$(cd "$(git rev-parse --git-common-dir)" && pwd)"
 KEY_SRC="$COMMON_DIR/git-crypt/keys/default"


### PR DESCRIPTION
## Problem
Two mishaps from the mishap bundle:

1. **Agent tool names**: `bachelorprojekt-ops.md` used opencode tool names (`run_shell_command`, `read_file`, etc.) instead of Claude Code names (`Bash`, `Read`, etc.). Claude Code resolves these to zero tools and refuses to spawn the agent.

2. **Worktree path conflict**: `CLAUDE.local.md`/Memory recommended `tmp/` paths, but `preflight-pr-scope.sh` requires `.worktrees/` for feature/fix branches. PR flow fails with FATAL.

## Fix
1. Updated `bachelorprojekt-ops.md` line 9: tools changed to `[Bash, Read, Glob, Grep]`; also updated reference in line 26.

2. Added path validation in `worktree-create.sh` (after line 66): auto-redirects non-conformant paths to `.worktrees/` for feature/fix branches with a clear warning message.

## Verify
```bash
task test:changed
```