### PR TITLE
test(brett): add E2E coverage for session lifecycle and hidden-figure filter [T001941]

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -222,6 +222,8 @@ export default defineConfig({
         '**/brett-mannequin.spec.ts',  // mannequin focus
         '**/brett-roles.spec.ts',      // C7 role enforcement (opens its own contexts)
         '**/brett-share-link.spec.ts', // T000608 public view-only share link
+        '**/brett-session-lifecycle.spec.ts', // session-active/round-phases/kick/handoff (opens its own contexts)
+        '**/brett-hidden-figures.spec.ts',    // E9 verdecktes Arbeiten — role-filter security test (opens its own contexts)
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/specs/brett-hidden-figures.spec.ts
+++ b/tests/e2e/specs/brett-hidden-figures.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+
+// Coverage-Lücke (Gap-Analyse dev-flow-e2e): E9 "verdecktes Arbeiten"
+// (figure_hide_set) ist als SICHERHEITSKRITISCH dokumentiert
+// (brett/src/server/hidden-filter.ts: "hidden-Figurendaten dürfen einen
+// Nicht-Leiter NIE erreichen — weder im Snapshot noch als Broadcast"),
+// war aber bislang ungetestet. Diese Datei prüft den Server-seitigen
+// Rollen-Filter end-to-end: ein Beobachter darf eine vom Leiter versteckte
+// Figur weder im Broadcast noch im Join-Snapshot sehen.
+
+const BRETT_URL = process.env.BRETT_URL
+  ?? (process.env.PROD_DOMAIN ? `https://brett.${process.env.PROD_DOMAIN}` : 'http://brett.localhost');
+const BRETT_OIDC_SECRET = process.env.BRETT_OIDC_SECRET ?? '';
+
+test.describe('Brett hidden figures (E9 — verdecktes Arbeiten)', () => {
+  test.skip(!BRETT_OIDC_SECRET, 'BRETT_OIDC_SECRET required to mint distinct e2e identities');
+
+  async function loginAs(context: BrowserContext, userId: string, name: string): Promise<void> {
+    const res = await context.request.post(`${BRETT_URL}/auth/e2e-login`, {
+      headers: { 'x-e2e-secret': BRETT_OIDC_SECRET, 'content-type': 'application/json' },
+      data: { userId, name, isAdmin: true },
+    });
+    expect(res.ok(), `e2e-login for ${userId}`).toBeTruthy();
+  }
+
+  async function waitForBoard(page: Page): Promise<void> {
+    await page.waitForFunction(() => {
+      const ws = (window as any).__brettWS;
+      return ws && ws.readyState === 1 && (window as any).STATE;
+    }, { timeout: 15000 });
+  }
+
+  async function sendWs(page: Page, msg: any): Promise<void> {
+    await page.evaluate((m) => (window as any).__brettWS.send(JSON.stringify(m)), msg);
+  }
+
+  test('a beobachter never receives a leiter-hidden figure — neither via broadcast nor join snapshot', async ({ browser }) => {
+    const room = `e2e-hidden-${Math.random().toString(36).slice(2, 8)}`;
+    const leiterCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const beobCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    await loginAs(leiterCtx, 'leiter-hidden-e2e', 'Leiter');
+    await loginAs(beobCtx, 'beob-hidden-e2e', 'Beobachter');
+
+    const leiter = await leiterCtx.newPage();
+    const beob = await beobCtx.newPage();
+
+    try {
+      // ── Leiter erstellt Session, beansprucht die leiter-Rolle ──────────────
+      await leiter.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(leiter);
+      await sendWs(leiter, { type: 'admin_session_create' });
+      await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'leiter-hidden-e2e', role: 'leiter' });
+
+      // Seeded figure des Leiters als Ziel verwenden.
+      await leiter.waitForFunction(() => (window as any).STATE?.figures?.length > 0, { timeout: 10000 });
+      const figureId: string = await leiter.evaluate(() => (window as any).STATE.figures[0].id);
+
+      // ── Beobachter tritt bei, BEVOR die Figur versteckt wird ───────────────
+      await beob.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(beob);
+      await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'beob-hidden-e2e', role: 'beobachter' });
+      await beob.waitForTimeout(300);
+      await beob.waitForFunction(
+        (id) => (window as any).STATE?.figures?.some((f: any) => f.id === id),
+        figureId,
+        { timeout: 10000 }
+      );
+
+      // ── Leiter versteckt die Figur → Beobachter muss sie als 'delete' sehen ─
+      await sendWs(leiter, { type: 'figure_hide_set', figureId, hidden: true });
+      await beob.waitForFunction(
+        (id) => !(window as any).STATE?.figures?.some((f: any) => f.id === id),
+        figureId,
+        { timeout: 10000 }
+      );
+
+      // Leiter behält die volle (halbtransparente) Sicht auf die Figur.
+      const leiterStillSeesIt: boolean = await leiter.evaluate(
+        (id) => (window as any).STATE.figures.some((f: any) => f.id === id),
+        figureId
+      );
+      expect(leiterStillSeesIt, 'the leiter must still see the hidden figure').toBe(true);
+
+      // ── Neuer Beobachter joint NACH dem Verstecken → Join-Snapshot darf die
+      //    Figur ebenfalls nicht enthalten (Snapshot-Filter, nicht nur Broadcast).
+      const latecomerCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+      await loginAs(latecomerCtx, 'latecomer-hidden-e2e', 'Spätzugang');
+      const latecomer = await latecomerCtx.newPage();
+      try {
+        await latecomer.goto(`${BRETT_URL}?room=${room}`);
+        await waitForBoard(latecomer);
+        await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'latecomer-hidden-e2e', role: 'beobachter' });
+        await latecomer.waitForTimeout(1000);
+
+        const latecomerSeesHidden: boolean = await latecomer.evaluate(
+          (id) => (window as any).STATE?.figures?.some((f: any) => f.id === id) ?? false,
+          figureId
+        );
+        expect(latecomerSeesHidden, 'a fresh join snapshot must not leak hidden figure data to a non-leiter').toBe(false);
+      } finally {
+        await latecomerCtx.close();
+      }
+
+      // ── Leiter zeigt die Figur wieder → Beobachter erhält sie erneut ────────
+      await sendWs(leiter, { type: 'figure_hide_set', figureId, hidden: false });
+      await beob.waitForFunction(
+        (id) => (window as any).STATE?.figures?.some((f: any) => f.id === id),
+        figureId,
+        { timeout: 10000 }
+      );
+    } finally {
+      await leiterCtx.close();
+      await beobCtx.close();
+    }
+  });
+});

--- a/tests/e2e/specs/brett-session-lifecycle.spec.ts
+++ b/tests/e2e/specs/brett-session-lifecycle.spec.ts
@@ -1,0 +1,177 @@
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+
+// Coverage-Lücke (Gap-Analyse dev-flow-e2e, T001935-Kontext): der Session-
+// Lifecycle jenseits von admin_session_create + admin_round_start war bisher
+// ungetestet — insbesondere der Schutz vor doppelter Session-Erzeugung
+// (session-active), der Pause/Stop-Zweig der Phasenmaschine, admin_kick und
+// admin_handoff_token. Diese Datei schließt diese Lücke serverseitig
+// (Protokoll-Ebene über das rohe WS, wie brett-roles.spec.ts).
+
+const BRETT_URL = process.env.BRETT_URL
+  ?? (process.env.PROD_DOMAIN ? `https://brett.${process.env.PROD_DOMAIN}` : 'http://brett.localhost');
+const BRETT_OIDC_SECRET = process.env.BRETT_OIDC_SECRET ?? '';
+
+test.describe('Brett session lifecycle', () => {
+  test.skip(!BRETT_OIDC_SECRET, 'BRETT_OIDC_SECRET required to mint distinct e2e identities');
+
+  async function loginAs(context: BrowserContext, userId: string, name: string): Promise<void> {
+    const res = await context.request.post(`${BRETT_URL}/auth/e2e-login`, {
+      headers: { 'x-e2e-secret': BRETT_OIDC_SECRET, 'content-type': 'application/json' },
+      data: { userId, name, isAdmin: true },
+    });
+    expect(res.ok(), `e2e-login for ${userId}`).toBeTruthy();
+  }
+
+  async function waitForBoard(page: Page): Promise<void> {
+    await page.waitForFunction(() => {
+      const ws = (window as any).__brettWS;
+      return ws && ws.readyState === 1 && (window as any).STATE;
+    }, { timeout: 15000 });
+  }
+
+  async function sendWs(page: Page, msg: any): Promise<void> {
+    await page.evaluate((m) => (window as any).__brettWS.send(JSON.stringify(m)), msg);
+  }
+
+  /** Install a listener that records every inbound message of the given type(s). */
+  async function captureMessages(page: Page, types: string[]): Promise<void> {
+    await page.evaluate((watchedTypes) => {
+      (window as any).__captured = [];
+      (window as any).__brettWS.addEventListener('message', (ev: MessageEvent) => {
+        try {
+          const m = JSON.parse(ev.data);
+          if (watchedTypes.includes(m.type)) (window as any).__captured.push(m);
+        } catch {}
+      });
+    }, types);
+  }
+
+  async function getCaptured(page: Page): Promise<any[]> {
+    return page.evaluate(() => (window as any).__captured ?? []);
+  }
+
+  test('admin_session_create rejects a duplicate create while the round is active (session-active)', async ({ browser }) => {
+    const room = `e2e-lifecycle-active-${Math.random().toString(36).slice(2, 8)}`;
+    const ctx = await browser.newContext({ ignoreHTTPSErrors: true });
+    await loginAs(ctx, 'leiter-active-e2e', 'Leiter');
+    const leiter = await ctx.newPage();
+
+    try {
+      await leiter.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(leiter);
+      await sendWs(leiter, { type: 'admin_session_create' });
+      await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'leiter-active-e2e', role: 'leiter' });
+      await sendWs(leiter, { type: 'admin_round_start' });
+      await leiter.waitForTimeout(500); // let session_phase_change (→ active) settle
+
+      await captureMessages(leiter, ['error']);
+      await sendWs(leiter, { type: 'admin_session_create' });
+      await leiter.waitForTimeout(500);
+
+      const errors = await getCaptured(leiter);
+      expect(errors.length, 'a second admin_session_create during an active round must be rejected').toBeGreaterThan(0);
+      expect(errors[0].reason).toBe('session-active');
+    } finally {
+      await ctx.close();
+    }
+  });
+
+  test('round lifecycle: start → pause → stop broadcasts the correct phase to all participants', async ({ browser }) => {
+    const room = `e2e-lifecycle-phase-${Math.random().toString(36).slice(2, 8)}`;
+    const leiterCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const watcherCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    await loginAs(leiterCtx, 'leiter-phase-e2e', 'Leiter');
+    await loginAs(watcherCtx, 'watcher-phase-e2e', 'Beobachter');
+    const leiter = await leiterCtx.newPage();
+    const watcher = await watcherCtx.newPage();
+
+    try {
+      await leiter.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(leiter);
+      await sendWs(leiter, { type: 'admin_session_create' });
+      await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'leiter-phase-e2e', role: 'leiter' });
+
+      await watcher.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(watcher);
+      await captureMessages(watcher, ['session_phase_change']);
+
+      await sendWs(leiter, { type: 'admin_round_start' });
+      await leiter.waitForTimeout(400);
+      await sendWs(leiter, { type: 'admin_round_pause' });
+      await leiter.waitForTimeout(400);
+      await sendWs(leiter, { type: 'admin_round_stop' });
+      await watcher.waitForTimeout(400);
+
+      const phases = (await getCaptured(watcher)).map((m: any) => m.phase);
+      expect(phases, 'watcher must observe active → paused → ended in order').toEqual(
+        expect.arrayContaining(['active', 'paused', 'ended'])
+      );
+      expect(phases.indexOf('active')).toBeLessThan(phases.indexOf('paused'));
+      expect(phases.indexOf('paused')).toBeLessThan(phases.indexOf('ended'));
+    } finally {
+      await leiterCtx.close();
+      await watcherCtx.close();
+    }
+  });
+
+  test('admin_kick disconnects the targeted participant', async ({ browser }) => {
+    const room = `e2e-lifecycle-kick-${Math.random().toString(36).slice(2, 8)}`;
+    const leiterCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const targetCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    await loginAs(leiterCtx, 'leiter-kick-e2e', 'Leiter');
+    await loginAs(targetCtx, 'target-kick-e2e', 'Zielspieler');
+    const leiter = await leiterCtx.newPage();
+    const target = await targetCtx.newPage();
+
+    try {
+      await leiter.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(leiter);
+      await sendWs(leiter, { type: 'admin_session_create' });
+      await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'leiter-kick-e2e', role: 'leiter' });
+
+      await target.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(target);
+
+      await sendWs(leiter, { type: 'admin_kick', playerId: 'target-kick-e2e' });
+
+      await target.waitForFunction(() => {
+        const ws = (window as any).__brettWS;
+        return !ws || ws.readyState === 2 || ws.readyState === 3; // CLOSING / CLOSED
+      }, { timeout: 10000 });
+    } finally {
+      await leiterCtx.close();
+      await targetCtx.close();
+    }
+  });
+
+  test('admin_handoff_token transfers the admin token and both sides observe the new holder', async ({ browser }) => {
+    const room = `e2e-lifecycle-handoff-${Math.random().toString(36).slice(2, 8)}`;
+    const leiterCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    const newAdminCtx = await browser.newContext({ ignoreHTTPSErrors: true });
+    await loginAs(leiterCtx, 'leiter-handoff-e2e', 'Leiter');
+    await loginAs(newAdminCtx, 'newadmin-handoff-e2e', 'Neuer Admin');
+    const leiter = await leiterCtx.newPage();
+    const newAdmin = await newAdminCtx.newPage();
+
+    try {
+      await leiter.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(leiter);
+      await sendWs(leiter, { type: 'admin_session_create' });
+      await sendWs(leiter, { type: 'admin_assign_role', targetPlayerId: 'leiter-handoff-e2e', role: 'leiter' });
+
+      await newAdmin.goto(`${BRETT_URL}?room=${room}`);
+      await waitForBoard(newAdmin);
+      await captureMessages(newAdmin, ['admin_token_changed']);
+
+      await sendWs(leiter, { type: 'admin_handoff_token', targetPlayerId: 'newadmin-handoff-e2e' });
+      await newAdmin.waitForTimeout(500);
+
+      const events = await getCaptured(newAdmin);
+      expect(events.length, 'the new holder must observe admin_token_changed').toBeGreaterThan(0);
+      expect(events[events.length - 1].holderPlayerId).toBe('newadmin-handoff-e2e');
+    } finally {
+      await leiterCtx.close();
+      await newAdminCtx.close();
+    }
+  });
+});

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -48,6 +48,12 @@
     "kind": "playwright"
   },
   {
+    "id": "E2E:brett-hidden-figures",
+    "file": "tests/e2e/specs/brett-hidden-figures.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
     "id": "E2E:brett-mannequin",
     "file": "tests/e2e/specs/brett-mannequin.spec.ts",
     "category": "E2E",
@@ -68,6 +74,12 @@
   {
     "id": "E2E:brett-roles",
     "file": "tests/e2e/specs/brett-roles.spec.ts",
+    "category": "E2E",
+    "kind": "playwright"
+  },
+  {
+    "id": "E2E:brett-session-lifecycle",
+    "file": "tests/e2e/specs/brett-session-lifecycle.spec.ts",
     "category": "E2E",
     "kind": "playwright"
   },


### PR DESCRIPTION
## Summary
- Gap-Analyse der Systembrett-WS-Serverlogik gegen bestehende Playwright-E2E-Specs
- Neu: `tests/e2e/specs/brett-session-lifecycle.spec.ts` — admin_session_create session-active-Ablehnung bei aktiver Runde, Runden-Phasenmaschine (start→pause→stop), admin_kick, admin_handoff_token
- Neu: `tests/e2e/specs/brett-hidden-figures.spec.ts` — E9 "verdecktes Arbeiten": prüft die als SICHERHEITSKRITISCH dokumentierte Rollenfilterung (hidden-Figuren dürfen einen Nicht-Leiter weder per Broadcast noch im Join-Snapshot erreichen)
- Beide Specs in `playwright.config.ts` (Projekt `brett-mentolder`) registriert, `test-inventory.json` regeneriert

## Test Plan
- [x] `npx tsc --noEmit` — keine Typfehler in den neuen Specs
- [x] Lokal ausgeführt: 5 Tests korrekt übersprungen (BRETT_OIDC_SECRET nicht lokal gesetzt — identisches Verhalten zu brett-roles.spec.ts/brett-share-link.spec.ts)
- [ ] CI/nightly e2e (secret vorhanden) grün

🤖 [T001941]