### PR TITLE
chore: health goals refresh [T001944]

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -343,7 +343,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-AGENTIC17** | Command-Orphans via S4 | 0 ✓ | ≤ 0 | `S4 command_globs gegen Referenzquellen; Config-Guard: ohne Config → 99` |
 | **G-AGENTIC01** | Ungescopte Agenten (security/infra/db ohne `tools:`) | 0 ✓ | ≤ 0 | `awk-Frontmatter-Check über .claude/agents/bachelorprojekt-{security,infra,db}.md` |
 | **G-AGENTIC10** | Agenten ohne dispatchende Skill | 0 ✓ | ≤ 0 | `grep -rlE '^agent: <name>' .claude/skills --include=SKILL.md je Agent` |
-| **G-DB04** | Backup-Alter (h) seit letztem db-backup-Job | 1 ✓ | ≤ 26h | `db_scalar Backup-Alter (health-goals-check.sh); Regressionswache T001738` |
+| **G-DB04** | Backup-Alter (h) seit letztem db-backup-Job | 8 ✓ | ≤ 26h | `db_scalar Backup-Alter (health-goals-check.sh); Regressionswache T001738` |
 | **G-DB08** | Tabellen >10k Rows mit Seq-Scan-Anteil >5 % | n/a | ≤ 3 | `db_scalar pg_stat_user_tables seq_scan-Quote (health-goals-check.sh)` |
 | **G-TEST05** | Vitest Line-Coverage `website/src/lib` | 85 % ✓ | ≥ 60 % | `cd website && pnpm vitest run --coverage` (in health-goals-check.sh, ohne --fast) |
 | **G-BRAIN12** | Brain-Manifest-Gruppen ohne Treffer (Ingest-Drift) | 0 ✓ | 0 | `bash scripts/brain-ingest-worklist.sh >/dev/null 2>&1 \| stderr-Warnungen 'hat 0 Treffer' zählen` |

--- a/website/src/lib/goals-data.generated.json
+++ b/website/src/lib/goals-data.generated.json
@@ -1236,7 +1236,7 @@
     "priority": "C",
     "direction": "lower",
     "baseline": null,
-    "current": 1,
+    "current": 8,
     "target": 26,
     "unit": "",
     "status": "unknown",


### PR DESCRIPTION
## Summary
- Health Goals neu gemessen via `bash scripts/health-goals-update.sh --full` (SSOT `.claude/lib/goals.md`)
- G-DB04 (Backup-Alter seit letztem db-backup-Job): 1h → 8h — weiterhin grün, Target ≤26h
- Alle übrigen Prio-C Green-Gates unverändert grün
- Website-Artefakt `website/src/lib/goals-data.generated.json` via `task health:goals:emit` neu erzeugt (Freshness-Gate)
- Prio-A/B-Freitextabschnitte bewusst nicht angefasst (Script-Scope beschränkt sich auf die maschinenlesbare Prio-C-Tabelle)
- Keine `--suggest-tickets`-Ticket-Erstellung — bewusst manuell, nicht Teil dieses Chores

## Test plan
- [x] `bash scripts/health-goals-update.sh --dry-run --full` zur Vorschau
- [x] `bash scripts/health-goals-update.sh --full` schreibt `.claude/lib/goals.md`
- [x] `task health:goals:emit` regeneriert `goals-data.generated.json`
- [x] `task freshness:regenerate` — keine weiteren stale Artefakte
- [x] `quality:check` — 0 neue/verschlechterte Violations

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017PL1NPfjpWdzGU6GCnsWx7