### PR TITLE
fix: mishap bundle — qwen35-iq4 model config, ticket-mcp --component, health-goals timeout [T001953]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -92,7 +92,7 @@
     "qwen35-iq4": {
       "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio - serialized (1 at a time). Try this first for subagent dispatch.",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes",
+      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#0EA5E9",
       "temperature": 0.7,
@@ -101,7 +101,7 @@
     "qwen3-14b": {
       "description": "Single-session implementation/planning agent: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes",
+      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
       "temperature": 0.7,
@@ -110,7 +110,7 @@
     "qwen35": {
       "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio - serialized (1 at a time)",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes",
+      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#22C55E",
       "temperature": 0.7,
@@ -119,7 +119,7 @@
     "qwen35-hq": {
       "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio - serialized (1 at a time), use when max per-call context matters more than concurrency",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes",
+      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#16A34A",
       "temperature": 0.7,

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2848,7 +2848,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 510,
+      "file_count": 511,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3318,6 +3318,7 @@
         "scripts/ticket-mcp/go/internal/tools/mishap_test.go",
         "scripts/ticket-mcp/go/internal/tools/planning.go",
         "scripts/ticket-mcp/go/internal/tools/triage.go",
+        "scripts/ticket-mcp/go/internal/tools/triage_test.go",
         "scripts/ticket-mcp/go/internal/tools/workflow.go",
         "scripts/ticket-mcp/go/internal/tools/workflow_test.go",
         "scripts/ticket-status-validate.sh",

--- a/openspec/changes/fix-t001948-unused-indexes/specs/health-goals.md
+++ b/openspec/changes/fix-t001948-unused-indexes/specs/health-goals.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: G-DB10 measurement SHALL exclude UNIQUE-constraint-backed indexes from the unused-index count
+
+The G-DB10 measurement query in `.claude/lib/goals.md` SHALL exclude indexes that back a `pg_constraint`
+UNIQUE entry (`i.indisunique` or `s.indexrelid IN (SELECT conindid FROM pg_constraint WHERE
+contype='u')`) from its `idx_scan = 0` unused-index count, because these indexes enforce business
+invariants and are not droppable regardless of scan activity.
+
+#### Scenario: a UNIQUE-constraint index with zero scans is not counted as "unused"
+
+- **GIVEN** an index that backs a `UNIQUE` constraint and has `idx_scan = 0`
+- **WHEN** the G-DB10 measurement query runs
+- **THEN** that index is excluded from the reported unused-index count
+
+### Requirement: truly unused, non-constraint-backed indexes SHALL be dropped
+
+Indexes with `idx_scan = 0` that do **not** back a `pg_constraint` UNIQUE entry SHALL be identified and
+dropped via `DROP INDEX CONCURRENTLY` after confirming no application code references the index by name.
+
+#### Scenario: G-DB10 reaches its target after cleanup
+
+- **GIVEN** the corrected measurement query reports the remaining truly-unused indexes
+- **WHEN** each is confirmed unreferenced and dropped
+- **THEN** the G-DB10 current value in `.claude/lib/goals.md` reaches its target (0)

--- a/openspec/changes/fix-t001949-container-cves/specs/health-goals.md
+++ b/openspec/changes/fix-t001949-container-cves/specs/health-goals.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: pinned container images SHALL carry zero CRITICAL CVEs per the Trivy baseline
+
+Every container image pinned in `k3d/*.yaml` SHALL be refreshed to a digest with zero CRITICAL-severity
+CVEs as reported by `trivy image --severity CRITICAL`, tracked against the baseline recorded in
+`docs/audits/2026-07-17-trivy-cve-baseline.md`.
+
+#### Scenario: alpine/k8s no longer reports CRITICAL CVEs
+
+- **GIVEN** `alpine/k8s:1.34.0` is pinned in one or more `k3d/*.yaml` manifests and reports CRITICAL CVEs
+  in the baseline
+- **WHEN** the image digest is bumped to a current stable tag
+- **THEN** `trivy image --severity CRITICAL` against the new digest reports zero CRITICAL findings
+
+### Requirement: the CVE health-goal current value SHALL reflect the post-bump scan
+
+After all pinned images in the baseline are refreshed, the corresponding health-goal current value in
+`.claude/lib/goals.md` SHALL be updated to match the post-bump Trivy scan result.
+
+#### Scenario: goals.md reflects zero CRITICAL CVEs after the bump sweep
+
+- **GIVEN** all images from the 2026-07-17 baseline have been bumped and rescanned
+- **WHEN** the goal's current value is refreshed
+- **THEN** it reads 0 CRITICAL CVEs across the pinned image set

--- a/openspec/changes/fix-t001950-lighthouse-perf/specs/health-goals.md
+++ b/openspec/changes/fix-t001950-lighthouse-perf/specs/health-goals.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: the website SHALL self-host its webfonts instead of loading them from Google Fonts
+
+The website SHALL serve its Inter/font-display fonts from `website/public/fonts/` via local `@font-face`
+declarations with `font-display: swap`, instead of a Google Fonts `<link>`, to remove the external DNS
+lookup and render-blocking request that costs Lighthouse Performance points.
+
+#### Scenario: no external Google Fonts request on page load
+
+- **GIVEN** the website's rendered HTML
+- **WHEN** the network requests during a Lighthouse run are inspected
+- **THEN** no request to `fonts.googleapis.com` or `fonts.gstatic.com` occurs
+
+### Requirement: the G-FE05 Lighthouse Performance score SHALL reach its target of ≥90
+
+After self-hosting fonts, deferring `sidekick-panels.css` out of the critical rendering path, and
+removing unused JS, the G-FE05 Lighthouse Performance score in `.claude/lib/goals.md` SHALL be
+re-measured and reach its target of ≥90.
+
+#### Scenario: G-FE05 reaches target after the optimization pass
+
+- **GIVEN** the three optimizations (self-hosted fonts, deferred CSS, reduced JS) are applied
+- **WHEN** a Lighthouse run against the live site completes
+- **THEN** the reported Performance score is ≥90

--- a/openspec/changes/fix-t001951-brain-ingest/specs/health-goals.md
+++ b/openspec/changes/fix-t001951-brain-ingest/specs/health-goals.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: the Brain Wiki ingest backlog SHALL reach zero missing worklist pages
+
+`scripts/brain-ingest.sh` SHALL be run to completion against the GPU-host ingest pool so that every page
+in the Brain worklist has a corresponding local ingest-state entry, closing the backlog reported by
+`scripts/brain-ingest-worklist.sh`.
+
+#### Scenario: the worklist backlog count reaches zero
+
+- **GIVEN** `scripts/brain-ingest-worklist.sh` reports a non-zero `missing_count`
+- **WHEN** `scripts/brain-ingest.sh --brain-repo <path>` completes a full ingest run without transform
+  or LLM-timeout failures
+- **THEN** a subsequent `scripts/brain-ingest-worklist.sh` run reports `missing_count: 0`

--- a/openspec/changes/fix-t001953-mishap-bundle/specs/fix-t001953-mishap-bundle.md
+++ b/openspec/changes/fix-t001953-mishap-bundle/specs/fix-t001953-mishap-bundle.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: opencode local subagents SHALL be bound to a model id whose context window matches their advertised size
+
+Every `agent` entry in `.opencode/agent-models.jsonc` whose `description` advertises a specific
+context size (e.g. "262k ctx") SHALL reference a `model` id in the same file whose `provider.*.models.*`
+definition actually carries that `limit.context` value. A subagent MUST NOT be bound to a smaller-context
+model variant than its description promises, because dev-flow prompts (plan intel bundles, active-plans
+context) routinely approach the advertised limit and silently produce no output when the actual bound
+model's context window is exceeded mid-generation.
+
+#### Scenario: qwen35-iq4 is bound to the 262k-context model variant
+
+- **GIVEN** `.opencode/agent-models.jsonc` defines both `qwen3.6-14b-a3b-fablevibes` (32k ctx, 4 parallel
+  slots) and `qwen3.6-14b-a3b-fablevibes@262k` (262k ctx, single-session) under the `lmstudio` provider
+- **WHEN** the `qwen35-iq4` agent's description advertises "262k ctx"
+- **THEN** its `model` field is `lmstudio/qwen3.6-14b-a3b-fablevibes@262k`, not the bare 32k-ctx id
+
+### Requirement: the `triage_ticket` MCP tool SHALL forward `component` to the underlying triage CLI
+
+`scripts/ticket-mcp/go/internal/tools/triage.go`'s `triage_ticket` tool SHALL declare a `component`
+parameter in its schema and pass it through as `--component <value>` to the `vda.sh ticket triage`
+CLI invocation whenever a non-empty value is supplied, mirroring how the CLI itself already wires
+`--component` to `tickets.tickets.component` (T001362/#2366).
+
+#### Scenario: triage_ticket with a component argument sets the ticket's component
+
+- **GIVEN** a `triage_ticket` MCP call with `id=T000XXX` and `component=infra`
+- **WHEN** the tool builds its CLI args
+- **THEN** the args include `--component infra`
+
+### Requirement: `health-goals-check.sh` network-dependent checks SHALL be bounded by a `timeout`
+
+Every check in `scripts/health-goals-check.sh` that shells out to a network-dependent tool without its
+own timeout flag (Lighthouse via `npx @lhci/cli autorun` against a live URL; the `trivy image` scan and
+its `kubectl get pods --all-namespaces` pod-image list) SHALL be wrapped in a `timeout <n>` guard, so a
+slow or unreachable dependency bounds that single check instead of hanging the whole report
+indefinitely — consistent with every other `kubectl` call in the script already using
+`--request-timeout`.
+
+#### Scenario: the Lighthouse check cannot hang the report
+
+- **GIVEN** `npx @lhci/cli autorun` is reachable but the target URL never responds
+- **WHEN** `health-goals-check.sh` runs without `--fast`
+- **THEN** the G-FE05 check aborts after its `timeout` bound instead of hanging indefinitely, and the
+  report still reaches its summary line

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -366,7 +366,7 @@ durations.sort(); p95=durations[int(len(durations)*0.95)] if durations else 0; p
 
 # ── SEC-TARGETS ──
 if [ "$FAST" = 0 ] && command -v kubectl >/dev/null 2>&1 && command -v trivy >/dev/null 2>&1; then
-  row target G-SEC06 "$(trivy image --severity HIGH,CRITICAL --exit-code 0 --format json $(kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.spec.containers[*].image}{\"\n\"}{end}' 2>/dev/null | sort -u | tr '\n' ' ') 2>/dev/null | jq '[.Results[].Vulnerabilities[] | select(.Severity=="HIGH" or .Severity=="CRITICAL")] | length' 2>/dev/null || echo "-")" le 0 "Container Images mit High/Critical CVEs (via Trivy)"
+  row target G-SEC06 "$(timeout 60 trivy image --severity HIGH,CRITICAL --exit-code 0 --format json $(timeout 10 kubectl get pods --all-namespaces --request-timeout=5s -o jsonpath='{range .items[*]}{.spec.containers[*].image}{\"\n\"}{end}' 2>/dev/null | sort -u | tr '\n' ' ') 2>/dev/null | jq '[.Results[].Vulnerabilities[] | select(.Severity=="HIGH" or .Severity=="CRITICAL")] | length' 2>/dev/null || echo "-")" le 0 "Container Images mit High/Critical CVEs (via Trivy)"
 else
   row target G-SEC06 "-" le 0 "Container CVEs (erfordert kubectl + Trivy — nicht messbar)"
 fi
@@ -374,7 +374,7 @@ fi
 # ── FE-TARGETS ──
 if [ "$FAST" = 0 ] && command -v npx >/dev/null 2>&1 && npx --yes @lhci/cli --version >/dev/null 2>&1; then
   row target G-FE05 "$(
-    score=$(npx @lhci/cli autorun --no-lighthouserc --collect.url=https://web.mentolder.de --collect.settings.chromeFlags='--headless --no-sandbox' --assert.preset=none 2>/dev/null | grep -oP 'Performance: \K[0-9]+' | head -1)
+    score=$(timeout 60 npx @lhci/cli autorun --no-lighthouserc --collect.url=https://web.mentolder.de --collect.settings.chromeFlags='--headless --no-sandbox' --assert.preset=none 2>/dev/null | grep -oP 'Performance: \K[0-9]+' | head -1)
     echo "${score:--}"
   )" ge 90 "Lighthouse Performance Score"
 else

--- a/scripts/ticket-mcp/go/internal/tools/triage.go
+++ b/scripts/ticket-mcp/go/internal/tools/triage.go
@@ -15,7 +15,7 @@ import (
 func RegisterTriageTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("triage_ticket",
-			mcp.WithDescription("Setzt Triage-Felder eines Tickets: type, severity, priority, attention_mode, status."),
+			mcp.WithDescription("Setzt Triage-Felder eines Tickets: type, severity, priority, attention_mode, status, component."),
 			mcp.WithString("id", mcp.Description("external_id z.B. T000123"), mcp.Required()),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)"),
 				mcp.Enum("mentolder", "korczewski")),
@@ -28,6 +28,7 @@ func RegisterTriageTools(s *server.MCPServer) {
 			mcp.WithString("attention_mode", mcp.Description("auto, ai_ready, needs_human"),
 				mcp.Enum("auto", "ai_ready", "needs_human")),
 			mcp.WithString("status", mcp.Description("Ziel-Status z.B. triage, planning, backlog")),
+			mcp.WithString("component", mcp.Description("Betroffene Komponente, z.B. website, infra, scripts")),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			a := getArgs(req)
@@ -40,6 +41,7 @@ func RegisterTriageTools(s *server.MCPServer) {
 			severity, _ := a["severity"].(string)
 			priority, _ := a["priority"].(string)
 			attentionMode, _ := a["attention_mode"].(string)
+			component, _ := a["component"].(string)
 			status, _ := a["status"].(string)
 			if status == "" {
 				status = "triage"
@@ -62,19 +64,7 @@ func RegisterTriageTools(s *server.MCPServer) {
 				return mcp.NewToolResultError(fmt.Sprintf("Ungültiger attention_mode: %s. Erlaubt: %s", attentionMode, strings.Join(validAttentionModes, ", "))), nil
 			}
 
-			args := []string{"triage", "--id", id, "--status", status, "--apply", "--no-comment"}
-			if priority != "" {
-				args = append(args, "--priority", priority)
-			}
-			if severity != "" {
-				args = append(args, "--severity", severity)
-			}
-			if mtype != "" {
-				args = append(args, "--type", mtype)
-			}
-			if attentionMode != "" {
-				args = append(args, "--attention-mode", attentionMode)
-			}
+			args := buildTriageArgs(id, status, priority, severity, mtype, attentionMode, component)
 
 			raw, err := runner.RunTicket(args, map[string]string{"BRAND": brand, "VDA_NONINTERACTIVE": "1"})
 			if err != nil {
@@ -107,4 +97,28 @@ func RegisterTriageTools(s *server.MCPServer) {
 			return mcp.NewToolResultText(text), nil
 		},
 	)
+}
+
+// buildTriageArgs assembles the CLI args for `vda.sh ticket triage` from the
+// optional triage fields. Only non-empty fields are passed through, so a
+// partial triage_ticket call never clobbers unrelated ticket fields (the CLI
+// itself only updates columns whose flag was explicitly provided).
+func buildTriageArgs(id, status, priority, severity, mtype, attentionMode, component string) []string {
+	args := []string{"triage", "--id", id, "--status", status, "--apply", "--no-comment"}
+	if priority != "" {
+		args = append(args, "--priority", priority)
+	}
+	if severity != "" {
+		args = append(args, "--severity", severity)
+	}
+	if mtype != "" {
+		args = append(args, "--type", mtype)
+	}
+	if attentionMode != "" {
+		args = append(args, "--attention-mode", attentionMode)
+	}
+	if component != "" {
+		args = append(args, "--component", component)
+	}
+	return args
 }

--- a/scripts/ticket-mcp/go/internal/tools/triage_test.go
+++ b/scripts/ticket-mcp/go/internal/tools/triage_test.go
@@ -1,0 +1,48 @@
+package tools
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildTriageArgsMinimal(t *testing.T) {
+	got := buildTriageArgs("T001953", "triage", "", "", "", "", "")
+	want := []string{"triage", "--id", "T001953", "--status", "triage", "--apply", "--no-comment"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildTriageArgs minimal = %v, want %v", got, want)
+	}
+}
+
+func TestBuildTriageArgsAllFields(t *testing.T) {
+	got := buildTriageArgs("T001953", "backlog", "hoch", "major", "bug", "ai_ready", "scripts")
+	want := []string{
+		"triage", "--id", "T001953", "--status", "backlog", "--apply", "--no-comment",
+		"--priority", "hoch",
+		"--severity", "major",
+		"--type", "bug",
+		"--attention-mode", "ai_ready",
+		"--component", "scripts",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildTriageArgs all fields = %v, want %v", got, want)
+	}
+}
+
+// TestBuildTriageArgsComponentOnly guards the T001953 regression: the
+// triage_ticket MCP tool used to accept a `component` argument in its
+// schema but never forwarded it to the underlying `vda.sh ticket triage`
+// CLI call, so component could never be set via MCP even though the CLI
+// itself supported --component.
+func TestBuildTriageArgsComponentOnly(t *testing.T) {
+	got := buildTriageArgs("T001953", "triage", "", "", "", "", "infra")
+	found := false
+	for i, a := range got {
+		if a == "--component" && i+1 < len(got) && got[i+1] == "infra" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("buildTriageArgs did not forward --component infra, got %v", got)
+	}
+}

--- a/tests/spec/health-goals.bats
+++ b/tests/spec/health-goals.bats
@@ -40,6 +40,27 @@ g_sec05_filter() {
   [ "$output" = "N somebody@example.com" ]
 }
 
+# --- T001953: unbounded network calls (G-SEC06 / G-FE05) must be timeout-wrapped ---
+# Mishap: health-goals-check.sh hung indefinitely after printing its header
+# because the G-FE05 (Lighthouse via npx @lhci/cli, hits a live URL) and
+# G-SEC06 (trivy image scan piped from `kubectl get pods`) checks had no
+# `timeout` guard, unlike every other kubectl call in this script which
+# uses --request-timeout. Regression-guard: both call sites must be wrapped
+# in `timeout <n>` so a slow/unreachable network dependency can never hang
+# the whole report.
+
+@test "G-FE05: the Lighthouse npx call is wrapped in a timeout" {
+  run grep -E 'score=\$\(timeout [0-9]+ npx @lhci/cli autorun' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "G-SEC06: the trivy image scan and its kubectl pod list are wrapped in a timeout" {
+  run grep -E 'timeout [0-9]+ trivy image' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -E 'timeout [0-9]+ kubectl get pods --all-namespaces' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
 # --- T001884: gen-goals-data.mjs (E4) ---
 
 setup_gen() {


### PR DESCRIPTION
## Summary

Three unrelated mishaps bundled under T001953:

1. **qwen35-iq4 (and qwen35/qwen35-hq/qwen3-14b) subagents return no text content.** All four `opencode` subagent definitions in `.opencode/agent-models.jsonc` advertise "262k ctx" but their `model` field pointed at `lmstudio/qwen3.6-14b-a3b-fablevibes` — the 32k-ctx / 4-parallel-slot LM Studio variant, not the already-defined-but-unreferenced `@262k` single-session variant. Large dev-flow prompts (plan intel bundles, active-plans context) routinely exceed the real 32k window, so the model runs out of context mid-generation and never emits a final text part → `"completed but produced no text content"`. Fixed by pointing all four agents at `lmstudio/qwen3.6-14b-a3b-fablevibes@262k`.
2. **`triage_ticket` MCP tool drops `component`.** The `vda.sh ticket triage --component` CLI flag already exists and is wired to `tickets.tickets.component` (since T001362/#2366) — only the Go MCP wrapper (`scripts/ticket-mcp/go/internal/tools/triage.go`) never declared or forwarded it. Added the schema param and threaded it through; extracted arg-building into `buildTriageArgs` with unit tests.
3. **`health-goals-check.sh` hangs indefinitely.** The G-FE05 Lighthouse check (`npx @lhci/cli autorun` against a live URL) and the G-SEC06 trivy/kubectl image scan had no `timeout` guard — every other kubectl call in the script uses `--request-timeout`, but these two didn't. Wrapped both in `timeout` so a slow/unreachable network dependency bounds the check instead of hanging forever.

## Test plan

- [x] `go build ./...` and `go test ./...` green in `scripts/ticket-mcp/go` (new `triage_test.go` covers `buildTriageArgs`, incl. a component-only regression case)
- [x] `bats tests/spec/health-goals.bats` green (2 new regression tests assert the `timeout` wrapper is present)
- [x] `bash scripts/health-goals-check.sh --quiet` (no `--fast`) completes in ~2m12s with exit 0 — previously hung indefinitely (reproduced: `timeout 20 npx @lhci/cli autorun ...` against `web.mentolder.de` hangs and is `Terminated` at 20s with no bound)
- [x] `task test:all` — 0 failures
- [x] `task test:changed` — 0 failures
- [x] `task freshness:regenerate` — no drift
- [x] `task test:inventory` — no drift

Closes T001953

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017PL1NPfjpWdzGU6GCnsWx7