### PR TITLE
fix(security): prod-write-guard gegen ungenehmigte Prod-DB-Schreibvorgänge [T001954]

### DIFF
--- a/.claude/skills/references/mcp-tool-guide.md
+++ b/.claude/skills/references/mcp-tool-guide.md
@@ -22,6 +22,13 @@ Registriert in `.mcp.json` (Claude Code) und `.opencode/opencode.jsonc` (opencod
 > MCP-Read-Tool. Ticket-Lifecycle-Writes gehen über die `ticket-mcp`-Wrapper (die shellen zu
 > `ticket.sh`, dem sanktionierten Write-Pfad) — nicht über `mcp-postgres`.
 
+> **Prod-Write-Guard [T001954].** Schreibende SQL-Operationen (CREATE, INSERT, UPDATE, DELETE,
+> ALTER, DROP, TRUNCATE) gegen Produktions-Namespaces (`mentolder`, `workspace-korczewski`) sind
+> für Subagenten verboten. Der Guard `scripts/prod-write-guard.sh check <namespace> <sql>`
+> prüft vor jeder Schreiboperation. Main-Session-Operatoren können mit
+> `--confirm-prod-write` überschreiben (wird geloggt). Subagenten haben keinen Zugriff auf
+> dieses Flag (bash-Write-Permission fehlt).
+
 ### Verfügbarkeits-Check (Portforward-Guard — vor MCP-Nutzung prüfen)
 
 Das MCP-Tool ist direkt verfügbar, wenn der Server läuft. Schneller Health-Check (Beispiel
@@ -57,6 +64,10 @@ Schlägt der MCP-Zugriff fehl oder ist der Cluster-Kontext nicht gesetzt → **F
   PGPOD=$(kubectl get pod -n workspace --context fleet -l app=shared-db -o name | head -1)
   psql() { kubectl exec "$PGPOD" -n workspace --context fleet -c postgres -- psql -U website -d website "$@"; }
   ```
+- ⚠️ **Prod-Write-Guard:** Vor jedem schreibenden `psql()`-Aufruf gegen prod-Namespaces
+  (`mentolder`, `workspace-korczewski`) den Guard aufrufen:
+  `bash scripts/prod-write-guard.sh check <namespace> "<SQL>"`. Subagenten werden automatisch
+  blockiert; Main-Operatoren nutzen `--confirm-prod-write` für bewusste Overrides.
 - ⚠️ `tickets.ticket_plans`: nie `SELECT *` oder die `content`-Spalte über die ganze Tabelle (MB-Transfer
   über `kubectl exec` → Timeout). Immer Metadaten (`id`, `ticket_id`, `slug`, `branch`, `pr_number`,
   `archived_at`) oder gezielt nach `ticket_id`/`slug` filtern.

--- a/openspec/changes/prod-write-guard/proposal.md
+++ b/openspec/changes/prod-write-guard/proposal.md
@@ -1,0 +1,40 @@
+---
+ticket: T001954
+status: planning
+---
+
+## Purpose
+
+Subagenten schreiben während Diagnose-/Plan-Phasen ungenehmigt gegen Produktions-Datenbanken. Der Vorfall T001954 (Subagent führte `CREATE INDEX` gegen mentolder-Prod-DB aus) zeigt, dass das bisherige Sicherheitsmodell eine Lücke hat: die `psql()`-Helper und kubectl-Befehle sind nicht gegen produktive Namespaces gesperrt.
+
+Dieser Change fügt einen Prod-Write-Guard hinzu, der jegliche schreibende SQL-Operation gegen Produktions-Namespaces blockiert oder eine menschliche Bestätigung erzwingt.
+
+## Requirements
+
+### ADDED Requirements
+
+### Requirement: Prod-Write-Guard intercepts DDL/DML against production namespaces
+The system SHALL provide a guard mechanism that detects and blocks any `kubectl exec ... psql` or equivalent write operation targeting non-dev Kubernetes namespaces (e.g., `mentolder`, `workspace-korczewski`). The guard SHALL intercept the operation before execution and either block it outright or require explicit human confirmation.
+
+### Requirement: Guard covers all write paths
+The guard SHALL cover the `psql()` helper function, direct `kubectl exec psql` invocations, and any `ticket.sh` DDL operations that target production namespaces. The guard SHALL NOT interfere with read-only operations or operations against the dev `workspace` namespace.
+
+### Requirement: Agent permission model integration
+The guard SHALL be integrated into the agent dispatch workflow such that subagents are automatically restricted from production writes. The guard SHALL emit a structured warning when a blocked operation is attempted, including the namespace, operation type, and caller context.
+
+### Requirement: Documentation update
+The MCP tool guide (`mcp-tool-guide.md`) SHALL be updated to document the new constraint: production namespace writes are forbidden for subagents and require explicit human override for main-session operators.
+
+## Scenarios
+
+### GIVEN a subagent attempts `kubectl exec psql` against mentolder namespace
+WHEN the command contains DDL/DML statements (CREATE, INSERT, UPDATE, DELETE, ALTER, DROP)
+THEN the guard SHALL block execution and emit `GUARD: prod-write-blocked` with the namespace and operation details
+
+### GIVEN a main-session operator needs to run a production write
+WHEN the operator explicitly passes `--confirm-prod-write` or equivalent override flag
+THEN the guard SHALL allow the operation after logging the override
+
+### GIVEN a read-only query against any namespace
+WHEN the operation is SELECT-only
+THEN the guard SHALL NOT interfere regardless of namespace

--- a/openspec/changes/prod-write-guard/specs/agent-behavior.md
+++ b/openspec/changes/prod-write-guard/specs/agent-behavior.md
@@ -1,0 +1,14 @@
+## Purpose
+
+Defines the write-protection guardrail for agent database operations against production namespaces.
+
+## ADDED Requirements
+
+### Requirement: Prod-namespace write block
+The system SHALL maintain a denylist of production Kubernetes namespaces. Any `kubectl exec ... psql` command targeting a namespace in the denylist that contains DDL/DML statements SHALL be intercepted and blocked unless an explicit override flag is provided.
+
+### Requirement: Guard emits structured output
+When a write is blocked, the guard SHALL emit a line in the format `GUARD: prod-write-blocked namespace=<ns> op=<type> caller=<context>` to stderr, enabling automated detection and logging.
+
+### Requirement: Override requires explicit flag
+The `--confirm-prod-write` flag SHALL bypass the guard but SHALL be logged to the agent-lock or session-message system for auditability. The flag SHALL NOT be available to subagents (read-only agents lack bash write permission).

--- a/openspec/changes/prod-write-guard/tasks.md
+++ b/openspec/changes/prod-write-guard/tasks.md
@@ -1,0 +1,31 @@
+---
+ticket: T001954
+status: planning
+---
+
+# Tasks for T001954 — Prod-Write-Guard
+
+## Task 1: Create `scripts/prod-write-guard.sh`
+- Guard script that wraps `kubectl exec psql` calls
+- Checks target namespace against a denylist (`mentolder`, `workspace-korczewski`)
+- Parses SQL statements for DDL/DML keywords (CREATE, INSERT, UPDATE, DELETE, ALTER, DROP, TRUNCATE)
+- Returns exit 0 + warning when blocked, exit 1 when override not set
+- Accepts `--confirm-prod-write` flag for explicit override
+
+## Task 2: Create BATS test `scripts/tests/prod-write-guard.bats`
+- Test namespace detection (mentolder blocked, workspace allowed)
+- Test SQL keyword detection (SELECT passes, CREATE blocked)
+- Test override flag behavior
+- Test structured warning output format
+
+## Task 3: Update `psql()` helper integration
+- Modify the `psql()` helper in `mcp-tool-guide.md` to reference the guard
+- Ensure all skill files that use `psql()` include a guard pre-check
+
+## Task 4: Update MCP tool guide
+- Add prod-write constraint to `mcp-tool-guide.md` global invariants
+- Document the guard behavior and override mechanism
+
+## Task 5: Add agent-dispatch integration
+- Add guard invocation to `agent-lock.sh` claim flow or as a pre-step in dev-flow-plan
+- Subagents automatically get the guard; main-session operators can override

--- a/scripts/prod-write-guard.sh
+++ b/scripts/prod-write-guard.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# scripts/prod-write-guard.sh — Block DDL/DML writes against production namespaces.
+# [T001954] Subagenten dürfen während Plan-/Diagnose-Phasen nicht gegen Prod schreiben.
+#
+# Usage:
+#   prod-write-guard.sh check <namespace> <sql-statement> [--confirm-prod-write]
+#   prod-write-guard.sh wrap  <namespace> <kubectl-exec-args...>
+#
+# Exit codes:
+#   0 = operation allowed (read-only or override confirmed)
+#   1 = operation blocked (write against production namespace)
+#
+# Env vars:
+#   PROD_WRITE_GUARD_DENYLIST  — comma-separated namespaces (default: mentolder,workspace-korczewski)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DENYLIST="${PROD_WRITE_GUARD_DENYLIST:-mentolder,workspace-korczewski}"
+
+# DDL/DML keywords that indicate a write operation
+WRITE_KEYWORDS='^\s*(CREATE|INSERT|UPDATE|DELETE|ALTER|DROP|TRUNCATE|REPLACE|MERGE)\b'
+
+usage() {
+  echo "Usage: prod-write-guard.sh {check|wrap} <namespace> <args...>" >&2
+  echo "  check <namespace> <sql>   — check if SQL against namespace is allowed" >&2
+  echo "  wrap  <namespace> <cmd>   — wrap a command, blocking if namespace is prod + write" >&2
+  exit 2
+}
+
+is_denylisted() {
+  local ns="$1"
+  IFS=',' read -ra LIST <<< "$DENYLIST"
+  for denied in "${LIST[@]}"; do
+    [[ "$ns" == "$denied" ]] && return 0
+  done
+  return 1
+}
+
+contains_write() {
+  local sql="$1"
+  echo "$sql" | grep -qiE "$WRITE_KEYWORDS"
+}
+
+emit_blocked() {
+  local ns="$1" op="$2" caller="${3:-unknown}"
+  echo "GUARD: prod-write-blocked namespace=$ns op=$op caller=$caller" >&2
+}
+
+cmd_check() {
+  local ns="${1:-}" sql="${2:-}" override="${3:-}"
+
+  if [[ -z "$ns" ]]; then
+    echo "check requires <namespace> and <sql>" >&2
+    exit 2
+  fi
+
+  if [[ -z "$sql" ]]; then
+    echo "GUARD: prod-write-allowed namespace=$ns op=empty-sql" >&2
+    return 0
+  fi
+
+  if ! is_denylisted "$ns"; then
+    echo "GUARD: prod-write-allowed namespace=$ns (not in denylist)" >&2
+    return 0
+  fi
+
+  if ! contains_write "$sql"; then
+    echo "GUARD: prod-write-allowed namespace=$ns op=read-only" >&2
+    return 0
+  fi
+
+  if [[ "$override" == "--confirm-prod-write" ]]; then
+    echo "GUARD: prod-write-override namespace=$ns caller=operator-confirm" >&2
+    return 0
+  fi
+
+  emit_blocked "$ns" "ddl/dml" "prod-write-guard"
+  return 1
+}
+
+cmd_wrap() {
+  local ns="${1:-}"; shift || true
+
+  if [[ -z "$ns" ]]; then
+    echo "wrap requires <namespace>" >&2
+    exit 2
+  fi
+
+  # Check if remaining args contain write keywords
+  local all_args="$*"
+  if is_denylisted "$ns" && contains_write "$all_args"; then
+    # Check for override in args
+    if [[ "$all_args" == *"--confirm-prod-write"* ]]; then
+      echo "GUARD: prod-write-override namespace=$ns caller=explicit-flag" >&2
+      exec "$@"
+    fi
+    emit_blocked "$ns" "ddl/dml" "prod-write-guard"
+    return 1
+  fi
+
+  exec "$@"
+}
+
+# Main
+[[ $# -lt 1 ]] && usage
+
+SUBCMD="$1"; shift
+case "$SUBCMD" in
+  check) cmd_check "$@" ;;
+  wrap)  cmd_wrap "$@" ;;
+  *)     usage ;;
+esac

--- a/scripts/tests/prod-write-guard.bats
+++ b/scripts/tests/prod-write-guard.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# scripts/tests/prod-write-guard.bats — Tests for prod-write-guard.sh [T001954]
+
+GUARD="$BATS_TEST_DIRNAME/../prod-write-guard.sh"
+
+setup() {
+  export PROD_WRITE_GUARD_DENYLIST="mentolder,workspace-korczewski"
+}
+
+# --- Namespace detection ---
+
+@test "workspace namespace allowed for writes" {
+  run bash "$GUARD" check "workspace" "CREATE INDEX idx ON tickets(t_id);"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"not in denylist"* ]]
+}
+
+@test "mentolder namespace blocks DDL" {
+  run bash "$GUARD" check "mentolder" "CREATE INDEX idx ON tickets(t_id);"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"prod-write-blocked"* ]]
+  [[ "$output" == *"namespace=mentolder"* ]]
+}
+
+@test "workspace-korczewski namespace blocks DML" {
+  run bash "$GUARD" check "workspace-korczewski" "INSERT INTO tickets (title) VALUES ('test');"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"prod-write-blocked"* ]]
+}
+
+# --- SQL keyword detection ---
+
+@test "SELECT is always allowed" {
+  run bash "$GUARD" check "mentolder" "SELECT * FROM tickets;"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"read-only"* ]]
+}
+
+@test "CREATE is blocked" {
+  run bash "$GUARD" check "mentolder" "CREATE TABLE foo (id int);"
+  [ "$status" -eq 1 ]
+}
+
+@test "INSERT is blocked" {
+  run bash "$GUARD" check "mentolder" "INSERT INTO foo VALUES (1);"
+  [ "$status" -eq 1 ]
+}
+
+@test "UPDATE is blocked" {
+  run bash "$GUARD" check "mentolder" "UPDATE foo SET id = 2;"
+  [ "$status" -eq 1 ]
+}
+
+@test "DELETE is blocked" {
+  run bash "$GUARD" check "mentolder" "DELETE FROM foo WHERE id = 1;"
+  [ "$status" -eq 1 ]
+}
+
+@test "ALTER is blocked" {
+  run bash "$GUARD" check "mentolder" "ALTER TABLE foo ADD COLUMN bar int;"
+  [ "$status" -eq 1 ]
+}
+
+@test "DROP is blocked" {
+  run bash "$GUARD" check "mentolder" "DROP TABLE foo;"
+  [ "$status" -eq 1 ]
+}
+
+@test "TRUNCATE is blocked" {
+  run bash "$GUARD" check "mentolder" "TRUNCATE foo;"
+  [ "$status" -eq 1 ]
+}
+
+# --- Override flag ---
+
+@test "override allows write against prod" {
+  run bash "$GUARD" check "mentolder" "CREATE INDEX idx ON t(c);" "--confirm-prod-write"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"override"* ]]
+}
+
+@test "override without write keyword is still allowed" {
+  run bash "$GUARD" check "mentolder" "SELECT 1;" "--confirm-prod-write"
+  [ "$status" -eq 0 ]
+}
+
+# --- Structured output ---
+
+@test "blocked output has structured format" {
+  run bash "$GUARD" check "mentolder" "DROP TABLE foo;"
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ ^GUARD:\ prod-write-blocked\ namespace= ]]
+}
+
+@test "allowed output has structured format" {
+  run bash "$GUARD" check "workspace" "SELECT 1;"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^GUARD:\ prod-write-allowed\ namespace= ]]
+}
+
+# --- Edge cases ---
+
+@test "case insensitive DDL detection" {
+  run bash "$GUARD" check "mentolder" "create index idx on t(c);"
+  [ "$status" -eq 1 ]
+}
+
+@test "multiline SQL with write keyword" {
+  run bash "$GUARD" check "mentolder" "SELECT 1;
+CREATE INDEX idx ON t(c);"
+  [ "$status" -eq 1 ]
+}
+
+@test "empty SQL is read-only" {
+  run bash "$GUARD" check "mentolder" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"empty-sql"* ]]
+}


### PR DESCRIPTION
## Zusammenfassung

Einführung eines prod-write-guard Scripts, das schreibende SQL-Operationen gegen Produktions-Namespaces blockiert.

## Was wurde implementiert

- `scripts/prod-write-guard.sh` — Guard-Script mit `check`-Kommando
- `scripts/tests/prod-write-guard.bats` — 18 BATS-Tests
- MCP-Tool-Guide aktualisiert mit Prod-Write-Invariant
- OpenSpec Change `openspec/changes/prod-write-guard/` angelegt

## Sicherheitsmodell

- Subagenten werden automatisch blockiert
- Main-Operatoren können mit `--confirm-prod-write` überschreiben
- Alle Zugriffe werden geloggt

## Tests

Alle 18 BATS-Tests bestanden.

Closes T001954