### PR TITLE
fix(db): brand-Spalten CHECK-Constraints für Datenintegrität [T001947]

### DIFF
--- a/migrations/20260719-brand-check-constraints.sql
+++ b/migrations/20260719-brand-check-constraints.sql
@@ -1,0 +1,135 @@
+-- T001947: Add CHECK constraints to brand columns
+-- Idempotent: uses DO $$ ... $$ blocks with exception handling
+-- Run: psql -U website -d website -f migrations/20260719-brand-check-constraints.sql
+
+BEGIN;
+
+-- bachelorprojekt.features (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE bachelorprojekt.features 
+        ADD CONSTRAINT chk_brand_features 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- brett.board_templates (mentolder only)
+DO $$ BEGIN
+    ALTER TABLE brett.board_templates 
+        ADD CONSTRAINT chk_brand_board_templates 
+        CHECK (brand = 'mentolder');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- brett.coaching_templates (mentolder only)
+DO $$ BEGIN
+    ALTER TABLE brett.coaching_templates 
+        ADD CONSTRAINT chk_brand_coaching_templates 
+        CHECK (brand = 'mentolder');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- bugs.bug_tickets (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE bugs.bug_tickets 
+        ADD CONSTRAINT chk_brand_bug_tickets 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- coaching.ki_config (korczewski, mentolder)
+DO $$ BEGIN
+    ALTER TABLE coaching.ki_config 
+        ADD CONSTRAINT chk_brand_ki_config 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- coaching.projects (mentolder only)
+DO $$ BEGIN
+    ALTER TABLE coaching.projects 
+        ADD CONSTRAINT chk_brand_coaching_projects 
+        CHECK (brand = 'mentolder');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- coaching.sessions (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE coaching.sessions 
+        ADD CONSTRAINT chk_brand_coaching_sessions 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- coaching.step_templates (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE coaching.step_templates 
+        ADD CONSTRAINT chk_brand_coaching_step_templates 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- knowledge.collections (mentolder only)
+DO $$ BEGIN
+    ALTER TABLE knowledge.collections 
+        ADD CONSTRAINT chk_brand_collections 
+        CHECK (brand = 'mentolder');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.factory_control (mentolder only)
+DO $$ BEGIN
+    ALTER TABLE tickets.factory_control 
+        ADD CONSTRAINT chk_brand_factory_control 
+        CHECK (brand = 'mentolder');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.feature_flags (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE tickets.feature_flags 
+        ADD CONSTRAINT chk_brand_feature_flags 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.pr_events (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE tickets.pr_events 
+        ADD CONSTRAINT chk_brand_pr_events 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.provider_config (has *, korczewski, mentolder)
+DO $$ BEGIN
+    ALTER TABLE tickets.provider_config 
+        ADD CONSTRAINT chk_brand_provider_config 
+        CHECK (brand IN ('*', 'mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.tags (empty, future-proof multi-brand)
+DO $$ BEGIN
+    ALTER TABLE tickets.tags 
+        ADD CONSTRAINT chk_brand_tags 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.ticket_counters (korczewski, mentolder)
+DO $$ BEGIN
+    ALTER TABLE tickets.ticket_counters 
+        ADD CONSTRAINT chk_brand_ticket_counters 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- tickets.tickets (korczewski, mentolder)
+DO $$ BEGIN
+    ALTER TABLE tickets.tickets 
+        ADD CONSTRAINT chk_brand_tickets 
+        CHECK (brand IN ('mentolder', 'korczewski'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+COMMIT;

--- a/openspec/changes/db-brand-check-constraints/proposal.md
+++ b/openspec/changes/db-brand-check-constraints/proposal.md
@@ -1,0 +1,37 @@
+---
+ticket: T001947
+status: planning
+---
+
+## Purpose
+
+17 Tabellen haben `brand`-Spalten ohne CHECK-Constraint. Tabellen ohne FK-Constraints auf `brands(id)` können beliebige, ungültige Brand-Werte aufnehmen. Selbst mit FK ist ein expliziter CHECK eine Verteidigungsschicht gegen Tippfehler und Migration-Fehler.
+
+Health-Goal G-DB03: 16 → 0 brand-Spalten ohne CHECK-Constraint.
+
+## Requirements
+
+### ADDED Requirements
+
+### Requirement: CHECK constraints on all brand columns
+Every table with a `brand` column SHALL have a CHECK constraint that restricts values to the set of valid brands. For single-brand tables: `CHECK (brand = 'mentolder')`. For multi-brand tables: `CHECK (brand IN ('mentolder', 'korczewski'))`. Views are excluded.
+
+### Requirement: Constraint naming convention
+All new CHECK constraints SHALL follow the naming pattern `chk_brand_<table_name>` for consistency with existing constraints.
+
+### Requirement: Idempotent migration
+The migration SHALL use `IF NOT EXISTS` logic or equivalent to be safely re-runnable. The migration SHALL NOT lock tables or cause downtime.
+
+## Scenarios
+
+### GIVEN a table with a brand column and no CHECK constraint
+WHEN the migration runs
+THEN a CHECK constraint is added restricting brand to valid values
+
+### GIVEN a table already has a CHECK constraint on brand
+WHEN the migration runs
+THEN the existing constraint is preserved (no-op)
+
+### GIVEN an INSERT with an invalid brand value
+WHEN the CHECK constraint is active
+THEN the INSERT fails with a constraint violation error

--- a/openspec/changes/db-brand-check-constraints/specs/database.md
+++ b/openspec/changes/db-brand-check-constraints/specs/database.md
@@ -2,7 +2,7 @@
 
 Ensures data integrity by adding CHECK constraints to all brand columns across the database schema.
 
-## Requirements
+## ADDED Requirements
 
 ### Requirement: brand column CHECK constraint coverage
 Every table with a `brand` column SHALL have a CHECK constraint that restricts the column to valid brand values. The constraint SHALL use the naming convention `chk_brand_<table_name>`. Tables that already have CHECK constraints are excluded.

--- a/openspec/changes/db-brand-check-constraints/specs/database.md
+++ b/openspec/changes/db-brand-check-constraints/specs/database.md
@@ -1,0 +1,11 @@
+## Purpose
+
+Ensures data integrity by adding CHECK constraints to all brand columns across the database schema.
+
+## Requirements
+
+### Requirement: brand column CHECK constraint coverage
+Every table with a `brand` column SHALL have a CHECK constraint that restricts the column to valid brand values. The constraint SHALL use the naming convention `chk_brand_<table_name>`. Tables that already have CHECK constraints are excluded.
+
+### Requirement: constraint value set
+For tables that serve only mentolder: `CHECK (brand = 'mentolder')`. For tables that serve both brands: `CHECK (brand IN ('mentolder', 'korczewski'))`. The valid brand set is determined by examining existing data and the table's FK relationship to `brands(id)`.

--- a/openspec/changes/db-brand-check-constraints/tasks.md
+++ b/openspec/changes/db-brand-check-constraints/tasks.md
@@ -1,0 +1,27 @@
+---
+ticket: T001947
+status: planning
+---
+
+# Tasks for T001947 — brand-Spalten CHECK-Constraints
+
+## Task 1: Audit existing brand columns
+Query all tables with `brand` columns and identify which ones lack CHECK constraints. Categorize by schema: bachelorprojekt, brett, bugs, coaching, knowledge, public, tickets.
+
+## Task 2: Create migration SQL
+Write an idempotent SQL migration that adds CHECK constraints to all identified tables. Use `DO $$ ... $$` blocks with exception handling for idempotency. Constraint pattern:
+- `chk_brand_<table_name>` naming convention
+- Single-brand: `CHECK (brand = 'mentolder')`
+- Multi-brand: `CHECK (brand IN ('mentolder', 'korczewski'))`
+
+## Task 3: Create OpenSpec delta spec
+Write the delta spec file under `specs/database.md` documenting the ADDED requirements.
+
+## Task 4: Test migration on dev cluster
+Apply the migration against the dev cluster (`workspace` namespace) and verify:
+- Constraints are created
+- Existing data passes validation
+- Invalid inserts are rejected
+
+## Task 5: Stage for prod deployment
+Once validated, the migration is ready for `task workspace:deploy` to both mentolder and korczewski namespaces.


### PR DESCRIPTION
## Zusammenfassung

CHECK-Constraints für alle brand-Spalten hinzugefügt, um Datenintegrität sicherzustellen.

## Was wurde implementiert

- `migrations/20260719-brand-check-constraints.sql` — Idempotent Migration für 16 Tabellen
- `openspec/changes/db-brand-check-constraints/` — OpenSpec Change mit Specs

## Details

- **16 Tabellen** mit CHECK-Constraints versehen (bachelorprojekt, brett, bugs, coaching, knowledge, tickets)
- **25 Tabellen** hatten bereits Constraints (public Schema)
- **Views** ausgelassen (eur_bookkeeping, v_timeline, v_billing_invoices_with_state)
- **Naming:** `chk_brand_<table_name>` Konsistenz
- **Single-brand:** `CHECK (brand = 'mentolder')` für mentolder-only Tabellen
- **Multi-brand:** `CHECK (brand IN ('mentolder', 'korczewski'))` für beide Brands
- **Sonderfall:** tickets.provider_config erlaubt `*` als Wildcard

## Testung

- Migration erfolgreich auf Dev-Cluster angewendet
- Invalid brand ('invalid_brand') wird korrekt abgelehnt
- Valid brand ('mentolder') funktioniert einwandfrei
- Idempotent: Mehrfacher Aufruf ohne Fehler

## Deployment

Migration ist bereit für `task workspace:deploy` auf mentolder und korczewski.

Closes T001947