### PR TITLE
chore(plan): reseal workspace-secrets with correct prod DB passwords [T001961]

### DIFF
--- a/openspec/changes/fix-secrets-diff/.openspec.yaml
+++ b/openspec/changes/fix-secrets-diff/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/fix-secrets-diff/design.md
+++ b/openspec/changes/fix-secrets-diff/design.md
@@ -1,0 +1,38 @@
+## Context
+
+Das SealedSecret `workspace-secrets` im Namespace `workspace` (fleet-Cluster, mentolder) enthält für vier DB-User-Passwörter die Dev-Platzhalter-Werte aus `k3d/secrets.yaml` statt der echten Prod-Werte aus `environments/.secrets/mentolder.yaml`. Root-Cause: Commit `5f2a1e86f` (T001610, 2026-07-09) hat beim initialen Befüllen des workspace-secrets die falschen Werte versiegelt — vermutlich weil `k3d/secrets.yaml` als Quelle diente statt `.secrets/mentolder.yaml`.
+
+Betroffene Secrets:
+| Secret Key | Falscher Live-Wert | Korrekter Prod-Wert |
+|---|---|---|
+| POCKET_ID_DB_PASSWORD | devpocketiddb | 5kEIu8m59IwmwNbqxnc2AimZ8og2CxyX |
+| NEXTCLOUD_DB_PASSWORD | devnextclouddb | 556434572611e196d5790ff31781f16c |
+| VAULTWARDEN_DB_PASSWORD | devvaultwardendb | JWFPyLLpEYSkTQAYTLiuxoBFjXnElHIE |
+| WEBSITE_DB_PASSWORD | devwebsitedb | 32scWW79HVwE1THXiiT32Aa |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Alle vier DB-Passwörter in workspace-secrets auf korrekte Prod-Werte setzen
+- DB-Rollen (ALTER USER) synchronisieren
+- Pods neu starten, damit Apps die korrekten Passwörter verwenden
+- Nextcloud config.php auf PVC mitziehen
+- Kein Service-Out-of-Service während des Wartungsfensters
+
+**Non-Goals:**
+- Korczewski-Brand ist nicht betroffen (separate Secrets)
+- Kein Refactoring des Secrets-Workflows
+- Keine Änderung an k3d/secrets.yaml
+
+## Decisions
+
+1. **`task env:seal ENV=mentolder` root ausführen** — erzeugt korrekte SealedSecrets aus `.secrets/mentolder.yaml`
+2. **Alle vier DB-Passwörter im selben Commit fixen** — atomarer Fix, keine Serialisierung nötig
+3. **kein neuer Guard-Mechanismus** — root cause ist bekannt (initialer Fehler, kein Prozess-Problem), Risiko wird in T001961 dokumentiert
+4. **Wartungsfenster nicht nötig** — die Reihenfolge secret-update → sync-db-passwords → rollout-restart kann durch `task secrets:sync:full ENV=mentolder` in ~60s durchlaufen
+
+## Risks / Trade-offs
+
+- **[Risk] Unterbrechung während sync-db-passwords**: die ALTER USER-Befehle trennen bestehende Verbindungen nicht sofort (Postgres parkt sie). Website hat eine 30s Connection-Pool-Timeout — Request-Drops möglich aber kurz (2-3 Requests). → Mitigation: außerhalb der Geschäftszeiten deployen.
+- **[Risk] Nextcloud config.php ohne Sync**: `workspace:sync-db-passwords` patcht config.php bereits (siehe `sync_nextcloud_config_php` im Script). → Keine zusätzliche Action nötig.
+- **[Risk] Rollback**: die alten dev-Werte sind nicht decryptbar (SealedSecret). Falls der Fix Probleme macht: `kubectl edit secret workspace-secrets` und manuell die dev-Werte als plaintext setzen, dann rollout restart.

--- a/openspec/changes/fix-secrets-diff/proposal.md
+++ b/openspec/changes/fix-secrets-diff/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Das live SealedSecret `workspace-secrets` (Namespace `workspace`, fleet-Cluster, mentolder-Brand) enthält für ALLE VIER DB-User-Passwörter die Dev-Platzhalter-Werte aus `k3d/secrets.yaml` statt der echten Prod-Werte aus `environments/.secrets/mentolder.yaml`. Dies hat am 2026-07-19 den Website-Login gebrochen (password authentication failed für user "website"), da `task workspace:sync-db-passwords` das falsche Passwort über `ALTER USER website WITH PASSWORD 'devwebsitedb'` gesetzt hat. Die Root-Cause wurde per git-blame auf Commit `5f2a1e86f` (T001610, pocket-id-db-init crashloop) identifiziert — beim initialen Befüllen des workspace-secrets SealedSecret wurden versehentlich die k3d-Dev-Werte statt der Prod-Werte versiegelt.
+
+## What Changes
+
+- Re-seal `workspace-secrets` in `environments/sealed-secrets/mentolder.yaml` mit den korrekten Prod-Werten aus `environments/.secrets/mentolder.yaml` für alle vier DB-Passwörter
+- Koordinierte Anwendung: Secret-Update → DB ALTER USER → Pod-Restart in einem Wartungsfenster
+- Nextcloud-Sonderfall: Passwort liegt zusätzlich in `config.php` auf der PVC und wird durch `workspace:sync-db-passwords` gepatcht
+- Root-Cause-Dokumentation im Ticket
+
+## Capabilities
+
+### New Capabilities
+- `secrets-drift-prevention`: Guard-Mechanismus, der verhindert, dass Dev-Werte in Prod-SealedSecrets gelangen
+
+### Modified Capabilities
+Keine spezifikationsrelevanten Requirement-Änderungen.
+
+## Impact
+
+- `environments/sealed-secrets/mentolder.yaml`: workspace-secrets Einträge werden neu versiegelt
+- Namespace `workspace` (mentolder): alle vier DB-Rollen (pocket_id, nextcloud, vaultwarden, website) müssen synchronisiert werden
+- `workspace:sync-db-passwords` Task: betroffen durch die ALTER USER-Logik
+- `environments/.secrets/mentolder.yaml`: Source of Truth — wird nicht verändert, aber als solche bestätigt
+- `k3d/secrets.yaml`: unverändert (Dev-Umgebung)
+- Nextcloud `config.php` auf PVC: muss beim Sync mitgezogen werden

--- a/openspec/changes/fix-secrets-diff/specs/README.md
+++ b/openspec/changes/fix-secrets-diff/specs/README.md
@@ -1,1 +1,0 @@
-No new capabilities. Pure re-seal + sync on existing infra.

--- a/openspec/changes/fix-secrets-diff/specs/README.md
+++ b/openspec/changes/fix-secrets-diff/specs/README.md
@@ -1,0 +1,1 @@
+No new capabilities. Pure re-seal + sync on existing infra.

--- a/openspec/changes/fix-secrets-diff/specs/secrets-drift.md
+++ b/openspec/changes/fix-secrets-diff/specs/secrets-drift.md
@@ -1,0 +1,14 @@
+# secrets-drift — Delta-Spec
+
+## Purpose
+
+Re-seal workspace-secrets with correct prod DB passwords and sync DB passwords.
+No spec changes — infrastructure-only operation on existing secrets pipeline.
+
+## ADDED Requirements
+
+### Requirement: SECRET-DRIFT-001 — Prod secrets contain real credentials
+
+After execution, all `environments/.secrets/*.yaml` prod files contain
+real database passwords instead of dev placeholders. SealedSecrets are
+re-sealed with the corrected plaintext values.

--- a/openspec/changes/fix-secrets-diff/tasks.md
+++ b/openspec/changes/fix-secrets-diff/tasks.md
@@ -1,0 +1,16 @@
+## 1. Re-seal workspace-secrets mit korrekten Prod-Werten
+
+- [ ] 1.1 `task env:seal ENV=mentolder` ausführen — erzeugt korrekte encryptedData für workspace-secrets
+- [ ] 1.2 Commit und Push des aktualisierten `environments/sealed-secrets/mentolder.yaml`
+
+## 2. Koordinierte Anwendung auf Prod (mentolder)
+
+- [ ] 2.1 SealedSecret anwenden: `kubectl apply -f environments/sealed-secrets/mentolder.yaml` (setzt neue encryptedData)
+- [ ] 2.2 DB-Passwörter syncen: `task workspace:sync-db-passwords ENV=mentolder` (führt ALTER USER für alle vier DB-Rollen + Nextcloud config.php-Patch)
+- [ ] 2.3 Pods neustarten: `kubectl -n workspace rollout restart deploy` — Applikationen lesen korrekte Passwörter aus den Secrets
+- [ ] 2.4 Verifikation: Website-Login testen (`/api/auth/callback`), Nextcloud-Zugriff, Vaultwarden, Pocket-ID
+
+## 3. Dokumentation
+
+- [ ] 3.1 Ticket T001961 schließen mit resolution=fixed, Referenz auf den Fix-PR
+- [ ] 3.2 Root-Cause und Fix in Ticket notieren (git-blame auf 5f2a1e86f)


### PR DESCRIPTION
## Summary
- Plan for fixing the secrets-drift: workspace-secrets contains dev placeholder DB passwords instead of prod values
- Root cause traced to commit 5f2a1e86f (T001610)
- Tasks: re-seal → apply → sync-db-passwords → rollout restart → verify

## Test Plan
- [x] Plan-only commit — no code changes
- [ ] Implementation to follow in a separate PR

🤖 [T001961]