### PR TITLE
chore(plan): fix mishap-bundle — subagent empty output + ticket-mcp component [T001962]

### DIFF
--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/.openspec.yaml
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/design.md
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/design.md
@@ -1,0 +1,26 @@
+## Context
+
+**Mishap 1 — qwen35-iq4 empty output:** Der Subagent läuft auf LM Studio (lokaler GPU-Host mit RTX 5070 Ti). Die Konfiguration in `.opencode/agent-models.jsonc` nutzt Qwen3.6-14B-A3B (IQ4_XS quantization, ~14B MoE, 4 parallel slots à 65k context). Das Modell startet, der Chat-Completion-Endpoint antwortet, aber der Prompt (insbesondere bei delegierten Research-Tasks mit umfangreichem Kontext) triggert keine generativen Tokens. Mögliche Ursachen: (a) Prompt-Template-Inkompatibilität (LM Studio vs. opencode-Format), (b) Context-Overflow durch zu großen System-Prompt + Skill-Content, (c) Modell-spezifisches Issue mit dem IQ4_XS Quant.
+
+**Mishap 2 — triage_ticket component-Parameter:** `ticket-mcp` ist ein remote MCP-Server. Der `triage_ticket` Tool akzeptiert laut JSON-Schema nur: `id, type, severity, priority, attention_mode, status`. `component` fehlt. Repo-Location des ticket-mcp Servers ist `brett/` (Go-basierter MCP-Server).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Mishap 1: Root Cause identifizieren, Fix bereitstellen (oder Workaround dokumentieren)
+- Mishap 2: component-Parameter zu triage_ticket hinzufügen, oder Workaround-Dokumentation in ticket-ops skill
+
+**Non-Goals:**
+- Komplette Überarbeitung des Subagent-Dispatch-Mechanismus
+- Weitere ticket-mcp Tools ändern
+
+## Decisions
+
+**Mishap 1:** Prompt-Template-Format prüfen. Qwen3.6-14B-A3B erwartet u.U. ChatML-Format (`<|im_start|>system...<|im_end|>`). opencode sendet ggf. OpenAI-kompatible Messages — das sollte funktionieren. Wahrscheinlicher: Context-Overflow bei langen Research-Prompts (Skill-Content + Ticket-Description + File-Contents). Quick-Win: Prompts kürzen, oder Debug-Logging aktivieren.
+
+**Mishap 2:** PR an `brett/` mit `component`-Feld im `triage_ticket`-Handler. Parallel Workaround-Dokumentation in ticket-ops skill (set_plan_meta für areas + add_comment für component-Info).
+
+## Risks / Trade-offs
+
+- **[Risk] Mishap 1 nicht reproduzierbar:** Subagent läuft auf GPU, Verhalten kann schwanken. → Workaround ist immer: Fallback auf inline-Execution.
+- **[Risk] PR für ticket-mcp blockiert:** Der ticket-mcp Server ist Go-basiert in `brett/`. Wenn Änderungen dort komplex sind, reicht Workaround-Dokumentation.

--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/proposal.md
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Zwei Mishaps aus dem Betrieb der Software Factory und des ticket-ops-Systems:
+
+**Mishap 1 — qwen35-iq4 subagent empty output**: Delegation an den qwen35-iq4 Subagenten (Qwen3.6-14B-A3B, IQ4_XS) liefert regelmäßig leere Ergebnisse zurück. Das Modell startet, produziert aber keinen Text — der aufrufende Prozess wartet vergeblich und muss die Arbeit inline wiederholen. Dies wurde heute erneut während der ticket-ops-Routine beobachtet (zwei Delegationen an qwen35-iq4 endeten mit leerem Output).
+
+**Mishap 2 — triage_ticket component-Parameter ohne Wirkung**: Der MCP-Tool `ticket-mcp_triage_ticket` akzeptiert laut Dokumentation keinen `component`-Parameter. Der Parameter muss stattdessen per Workaround gesetzt werden (z.B. via `set_plan_meta` für areas und direkten SQL/Shell-Zugriff für component). Dies erschwert die automatisierte Triage.
+
+## What Changes
+
+- **Mishap 1**: Ursachenforschung für leeren Subagent-Output, ggf. Fix (z.B. Prompt-Format, Kontext-Limit, Modell-Konfiguration)
+- **Mishap 2**: Entweder `ticket-mcp` erweitern um component-Parameter, oder Workaround dokumentieren
+
+## Capabilities
+
+### New Capabilities
+Keine neuen Capabilities.
+
+### Modified Capabilities
+- `ticket-mcp`: Der `triage_ticket`-Tool soll einen `component`-Parameter akzeptieren
+
+## Impact
+
+- `.opencode/agent-models.jsonc`: mögliche Anpassung der qwen35-iq4 Prompt-Vorlage
+- `ticket-mcp` Server: möglicher PR für component-Unterstützung
+- `.agents/skills/ticket-ops/SKILL.md`: aktualisierte Workaround-Dokumentation

--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/specs/README.md
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/specs/README.md
@@ -1,1 +1,0 @@
-No new capabilities. Documentation-only change for ticket-ops skill.

--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/specs/README.md
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/specs/README.md
@@ -1,0 +1,1 @@
+No new capabilities. Documentation-only change for ticket-ops skill.

--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/specs/mishap-bundle.md
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/specs/mishap-bundle.md
@@ -1,0 +1,18 @@
+# mishap-bundle — Delta-Spec
+
+## Purpose
+
+Fix two mishaps: qwen35-iq4 subagent empty output and triage_ticket component parameter.
+No spec changes — implementation fixes to subagent prompt handling and ticket-mcp.
+
+## ADDED Requirements
+
+### Requirement: MISHAP-001 — Subagent output is non-empty
+
+The qwen35-iq4 subagent returns meaningful output instead of empty strings
+when delegated tasks complete or timeout.
+
+### Requirement: MISHAP-002 — triage_ticket accepts component parameter
+
+The ticket-mcp triage_ticket tool correctly processes the component field
+without silent failures.

--- a/openspec/changes/fix-mishap-subagent-ticket-mcp/tasks.md
+++ b/openspec/changes/fix-mishap-subagent-ticket-mcp/tasks.md
@@ -1,0 +1,13 @@
+## 1. Mishap 1 — Subagent Empty Output
+
+- [ ] 1.1 Prompt-Template in `.opencode/agent-models.jsonc` prüfen (ChatML-Format? Context-Window-Limit?)
+- [ ] 1.2 Test-Delegation mit minimalem Prompt (ohne Research-Context) zur Reproduktion
+- [ ] 1.3 Fix implementieren: Prompt kürzen, Template-Korrektur, oder Dokumentation des Workarounds
+- [ ] 1.4 Workaround im ticket-ops skill dokumentieren (Fallback auf inline-Execution bei leerem Output)
+
+## 2. Mishap 2 — triage_ticket component-Parameter
+
+- [ ] 2.1 ticket-mcp Server Code in `brett/` lokalisieren und `component`-Feld im `triage_ticket`-Handler ergänzen
+- [ ] 2.2 MCP-Tool JSON-Schema erweitern um optionalen `component`-Parameter
+- [ ] 2.3 PR erstellen und CI grün abwarten
+- [ ] 2.4 (Parallel) Workaround-Dokumentation in ticket-ops skill: component per add_comment + set_plan_meta setzen


### PR DESCRIPTION
## Summary
- Plan for fixing two mishaps: qwen35-iq4 subagent empty output + triage_ticket component parameter
- Tasks: investigate subagent prompt template / context overflow, add component to ticket-mcp triage_ticket

## Test Plan
- [x] Plan-only commit — no code changes
- [ ] Implementation to follow

🤖 [T001962]