### PR TITLE
fix(opencode): lower fablevibes temps to fix tool-calls leaking into think block [T001970]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -72,14 +72,14 @@
           }
         },
         "qwen3.6-14b-a3b-fablevibes": {
-          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 32k ctx, 4 parallel slots)",
+          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 32k ctx, 4 parallel slots)",
           "limit": {
             "context": 32768,
             "output": 8192
           }
         },
         "qwen3.6-14b-a3b-fablevibes@262k": {
-          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx, concurrent/single-session)",
+          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx, concurrent/single-session)",
           "limit": {
             "context": 262000,
             "output": 8192
@@ -90,39 +90,39 @@
   },
   "agent": {
     "qwen35-iq4": {
-      "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio - serialized (1 at a time). Try this first for subagent dispatch.",
+      "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time). Try this first for subagent dispatch.",
       "mode": "subagent",
       "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#0EA5E9",
-      "temperature": 0.7,
+      "temperature": 0.2,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     },
     "qwen3-14b": {
-      "description": "Single-session implementation/planning agent: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio",
+      "description": "Single-session implementation/planning agent: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio",
       "mode": "subagent",
       "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
-      "temperature": 0.7,
+      "temperature": 0.2,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     },
     "qwen35": {
-      "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio - serialized (1 at a time)",
+      "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time)",
       "mode": "subagent",
       "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#22C55E",
-      "temperature": 0.7,
+      "temperature": 0.2,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     },
     "qwen35-hq": {
-      "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) on LM Studio - serialized (1 at a time), use when max per-call context matters more than concurrency",
+      "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time), use when max per-call context matters more than concurrency",
       "mode": "subagent",
       "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#16A34A",
-      "temperature": 0.7,
+      "temperature": 0.2,
       "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
     }
   }

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -80,7 +80,7 @@
       },
       "models": {
         "qwen3.6-14b-a3b-fablevibes@262k": {
-          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx, concurrent)",
+          "name": "Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx, concurrent)",
           "limit": {
             "context": 262000,
             "output": 8192

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -55,6 +55,7 @@ const NAMED_SCOPES = [
   'terminal',
   'wg',
   'auto',
+  'opencode',
 ];
 
 const TICKET_SCOPE_RE = /^T\d{6}$/;


### PR DESCRIPTION
## Summary
- Root cause diagnostiziert: `qwen3.6-14b-a3b-fablevibes` emittiert bei temp ≥0.6 Tool-Calls z.T. **innerhalb des `<think>`-Blocks** — LM Studios Parser liest nur den Content-Kanal, der Call wird stillschweigend verworfen (leere Antwort, `tool_calls: []`).
- Empirie (12–18 Runs pro Setting): temp 0.7 → ~60 % Erfolg, temp 0.6/top_p 0.95 → ~83 %, **temp 0.2 → ~94 %**.
- Fix: Temperatur aller fablevibes-Subagenten in `.opencode/agent-models.jsonc` und `.opencode/opencode.jsonc` von 0.7 → 0.2.
- Nebenbefund korrigiert: Quant-Beschreibungen sagten `Q4_K_M`, die lokale GGUF ist `MXFP4_MOE`.
- Neuer Commit-Scope `opencode` registriert (`commitlint.config.cjs`).

## Test Plan
- [x] Repro + Messung direkt gegen LM Studio `/v1/chat/completions` (get_weather-Tool)
- [x] End-to-end via `opencode run` mit Bash-Tool-Call verifiziert
- [x] JSONC-Validität beider Configs geprüft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PL1NPfjpWdzGU6GCnsWx7

🤖 [T001970]