### PR TITLE
fix(infra): korczewski Brain-Dashboard-Link 404 — toter Ingress + BRAIN_EXTERNAL_URL [T001976]

### DIFF
--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -44,7 +44,7 @@ env_vars:
   DOCS_URL: "https://docs.korczewski.de"
   AUTH_EXTERNAL_URL: "https://auth.korczewski.de"
   VAULT_EXTERNAL_URL: "https://vault.korczewski.de"
-  BRAIN_EXTERNAL_URL: "https://brain.korczewski.de"
+  BRAIN_EXTERNAL_URL: "https://brain.mentolder.de"
   WHITEBOARD_EXTERNAL_URL: "https://files.korczewski.de/apps/files"
   TRAEFIK_EXTERNAL_URL: "https://traefik.korczewski.de"
   MAIL_EXTERNAL_URL: "https://mail.korczewski.de"

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -42,7 +42,7 @@ env_vars:
   DOCS_URL: "https://docs.korczewski.de"
   AUTH_EXTERNAL_URL: "https://auth.korczewski.de"
   VAULT_EXTERNAL_URL: "https://vault.korczewski.de"
-  BRAIN_EXTERNAL_URL: "https://brain.korczewski.de"
+  BRAIN_EXTERNAL_URL: "https://brain.mentolder.de"
   WHITEBOARD_EXTERNAL_URL: "https://files.korczewski.de/apps/files"
   TRAEFIK_EXTERNAL_URL: "https://traefik.korczewski.de"
   MAIL_EXTERNAL_URL: "https://mail.korczewski.de"

--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -75,6 +75,13 @@ patches:
       kind: Service
       metadata:
         name: oauth2-proxy-brain
+  - target: { group: networking.k8s.io, version: v1, kind: Ingress, name: workspace-ingress-brain }
+    patch: |-
+      $patch: delete
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
+      metadata:
+        name: workspace-ingress-brain
 
   # livekit-recordings-pvc uses the base manifest's storage class (local-path),
   # tied to the livekit pin-node (pk-hetzner-6). Acceptable because livekit-* are


### PR DESCRIPTION
## Problem

Der Brain-Link im korczewski-Admin-Dashboard führt auf `https://brain.korczewski.de` → **404**. Brain ist mentolder-only (T001569): `prod-korczewski/kustomization.yaml` exkludiert Deployment + Services per `$patch: delete`, aber der Ingress `workspace-ingress-brain` aus `prod/ingress.yaml` wurde nie mit exkludiert und zeigt auf den nicht existierenden Service `oauth2-proxy-brain:4180`.

## Fix

- `prod-korczewski/kustomization.yaml`: Inline-`$patch: delete` für den Ingress (gleiche Konvention wie die bestehenden Brain-Deletes)
- `environments/korczewski.yaml` + `environments/fleet-korczewski.yaml`: `BRAIN_EXTERNAL_URL` → `https://brain.mentolder.de` — der Dashboard-Link zeigt jetzt auf die eine echte Brain-Instanz statt auf eine tote Domain

## Verifikation

- `kubectl kustomize prod-fleet/korczewski` → 0 Treffer für brain/oauth2-proxy-brain/workspace-ingress-brain
- `kubectl kustomize prod-fleet/mentolder` → Ingress unverändert vorhanden
- `task workspace:validate` ✓ · `task env:validate` ✓ · `task test:all` 52/52 ✓ · `task freshness:check` ✓

Nach Merge: `workspace:deploy ENV=korczewski` + stray Ingress im Cluster löschen (apply prunt nicht).

Ticket: T001976

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFdJjf3Z2kG2C7mgbKCT61