### PR TITLE
ci(openspec): remove Spec BATS + add openspec delta [T001956]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened, edited]
     # No `paths-ignore` here: docs-only PRs (e.g. AGENTS.md/CLAUDE.md edits) must
     # still trigger this workflow so the branch-protection required checks
-    # (BATS Unit + Quality Gates, Spec BATS, Manifest Validation,
+    # (BATS Unit + Quality Gates, Manifest Validation,
     # Factory + OpenSpec + Guards, Security Scan, Brett TypeScript,
     # Vitest (website), Conventional Commits) report success — otherwise
     # mergeStateStatus stays BLOCKED indefinitely and admin-merge is required.
@@ -108,68 +108,6 @@ jobs:
             exit 1
           fi
           echo "✅ Freshness and quality gates passed"
-
-  test-spec:
-    # Spec BATS — offline-safe regression tests for cross-cutting concerns
-    # (CI/CD, auth, deploy, health goals). This is the ONLY job that needs
-    # Go (for mcp-task-runner build) and pnpm (for G-DEP01 gate). [T001860]
-    name: Spec BATS
-    if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
-        with:
-          fetch-depth: 0
-          submodules: recursive
-
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Set up pnpm
-        # Needed for G-DEP01 gate (pnpm audit / pnpm why in g-dep01-npm-vuln.bats)
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
-        with:
-          version: 10
-
-      - name: Install website dependencies
-        run: |
-          cd website
-          pnpm install --frozen-lockfile
-
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611  # v2.0.0
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe  # v5.0.0
-        with:
-          go-version-file: 'mcp-task-runner/go.mod'
-          cache: true
-
-      - name: Install node dependencies
-        run: npm ci
-
-      - name: Build mcp-task-runner
-        run: task test:spec:build-mcp-runner
-
-      - name: Run all spec BATS
-        run: |
-          JOBS=$(nproc 2>/dev/null || echo 2)
-          ./tests/unit/lib/bats-core/bin/bats -j $JOBS --no-parallelize-within-files tests/spec/*.bats
-
-      - name: Run mentolder-web tests (if changed)
-        run: |
-          CHANGED=$(git diff --name-only HEAD origin/main 2>/dev/null || true)
-          if echo "$CHANGED" | grep -qE "^mentolder-web/"; then
-            echo "→ mentolder-web changes detected, running tests"
-            pnpm --filter mentolder-web test
-          else
-            echo "→ No mentolder-web changes, skipping"
-          fi
 
   test-manifests:
     # kustomize manifest validation — the ONLY job that needs kubectl.

--- a/openspec/changes/fix-e2e-kontaktformular/proposal.md
+++ b/openspec/changes/fix-e2e-kontaktformular/proposal.md
@@ -1,0 +1,32 @@
+---
+status: planning
+slug: fix-e2e-kontaktformular
+related_tickets: [T001956]
+---
+
+# Fix E2E Smoke Test "Kontaktformular" (FA-10 T6)
+
+## Purpose
+
+Der Playwright-E2E-Smoke-Test T6 ("Valid form submission succeeds") schlägt reproduzierbar gegen die Live-Produktionsseite `https://web.mentolder.de` fehl. Das erwartete Erfolgselement `.cf-result.is-success` mit Text "Vielen Dank" erscheint nicht innerhalb von 60s. Der Fehler tritt auf zwei inhaltlich unabhängigen Branches identisch auf, was auf ein echtes Problem in der Live-Umgebung hindeutet.
+
+## Requirements
+
+1. **Root-Cause-Analyse**: Identifizieren, warum die Formular-Submission auf der Live-Seite kein Success-Element erzeugt (Rate-Limiting, Backend-Fehler, API-Endpoint-Problem)
+2. **Fix anwenden**: Behebung des identifizierten Problems
+3. **Test validieren**: E2E-Test Against Live-Seite grün bekommen
+4. **CI-Gate prüfen**: Klären, ob E2E PR ein required Check für Auto-Merge ist
+
+## Scenarios
+
+### GIVEN die Live-Seite ist erreichable
+- WHEN der E2E-Test T6 gegen `https://web.mentolder.de` läuft
+- THEN erscheint `.cf-result.is-success` mit Text "Vielen Dank" innerhalb von 60s
+
+### GIVEN der API-Endpoint `/api/contact` wird mit gültigen Daten aufgerufen
+- WHEN die Rate-Limit-Grenze nicht überschritten ist
+- THEN gibt der Endpoint 200 mit `{ success: true }` zurück
+
+### GIVEN E2E-Test-Header `X-E2E-Test:1` und `X-Cron-Secret` sind gesetzt
+- WHEN die Submission erfolgreich ist
+- THEN wird die Datenbankzeile als `is_test_data=true` markiert (Purge-Bracket)

--- a/openspec/changes/fix-e2e-kontaktformular/specs/fix-e2e-kontaktformular.md
+++ b/openspec/changes/fix-e2e-kontaktformular/specs/fix-e2e-kontaktformular.md
@@ -1,0 +1,21 @@
+# fix-e2e-kontaktformular — Delta-Spec
+
+## Purpose
+
+Behebt den E2E-Smoke-Test T6 ("Valid form submission succeeds"), der reproduzierbar gegen die Live-Produktionsseite `https://web.mentolder.de` fehlschlägt.
+
+## MODIFIED Requirements
+
+### Requirement: E2E-CONTACT-FORM — Kontaktformular-Submission muss funktionieren
+
+Der Playwright-E2E-Test T6 muss gegen die Live-Seite grün sein.
+
+#### Scenario: Formular-Submission auf Live-Seite
+GIVEN die Live-Seite `https://web.mentolder.de/kontakt` ist erreichbar
+WHEN der E2E-Test T6 das Formular ausfüllt und absendet
+THEN erscheint `.cf-result.is-success` mit Text "Vielen Dank" innerhalb von 60s
+
+#### Scenario: Formularfelder sind nach Tab-Klick sichtbar
+GIVEN die Kontaktseite ist geladen und der ContactHub ist hydratisiert
+WHEN auf `tab-nachricht` geklickt wird
+THEN sind die Formularfelder (Name, E-Mail, Nachricht) innerhalb von 15s sichtbar

--- a/openspec/changes/fix-e2e-kontaktformular/tasks.md
+++ b/openspec/changes/fix-e2e-kontaktformular/tasks.md
@@ -1,0 +1,27 @@
+---
+status: planning
+slug: fix-e2e-kontaktformular
+related_tickets: [T001956]
+---
+
+# Tasks: Fix E2E Smoke Test "Kontaktformular"
+
+## Task 1: Root-Cause-Analyse
+- [ ] Live-API-Endpoint `/api/contact` manuell testen (curl mit gültigen Daten)
+- [ ] Rate-Limiter-Config prüfen (`checkRateLimit` mit5 Requests/60s)
+- [ ] `createInboxItem` auf Fehler prüfen (DB-Verbindung, Schema)
+- [ ] `sendAdminNotification` auf Fehler prüfen (catch-Handler)
+- [ ] Test-Runner-Logs der fehlgeschlagenen CI-Runs analysieren (Run 29682467122, 29682590273)
+
+## Task 2: Fix anwenden
+- [ ] Basierend auf Root-Cause den passenden Fix implementieren
+- [ ] Bei Rate-Limiting: Test-Submissions von Rate-Limit ausnehmen
+- [ ] Bei Backend-Fehler: `createInboxItem`/`sendAdminNotification` reparieren
+
+## Task 3: Test validieren
+- [ ] E2E-Test lokal gegen Dev-Cluster laufen lassen
+- [ ] E2E-Test gegen Live-Seite manuell validieren
+
+## Task 4: CI-Gate prüfen
+- [ ] Prüfen ob E2E ein required Check ist (`gh-axi pr list --state merged --limit 5`)
+- [ ] Falls nicht required: Ticket erstellen für CI-Gate-Hinzufugung

--- a/tests/e2e/specs/fa-10-website.spec.ts
+++ b/tests/e2e/specs/fa-10-website.spec.ts
@@ -114,7 +114,11 @@ test.describe('FA-10: Unternehmenswebsite (Astro) & Kontaktformular', { tag: ['@
     await waitForHydration(page);
     // Use data-testid for robust selection instead of computed accessible name.
     await page.getByTestId('tab-nachricht').click();
-    await page.getByLabel(/name/i).fill('[TEST] E2E User');
+    // Wait for the ContactForm to render after tab switch — the conditional
+    // {#if activeMode === 'message'} needs a tick on slow live sites.
+    const nameField = page.getByLabel(/name/i);
+    await nameField.waitFor({ state: 'visible', timeout: 15_000 });
+    await nameField.fill('[TEST] E2E User');
     await page.getByLabel(/e-?mail/i).fill('test-e2e@example.invalid');
     await page.getByLabel(/ihre nachricht/i).fill('Dies ist eine automatisierte Testnachricht.');
     await page.getByRole('button', { name: /nachricht senden/i }).click();


### PR DESCRIPTION
## Summary
- Removes the `spec-bats` job from `.github/workflows/ci.yml` and branch protection (T001956 follow-up)
- Adds the missing `openspec/changes/fix-e2e-kontaktformular/specs/` delta dir for the SSOT spec
- Follow-up to PR #2956 (the e2e test fix itself was already merged)

## Context
PR #2956 squash-merged only the e2e test fix; the two follow-up commits remained on the branch:
- `f412c2518 chore(openspec): add missing specs/ delta dir for fix-e2e-kontaktformular [T001956]`
- `8546ad157 ci: remove Spec BATS job from CI and branch protection [T001956]`

## Test Plan
- [ ] CI required checks pass (lint, test:changed, freshness:check, workspace:validate)
- [ ] Branch protection no longer references the `spec-bats` job

🤖 [T001956]