### PR TITLE
chore(opencode): deny webfetch/websearch for factory implementer subagents [T001981]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -96,7 +96,7 @@
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#0EA5E9",
       "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
+      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
     },
     "qwen3-14b": {
       "description": "Single-session implementation/planning agent: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio",
@@ -105,7 +105,7 @@
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
       "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
+      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
     },
     "qwen35": {
       "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time)",
@@ -114,7 +114,7 @@
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#22C55E",
       "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
+      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
     },
     "qwen35-hq": {
       "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time), use when max per-call context matters more than concurrency",
@@ -123,7 +123,7 @@
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#16A34A",
       "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny" }
+      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
     }
   }
 }


### PR DESCRIPTION
## Was

Setzt `webfetch`/`websearch` in den permission-Blöcken der vier opencode-Subagenten (`qwen35-iq4`, `qwen3-14b`, `qwen35`, `qwen35-hq`) in `.opencode/agent-models.jsonc` auf `deny`.

## Warum

Quick Win aus dem Agentic-Trends-Radar 2026-07-19 (Trend "Sandboxing/Permission-Profile"): Die Subagenten erbten `webfetch/websearch=allow` aus `opencode.jsonc` — unbeaufsichtigte Autopilot-Worker mit offenem Prompt-Injection-Vektor über Webinhalte. Die interaktive Haupt-Session behält Webzugriff (kein globaler Deny).

Restlücke (bewusst out of scope): der Haupt-`build`-Agent des Autopiloten läuft weiter mit globalem allow — adressiert das separate OS-Sandbox-Experiment (Radar-Kandidat #4).

## Verifikation

- `npx bats tests/spec/background-agents-fallback.bats` → 6/6 ok
- `task test:changed` → 52/52 pass
- `task freshness:check` → grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFdJjf3Z2kG2C7mgbKCT61
