### PR TITLE
fix(factory): pre-create feature worktree before launching pipeline [T001983]

### DIFF
--- a/.claude/workflows/agentic-trends-radar.js
+++ b/.claude/workflows/agentic-trends-radar.js
@@ -1,0 +1,143 @@
+export const meta = {
+  name: 'agentic-trends-radar',
+  description: 'Aggregiert aktuelle Trends im agentischen Software-Engineering und bewertet sie gegen unseren SDLC (Adopt/Trial/Hold)',
+  whenToUse: 'Regelmäßig (z. B. monatlich) oder auf Zuruf, um zu entscheiden, welche neuen agentischen SWE-Praktiken wir übernehmen sollten',
+  phases: [
+    { title: 'Sweep', detail: '5 Rechercheure mit je eigenem Suchwinkel (Vendor, Forschung, Community, OSS, Praxis)' },
+    { title: 'Konsolidieren', detail: 'Dedup + Ranking auf max. 10 distinkte Trends' },
+    { title: 'Bewerten', detail: 'Pro Trend: Fit gegen unseren SDLC, Verdict adopt/trial/hold/skip' },
+    { title: 'Synthese', detail: 'Radar-Report mit konkreten Übernahme-Vorschlägen' },
+  ],
+}
+
+// args: { date: 'YYYY-MM-DD' (Pflicht, da Date.now() im Workflow nicht verfügbar), windowMonths?: number }
+const DATE = (args && args.date) || 'unbekannt'
+const WINDOW = (args && args.windowMonths) || 4
+
+// Kompakte Selbstbeschreibung unseres SDLC — Referenzrahmen für die Bewertung.
+const OUR_SDLC = `
+Unser SDLC (Kubernetes-Workspace-Plattform, Solo-Hauptentwickler + Agenten-Flotte):
+- Spec-getrieben: OpenSpec-Change-Workflow (propose → apply → archive, Delta-Specs mergen in SSOT-Specs unter openspec/specs/), fail-closed CI-Validierung.
+- Orchestrator-Skills: dev-flow-plan (Brainstorming → Spec → Plan, committed auf Branch), dev-flow-execute (Implementierung, Verify, PR, Auto-Merge), dev-flow-chore (inline). Darunter generische "superpowers"-Skills: TDD, systematic-debugging, writing-plans, verification-before-completion.
+- Software Factory: Ticket-Pipeline (PostgreSQL-Ticketsystem, Phase-Events, Autopilot), die Tickets automatisiert mit lokalen LLM-Subagenten (qwen3.5-Varianten via opencode/LM Studio) abarbeitet; Quality-Gates als verify-Phase-Events; Merge = Ticket-Abschluss; DORA-Metriken inkl. Change-Failure-Rate-Gate (fix()-Commits brauchen Bug-Ticket).
+- Agenten: 6 Domänen-Subagenten (website/ops/infra/test/db/security) mit Routing-Tabelle; MCP-Server für k8s, Postgres, Tickets, Factory; codebase-memory-MCP (Code-Knowledge-Graph mit Call-Tracing); generierte Agent-Routing-Karten (goals/tools/danger maps).
+- Hygiene: Worktree-Pflicht für mutierende Arbeit, agent-lock-Session-Koordination, Mishap-Tracker (Fehlersammlung als Aggregat-Tickets), Task-Oracle (LLM-Routing natürlicher Sprache auf Taskfile-Kommandos), Release-Notes-Generierung per LLM.
+- CI/CD: GitHub Actions, BATS + Playwright, Squash-Merge, push-basiertes Deploy auf k3s-Fleet (kein GitOps-Reconciler), nightly E2E.
+- Besonderheit: Multi-Harness (Claude Code + opencode mit lokalen Modellen), lokale GPU-Inferenz, DSGVO/on-prem.
+`.trim()
+
+const TRENDS_SCHEMA = {
+  type: 'object',
+  required: ['trends'],
+  properties: {
+    trends: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'summary', 'sources', 'momentum'],
+        properties: {
+          name: { type: 'string', description: 'Kurzer prägnanter Trend-Name' },
+          summary: { type: 'string', description: '2-4 Sätze: Was ist es, warum jetzt relevant' },
+          sources: { type: 'array', items: { type: 'string' }, description: 'URLs der Belege' },
+          momentum: { type: 'string', enum: ['emerging', 'accelerating', 'mainstream'], description: 'Reifegrad/Dynamik' },
+        },
+      },
+    },
+  },
+}
+
+const MERGED_SCHEMA = {
+  type: 'object',
+  required: ['trends'],
+  properties: {
+    trends: {
+      type: 'array',
+      maxItems: 10,
+      items: {
+        type: 'object',
+        required: ['name', 'summary', 'sources', 'momentum', 'relevance_hint'],
+        properties: {
+          name: { type: 'string' },
+          summary: { type: 'string' },
+          sources: { type: 'array', items: { type: 'string' } },
+          momentum: { type: 'string' },
+          relevance_hint: { type: 'string', description: '1 Satz: warum potenziell relevant für unseren SDLC' },
+        },
+      },
+    },
+    dropped: { type: 'array', items: { type: 'string' }, description: 'Verworfene/gemergte Trend-Namen mit Kurzgrund' },
+  },
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  required: ['verdict', 'rationale', 'borrow_what', 'effort', 'risks'],
+  properties: {
+    verdict: { type: 'string', enum: ['adopt', 'trial', 'hold', 'skip'] },
+    rationale: { type: 'string', description: '2-4 Sätze Begründung, explizit gegen unseren SDLC gespiegelt' },
+    borrow_what: { type: 'string', description: 'Konkret: welches Element würden wir übernehmen und wo würde es andocken (welcher Skill/Workflow/Komponente)' },
+    already_covered: { type: 'string', description: 'Was davon haben wir schon (ggf. unter anderem Namen)' },
+    effort: { type: 'string', enum: ['S', 'M', 'L'], description: 'Grober Einführungsaufwand' },
+    risks: { type: 'string', description: 'Hauptrisiken/Nebenwirkungen der Übernahme' },
+  },
+}
+
+const ANGLES = [
+  {
+    key: 'vendor',
+    prompt: `Recherchiere per Websuche die neuesten Entwicklungen (letzte ${WINDOW} Monate, heute ist ${DATE}) bei agentischen Coding-Tools der großen Anbieter: Anthropic/Claude Code (Skills, Subagenten, Hooks, Sandboxing, Cloud-Agenten), OpenAI Codex, Cursor, GitHub Copilot (Workspace/Agents), Google (Jules/Antigravity/Gemini CLI), Cognition/Devin, Amp/Sourcegraph. Fokus: neue FÄHIGKEITEN und WORKFLOW-MUSTER, die Teams in ihren SDLC einbauen (nicht Marketing). Nutze ToolSearch um WebSearch/WebFetch zu laden. Liefere max. 6 distinkte Trends mit Quellen-URLs.`,
+  },
+  {
+    key: 'research',
+    prompt: `Recherchiere per Websuche aktuelle Forschung (letzte ${WINDOW} Monate, heute ist ${DATE}) zu agentischem Software-Engineering: arXiv/HuggingFace-Papers zu Multi-Agent-Coding, SWE-bench-Fortschritten, automatischer Verifikation/Repair, Spec-basierter Generierung, Agent-Memory, Kontext-Management, LLM-as-Judge für Code-Review. Fokus: Ergebnisse, die PRAKTISCH in einen Team-SDLC übertragbar sind. Nutze ToolSearch um WebSearch/WebFetch zu laden. Liefere max. 6 distinkte Trends mit Quellen-URLs.`,
+  },
+  {
+    key: 'community',
+    prompt: `Recherchiere per Websuche den aktuellen Praktiker-Diskurs (letzte ${WINDOW} Monate, heute ist ${DATE}) zu agentischen Entwicklungs-Workflows: Hacker News, Reddit (r/ClaudeAI, r/LocalLLaMA, r/ExperiencedDevs), einschlägige Blogs/Newsletter (Simon Willison, Pragmatic Engineer u. ä.). Fokus: Welche WORKFLOW-MUSTER setzen sich bei erfahrenen Teams durch, welche gelten als gescheitert/überhypt (Anti-Patterns explizit mitnehmen). Nutze ToolSearch um WebSearch/WebFetch zu laden. Liefere max. 6 distinkte Trends mit Quellen-URLs.`,
+  },
+  {
+    key: 'oss',
+    prompt: `Recherchiere per Websuche das Open-Source-Ökosystem für agentisches Software-Engineering (letzte ${WINDOW} Monate, heute ist ${DATE}): trending GitHub-Repos, MCP-Server-Ökosystem, Agent-Harnesses/Orchestrierungs-Frameworks, Spec-driven-Dev-Tools (z. B. spec-kit, OpenSpec u. ä.), Code-Review-Bots, Agent-Memory-/Kontext-Systeme, Sandboxing. Fokus: Werkzeuge mit echter Adoption, die man in einen bestehenden SDLC integrieren kann. Nutze ToolSearch um WebSearch/WebFetch zu laden. Liefere max. 6 distinkte Trends mit Quellen-URLs.`,
+  },
+  {
+    key: 'practices',
+    prompt: `Recherchiere per Websuche, wie Engineering-Teams ihren SDLC konkret für Agenten umgebaut haben (letzte ${WINDOW} Monate, heute ist ${DATE}): Engineering-Blogs (Anthropic, Shopify, Vercel, Sentry, Faire, Block/Goose etc.), Konferenz-Talks, "agent-native repository"-Praktiken (AGENTS.md, CI-Gates für Agenten-PRs, Review-Strategien für KI-Code, parallele Agenten-Flotten, Eval-getriebene Entwicklung). Fokus: übertragbare PROZESS-Änderungen, nicht Tool-Werbung. Nutze ToolSearch um WebSearch/WebFetch zu laden. Liefere max. 6 distinkte Trends mit Quellen-URLs.`,
+  },
+]
+
+phase('Sweep')
+log(`Starte 5 Sweep-Agenten (Zeitfenster: letzte ${WINDOW} Monate bis ${DATE})`)
+const sweeps = await parallel(ANGLES.map(a => () =>
+  agent(a.prompt, { label: `sweep:${a.key}`, phase: 'Sweep', schema: TRENDS_SCHEMA })
+))
+const raw = sweeps.filter(Boolean).flatMap((r, i) =>
+  r.trends.map(t => ({ ...t, angle: ANGLES[i] ? ANGLES[i].key : 'unknown' }))
+)
+log(`${raw.length} Roh-Trends aus ${sweeps.filter(Boolean).length}/5 Sweeps`)
+if (raw.length === 0) return { error: 'Kein Sweep lieferte Ergebnisse — vermutlich kein Web-Zugriff in den Subagenten.' }
+
+phase('Konsolidieren')
+const merged = await agent(
+  `Hier sind ${raw.length} Roh-Trends zu agentischem Software-Engineering aus 5 Suchwinkeln (vendor/research/community/oss/practices), teils überlappend:\n\n${JSON.stringify(raw, null, 2)}\n\nUnser Kontext:\n${OUR_SDLC}\n\nAufgabe: Dedupliziere und merge zu maximal 10 DISTINKTEN Trends, gerankt nach potenzieller Relevanz für unseren SDLC. Behalte pro Trend die besten Quellen-URLs (gemergt aus Duplikaten). Verwirf reine Produkt-News ohne Prozess-Implikation und Dinge, die wir offensichtlich schon vollständig haben — liste Verworfenes mit Kurzgrund unter "dropped". Anti-Patterns/gescheiterte Muster sind als eigener Trend zulässig (wertvoll als Negativ-Signal).`,
+  { label: 'dedup+rank', phase: 'Konsolidieren', schema: MERGED_SCHEMA }
+)
+if (!merged || !merged.trends || merged.trends.length === 0) return { error: 'Konsolidierung lieferte keine Trends.', raw }
+log(`${merged.trends.length} konsolidierte Trends, ${(merged.dropped || []).length} verworfen`)
+
+phase('Bewerten')
+const assessed = await parallel(merged.trends.map(t => () =>
+  agent(
+    `Bewerte den folgenden Trend im agentischen Software-Engineering NÜCHTERN gegen unseren konkreten SDLC. Sei skeptisch: "hold" oder "skip" sind völlig legitime Verdicts — wir wollen keine Mode-Adoption, sondern nur Dinge mit klarem Mehrwert gegenüber dem, was wir schon haben. Prüfe explizit, ob wir das Muster unter anderem Namen bereits implementiert haben.\n\nTrend: ${t.name}\nZusammenfassung: ${t.summary}\nMomentum: ${t.momentum}\nQuellen: ${(t.sources || []).join(', ')}\n\nUnser SDLC:\n${OUR_SDLC}\n\nVerdict-Skala: adopt = jetzt übernehmen, klarer Nutzen, geringer Aufwand · trial = in einem begrenzten Experiment/Ticket erproben · hold = beobachten, noch nicht reif oder Nutzen unklar · skip = passt nicht zu uns / haben wir schon / Anti-Pattern. Bei borrow_what: benenne den konkreten Andockpunkt (welcher Skill, welche Pipeline-Phase, welche Komponente).`,
+    { label: `assess:${t.name.slice(0, 40)}`, phase: 'Bewerten', schema: VERDICT_SCHEMA }
+  ).then(v => ({ trend: t, assessment: v }))
+))
+const results = assessed.filter(x => x && x.assessment)
+log(`${results.length}/${merged.trends.length} Trends bewertet`)
+
+phase('Synthese')
+const report = await agent(
+  `Erstelle aus diesen bewerteten Trends einen deutschsprachigen "Agentic SWE Trend-Radar"-Report (Markdown, Stand ${DATE}) für den Hauptentwickler unserer Plattform. Struktur: 1) TL;DR (3-5 Sätze), 2) Radar-Tabelle (Trend | Momentum | Verdict | Aufwand), 3) je Abschnitt pro Verdict-Kategorie (adopt zuerst) mit Begründung, konkretem Übernahme-Vorschlag inkl. Andockpunkt und Risiken, 4) "Bereits abgedeckt"-Liste (was wir schon haben — Bestätigung unseres Kurses), 5) empfohlene nächste Schritte als konkrete Ticket-Kandidaten (Titel + 1-Satz-Scope). Quellen-URLs als Links erhalten. Technische Begriffe englisch lassen. Sei konkret und entscheidungsorientiert, kein Berater-Blabla.\n\nUnser SDLC:\n${OUR_SDLC}\n\nBewertete Trends:\n${JSON.stringify(results, null, 2)}\n\nVerworfen bei Konsolidierung:\n${JSON.stringify(merged.dropped || [], null, 2)}\n\nGib NUR das Markdown-Dokument zurück.`,
+  { label: 'radar-report', phase: 'Synthese' }
+)
+
+return { report, results, dropped: merged.dropped || [] }

--- a/scripts/factory/dispatcher-bridge.sh
+++ b/scripts/factory/dispatcher-bridge.sh
@@ -33,13 +33,21 @@ if [[ "$launch_count" -eq 0 ]]; then
   exit 0
 fi
 
-# Budget check + pipeline launch for each feature
-for row in $(echo "$prep" | jq -c '.launch[]' 2>/dev/null); do
+# Budget check + pipeline launch for each feature.
+# Iterate compact-JSON rows safely: the previous `for row in $(...)` form split
+# on IFS whitespace, so any title with spaces (e.g. T001945's
+# "Health-Goal: G-SIZE02 — Großdateien … (17 → ≤8)") caused the loop to fire
+# once per whitespace-delimited fragment with empty ext_id/brand, blocking at
+# the budget-guard without ever launching the pipeline. `mapfile` reads the
+# newline-delimited rows verbatim.
+mapfile -t launch_rows < <(echo "$prep" | jq -c '.launch[]' 2>/dev/null)
+for row in "${launch_rows[@]}"; do
   ext_id="$(echo "$row" | jq -r '.external_id')"
   brand="$(echo "$row" | jq -r '.brand // "mentolder"')"
   title="$(echo "$row" | jq -r '.title // ""')"
   branch="$(echo "$row" | jq -r '.branch // ""')"
   plan_path="$(echo "$row" | jq -r '.plan_path // ""')"
+  wt_path="$(echo "$row" | jq -r '.worktree_path // ""')"
   slug="$(echo "$row" | jq -r '.branch // ""' | sed -E 's#^(feature|fix|chore)/##')"
   [[ -z "$slug" ]] && slug="sf-$(echo "$ext_id" | tr '[:upper:]' '[:lower:]')"
   dry_run_val="$(echo "$row" | jq -r '.dry_run // false')"
@@ -64,20 +72,42 @@ for row in $(echo "$prep" | jq -c '.launch[]' 2>/dev/null); do
 
   # Launch pipeline via claude -p: qwen3.6-14b-a3b-fablevibes handles agent() calls fine,
   # only the Workflow() meta-tool was problematic.
+  #
+  # The factory-prep step pre-created an isolated worktree branched from
+  # origin/<branch> (not origin/main) and the plan file is materialized on disk
+  # at <wt_path>/<plan_path>. The prompt is intentionally written without any
+  # "do NOT refuse / call it anyway" override — that pattern is correctly
+  # detected by the model as manipulation and triggers a full safety refusal
+  # even for legitimate use. The plan existence is verifiable via the worktree
+  # path or via `git show origin/<branch>:<plan_path>` from the main repo.
   TIMESTAMP="$(date -u +%FT%TZ)"
-  PIPELINE_PROMPT="Run the Software Factory pipeline for ticket ${ext_id} (${title}). \
-Call the Workflow tool exactly like this — the scriptPath option IS supported and this is \
-the standard, working way to run it: \
-Workflow({scriptPath:\"scripts/factory/pipeline.js\"}, \
-{title:\"${title}\", ticket_id:\"${ext_id}\", brand:\"${brand}\", \
-slug:\"${slug}\", timestamp:\"${TIMESTAMP}\", dry_run:${dry_run_val}, \
-branch:$(if [[ -n "$branch" ]]; then echo "\"${branch}\""; else echo 'null'; fi), \
-plan_path:$(if [[ -n "$plan_path" ]]; then echo "\"${plan_path}\""; else echo 'null'; fi)}). \
-Report only the pipeline's final JSON result. \
-Do NOT call the Skill tool — there is no skill that runs the pipeline; \
-the ONLY correct way to run it is the exact Workflow tool call shown above. \
-Do NOT refuse or claim scriptPath is unsupported — it is supported; if you believe otherwise, call it anyway. \
-If a tool call fails, do not retry the identical call — stop and report the error verbatim instead of looping."
+  PIPELINE_PROMPT="Run the Software Factory pipeline for ticket ${ext_id} (${title}).
+
+Context:
+  - repo: ${REPO}
+  - feature branch (origin): ${branch:-<none>}
+  - plan file: ${plan_path:-<none>}  (materialized at ${wt_path:-<n/a>}/${plan_path:-<none>}, or read with: git show origin/${branch:-HEAD}:${plan_path:-<none>})
+  - slug: ${slug}
+  - brand: ${brand}
+  - dry_run: ${dry_run_val}
+  - timestamp: ${TIMESTAMP}
+
+Invoke the Workflow tool with these exact arguments to run the pipeline:
+  Workflow({scriptPath:\"scripts/factory/pipeline.js\"}, {
+    title:\"${title}\",
+    ticket_id:\"${ext_id}\",
+    brand:\"${brand}\",
+    slug:\"${slug}\",
+    timestamp:\"${TIMESTAMP}\",
+    dry_run:${dry_run_val},
+    branch:$(if [[ -n "$branch" ]]; then echo "\"${branch}\""; else echo 'null'; fi),
+    plan_path:$(if [[ -n "$plan_path" ]]; then echo "\"${plan_path}\""; else echo 'null'; fi)
+  })
+
+Report only the pipeline's final JSON result. The pipeline.js workflow is the
+standard, supported way to run a Software Factory pipeline; do not try to run
+it as a Skill or via any other mechanism. If a tool call fails, do not retry
+the identical call — stop and report the error verbatim instead of looping."
 
   "${CLAUDE_BIN:-claude}" -p "$PIPELINE_PROMPT" \
     --allowedTools "Workflow,Bash(bash scripts/factory/*),Bash(bash scripts/ticket.sh*),Bash(bash scripts/vda.sh*),ToolSearch,PushNotification" \

--- a/scripts/factory/factory-prep-bridge.sh
+++ b/scripts/factory/factory-prep-bridge.sh
@@ -137,6 +137,24 @@ for brand in mentolder korczewski; do
       continue
     fi
 
+    # Pre-create the worktree at the same path pipeline.js will use, branched
+    # from origin/<branch> (not origin/main) so the plan file is materialized
+    # on disk before the launched `claude -p` session runs its safety-check.
+    # Without this, the LLM refuses to invoke Workflow because
+    # $plan_path doesn't exist in the main checkout (only on the feature branch),
+    # the prompt override is correctly flagged as manipulation, and the pipeline
+    # exits immediately — leaving the slot held, watchdog reset, cycle repeats.
+    wt_path=null
+    wt_slug=$(echo "${branch}" | sed -E 's#^(feature|fix|chore)/##')
+    wt_path="${REPO}/.worktrees/${wt_slug}-reuse"
+    if ! bash "$REPO/scripts/worktree-create.sh" "${branch}" "${wt_path}" "origin/${branch}" >/dev/null 2>&1; then
+      log "SKIP reason=worktree_failed ticket=$ext_id (pre-create at ${wt_path} failed)"
+      BRAND="$brand" bash "$REPO/scripts/ticket.sh" release-slot --id "$ext_id" >/dev/null 2>&1 || true
+      skipped=$(echo "$skipped" | jq -c --arg b "$brand" --arg r "worktree_failed" '. + [{"brand":$b,"reason":$r}]')
+      continue
+    fi
+    log "pre-created worktree for $ext_id at ${wt_path}"
+
     launch=$(echo "$launch" | jq -c \
       --arg b "$brand" \
       --arg e "$ext_id" \
@@ -144,8 +162,9 @@ for brand in mentolder korczewski; do
       --arg t "$title" \
       --arg br "${branch:-null}" \
       --arg p "${plan_path:-null}" \
+      --arg w "${wt_path}" \
       --argjson dr "$dr" \
-      '. + [{"brand":$b, "external_id":$e, "slot":$s, "title":$t, "branch":$br, "plan_path":$p, "dry_run":$dr}]')
+      '. + [{"brand":$b, "external_id":$e, "slot":$s, "title":$t, "branch":$br, "plan_path":$p, "worktree_path":$w, "dry_run":$dr}]')
   done
 done
 

--- a/scripts/vda/factory-prep.sh
+++ b/scripts/vda/factory-prep.sh
@@ -114,10 +114,30 @@ run_prep() {
         [[ -n "${pp}" ]] && plan_path="${pp}"
       fi
 
+      # Pre-create the worktree at the same path pipeline.js will use, branched
+      # from origin/<branch> (not origin/main) so the plan file is materialized
+      # on disk before the launched `claude -p` session runs its safety-check.
+      # Without this, the LLM refuses to invoke Workflow because
+      # $plan_path doesn't exist in the main checkout (only on the feature branch),
+      # the prompt override is correctly flagged as manipulation, and the pipeline
+      # exits immediately — leaving the slot held, watchdog reset, cycle repeats.
+      wt_path=null
+      if [[ "${branch}" != "null" && -n "${branch}" ]]; then
+        wt_slug=$(echo "${branch}" | sed -E 's#^(feature|fix|chore)/##')
+        wt_path="${REPO}/.worktrees/${wt_slug}-reuse"
+        if ! bash "${REPO}/scripts/worktree-create.sh" "${branch}" "${wt_path}" "origin/${branch}" >/dev/null 2>&1; then
+          log "SKIP reason=worktree_failed ticket=${ext_id} (pre-create at ${wt_path} failed)"
+          BRAND="${brand}" bash "${REPO}/scripts/ticket.sh" release-slot --id "${ext_id}" 2>/dev/null || true
+          final_skipped=$(echo "${final_skipped}" | jq -c --arg b "${brand}" --arg r "worktree_failed" '. + [{"brand":$b,"reason":$r}]')
+          continue
+        fi
+        log "pre-created worktree for ${ext_id} at ${wt_path}"
+      fi
+
       final_launch=$(echo "${final_launch}" | jq -c \
         --arg b "${brand}" --arg e "${ext_id}" --argjson s "${slot}" \
-        --arg t "${title:-}" --arg br "${branch:-null}" --arg p "${plan_path:-null}" --argjson dr "${dry_run}" \
-        '. + [{"brand":$b, "external_id":$e, "slot":$s, "title":$t, "branch":$br, "plan_path":$p, "dry_run":$dr}]')
+        --arg t "${title:-}" --arg br "${branch:-null}" --arg p "${plan_path:-null}" --arg w "${wt_path}" --argjson dr "${dry_run}" \
+        '. + [{"brand":$b, "external_id":$e, "slot":$s, "title":$t, "branch":$br, "plan_path":$p, "worktree_path":$w, "dry_run":$dr}]')
     done
   done
 

--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -1179,6 +1179,18 @@
       "status": "plan_staged"
     }
   ],
+  "T001979": [
+    {
+      "slug": "openspec-drift-gate",
+      "status": "plan_staged"
+    }
+  ],
+  "T001980": [
+    {
+      "slug": "factory-eval-scale",
+      "status": "plan_staged"
+    }
+  ],
   "TBD": [
     {
       "slug": "2026-06-21-secrets-deploy-automation",


### PR DESCRIPTION
## Summary
- `dispatcher-bridge.sh` launched `claude -p` for the Software Factory pipeline before the feature worktree existed. The plan path wasn't present in the main checkout (only on the feature branch), so the model correctly flagged the Workflow tool-call instructions as a manipulation attempt and refused — the pipeline aborted immediately, the slot stayed held, the watchdog reset, and the cycle repeated.
- `factory-prep-bridge.sh` / `factory-prep.sh` now pre-create the worktree under `.worktrees/<slug>-reuse` (branched from `origin/<branch>`) before handing off to the pipeline launch, so the plan file is materialized on disk when the safety check runs.
- `dispatcher-bridge.sh` also switches launch-row iteration from word-splitting (`for row in $(...)`) to `mapfile`, since ticket titles containing spaces or em-dashes previously fragmented the budget-guard loop.
- Bundled: persist the `agentic-trends-radar` Workflow script under `.claude/workflows/` so future invocations can resume via `scriptPath`.

Closes T001983

## Test plan
- [x] `bash -n` syntax check on all three modified shell scripts
- [ ] CI: BATS + kustomize + Taskfile dry-run (offline suite)
- [ ] Freshness/test-inventory check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9BURA1e7HkSSww1TtzJpz