### PR TITLE
chore(openspec): add scenario coverage for 26 SSOT requirements + validator ratchet [T002004]

### DIFF
--- a/openspec/specs/admin-cockpit.md
+++ b/openspec/specs/admin-cockpit.md
@@ -762,17 +762,45 @@ The system SHALL render the ticket title in `TicketRow.svelte` as an `<a class="
 
 The system SHALL NOT define or pass an `onOpenDrawer` prop on `TicketRow` or `CockpitTable`; the corresponding test for the title-click drawer flow MUST be removed.
 
+#### Scenario: No onOpenDrawer prop remains in the table components
+
+- **GIVEN** the components `TicketRow.svelte` and `CockpitTable.svelte`
+- **WHEN** searching their source for `onOpenDrawer`
+- **THEN** there are zero matches
+- **AND** no unit test asserts a title-click drawer flow
+
 ### Requirement: Cockpit mountet keinen TicketDrawer mehr
 
 The system SHALL NOT mount a `TicketDrawer` component in `Cockpit.svelte`, SHALL NOT import `TicketDrawer`, and SHALL NOT track `drawerTicket` / `drawerOpen` state. The `TicketCreateModal` mount is preserved.
+
+#### Scenario: Cockpit renders without drawer state
+
+- **GIVEN** `Cockpit.svelte`
+- **WHEN** searching its source for `TicketDrawer`, `drawerTicket`, or `drawerOpen`
+- **THEN** there are zero matches
+- **AND** the `TicketCreateModal` mount is still present
 
 ### Requirement: cockpitStore enthält keine aktive-Ticket-State
 
 The system SHALL NOT export a `setActiveTicket` function or carry an `activeTicket: string | null` field on `CockpitState`; the corresponding unit tests SHALL be removed.
 
+#### Scenario: cockpitStore exposes no active-ticket API
+
+- **GIVEN** the cockpit store module
+- **WHEN** searching its exports for `setActiveTicket` and `CockpitState` for an `activeTicket` field
+- **THEN** neither exists
+- **AND** no unit test references them
+
 ### Requirement: TicketDrawer-Dateien sind gelöscht
 
 The system SHALL delete `website/src/components/admin/TicketDrawer.svelte` and its unit-test file, and `website/src/components/admin/TicketDrawerContent.svelte` if it exists; no import of `TicketDrawer` SHALL remain in any `.svelte`, `.ts`, or `.astro` file.
+
+#### Scenario: Drawer component files no longer exist
+
+- **GIVEN** the repository working tree
+- **WHEN** checking `website/src/components/admin/` for `TicketDrawer.svelte` and `TicketDrawerContent.svelte`
+- **THEN** neither file exists
+- **AND** `grep -r "TicketDrawer" website/src --include='*.svelte' --include='*.ts' --include='*.astro'` returns no matches
 
 ---
 

--- a/openspec/specs/agent-behavior.md
+++ b/openspec/specs/agent-behavior.md
@@ -11,10 +11,43 @@ Definiert Verhaltens-Guardrails für Agenten-Operationen gegen Produktionsumgebu
 ### Requirement: Prod-namespace write block
 The system SHALL maintain a denylist of production Kubernetes namespaces. Any `kubectl exec ... psql` command targeting a namespace in the denylist that contains DDL/DML statements SHALL be intercepted and blocked unless an explicit override flag is provided.
 
+#### Scenario: DML against a denylisted namespace is blocked
+
+- **GIVEN** the namespace `workspace` is on the production denylist
+- **WHEN** an agent runs `kubectl exec -n workspace ... psql -c "UPDATE tickets SET ..."` without an override flag
+- **THEN** the guard intercepts the command and it is not executed
+- **AND** the guard exits non-zero
+
+#### Scenario: Read-only query against a denylisted namespace passes
+
+- **GIVEN** the namespace `workspace` is on the production denylist
+- **WHEN** an agent runs `kubectl exec -n workspace ... psql -c "SELECT count(*) FROM tickets"`
+- **THEN** the command is executed normally (no DDL/DML detected)
+
 ### Requirement: Guard emits structured output
 When a write is blocked, the guard SHALL emit a line in the format `GUARD: prod-write-blocked namespace=<ns> op=<type> caller=<context>` to stderr, enabling automated detection and logging.
 
+#### Scenario: Blocked write produces a parseable stderr line
+
+- **GIVEN** a DML command against a denylisted namespace is intercepted
+- **WHEN** the guard blocks it
+- **THEN** stderr contains a line matching `GUARD: prod-write-blocked namespace=<ns> op=<type> caller=<context>`
+- **AND** the line is machine-parseable for automated detection
+
 ### Requirement: Override requires explicit flag
 The `--confirm-prod-write` flag SHALL bypass the guard but SHALL be logged to the agent-lock or session-message system for auditability. The flag SHALL NOT be available to subagents (read-only agents lack bash write permission).
+
+#### Scenario: Explicit override bypasses the guard with audit trail
+
+- **GIVEN** a DML command against a denylisted namespace
+- **WHEN** it is invoked with `--confirm-prod-write`
+- **THEN** the command executes
+- **AND** the override is recorded in the agent-lock or session-message system
+
+#### Scenario: Subagents cannot use the override
+
+- **GIVEN** a read-only subagent without bash write permission
+- **WHEN** it attempts a prod write with `--confirm-prod-write`
+- **THEN** the override is not available and the write remains blocked
 
 <!-- merged from change delta agent-behavior.md (e3d4ff2c50fa) -->

--- a/openspec/specs/astro-type-check.md
+++ b/openspec/specs/astro-type-check.md
@@ -13,14 +13,12 @@ Typsichere Entwicklung im Astro-Website-Projekt durch kontinuierliche statische 
 
 `astro check` muss ohne Fehler (`0 errors`) durchlaufen. Warnungen und Hints dürfen vorkommen, werden aber auf 0 angestrebt.
 
-**Scenarios:**
+#### Scenario: astro check passes with zero errors
 
-```
-GIVEN the website project with all TypeScript source files
-WHEN running `cd website && npx astro check`
-THEN the output shows "0 errors"
-AND the process exits with code 0
-```
+- **GIVEN** the website project with all TypeScript source files
+- **WHEN** running `cd website && npx astro check`
+- **THEN** the output shows "0 errors"
+- **AND** the process exits with code 0
 
 ### Requirement: Fixture Factory for Cockpit Types
 
@@ -29,14 +27,12 @@ AND the process exits with code 0
 
 Eine zentrale Fixture-Factory `website/src/lib/tickets/__tests__/fixtures.ts` stellt typsichere Default-Objekte für `RollupMetrics`, `FeatureNode`, `ProductNode` und `PortfolioPayload` bereit.
 
-**Scenarios:**
+#### Scenario: Fixture factory provides typed defaults with overrides
 
-```
-GIVEN a test file that needs a RollupMetrics test object
-WHEN the test imports `makeRollup` from the fixtures module
-THEN calling `makeRollup()` returns a valid RollupMetrics with all required fields
-AND calling `makeRollup({ awaitingDeploy: 5 })` overrides only that field
-```
+- **GIVEN** a test file that needs a RollupMetrics test object
+- **WHEN** the test imports `makeRollup` from the fixtures module
+- **THEN** calling `makeRollup()` returns a valid RollupMetrics with all required fields
+- **AND** calling `makeRollup({ awaitingDeploy: 5 })` overrides only that field
 
 ### Requirement: Check Script
 
@@ -45,13 +41,11 @@ AND calling `makeRollup({ awaitingDeploy: 5 })` overrides only that field
 
 `website/package.json` enthält ein `"astro:check": "astro check"` Script für lokale Entwickler.
 
-**Scenarios:**
+#### Scenario: Local check script runs astro check
 
-```
-GIVEN a developer working on the website project
-WHEN running `cd website && pnpm astro:check`
-THEN astro check runs and reports any TypeScript errors
-```
+- **GIVEN** a developer working on the website project
+- **WHEN** running `cd website && pnpm astro:check`
+- **THEN** astro check runs and reports any TypeScript errors
 
 ### Requirement: CI Advisory Gate
 
@@ -60,12 +54,10 @@ THEN astro check runs and reports any TypeScript errors
 
 Ein neuer CI-Job `Astro TypeScript Check` in `.github/workflows/ci.yml` führt `astro check` bei jedem PR aus.
 
-**Scenarios:**
+#### Scenario: CI job passes on a clean PR
 
-```
-GIVEN a pull request with zero TypeScript errors
-WHEN CI runs
-THEN the "Astro TypeScript Check" job passes
-```
+- **GIVEN** a pull request with zero TypeScript errors
+- **WHEN** CI runs
+- **THEN** the "Astro TypeScript Check" job passes
 
 <!-- merged from change delta astro-type-check.md on 2026-06-28 -->

--- a/openspec/specs/ci-cd.md
+++ b/openspec/specs/ci-cd.md
@@ -1153,6 +1153,13 @@ using three independent CI jobs: one shared build job and two parallel, independ
 
 **Migration:** Tests in `tests/unit/website-ci-deploy.bats` wurden auf `build-website.yml` umgezeigt (T001229). Keine weitere Migration nötig.
 
+#### Scenario: Standalone korczewski workflow stays removed
+
+- **GIVEN** the repository working tree
+- **WHEN** listing `.github/workflows/`
+- **THEN** `build-website-korczewski.yml` does not exist
+- **AND** `build-website.yml` contains the korczewski deploy job that replaced it
+
 <!-- merged from change delta ci-cd.md on 2026-06-28 -->
 
 ### Requirement: PR-Gate — Offline Tests (bestehend)
@@ -1161,6 +1168,13 @@ _Modification:_ Die vormalige LOC-Budget-Gate (S6, `task loc:check` als Teil
 von `task test:code-quality`) wurde entfernt. `docs/code-quality/loc-budget.json`
 und `scripts/check-loc-budget.mjs` wurden gelöscht; `task test:code-quality`
 läuft wieder nur mit den S1-S4-Gates aus `task quality:check`.
+
+#### Scenario: LOC budget gate stays removed from the offline test suite
+
+- **GIVEN** the repository working tree
+- **WHEN** inspecting `task test:code-quality` and the files `docs/code-quality/loc-budget.json` / `scripts/check-loc-budget.mjs`
+- **THEN** neither file exists
+- **AND** `task test:code-quality` runs only the S1-S4 gates from `task quality:check` (no `task loc:check` step)
 
 <!-- merged from change delta ci-cd.md on 2026-06-30 -->
 

--- a/openspec/specs/openspec-pgvector.md
+++ b/openspec/specs/openspec-pgvector.md
@@ -39,12 +39,38 @@ The system SHALL provide `GET /api/openspec/search?q=<query>&limit=<n>` which em
 
 The system SHALL add a `--semantic <query>` flag to `scripts/plan-context.sh` that queries `/api/openspec/search` and emits a `## semantically similar` section. If the API is unreachable, the script SHALL silently fall back to the grep-only output (exit 0).
 
+#### Scenario: Semantic section appears when the API is reachable
+
+- **GIVEN** `/api/openspec/search` is reachable and returns at least one result
+- **WHEN** `bash scripts/plan-context.sh infra --semantic "sealed secrets"` runs
+- **THEN** the output contains a `## semantically similar` section listing the results
+
+#### Scenario: Unreachable API falls back to grep-only output
+
+- **GIVEN** `/api/openspec/search` is unreachable
+- **WHEN** `bash scripts/plan-context.sh infra --semantic "sealed secrets"` runs
+- **THEN** the script exits 0
+- **AND** emits the grep-only output without a `## semantically similar` section
+
 ### Requirement: MCP-Tool openspec_find_similar
 
 The system SHALL expose an MCP tool `openspec_find_similar` (registered in `scripts/factory/mcp-server.mjs`) that wraps `/api/openspec/search` for agent-side discovery.
 
+#### Scenario: Agent finds similar specs via MCP
+
+- **GIVEN** the factory MCP server is running and `knowledge.chunks` contains indexed OpenSpec chunks
+- **WHEN** an agent calls `openspec_find_similar` with a query string
+- **THEN** the tool returns the `/api/openspec/search` results (slug, path, score, snippet) as structured output
+
 ### Requirement: Embedding-Modell-Konsistenz ohne Mixed-Model-Error
 
 The system SHALL store exactly one `embedding_model` value per `knowledge.collections` row, mirrored from `createCollection`'s default (`bge-m3` when `LLM_ENABLED=true`, else `voyage-multilingual-2`). Re-indexing SHALL use the same model as the existing collection — no mixed-model inserts.
+
+#### Scenario: Re-indexing keeps the collection's embedding model
+
+- **GIVEN** the `specs_plans` collection exists with `embedding_model='bge-m3'`
+- **WHEN** `node scripts/openspec-embed.mjs` re-indexes documents into that collection
+- **THEN** all new chunks are embedded with `bge-m3`
+- **AND** no row in the collection ends up with a different `embedding_model` value
 
 <!-- from archive/2026-06-21-openspec-pgvector/tasks.md lines 1-180 -->

--- a/openspec/specs/openspec-workflow.md
+++ b/openspec/specs/openspec-workflow.md
@@ -510,6 +510,26 @@ but contains no `### Requirement:` heading.
 
 ---
 
+### Requirement: SSOT-Requirement ohne Szenario schlägt fail-closed fehl
+<!-- bats: openspec-workflow.bats -->
+
+The system SHALL exit non-zero when any `### Requirement:` in an SSOT spec under
+`openspec/specs/` declares no `#### Scenario:` entry before the next requirement header
+(scenario-coverage ratchet, T002004). Archived one-off specs under `openspec/specs/archive/`
+are exempt (directory entries are not validated as components).
+
+#### Scenario: Requirement ohne Szenario wird vom Validator gemeldet *(BATS)*
+- **GIVEN** eine temporäre SSOT-Spec mit `## Purpose`, `## Requirements` und einem `### Requirement:` ohne `#### Scenario:`
+- **WHEN** `validateSpec` aus `scripts/openspec-validate.ts` auf die Datei läuft
+- **THEN** enthält das Ergebnis einen Fehler mit `has no '#### Scenario:' entry`
+
+#### Scenario: Vollständig szenarierte Spec passiert den Validator *(BATS)*
+- **GIVEN** eine SSOT-Spec, in der jedes `### Requirement:` mindestens ein `#### Scenario:` deklariert
+- **WHEN** `validateSpec` auf die Datei läuft
+- **THEN** liefert es keine Szenario-Fehler
+
+---
+
 ### Requirement: openspec weist unbekannte Verben mit Fehler und Usage ab
 <!-- bats: openspec.bats -->
 

--- a/openspec/specs/portal.md
+++ b/openspec/specs/portal.md
@@ -641,3 +641,15 @@ The system SHALL pass all steps of System-Test 10 (Externe Dienste & öffentlich
 
 The system SHALL provide an authenticated coaching-studio service for the coach to run
 KI-supported 10-level systemic coaching sessions with international clients.
+
+#### Scenario: Authenticated coach reaches the studio
+
+- **GIVEN** a user with a valid coach session
+- **WHEN** they open the coaching-studio entry point in the portal
+- **THEN** the studio loads and allows starting a KI-supported 10-level systemic coaching session
+
+#### Scenario: Unauthenticated access is rejected
+
+- **GIVEN** a visitor without a valid session
+- **WHEN** they request a coaching-studio URL directly
+- **THEN** the request is rejected or redirected to login (no studio content is served)

--- a/openspec/specs/secrets-deploy-automation.md
+++ b/openspec/specs/secrets-deploy-automation.md
@@ -37,12 +37,32 @@ The system SHALL provide `tests/spec/fleet-operations.bats` (BATS) that reads `e
 
 The system SHALL annotate all keys that are intentionally only in the legacy sealed-secrets files with `legacy_only: true` in `environments/schema.yaml` (e.g. the 12 WG Mesh keys, the 3 MCP Keycloak keys for korczewski-legacy). The annotation SHALL be parseable by the BATS fleet-completeness guard.
 
+#### Scenario: Guard parses the legacy_only annotation
+
+- **GIVEN** `environments/schema.yaml` marks a key (e.g. a WG Mesh key) with `legacy_only: true`
+- **WHEN** the BATS fleet-completeness guard parses the schema
+- **THEN** the key is recognized as legacy-only and excluded from the fleet-superset assertion
+
 ### Requirement: Reference-Doc zur SealedSecret-Architektur
 
 The system SHALL provide `docs/superpowers/references/secrets-architecture.md` documenting the sealed-secrets file topology (`fleet-*.yaml` is the source of truth, `*.yaml` is the legacy location, the sync rule is one-way: `fleet-*.yaml` ⊇ `*.yaml` minus `legacy_only: true`).
 
+#### Scenario: Reference doc exists and states the sync rule
+
+- **GIVEN** the repository working tree
+- **WHEN** reading `docs/superpowers/references/secrets-architecture.md`
+- **THEN** the file exists
+- **AND** documents `fleet-*.yaml` as source of truth and the one-way sync rule (`fleet-*.yaml` ⊇ `*.yaml` minus `legacy_only: true`)
+
 ### Requirement: Security-Agent Verweis auf SealedSecret-Architektur
 
 The system SHALL add a §Secrets-Dateiarchitektur section in `.claude/agents/bachelorprojekt-security.md` pointing at the reference doc.
+
+#### Scenario: Security agent links the architecture reference
+
+- **GIVEN** the agent definition `.claude/agents/bachelorprojekt-security.md`
+- **WHEN** searching it for a Secrets-Dateiarchitektur section
+- **THEN** the section exists
+- **AND** references `docs/superpowers/references/secrets-architecture.md`
 
 <!-- from archive/2026-06-21-secrets-deploy-automation/tasks.md lines 1-100 -->

--- a/openspec/specs/security.md
+++ b/openspec/specs/security.md
@@ -56,3 +56,10 @@ The system SHALL route `/api/mcp/svc/*` traffic through `BUSINESS_TOKEN`/`CLUSTE
 ### Requirement: Secret-Rotation für MCP_KEYCLOAK_CLIENT_SECRET
 
 The system SHALL provide `task secret-rotation:rotate ENV=korczewski TARGET=mcp-keycloak` as the documented rotation path, followed by `kubectl --context fleet rollout restart deploy/mcp-auth-proxy -n workspace-korczewski` to pick up the new secret without a full cluster restart.
+
+#### Scenario: Rotation path updates the secret without cluster restart
+
+- **GIVEN** an operator needs to rotate `MCP_KEYCLOAK_CLIENT_SECRET` for the korczewski brand
+- **WHEN** they run `task secret-rotation:rotate ENV=korczewski TARGET=mcp-keycloak` followed by `kubectl --context fleet rollout restart deploy/mcp-auth-proxy -n workspace-korczewski`
+- **THEN** the deployment restarts with the new secret value
+- **AND** no other workload in the namespace is restarted

--- a/openspec/specs/sidekick-assistant.md
+++ b/openspec/specs/sidekick-assistant.md
@@ -598,6 +598,13 @@ with exit code 0; it SHALL return exit code 1 when the events file is absent or 
 
 The system SHALL provide `website/migrations/20260621_create_ai_call_log.sql` creating a `public.ai_call_log` table with columns `id, ts, workflow, model, prompt_tokens, completion_tokens, latency_ms, error, user_sub, metadata` and indexes `ai_call_log_ts` (DESC) and `ai_call_log_workflow` (workflow, ts DESC). The migration SHALL be idempotent (`IF NOT EXISTS`).
 
+#### Scenario: Migration is idempotent on re-run
+
+- **GIVEN** the `ai_call_log` migration has already been applied
+- **WHEN** `website/migrations/20260621_create_ai_call_log.sql` is executed again
+- **THEN** it completes without error (`IF NOT EXISTS` guards table and indexes)
+- **AND** the table keeps its columns and the `ai_call_log_ts` / `ai_call_log_workflow` indexes
+
 ### Requirement: ai-metrics Pure Module
 
 The system SHALL provide `website/src/lib/ai-metrics.ts` exporting two functions: `withAiMetrics(workflow, fn, modelHint?)` for Anthropic-Form call-sites (auto-extracts `result.usage.{input,output}_tokens` and `result.model`), and `logAiCall(metrics)` for non-Anthropic call-sites (RAG/embeddings). Both SHALL be fire-and-forget (Insert-Fehler werden auf stderr geloggt, Exit 0). `ai-metrics.ts` SHALL NOT import `assistant/llm.ts` (no import cycles).
@@ -620,6 +627,19 @@ The system SHALL provide `website/src/lib/ai-metrics.ts` exporting two functions
 
 The system SHALL provide `GET /api/admin/ai-quality` (admin-only via `getSession` + `isAdmin` pattern, 401 ohne Admin-Session) that aggregates `ai_call_log` rows into `{ health: {ok, total, errors_24h, p95_latency_ms}, last24h: { calls, tokens, cost_usd, by_workflow: [...] }, recentErrors: [...] }`. Cost SHALL be computed at query time (tokens × model price/1k).
 
+#### Scenario: Admin receives aggregated AI-quality payload
+
+- **GIVEN** an authenticated admin session and existing `ai_call_log` rows
+- **WHEN** `GET /api/admin/ai-quality` is called
+- **THEN** the response is HTTP 200 with `health`, `last24h` (including `by_workflow`), and `recentErrors` sections
+- **AND** `cost_usd` is computed at query time from tokens × model price/1k
+
+#### Scenario: Non-admin request is rejected
+
+- **GIVEN** a request without an admin session
+- **WHEN** `GET /api/admin/ai-quality` is called
+- **THEN** the endpoint responds with HTTP 401 and no aggregation data
+
 ### Requirement: AiQualitySidekickView Svelte-Komponente
 
 The system SHALL provide `website/src/components/assistant/AiQualitySidekickView.svelte` rendering health indicator, 24h summary, cost chart, and recent error list. The view SHALL be registered as a Sidekick view in `sidekick-nudge.ts` (`'ai-quality'` to `View` union + `KNOWN_VIEWS`).
@@ -637,24 +657,38 @@ The system SHALL provide `website/src/components/assistant/AiQualitySidekickView
 
 The system SHALL NOT render the SidekickHome items for `tickets`, `inbox`, `pipeline` or `loslernen`. The remaining items (coaching, source, container, ai-quality) SHALL be renumbered 01-N in the order they appear.
 
-### Requirement: PortalSidekick.svelte ohne View-Branches für entfernte Views
-
-The system SHALL NOT include the `tickets`, `inbox`, or `pipeline` view branches in `PortalSidekick.svelte`. The `View` union, `titleMap`, and `decideBanner`/`shouldShowLearnDot` references SHALL be cleaned up accordingly. The `learning/summary`, `tickets`, and `inbox` API fetches SHALL be removed (only `container-count` remains).
-
-### Requirement: sidekick-nudge.ts ohne Banner/LearnDot
-
-The system SHALL NOT export `decideBanner`, `BannerDecision`, `BannerInput`, or `shouldShowLearnDot` from `website/src/lib/assistant/sidekick-nudge.ts`. `SidekickView` and `KNOWN_VIEWS` SHALL be reduced to the post-cleanup view set.
-
-### Requirement: mediaviewer-bridge.ts Session-Protokoll
-
-The system SHALL extend `HostInbound.setMode.mode` to accept `'brainstorm'`, and SHALL add `sessionStarted` and `sessionProgress` events to `HostOutbound` in `mediaviewer-bridge.ts`. The `buildSetModeMessage` and `parseOutbound` helpers SHALL be updated accordingly, with tests covering the new cases.
-
 #### Scenario: Removed View wird im Sidekick nicht gerendert
 
 - **GIVEN** `tickets`, `inbox`, `pipeline` sind aus `KNOWN_VIEWS` entfernt
 - **WHEN** PortalSidekick mounted
 - **THEN** ist keiner der drei Einträge in der Sidekick-Item-Liste sichtbar
 - **AND** `grep -nE 'progressSub|summary|banner|pendingTickets|pendingInbox|loslernen' website/src/components/assistant/SidekickHome.svelte` ist leer
+
+### Requirement: PortalSidekick.svelte ohne View-Branches für entfernte Views
+
+The system SHALL NOT include the `tickets`, `inbox`, or `pipeline` view branches in `PortalSidekick.svelte`. The `View` union, `titleMap`, and `decideBanner`/`shouldShowLearnDot` references SHALL be cleaned up accordingly. The `learning/summary`, `tickets`, and `inbox` API fetches SHALL be removed (only `container-count` remains).
+
+#### Scenario: PortalSidekick keeps only the container-count fetch
+
+- **GIVEN** `PortalSidekick.svelte`
+- **WHEN** searching its source for the `tickets`, `inbox`, or `pipeline` view branches and the `learning/summary`, `tickets`, `inbox` API fetches
+- **THEN** none of them exist
+- **AND** the only remaining API fetch is `container-count`
+
+### Requirement: sidekick-nudge.ts ohne Banner/LearnDot
+
+The system SHALL NOT export `decideBanner`, `BannerDecision`, `BannerInput`, or `shouldShowLearnDot` from `website/src/lib/assistant/sidekick-nudge.ts`. `SidekickView` and `KNOWN_VIEWS` SHALL be reduced to the post-cleanup view set.
+
+#### Scenario: Banner/LearnDot exports are gone from sidekick-nudge
+
+- **GIVEN** `website/src/lib/assistant/sidekick-nudge.ts`
+- **WHEN** searching its exports for `decideBanner`, `BannerDecision`, `BannerInput`, or `shouldShowLearnDot`
+- **THEN** none of them is exported
+- **AND** `SidekickView` / `KNOWN_VIEWS` contain only the post-cleanup view set
+
+### Requirement: mediaviewer-bridge.ts Session-Protokoll
+
+The system SHALL extend `HostInbound.setMode.mode` to accept `'brainstorm'`, and SHALL add `sessionStarted` and `sessionProgress` events to `HostOutbound` in `mediaviewer-bridge.ts`. The `buildSetModeMessage` and `parseOutbound` helpers SHALL be updated accordingly, with tests covering the new cases.
 
 #### Scenario: Session-Protokoll für Brainstorm-View
 

--- a/scripts/openspec-validate.ts
+++ b/scripts/openspec-validate.ts
@@ -119,6 +119,7 @@ export function validateChange(changeDir: string, specsRoot?: string): ChangeVal
  *   - `## Purpose` H2 header is present
  *   - `## Requirements` H2 header is present
  *   - at least one `### Requirement:` H3 entry is present under Requirements
+ *   - every `### Requirement:` declares at least one `#### Scenario:` (ratchet, T002004)
  */
 export function validateSpec(specFile: string): Pick<ValidationResult, 'errors'> {
   const content = readFileSync(specFile, 'utf-8')
@@ -135,6 +136,12 @@ export function validateSpec(specFile: string): Pick<ValidationResult, 'errors'>
   }
   if (/^## Requirement: /m.test(content)) {
     errors.push(`${specFile}: uses H2 '## Requirement:' (must be H3 '### Requirement:')`)
+  }
+  for (const block of content.split(/^### Requirement: /m).slice(1)) {
+    const name = block.split('\n', 1)[0].trim()
+    if (!/^#### Scenario: /m.test(block)) {
+      errors.push(`${specFile}: requirement '${name}' has no '#### Scenario:' entry`)
+    }
   }
 
   return { errors }

--- a/tests/spec/openspec-workflow.bats
+++ b/tests/spec/openspec-workflow.bats
@@ -247,3 +247,68 @@ YAML
   run bash -c "cd '$REPO' && npx tsx -e \"import {validateTree} from './scripts/openspec-validate.ts'; const r=validateTree('openspec'); process.exit(r.ok?0:1)\""
   [ "$status" -eq 0 ]
 }
+
+# ── T002004: scenario-coverage ratchet ───────────────────────────────#
+
+@test "T002004: validateSpec rejects a requirement without a scenario" {
+  local tmp
+  tmp="$(mktemp -d)"
+  cat > "$tmp/spec.md" <<'EOF'
+# demo
+
+## Purpose
+
+Demo.
+
+## Requirements
+
+### Requirement: Hat kein Szenario
+
+The system SHALL do something.
+EOF
+  run bash -c "cd '$REPO' && npx tsx -e 'import {validateSpec} from \"./scripts/openspec-validate.ts\"; const r=validateSpec(process.argv[1]); if(r.errors.length){console.error(r.errors.join(\"\n\")); process.exit(1)}' '$tmp/spec.md'"
+  rm -rf "$tmp"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"has no '#### Scenario:' entry"* ]]
+}
+
+@test "T002004: validateSpec passes a fully scenario-covered spec" {
+  local tmp
+  tmp="$(mktemp -d)"
+  cat > "$tmp/spec.md" <<'EOF'
+# demo
+
+## Purpose
+
+Demo.
+
+## Requirements
+
+### Requirement: Hat ein Szenario
+
+The system SHALL do something.
+
+#### Scenario: Es passiert
+
+- **GIVEN** a
+- **WHEN** b
+- **THEN** c
+EOF
+  run bash -c "cd '$REPO' && npx tsx -e 'import {validateSpec} from \"./scripts/openspec-validate.ts\"; const r=validateSpec(process.argv[1]); if(r.errors.length){console.error(r.errors.join(\"\n\")); process.exit(1)}' '$tmp/spec.md'"
+  rm -rf "$tmp"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002004: every SSOT requirement in openspec/specs/ declares a scenario" {
+  local missing=0 f
+  for f in "$REPO"/openspec/specs/*.md; do
+    if awk '/^### Requirement:/{if(name && scen==0){print FILENAME": "name; bad=1} name=$0; scen=0; next}
+            /^#### Scenario:/{scen=1}
+            END{if(name && scen==0){print FILENAME": "name; bad=1} exit bad}' "$f"; then
+      :
+    else
+      missing=1
+    fi
+  done
+  [ "$missing" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Rüstet alle 26 SSOT-Requirements ohne Szenarien (9 Specs) mit GIVEN/WHEN/THEN-Szenarien nach: admin-cockpit, agent-behavior, astro-type-check, ci-cd, openspec-pgvector, portal, secrets-deploy-automation, security, sidekick-assistant
- Normalisiert die 4 Legacy-`**Scenarios:**`-Fenced-Blöcke in astro-type-check auf kanonische `#### Scenario:`-Header
- Verschiebt ein fehlplatziertes Szenario in sidekick-assistant unter das richtige Requirement
- Validator-Ratchet (T002004): `validateSpec` in `scripts/openspec-validate.ts` schlägt jetzt fail-closed fehl, wenn ein SSOT-Requirement kein `#### Scenario:` deklariert — dokumentiert als neues Requirement in openspec-workflow.md
- 3 neue BATS-Tests in `tests/spec/openspec-workflow.bats` (Ratchet-Regression + Repo-weiter Coverage-Sweep)

## Test Plan
- [x] `bash scripts/openspec.sh validate` grün (mit aktivem Ratchet über alle 69 Specs)
- [x] `npx bats tests/spec/openspec-workflow.bats -f T002004` — 3/3 ok
- [x] `task test:changed` — 52/52 pass
- [x] `task freshness:regenerate` + `task freshness:check` — keine Drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm3LLiQwivuaSryXF1CucH