### PR TITLE
chore(ci): bump commit-lint job timeout from 5 to 15 minutes [T002049]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,10 @@ jobs:
   commit-lint:
     name: Conventional Commits
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 5min was too tight for the full-history checkout below on a repo with
+    # many short-lived feature/chore branches — observed cancellations
+    # ("The operation was canceled") mid-fetch on PR #3029 [T002049].
+    timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
       # Checkout IS needed here despite the PR-title check above being pure


### PR DESCRIPTION
## Summary
- `commit-lint` job timeout: 5 → 15 minutes.
- Follow-up to #3028: that PR shrank `test-bats`'s checkout but had to keep `commit-lint`'s `fetch-depth: 0`, since its later "Validate individual commit messages" / "commit-vs-diff consistency" steps need the full commit range locally.
- The full `+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*` fetch can exceed 5 minutes on this repo (many short-lived feature/chore branches) — observed cancelling PR #3029's check mid-fetch.

## Test plan
- [x] `task freshness:check` green
- [x] YAML syntax validated
- [ ] CI green on this PR