### PR TITLE
chore(ci): add filter:blob:none to commit-lint checkout to speed up blobless clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: false
+          filter: blob:none
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `filter: blob:none` to the `commit-lint` job's `actions/checkout` step
- The job still uses `fetch-depth: 0` (needed for per-commit validation across the PR range), but skipping blob content makes the checkout dramatically faster
- `git log` and `git diff --name-only` only need commit/tree metadata, not file contents
- Addresses the root cause of the timeout that T002049 workaround-bumped to 15 minutes

## Test Plan
- [ ] CI run should complete the checkout in seconds rather than timing out

[#T002049]