### PR TITLE
fix(factory): [T002051] fix classify-failure manifest regex and add ticket-id branch convention to dev-flow-plan

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -165,21 +165,22 @@ Der Implementierungsplan wird **ausschließlich** in `openspec/changes/<slug>/ta
 Falls neue E2E-Tests geplant sind, weise das passende Playwright-Projekt zu (siehe [dev-flow-gotchas](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md) für Zuordnungstabelle).
 ### Phase B: Worktree anlegen + Artefakte übertragen
 #### Schritt B.1: Worktree anlegen
+
+> **Ticket-vor-Branch-Check (T001917, T002050):** Prüfe vor der Worktree-Anlage, ob bereits ein Ticket existiert oder in Schritt 4.5 ein neues angelegt wird. Ist `TICKET_EXT_ID` bekannt, benenne den Branch **immer** mit Ticket-ID-Suffix (z.B. `feature/<slug>-t002050` statt `feature/<slug>`). Falls noch kein Ticket existiert, erstelle das Ticket VOR der Worktree-Anlage (siehe Schritt 4.5), um dessen `TICKET_EXT_ID` direkt in den Branch-Namen aufzunehmen. Sonst schlägt `preflight-pr-scope.sh` beim PR fehl (PR-Titel-Ticket-ID ≠ Branch-Name) und der Branch muss nachträglich umbenannt werden.
+
 Erstelle den Worktree NACH dem Propose (niemals `.claude/worktrees/` verwenden!):
 ```bash
 # git-crypt-safe: creates the worktree, handles git-crypt, inits submodules
-bash scripts/worktree-create.sh feature/<slug> .worktrees/<slug>
+bash scripts/worktree-create.sh feature/<slug>-t<id> .worktrees/<slug>
 
 # Doppelarbeit verhindern: Branch claimen (Session-Koordination [T000510]).
-bash scripts/agent-lock.sh claim branch "feature/<slug>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
+bash scripts/agent-lock.sh claim branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
   || { echo "🛑 Branch wird bereits von einer anderen Session bearbeitet — koordinieren oder anderen slug wählen."; exit 1; }
 
-# Ticket-Claim (Session-Koordination [T000510]) — nur falls die Ticket-ID schon bekannt
-# ist (z. B. von feature-intake übergeben). Ist noch keine Ticket-ID bekannt, holt
-# Schritt 4.5 den Claim nach, sobald das Ticket dort angelegt/wiederverwendet wird. [T001386]
+# Ticket-Claim (Session-Koordination [T000510])
 if [[ -n "${TICKET_EXT_ID:-}" ]]; then
   bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
-    --branch "feature/<slug>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
+    --branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
     || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet — koordinieren."; exit 1; }
 fi
 ```

--- a/scripts/factory/classify-failure.sh
+++ b/scripts/factory/classify-failure.sh
@@ -32,7 +32,7 @@ classify_failure() {
   if grep -qiE 'sealedsecret|no key could decrypt|could not decrypt|sealed-secrets' "$log"; then
     echo "secret"; return 0
   fi
-  if grep -qiE 'kustomize build|kubectl apply.*error|error validating data|unable to recognize|manifest' "$log"; then
+  if grep -qiE 'kustomize build|kubectl apply.*error|error validating data|unable to recognize|manifest error|invalid manifest|manifest validation' "$log"; then
     echo "manifest"; return 0
   fi
   # Generic build classes.

--- a/tests/local/FA-SF-33-classify-failure.bats
+++ b/tests/local/FA-SF-33-classify-failure.bats
@@ -70,3 +70,11 @@ _cf() { source scripts/factory/classify-failure.sh; classify_failure "$TMPLOG"; 
   [ "$status" -eq 0 ]
   [ "$output" = "freshness" ]
 }
+
+@test "FA-SF-33: harmless log with word manifest does not classify as manifest" {
+  printf 'Checking route-manifest.json... ok\nAll checks passed cleanly\n' > "$TMPLOG"
+  run _cf
+  [ "$status" -eq 0 ]
+  [ "$output" != "manifest" ]
+}
+


### PR DESCRIPTION
Fixes T002051 (Mishap-Bundle)

- **Mishap 1**: Restrict `classify-failure.sh` `manifest` failure classification regex to explicit error contexts (`manifest error`, `invalid manifest`, `manifest validation`) so harmless log output containing the word 'manifest' (e.g. freshness checks) does not trigger false-positive build-loop aborts. Added unit test in `FA-SF-33-classify-failure.bats`.
- **Mishap 2**: Updated `dev-flow-plan/SKILL.md` (Schritt B.1) to include the Ticket-vor-Branch-Check (T001917, T002050) requiring pre-allocation of ticket IDs before creating worktrees/branches (`feature/<slug>-t<id>`), preventing `preflight-pr-scope.sh` title-vs-branch mismatches.