### PR TITLE
fix(website): drop redundant brand-link aria-label [T002053]

### DIFF
--- a/website/src/components/Navigation.svelte
+++ b/website/src/components/Navigation.svelte
@@ -62,7 +62,7 @@
 <header class="topbar" aria-label={t(locale, 'nav.aria-main')}>
   <div class="wrap">
     <!-- Brand mark -->
-    <a href="/" class="brand" aria-label={`${brandWord}.`}>
+    <a href="/" class="brand">
       <div class="mark" aria-hidden="true">
         <svg class="mark-m" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <text x="16" y="22" text-anchor="middle" fill="currentColor" font-family="Georgia, serif" font-weight="bold" font-size="18">m</text>

--- a/website/src/components/Navigation.test.ts
+++ b/website/src/components/Navigation.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/svelte';
 import NavMobile from './NavMobile.svelte';
+import Navigation from './Navigation.svelte';
+
+describe('Navigation.svelte — brand link accessible name (WCAG 2.5.3, T002053)', () => {
+  it('does not override the brand link accessible name with a redundant aria-label', () => {
+    // The brand link renders its label from visible text (`{brandWord}.`).
+    // An explicit aria-label duplicating that text triggers axe
+    // `label-content-name-mismatch` (WCAG 2.5.3): the accessible name is not
+    // reliably recognised as containing the composite visible text. Removing it
+    // lets the accessible name derive from the visible text, so it can never
+    // mismatch itself.
+    const { container } = render(Navigation, { props: { siteTitle: 'mentolder.de' } });
+    const brand = container.querySelector('a.brand');
+    expect(brand).toBeTruthy();
+
+    // The visible label must be present so the accessible name can derive from it.
+    const visible = (brand!.querySelector('.brand-name')?.textContent ?? '').trim();
+    expect(visible.length).toBeGreaterThan(0);
+
+    // No redundant explicit aria-label: the accessible name is computed from the
+    // visible text, so axe's label-content-name-mismatch can no longer fire.
+    expect(brand!.getAttribute('aria-label')).toBeNull();
+  });
+});
 
 describe('NavMobile.svelte', () => {
   const baseProps = {


### PR DESCRIPTION
## Summary
- Remove the explicit `aria-label` from the header brand link in `Navigation.svelte`.
- It duplicated the visible composite text (`{brandWord}.`), tripping the
  Lighthouse/axe `label-content-name-mismatch` audit (WCAG 2.5.3, score 0 on
  web.mentolder.de). With no override, the accessible name derives from the
  visible text and can no longer mismatch itself.
- The `aria-hidden="true"` mark SVG stays excluded from the accessible name.
- Kore footer brand (`KoreHomepage.svelte`) is a plain `<div>` with no aria-label
  override, so it has no equivalent issue — no change needed.

## Test Plan
- [x] Added a RED-first Vitest case in `Navigation.test.ts` asserting the brand
      link exposes no redundant `aria-label` (failed before fix, passes after).
- [x] `pnpm --dir website test:unit` (Navigation suite green)
- [x] `task test:changed` green (52/52)
- [x] `task freshness:regenerate` + `task freshness:check` clean

🤖 [T002053]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vx5X6gX3dabRDszHT6tg3