### PR TITLE
fix(infra): website-scoped security-headers so web.mentolder.de stays crawlable [T002052]

### DIFF
--- a/prod-fleet/website-mentolder/kustomization.yaml
+++ b/prod-fleet/website-mentolder/kustomization.yaml
@@ -6,4 +6,6 @@ resources:
   - ../../k3d/website-seller-config.yaml
   # mentolder HTTPS Ingress (tracked here to survive cluster rebuilds — T000146)
   - ../website-common/domain-config.yaml
+  # T002052: website-scoped security-headers (no noindex) — keeps the public site crawlable
+  - website-security-headers.yaml
   - website-ingress-web.yaml

--- a/prod-fleet/website-mentolder/website-ingress-web.yaml
+++ b/prod-fleet/website-mentolder/website-ingress-web.yaml
@@ -4,8 +4,10 @@ metadata:
   name: website-ingress-web
   namespace: website
   annotations:
+    # T002052: use the website-scoped security-headers (no noindex) so the public
+    # site stays crawlable. Internal services keep workspace-security-headers (noindex).
     traefik.ingress.kubernetes.io/router.middlewares: >-
-      workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd,workspace-security-headers@kubernetescrd,workspace-rate-limit-web@kubernetescrd,website-website-compress@kubernetescrd
+      workspace-redirect-https@kubernetescrd,workspace-hsts-headers@kubernetescrd,website-website-security-headers@kubernetescrd,workspace-rate-limit-web@kubernetescrd,website-website-compress@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:

--- a/prod-fleet/website-mentolder/website-security-headers.yaml
+++ b/prod-fleet/website-mentolder/website-security-headers.yaml
@@ -1,0 +1,19 @@
+# Security-headers Middleware for the website namespace (mentolder brand).
+# Mirrors prod/traefik-middlewares.yaml's shared security-headers, but WITHOUT
+# X-Robots-Tag: noindex — the public website must be crawlable (T002052).
+# The shared workspace/security-headers keeps noindex for internal services
+# (Keycloak, Nextcloud, …); only the public site opts out via this override.
+# Analogous to prod-fleet/website-korczewski/website-security-headers.yaml.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: website-security-headers
+  namespace: website
+spec:
+  headers:
+    customResponseHeaders:
+      X-Frame-Options: "SAMEORIGIN"
+      X-Content-Type-Options: "nosniff"
+      X-XSS-Protection: "1; mode=block"
+      Referrer-Policy: "strict-origin-when-cross-origin"
+      Permissions-Policy: "camera=(self), microphone=(self), geolocation=(), payment=()"

--- a/prod/traefik-middlewares.yaml
+++ b/prod/traefik-middlewares.yaml
@@ -19,7 +19,13 @@ spec:
     stsIncludeSubdomains: true
     forceSTSHeader: true
 ---
-# ── Security-HTTP-Header (alle Production-Services) ──────────────
+# ── Security-HTTP-Header (interne Production-Services) ──────────────
+# X-Robots-Tag: noindex hält interne Dienste (Keycloak, Nextcloud, Vaultwarden, …)
+# aus Suchmaschinen. Die öffentliche Website nutzt bewusst NICHT diese Middleware,
+# sondern eine website-scoped Variante ohne noindex (siehe
+# prod-fleet/website-{mentolder,korczewski}/website-security-headers.yaml, T002052).
+# Der noindex MUSS hier explizit stehen, sonst entfernt ein workspace:deploy den
+# live vorhandenen Header und macht interne Login-Seiten indexierbar.
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -33,6 +39,7 @@ spec:
       X-XSS-Protection: "1; mode=block"
       Referrer-Policy: "strict-origin-when-cross-origin"
       Permissions-Policy: "camera=(self), microphone=(self), geolocation=(), payment=()"
+      X-Robots-Tag: "noindex"
 ---
 # ── Security-Header-Variante für eingebettete Widgets (iframe-kompatibel) ──
 # Verwendet für: mediaviewer.${PROD_DOMAIN} (im Admin-Sidekick als iframe)

--- a/tests/spec/website-core.bats
+++ b/tests/spec/website-core.bats
@@ -19,6 +19,9 @@ PERF_GLOBAL_CSS="$BATS_TEST_DIRNAME/../../website/src/styles/global.css"
 PERF_LAYOUT="$BATS_TEST_DIRNAME/../../website/src/layouts/Layout.astro"
 PERF_MENTOLDER_ING="$BATS_TEST_DIRNAME/../../prod-fleet/website-mentolder/website-ingress-web.yaml"
 PERF_KORCZEWSKI_KUST="$BATS_TEST_DIRNAME/../../prod-fleet/website-korczewski/kustomization.yaml"
+MENTOLDER_SEC_HEADERS="$BATS_TEST_DIRNAME/../../prod-fleet/website-mentolder/website-security-headers.yaml"
+MENTOLDER_KUST="$BATS_TEST_DIRNAME/../../prod-fleet/website-mentolder/kustomization.yaml"
+SHARED_MIDDLEWARES="$BATS_TEST_DIRNAME/../../prod/traefik-middlewares.yaml"
 
 # ── T001433: Token alias layer ───────────────────────────────────────────────
 @test "T001433 alias: admin-foundation.css color-bearing tokens all reference var(--...)" {
@@ -313,4 +316,43 @@ PERF_KORCZEWSKI_KUST="$BATS_TEST_DIRNAME/../../prod-fleet/website-korczewski/kus
   HOMEPAGE_JSON="$BATS_TEST_DIRNAME/../../website/content/mentolder/homepage.json"
   run grep -q '"avatarSrc": "/gerald.webp"' "$HOMEPAGE_JSON"; [ "$status" -eq 0 ]
   run grep -q 'gerald.jpg' "$HOMEPAGE_JSON"; [ "$status" -ne 0 ]
+}
+
+# ── T002052: web.mentolder.de crawlability — noindex must not reach the public site ──
+# The shared workspace/security-headers middleware sets X-Robots-Tag: noindex (correct for
+# internal services like Keycloak/Nextcloud). The public website must NOT inherit it, or it
+# is deindexed from search engines (Lighthouse is-crawlable = 0). mentolder must use its own
+# website-scoped security-headers middleware without noindex — mirroring website-korczewski.
+
+@test "T002052 crawlable: mentolder website ingress does NOT reference the shared noindex security-headers" {
+  run grep -q 'workspace-security-headers@kubernetescrd' "$PERF_MENTOLDER_ING"
+  [ "$status" -ne 0 ]
+}
+
+@test "T002052 crawlable: mentolder website ingress references its own website-scoped security-headers" {
+  run grep -q 'website-website-security-headers@kubernetescrd' "$PERF_MENTOLDER_ING"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002052 crawlable: mentolder has a website-scoped security-headers middleware without noindex" {
+  [ -f "$MENTOLDER_SEC_HEADERS" ]
+  run grep -q 'name: website-security-headers' "$MENTOLDER_SEC_HEADERS"
+  [ "$status" -eq 0 ]
+  # must NOT set an X-Robots-Tag header line (comments mentioning noindex are fine)
+  run grep -Ei '^[[:space:]]*X-Robots-Tag:' "$MENTOLDER_SEC_HEADERS"
+  [ "$status" -ne 0 ]
+}
+
+@test "T002052 crawlable: mentolder kustomization wires the website-security-headers middleware" {
+  run grep -q 'website-security-headers.yaml' "$MENTOLDER_KUST"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002052 drift-guard: shared security-headers explicitly sets X-Robots-Tag noindex for internal services" {
+  # Keep internal services noindexed even after workspace:deploy — the noindex must be
+  # explicit in git, not live-only drift that a redeploy would silently remove.
+  run grep -A12 '^  name: security-headers$' "$SHARED_MIDDLEWARES"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi 'X-Robots-Tag'
+  echo "$output" | grep -qi 'noindex'
 }


### PR DESCRIPTION
## Problem
`web.mentolder.de` returned `X-Robots-Tag: noindex` → excluded from search engines (Lighthouse `is-crawlable` = 0). It is the **primary public production frontend**, so this deindexed the live site.

## Root cause
The mentolder website Ingress referenced the shared `workspace/security-headers` Traefik middleware, which sets `noindex` (correct for internal services like Keycloak/Nextcloud, wrong for the public site). The app-level `index, follow` from PR #3035 was overridden by Traefik. korczewski already had its own website-scoped middleware without noindex; mentolder lacked the equivalent.

## Fix
- **New** `prod-fleet/website-mentolder/website-security-headers.yaml` — website-scoped headers **without** noindex (mirrors korczewski)
- `website-ingress-web` now references `website-website-security-headers` instead of `workspace-security-headers`
- kustomization wires the new middleware
- **Drift-hardening:** `prod/traefik-middlewares.yaml` shared `security-headers` now sets `X-Robots-Tag: noindex` explicitly in git — previously live-only drift, so a `workspace:deploy` could have silently un-noindexed internal login pages

## Verification
- 5 new RED→GREEN BATS tests in `tests/spec/website-core.bats` (T002052)
- `kustomize build prod-fleet/website-mentolder` renders the new middleware + updated annotation
- **Live hotfix already applied** to the fleet cluster (same change) to end the SEO incident; this PR reconciles git with that state

🤖 Generated with [Claude Code](https://claude.com/claude-code)