### PR TITLE
chore(ci): use built-in GITHUB_TOKEN for LHCI status to fix 401 [T002055]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,11 @@ jobs:
     needs: [vitest-website]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # LHCI posts an advisory commit status; the built-in GITHUB_TOKEN needs
+    # statuses:write to do so (no more expiring personal access token to maintain).
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -444,7 +449,9 @@ jobs:
       - name: Run Lighthouse audit
         continue-on-error: true
         env:
-          LHCI_GITHUB_TOKEN: ${{ secrets.LHCI_GITHUB_TOKEN }}
+          # Built-in Actions token (statuses:write above) — replaces the expired
+          # personal access token that caused "GitHub responded with 401".
+          LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           lhci autorun || true
 


### PR DESCRIPTION
## Problem
The Lighthouse job posts an advisory commit status via `LHCI_GITHUB_TOKEN` — a personal access token that expired, causing `GitHub responded with 401 { "message": "Bad credentials" }` at the end of every run.

## Fix
Feed `LHCI_GITHUB_TOKEN` from the built-in `${{ secrets.GITHUB_TOKEN }}` and grant the job `statuses: write`. No personal access token to rotate anymore; the status posting authenticates with the ephemeral Actions token.

The run stays non-blocking (`continue-on-error: true` + `lhci autorun || true`) — this only removes the 401 from the status-posting step.

> Alternative (if you prefer keeping a PAT): update the `LHCI_GITHUB_TOKEN` repo secret instead — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)