### PR TITLE
fix(scripts): Add pre-flight ticket-liveness check to prevent factory race [T002038]

### DIFF
--- a/.claude/skills/references/session-coordination.md
+++ b/.claude/skills/references/session-coordination.md
@@ -122,6 +122,65 @@ ins `.reap.log` geschrieben (im Lock-Verzeichnis).
 > noch aktiv nutzt. Nach jedem Reap-Fenster die eigenen Claims verifizieren:
 > `bash scripts/agent-lock.sh list` — fehlt ein Claim, neu setzten.
 
+## Factory vs Interactive Race — Pre-Flight Claim-Pattern [T002038]
+
+### Die Race
+
+Eine interaktive `dev-flow-execute`-Session kann mit der Factory-Pipeline um
+dasselbe Ticket `plan_staged` konkurrieren:
+
+```
+Zeit │ Factory PREP                    │ Interaktive Session
+─────┼──────────────────────────────────┼────────────────────────
+  t1 │ check agent-lock → "free"       │
+  t2 │ launcht claude-Session          │
+  t3 │ (Session startet)               │
+  t4 │                                 │ dev-flow-execute startet
+  t5 │ (lädt Plan, erzeugt Worktree)   │ Schritt -1: Reap + Sync
+  t6 │                                 │ Schritt 0: Worktree
+  t7 │                                 │ Schritt 1: Plan laden
+  t8 │ claim ticket → "held by other"  │
+  t9 │ ❌ STOP (Doppelarbeit erkannt)   │ Schritt 1.4: claim → OK
+     │                                 │ ... aber Factory hat bis t8
+     │                                 │ bereits implementiert + gemergt!
+```
+
+**Problem:** Der Claim kam zu spät (Schritt 1.4). Die Factory hatte den
+gesamten Workflow (implement→PR→merge→close) abgeschlossen, während die
+interaktive Session noch in der Startup-Phase war.
+
+### Die Lösung: Pre-Flight Claim in Schritt −1
+
+Seit [T002038] wird der Ticket-Claim + Status-Check **vor** jeder
+Git-Operation in einem dedizierten Pre-Flight-Schritt (−1) platziert:
+
+1. **Ticket-Status prüfen** — `vda.sh ticket get --id $TICKET_ID` → wenn
+   `done`/`archived`/`merged`, sofort abbrechen.
+2. **Atomischer Claim** — `agent-lock.sh check-and-claim ticket $TICKET_ID`
+   (neues Kommando seit T002038, kombiniert Check + Claim unter flock).
+3. **Ankündigung broadcasten** — `agent-msg.sh post "dev-flow-execute startet
+   Arbeit an Ticket $TICKET_ID" --to all`
+
+### Aufbau der Pre-Flight-Schritte
+
+Siehe `dev-flow-execute/SKILL.md` Schritte `−1.0` bis `−1.3` (Claude Code)
+bzw. `opencode-flow-execute/SKILL.md` Schritt `−1.0` bis `−1.2` (opencode).
+
+### check-and-claim — atomische Operation
+
+`agent-lock.sh check-and-claim` führt drei Prüfungen in einem Aufruf aus:
+
+1. **Status-Check (optional):** Ein externes Skript (`--status-check <pfad>`)
+   wird mit der Ticket-ID als Argument aufgerufen. Return-Code 0 = Ticket noch
+   gültig (plan_staged), non-zero = Claim verweigert (exit 2).
+2. **Advisory Check:** Falls der Lock bereits von einer ANDEREN Session
+   gehalten wird, sofortiger Abbruch (exit 1) — ohne den Lock zu schreiben.
+3. **Atomic Claim:** Unter `flock` (`.registry.lock`) wird der Lock
+   geschrieben — serialisiert gegen alle anderen `claim`/`check-and-claim`-
+   Aufrufe.
+
+Exit-Codes: 0=claimed, 1=held by other, 2=status-check refused.
+
 ## Freigeben (nach Merge, VOR dem Worktree-Remove)
 
 ```bash

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -20,7 +20,64 @@ mcp__mcp-postgres__query({ sql: "SELECT external_id, title FROM tickets.tickets 
 ```
 Bei mehreren: den User in Plain-Text fragen, welche Ticket-ID.
 
-## Schritt −1: Main sync + Reaper
+## Schritt −1: Pre-Flight — Ticket-Lock & Status (vor allen Git-Operationen) [T002038]
+
+Bevor irgendeine Git-Operation oder Worktree-Erzeugung läuft, MUSS die Session
+das Ticket als erstes sichern. Dieses frühe Claimen verhindert die Race
+zwischen dev-flow-execute und der Factory-Pipeline: die Factory PREP prüft
+agent-lock auf "held" und überspringt das Ticket, wenn eine interaktive Session
+es bereits claimed hat — ABER nur wenn der Claim VOR dem ersten Factory-Check
+platziert ist. [T002038-M1]
+
+### Schritt −1.0: Ticket-Status aus der DB prüfen
+
+```bash
+TICKET_JSON=$(./scripts/vda.sh ticket get --id "$TICKET_ID")
+TICKET_STATUS=$(echo "$TICKET_JSON" | jq -r '.status // empty')
+case "$TICKET_STATUS" in
+  done|archived|merged)
+    echo "❌ Ticket $TICKET_ID ist bereits $TICKET_STATUS — kein dev-flow-execute nötig." >&2
+    exit 1
+    ;;
+  in_progress)
+    echo "⚠️  Ticket $TICKET_ID ist bereits in_progress. Ein anderes Cluster arbeitet evtl. parallel."
+    echo "   Fortsetzung auf eigenes Risiko. Abbruch: exit 1"
+    # Nicht blockierend — eine laufende Session kann legitimerweise fortgesetzt werden.
+    # Der Claim-Schutz (Schritt −1.1) verhindert Doppelarbeit.
+    ;;
+  plan_staged)
+    echo "✅ Ticket $TICKET_ID ist plan_staged — fortfahren."
+    ;;
+  *)
+    echo "⚠️  Ticket $TICKET_ID hat Status '$TICKET_STATUS' — unerwartet, aber nicht blockierend."
+    ;;
+esac
+```
+
+### Schritt −1.1: Ticket claimen (atomic check-and-claim) [T002038-M2]
+
+```bash
+bash scripts/agent-lock.sh check-and-claim ticket "$TICKET_ID" \
+  --branch "$(git branch --show-current)" \
+  --label opencode-flow-execute
+RET=$?
+case $RET in
+  0) echo "✅ Ticket $TICKET_ID erfolgreich geclaimed." ;;
+  1) echo "❌ Ticket $TICKET_ID wird bereits von einer anderen Session bearbeitet." >&2
+     echo "   → Session-Koordination: agent-msg.sh read --mine --unread" >&2
+     exit 1 ;;
+  2) echo "❌ Ticket $TICKET_ID ist bereits done/merged — Status-Check verweigert Claim." >&2
+     exit 1 ;;
+esac
+```
+
+### Schritt −1.2: Ankündigung broadcasten [T002038-M3]
+
+```bash
+bash scripts/agent-msg.sh post "dev-flow-execute startet Arbeit an Ticket $TICKET_ID" --to all
+```
+
+## Schritt 0: Main sync + Reaper
 
 ```bash
 bash scripts/agent-lock.sh reap
@@ -56,10 +113,14 @@ BRANCH=$(echo "$PLAN_REF" | sed -n 's/.*branch=\([^ ]*\).*/\1/p')
 PLAN_FILE=$(echo "$PLAN_REF" | sed -n 's/.*plan=\([^ ]*\).*/\1/p')
 ```
 
-## Schritt 1.4: Doppelarbeit-Guard
+## Schritt 1.4: Doppelarbeit-Guard (bereits in Schritt −1 erfolgt)
 
-```
-agent-lock.sh claim ticket T000XXX --branch feature/<slug> --worktree .worktrees/<slug> --label opencode-flow-execute
+Der Ticket-Claim wurde bereits in Schritt −1.1 platziert. Dieser Schritt ist
+nur noch eine Verifikation, dass der Claim noch gültig ist:
+
+```bash
+bash scripts/agent-lock.sh check ticket "$TICKET_ID" | head -1 | grep -q '^mine$' \
+  || { echo "❌ Ticket $TICKET_ID nicht mehr von dieser Session geclaimed — abbruch." >&2; exit 1; }
 ```
 
 ## Schritt 1.5: Ticket auf in_progress setzen

--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -259,6 +259,46 @@ cmd_check() {
   echo "held"; cat "$f"; return 3
 }
 
+# Atomic check-and-claim for ticket scope. Avoids the TOCTOU window between
+# cmd_check (advisory) and cmd_claim (lock). Returns same exit codes as claim
+# (0=ok, 1=held by other) but never writes a lock if the ticket-status DB check
+# signals the ticket is already done/merged. [T002038]
+cmd_check_and_claim() {
+  local scope="$1" id="${2:-}"; shift 2 2>/dev/null || shift $#
+  # --status-check <path> is optional: point to a script that returns 0 iff the
+  # ticket is still live (plan_staged) and not yet done/merged.
+  local status_check_script=""
+  while [ $# -gt 0 ]; do case "$1" in
+    --status-check) status_check_script="$2"; shift 2;;
+    --label) LABEL="$2"; shift 2;; --worktree) WT="$2"; shift 2;;
+    --branch) BRANCH="$2"; shift 2;; --ticket) TICKET="$2"; shift 2;;
+    *) shift;; esac; done
+
+  # 1) Optional external status-check (e.g. ticket.sh get --id + jq).
+  #    If the ticket is already done/merged/archived, refuse the claim.
+  if [ -n "$status_check_script" ]; then
+    if ! bash "$status_check_script" "$id" 2>/dev/null; then
+      echo "AGENT-LOCK: Ticket $id status check FAILED (done/merged?) — refusing claim." >&2
+      return 2
+    fi
+  fi
+
+  # 2) Check first (advisory, no lock) for early exit: if held by another
+  #    session, don't bother writing.
+  local f; f="$(_lock_file "$scope" "$id")"
+  if [ -f "$f" ] && ! _reapable "$f"; then
+    if [ "$(_lock_field "$f" owner_sid)" != "$(_my_sid)" ]; then
+      echo "AGENT-LOCK: $scope/$id bereits $(_holder_msg "$f")" >&2
+      return 1
+    fi
+    # Our own lock — refresh via cmd_claim (which re-reads existing fields).
+  fi
+
+  # 3) Atomic claim under flock. Only cmd_claim acquires the registry lock, so
+  #    two concurrent check-and-claim calls serialize here.
+  cmd_claim "$scope" "$id" --label "$LABEL" --worktree "$WT" --branch "$BRANCH" --ticket "$TICKET"
+}
+
 cmd_list() {
   local d; d="$(_lock_dir)"; [ -d "$d" ] || { echo "(keine aktiven Claims)"; return 0; }
   printf '%-14s %-24s %-8s %-10s %-6s %s\n' SCOPE ID TOOL SID STATE LABEL
@@ -361,12 +401,13 @@ main() {
     refresh) cmd_refresh "$@";;
     release) cmd_release "$@";;
     check)   cmd_check "$@";;
+    check-and-claim) cmd_check_and_claim "$@";;
     list)    cmd_list "$@";;
     reap)    cmd_reap "$@";;
     mine)    _my_sid;;
     guard-precommit)    cmd_guard_precommit "$@";;
     guard-postcheckout) cmd_guard_postcheckout "$@";;
-    *) echo "Usage: agent-lock.sh {claim|refresh|release|check|list|reap|mine|guard-precommit|guard-postcheckout}" >&2; return 2;;
+    *) echo "Usage: agent-lock.sh {claim|refresh|release|check|check-and-claim|list|reap|mine|guard-precommit|guard-postcheckout}" >&2; return 2;;
   esac
 }
 main "$@"


### PR DESCRIPTION
## Summary
- Added check-and-claim command to agent-lock.sh (atomic DB status check + lock under flock)
- Added pre-flight steps (−1.0 to −1.2) to both dev-flow-execute skill variants
- Prevents parallel factory sessions from racing on same ticket

## Test Plan
- [ ] agent-lock bats tests pass
- [ ] CI grün

🤖 [T002038]