### PR TITLE
docs(mcp): Document gh pr edit GraphQL deprecation and REST fallback [T002042]

### DIFF
--- a/.claude/skills/references/gh-axi.md
+++ b/.claude/skills/references/gh-axi.md
@@ -21,3 +21,20 @@ gh-axi setup hooks               # Optionale Agent-Session-Hooks installieren
 ### Wann `gh` statt `gh-axi`
 
 `gh-axi` deckt die häufigen read/view-Flows ab. Für Operationen ohne `gh-axi`-Pendant (z. B. `gh pr create`, `gh pr merge`, `gh api`) direkt `gh` nutzen — die SessionStart-Hook-Ausgabe zeigt den verfügbaren Befehlssatz.
+
+### Achtung: `gh pr edit --title` — GraphQL-Deprecation [T002042, T002048]
+
+`gh pr edit --title` scheitert an einer Projects-Classic-GraphQL-Deprecation-Warning, die GitHub CLI
+unbehandelt durchreicht — der Title-Change wird **silent no-op**.
+
+**Stattdessen die REST API direkt nutzen:**
+```bash
+# Fehlanfällig (vermeiden):
+gh pr edit <N> --title "neuer Titel"
+
+# REST-API-Fallback (immer):
+gh api repos/{owner}/{repo}/pulls/<N> -X PATCH -f title="neuer Titel"
+```
+
+**Label-Edit (`--add-label`):** nicht betroffen (eigener GraphQL-Endpunkt ohne Deprecation), kann
+weiter `gh pr edit` nutzen.


### PR DESCRIPTION
## Summary
- Documents the Projects-classic GraphQL deprecation warning that causes gh pr edit --title to silently no-op
- Adds REST API fallback (gh api repos/.../pulls/N -X PATCH -f title=...) in gh-axi.md
- Also fixes T002048 (same root cause)

## Test Plan
- [ ] CI grün

🤖 [T002042] [T002048]