### PR TITLE
fix(website): inline critical CSS + lazy-load GoalsDashboard to cut render-blocking [T002057]

### DIFF
--- a/tests/spec/website-core.bats
+++ b/tests/spec/website-core.bats
@@ -22,6 +22,7 @@ PERF_KORCZEWSKI_KUST="$BATS_TEST_DIRNAME/../../prod-fleet/website-korczewski/kus
 MENTOLDER_SEC_HEADERS="$BATS_TEST_DIRNAME/../../prod-fleet/website-mentolder/website-security-headers.yaml"
 MENTOLDER_KUST="$BATS_TEST_DIRNAME/../../prod-fleet/website-mentolder/kustomization.yaml"
 SHARED_MIDDLEWARES="$BATS_TEST_DIRNAME/../../prod/traefik-middlewares.yaml"
+KORE_HOMEPAGE="$BATS_TEST_DIRNAME/../../website/src/components/kore/KoreHomepage.svelte"
 
 # ── T001433: Token alias layer ───────────────────────────────────────────────
 @test "T001433 alias: admin-foundation.css color-bearing tokens all reference var(--...)" {
@@ -355,4 +356,33 @@ SHARED_MIDDLEWARES="$BATS_TEST_DIRNAME/../../prod/traefik-middlewares.yaml"
   [ "$status" -eq 0 ]
   echo "$output" | grep -qi 'X-Robots-Tag'
   echo "$output" | grep -qi 'noindex'
+}
+
+# ── T002057: cut render-blocking CSS on the public homepage ──────────────────
+# global.css is critical CSS (:root vars, html/body base, typography) — deferring
+# it would cause FOUC, so it is INLINED into the <head> via a ?inline import + an
+# is:inline <style> block instead of an auto-injected blocking <link>. If Tailwind
+# v4 cannot process ?inline cleanly the fallback keeps the blocking import — in
+# that case global.css stays a legitimate blocking critical-CSS <link> and this
+# first test is flipped to assert the documented blocking import.
+
+@test "T002057 perf: Layout.astro inlines global.css (?inline import + is:inline style block)" {
+  run grep -Eq "import .* from '\.\./styles/global\.css\?inline'" "$PERF_LAYOUT"
+  [ "$status" -eq 0 ]
+  run grep -q 'set:html=' "$PERF_LAYOUT"
+  [ "$status" -eq 0 ]
+  run grep -q 'is:inline' "$PERF_LAYOUT"
+  [ "$status" -eq 0 ]
+  # the old blocking side-effect import must be gone
+  run grep -Eq "^import '\.\./styles/global\.css';" "$PERF_LAYOUT"
+  [ "$status" -ne 0 ]
+}
+
+@test "T002057 perf: KoreHomepage.svelte lazy-loads GoalsDashboard (no static top-level import)" {
+  # static top-level import would pull GoalsDashboard.css into the homepage entry graph
+  run grep -Eq "^[[:space:]]*import GoalsDashboard from" "$KORE_HOMEPAGE"
+  [ "$status" -ne 0 ]
+  # must be loaded dynamically instead
+  run grep -q "import('../GoalsDashboard.svelte')" "$KORE_HOMEPAGE"
+  [ "$status" -eq 0 ]
 }

--- a/website/src/components/kore/KoreHomepage.svelte
+++ b/website/src/components/kore/KoreHomepage.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import Timeline from '../Timeline.svelte';
-  import GoalsDashboard from '../GoalsDashboard.svelte';
+  // T002057: GoalsDashboard (with its GoalsDashboard.css) only renders in the Kore
+  // branch. A static top-level import pulled its CSS into the shared homepage entry
+  // graph, making GoalsDashboard.css render-blocking on the mentolder homepage where
+  // this component is never rendered. Load it dynamically so its CSS lands in its own
+  // async chunk and drops out of the static homepage graph.
   import type { DaySlots } from '../../lib/caldav';
   import type { BrandConfig, FooterConfig, HomepageService } from '../../config/types';
 
@@ -349,7 +353,9 @@
     <h2>Repo Health, <em>gemessen.</em></h2>
     <span class="hint">Mess-Stichtag: 2026-06-28</span>
   </div>
-  <GoalsDashboard />
+  {#await import('../GoalsDashboard.svelte') then { default: GoalsDashboard }}
+    <GoalsDashboard />
+  {/await}
 </section>
 
 <!-- ═══════════════════════════════ FOOTER ════════════════════════════════ -->

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -3,7 +3,12 @@ import Navigation from '../components/Navigation.svelte';
 import Footer from '../components/Footer.astro';
 import CookieConsent from '../components/CookieConsent.svelte';
 import PortalSidekick from '../components/PortalSidekick.svelte';
-import '../styles/global.css';
+// T002057: global.css is critical CSS (:root vars, html/body base, typography
+// .t-*, .prose). Deferring it would cause FOUC. Instead of Astro auto-emitting a
+// render-blocking <link> for this side-effect import, import the fully-processed
+// CSS as a string (?inline) and inline it into the <head> as the first critical
+// style block below — same styles, zero extra render-blocking requests.
+import globalCss from '../styles/global.css?inline';
 // T001950: sidekick-panels.css (~180KB) styles PortalSidekick's drawer
 // sub-views (help, questionnaire, agent-guide, ...) which only render after
 // the user opens the FAB. On the public homepage it was previously a
@@ -53,6 +58,7 @@ const siteDomain = prodDomain ? `https://web.${prodDomain}` : '';
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <style set:html={globalCss} is:inline></style>
     <link rel="alternate" hreflang="de" href={`${siteDomain}${dePath}`} />
     <link rel="alternate" hreflang="en" href={`${siteDomain}${enPath}`} />
     <link rel="alternate" hreflang="x-default" href={`${siteDomain}${dePath}`} />


### PR DESCRIPTION
## Summary
- **Fix 1 — inline critical CSS:** `Layout.astro` now imports `global.css?inline`
  and emits it as a single `<style set:html={globalCss} is:inline>` block in the
  `<head>` instead of an auto-injected render-blocking `<link>`. global.css is
  critical CSS (`:root` vars, `html`/`body` base, `.t-*` typography, `.prose`), so
  deferring it would cause FOUC — inlining keeps styles applied at first paint with
  zero extra blocking requests. Tailwind v4 processing of `?inline` verified clean
  (no fallback needed).
- **Fix 2 — lazy-load GoalsDashboard:** `KoreHomepage.svelte` now loads
  `GoalsDashboard` via `{#await import('../GoalsDashboard.svelte')}` instead of a
  static top-level import. GoalsDashboard only renders in the Kore/korczewski
  branch, but the static import pulled `GoalsDashboard.css` into the shared
  homepage entry graph, making it render-blocking on the mentolder homepage where
  the component never renders. It now lands in its own async chunk.

## Build verification
- `pnpm build` succeeds.
- Inline global CSS is fully Tailwind-processed and non-empty: server chunk
  `Layout_*.mjs` contains `:root` + `.t-eyebrow`, no raw `@tailwind` directives.
- GoalsDashboard is a separate async chunk: KoreHomepage client JS references it
  via `import(\`./GoalsDashboard.*.js\`)`, and `GoalsDashboard.*.css` is emitted as
  its own `_astro/GoalsDashboard.*.css` — not bundled into the homepage entry CSS.
- Render-blocking stylesheets on mentolder homepage: before → global.css `<link>` +
  GoalsDashboard.css in entry graph; after → both removed (inline + async chunk).

## Test Plan
- [x] Added T002057 source-structure assertions in `tests/spec/website-core.bats`
      (RED before change, GREEN after) — full suite 43/43 green.
- [x] `task test:changed`, `task freshness:regenerate`, `task freshness:check` green.
- [x] `task test:inventory` — no diff.

🤖 [T002057]