### PR TITLE
fix(website): remove PortalSidekick from public layout + revert global.css inline [T002058]

### DIFF
--- a/tests/spec/website-core.bats
+++ b/tests/spec/website-core.bats
@@ -298,11 +298,11 @@ KORE_HOMEPAGE="$BATS_TEST_DIRNAME/../../website/src/components/kore/KoreHomepage
   run grep -q 'googleapis' "$PERF_GLOBAL_CSS"; [ "$status" -ne 0 ]
 }
 
-@test "T001922 perf: Layout.astro hydrates CookieConsent + PortalSidekick client:idle" {
+@test "T001922 perf: Layout.astro hydrates CookieConsent client:idle" {
+  # T002058: PortalSidekick was removed from the public Layout (its island CSS was
+  # render-blocking) — see the dedicated T002058 test below. CookieConsent stays.
   run grep -q '<CookieConsent client:idle' "$PERF_LAYOUT"; [ "$status" -eq 0 ]
-  run grep -q '<PortalSidekick client:idle' "$PERF_LAYOUT"; [ "$status" -eq 0 ]
   run grep -q '<CookieConsent client:load' "$PERF_LAYOUT"; [ "$status" -ne 0 ]
-  run grep -q '<PortalSidekick client:load' "$PERF_LAYOUT"; [ "$status" -ne 0 ]
 }
 
 @test "T001922 perf: mentolder prod Ingress binds website-compress" {
@@ -358,23 +358,18 @@ KORE_HOMEPAGE="$BATS_TEST_DIRNAME/../../website/src/components/kore/KoreHomepage
   echo "$output" | grep -qi 'noindex'
 }
 
-# ── T002057: cut render-blocking CSS on the public homepage ──────────────────
-# global.css is critical CSS (:root vars, html/body base, typography) — deferring
-# it would cause FOUC, so it is INLINED into the <head> via a ?inline import + an
-# is:inline <style> block instead of an auto-injected blocking <link>. If Tailwind
-# v4 cannot process ?inline cleanly the fallback keeps the blocking import — in
-# that case global.css stays a legitimate blocking critical-CSS <link> and this
-# first test is flipped to assert the documented blocking import.
+# ── T002057/T002058: cut render-blocking CSS on the public homepage ──────────
+# global.css is critical CSS (:root vars, html/body base, typography). T002057
+# tried a ?inline import, but that inlined the FULL Tailwind output (~95KB) into
+# every page for zero measured FCP/LCP gain (render-blocking cost is 0ms in
+# traces). T002058 reverts it to a plain side-effect import — a small (~20KB)
+# blocking critical-CSS <link> is correct here.
 
-@test "T002057 perf: Layout.astro inlines global.css (?inline import + is:inline style block)" {
-  run grep -Eq "import .* from '\.\./styles/global\.css\?inline'" "$PERF_LAYOUT"
-  [ "$status" -eq 0 ]
-  run grep -q 'set:html=' "$PERF_LAYOUT"
-  [ "$status" -eq 0 ]
-  run grep -q 'is:inline' "$PERF_LAYOUT"
-  [ "$status" -eq 0 ]
-  # the old blocking side-effect import must be gone
+@test "T002058 perf: Layout.astro imports global.css as a plain blocking side-effect (no ?inline bloat)" {
   run grep -Eq "^import '\.\./styles/global\.css';" "$PERF_LAYOUT"
+  [ "$status" -eq 0 ]
+  # the ?inline import + is:inline style block must be gone (they inlined ~95KB)
+  run grep -Eq "styles/global\.css\?inline" "$PERF_LAYOUT"
   [ "$status" -ne 0 ]
 }
 
@@ -385,4 +380,16 @@ KORE_HOMEPAGE="$BATS_TEST_DIRNAME/../../website/src/components/kore/KoreHomepage
   # must be loaded dynamically instead
   run grep -q "import('../GoalsDashboard.svelte')" "$KORE_HOMEPAGE"
   [ "$status" -eq 0 ]
+}
+
+@test "T002058 perf: public Layout.astro does not render PortalSidekick (Astro hoists island CSS render-blocking)" {
+  # Astro eagerly links ALL CSS reachable from a client island into the <head>,
+  # so the sidekick's drawer-view CSS blocked render on every public page. The
+  # sidekick lives in PortalLayout/AdminLayout (authenticated) — not the public one.
+  # match actual import/render, not comment mentions of the name
+  run grep -Eq "<PortalSidekick|import PortalSidekick" "$PERF_LAYOUT"
+  [ "$status" -ne 0 ]
+  # its ~180KB sidekick-panels.css preload machinery must be gone too
+  run grep -q "sidekick-panels\.css" "$PERF_LAYOUT"
+  [ "$status" -ne 0 ]
 }

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -2,23 +2,12 @@
 import Navigation from '../components/Navigation.svelte';
 import Footer from '../components/Footer.astro';
 import CookieConsent from '../components/CookieConsent.svelte';
-import PortalSidekick from '../components/PortalSidekick.svelte';
-// T002057: global.css is critical CSS (:root vars, html/body base, typography
-// .t-*, .prose). Deferring it would cause FOUC. Instead of Astro auto-emitting a
-// render-blocking <link> for this side-effect import, import the fully-processed
-// CSS as a string (?inline) and inline it into the <head> as the first critical
-// style block below — same styles, zero extra render-blocking requests.
-import globalCss from '../styles/global.css?inline';
-// T001950: sidekick-panels.css (~180KB) styles PortalSidekick's drawer
-// sub-views (help, questionnaire, agent-guide, ...) which only render after
-// the user opens the FAB. On the public homepage it was previously a
-// render-blocking <link>, adding ~180KB to the critical rendering path for
-// UI that is never visible on first paint. Import it as a plain asset URL
-// (no auto-injected blocking <link>) and swap it in async via the
-// preload+onload pattern below. It stays eagerly loaded (blocking) in
-// PortalLayout.astro / AdminLayout.astro, where the sidekick is core,
-// above-the-fold UI.
-import sidekickPanelsCssUrl from '../styles/sidekick-panels.css?url';
+// global.css is critical CSS (:root vars, html/body base, typography .t-*,
+// .prose). It stays a small (~20KB) render-blocking <link> emitted by Astro for
+// this side-effect import. T002057 tried ?inline, but that inlined the FULL
+// Tailwind output (~95KB) into every page for zero measured FCP/LCP gain — the
+// render-blocking cost of this stylesheet is 0ms in traces (T002058). Reverted.
+import '../styles/global.css';
 import fontsCssUrl from '../styles/fonts.css?url';
 import { config } from '../config/index';
 import { getEffectiveNavigation } from '../lib/content';
@@ -58,7 +47,6 @@ const siteDomain = prodDomain ? `https://web.${prodDomain}` : '';
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <style set:html={globalCss} is:inline></style>
     <link rel="alternate" hreflang="de" href={`${siteDomain}${dePath}`} />
     <link rel="alternate" hreflang="en" href={`${siteDomain}${enPath}`} />
     <link rel="alternate" hreflang="x-default" href={`${siteDomain}${dePath}`} />
@@ -103,13 +91,6 @@ const siteDomain = prodDomain ? `https://web.${prodDomain}` : '';
     {isKore && <link rel="stylesheet" href="/brand/korczewski/colors_and_type.css" />}
     {isKore && <link rel="stylesheet" href="/brand/korczewski/app.css" />}
     {isKore && <link rel="stylesheet" href="/brand/korczewski/kore-website.css" />}
-    <link
-      rel="preload"
-      as="style"
-      href={sidekickPanelsCssUrl}
-      onload="this.onload=null;this.rel='stylesheet'"
-    />
-    <noscript><link rel="stylesheet" href={sidekickPanelsCssUrl} /></noscript>
   </head>
   <body class={`min-h-screen flex flex-col${isKore ? ' kore' : ''}`} style="background:var(--ink-900); color:var(--fg);">
     <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded" style="background:var(--brass); color:var(--ink-900); font-weight:600;">
@@ -123,6 +104,10 @@ const siteDomain = prodDomain ? `https://web.${prodDomain}` : '';
     <Footer />
 
     <CookieConsent client:idle />
-    <PortalSidekick client:idle />
+    {/* T002058: PortalSidekick removed from the public Layout. Astro eagerly links
+        ALL CSS reachable from a client island (regardless of client:idle/only), so
+        the sidekick's drawer-view CSS was render-blocking on every public page for a
+        FAB anonymous visitors rarely use. It stays in PortalLayout/AdminLayout where
+        it is core, authenticated UI. */}
   </body>
 </html>


### PR DESCRIPTION
## Real root cause
The homepage render-blocking CSS was **not** fixable via component directives. Astro eagerly links **all** CSS reachable from a client island into the `<head>`, regardless of `client:idle` vs `client:only` — I verified a `client:only` build still emitted all 9 blocking stylesheets. So the `PortalSidekick`'s dynamically-imported drawer-view CSS (`SupportView`, `QuestionnaireView`, `MediaviewerPanel`, `CockpitSidekickView` + `PortalSidekick.css`) was render-blocking on every public page — for a FAB anonymous visitors rarely use.

## Fix
- **Remove `PortalSidekick`** (+ its ~180KB `sidekick-panels.css` preload machinery) from the public `Layout.astro`. It stays in `PortalLayout`/`AdminLayout` where it is core, authenticated UI.
- **Revert #3059's `global.css` `?inline`** — it inlined the FULL Tailwind output (~95KB) into every page for **zero** measured FCP/LCP gain (render-blocking cost is 0ms in traces). Back to a small (~20KB) blocking critical-CSS `<link>`.

## Verification (local SSR build + running server)
Public homepage `<head>` blocking stylesheets: **9 → 4**.
- Removed: `PortalSidekick.css`, `SupportView.css`, `QuestionnaireView.css`, `MediaviewerPanel.css`, `CockpitSidekickView.css`, `sidekick-panels.css` preload
- Remaining 4: `pages` / `global` / `Layout` (legitimate critical CSS) + `GoalsDashboard` (separate, mentolder-only remnant via KoreHomepage static import — follow-up)
- Inline `<style>` bytes: ~95KB → ~3.5KB (bloat gone)
- 3 RED→GREEN structure tests; full `website-core.bats` green (44); FOUC-safe (global.css blocking, tiny inline)

## Behavior note
Removes the sidekick FAB from **public marketing pages** (intentional — decided). Portal/Admin keep it. E2E `fa-10` waits on a specific island selector (not a count), so it is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)