### PR TITLE
refactor(website): move GoalsDashboard from public Kore homepage to admin sidebar [T002059]

### DIFF
--- a/tests/spec/website-core.bats
+++ b/tests/spec/website-core.bats
@@ -373,12 +373,19 @@ KORE_HOMEPAGE="$BATS_TEST_DIRNAME/../../website/src/components/kore/KoreHomepage
   [ "$status" -ne 0 ]
 }
 
-@test "T002057 perf: KoreHomepage.svelte lazy-loads GoalsDashboard (no static top-level import)" {
-  # static top-level import would pull GoalsDashboard.css into the homepage entry graph
-  run grep -Eq "^[[:space:]]*import GoalsDashboard from" "$KORE_HOMEPAGE"
+@test "T002059 move: KoreHomepage.svelte no longer renders GoalsDashboard (moved to /admin/repohealth)" {
+  # GoalsDashboard moved to the admin panel; the public Kore homepage must not
+  # import or render it (its CSS was render-blocking and leaked onto mentolder).
+  run grep -q "GoalsDashboard.svelte" "$KORE_HOMEPAGE"
   [ "$status" -ne 0 ]
-  # must be loaded dynamically instead
-  run grep -q "import('../GoalsDashboard.svelte')" "$KORE_HOMEPAGE"
+  run grep -q "<GoalsDashboard" "$KORE_HOMEPAGE"
+  [ "$status" -ne 0 ]
+}
+
+@test "T002059 move: AdminSidebarNav has a /admin/repohealth entry labelled Repo Health" {
+  run grep -Eq "href:[[:space:]]*'/admin/repohealth'" "$SIDEBAR_NAV"
+  [ "$status" -eq 0 ]
+  run grep -Eq "label:[[:space:]]*'Repo Health'" "$SIDEBAR_NAV"
   [ "$status" -eq 0 ]
 }
 

--- a/website/src/components/admin/AdminSidebarNav.astro
+++ b/website/src/components/admin/AdminSidebarNav.astro
@@ -57,6 +57,7 @@ const navSections: { label?: string; items: NavItem[]; accordion?: boolean }[] =
     label: 'Infrastruktur',
     items: [
       { href: '/admin/pipeline', label: 'Pipeline', icon: 'activity', matches: ['/admin/pipeline'] },
+      { href: '/admin/repohealth', label: 'Repo Health', icon: 'monitor', matches: ['/admin/repohealth'] },
       { href: '/admin/einstellungen/benachrichtigungen', label: 'Einstellungen', icon: 'settings', matches: ['/admin/einstellungen/'] },
       { href: brettUrl,                               label: 'Systembrett',  icon: 'brett', external: true },
       { href: '/admin/live',                          label: 'Live-Stream',  icon: 'broadcast', matches: ['/admin/live', '/admin/stream'] },

--- a/website/src/components/kore/KoreHomepage.svelte
+++ b/website/src/components/kore/KoreHomepage.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
   import Timeline from '../Timeline.svelte';
-  // T002057: GoalsDashboard (with its GoalsDashboard.css) only renders in the Kore
-  // branch. A static top-level import pulled its CSS into the shared homepage entry
-  // graph, making GoalsDashboard.css render-blocking on the mentolder homepage where
-  // this component is never rendered. Load it dynamically so its CSS lands in its own
-  // async chunk and drops out of the static homepage graph.
   import type { DaySlots } from '../../lib/caldav';
   import type { BrandConfig, FooterConfig, HomepageService } from '../../config/types';
 
@@ -346,17 +341,9 @@
   </section>
 {/if}
 
-<!-- ═══════════════════════════════ HEALTH DASHBOARD ═════════════════════ -->
-<section class="w-section" id="health">
-  <div class="head">
-    <span class="num"><!-- dynamic --></span>
-    <h2>Repo Health, <em>gemessen.</em></h2>
-    <span class="hint">Mess-Stichtag: 2026-06-28</span>
-  </div>
-  {#await import('../GoalsDashboard.svelte') then { default: GoalsDashboard }}
-    <GoalsDashboard />
-  {/await}
-</section>
+<!-- T002059: the Repo-Health dashboard moved to /admin/repohealth (admin-only).
+     It used to render publicly here; Astro hoisted its GoalsDashboard.css into the
+     homepage graph (render-blocking, and leaking onto the mentolder homepage). -->
 
 <!-- ═══════════════════════════════ FOOTER ════════════════════════════════ -->
 <footer class="w-foot">


### PR DESCRIPTION
## What
Moves `GoalsDashboard` (the repo-health dashboard) off the **public** korczewski homepage and into the admin panel, with a sidebar entry to reach it.

## Why
It rendered publicly in the `#health` section of the korczewski homepage. Astro hoisted its `GoalsDashboard.css` into the homepage module graph → render-blocking, and it **leaked onto the mentolder homepage** too (via the shared `index.astro` → `KoreHomepage` static import, even though not rendered there). This was the last spurious render-blocking stylesheet after the sidekick removal (#3062).

## Change
- Remove the public `#health` section from `KoreHomepage.svelte` (the component is props-less and self-contained, reading `goals-data.generated.json`).
- Add a **"Repo Health"** entry to `AdminSidebarNav.astro` (Infrastruktur group, both brands) — the invoke button the move needed.
- `/admin/repohealth.astro` already renders `<GoalsDashboard client:load />` behind the standard `getSession`/`isAdmin` guard — unchanged.

## Verification
- Local SSR build: mentolder homepage `<head>` blocking stylesheets **4 → 3** (only the legitimate critical CSS `pages`/`global`/`Layout` remain). `GoalsDashboard.css` gone.
- 2 RED→GREEN tests (T002059); full `website-core.bats` green (45).

## Behavior note
Removes the public repo-health section from **korczewski.de** (intentional — it becomes an admin-only tool, reachable via the new sidebar link for both brands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)