### PR TITLE
fix(ci): prevent git tag fetch bloat and optimize shallow checkouts [T001860]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,11 +21,14 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - name: Checkout (full history)
+      - name: Checkout
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
+
+      - name: Fetch origin/main for diffing (shallow)
+        run: git fetch --no-tags --prune --depth=1 origin main:refs/remotes/origin/main
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -58,8 +58,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
+
+      - name: Fetch origin/main for diffing (shallow)
+        run: git fetch --no-tags --prune --depth=1 origin main:refs/remotes/origin/main
 
       - name: Check if E2E-relevant files changed
         id: filter

--- a/.github/workflows/freshness-regen.yml
+++ b/.github/workflows/freshness-regen.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: false
           submodules: recursive
           token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Ensures `fetch-tags: false` and `--no-tags --prune` on git checkout/fetch steps across GitHub Actions workflows.
- Replaces full depth checkouts (`fetch-depth: 0`) with shallow checkouts (`fetch-depth: 1` + shallow `git fetch --no-tags --prune --depth=1 origin main`) in `e2e-pr.yml`, `ai-review.yml`, and `freshness-regen.yml` to reduce clone overhead.

## Test Plan
- Ran `task freshness:check` locally in worktree.