### PR TITLE
chore(opencode): fix stale configs and align opencode-flow-* skills with dev-flow-*

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "lmstudio/qwen3.6-14b-a3b-fablevibes",
+  "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
   "permission": {
     "read": "allow",
     "edit": "allow",
@@ -62,13 +62,17 @@
       "npm": "@ai-sdk/openai-compatible",
       "name": "llama.cpp MTP (Windows)",
       "options": {
-        "baseURL": "http://localhost:8080",
+        "baseURL": "http://127.0.0.1:8091/v1",
         "timeout": 600000,
         "chunkTimeout": 120000
       },
       "models": {
         "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": {
-          "name": "Gemma 4 12B QAT (Q4_K_XL) + MTP"
+          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp b9553+CUDA13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 6, -np 4 parallel slots over -c 16384 total ctx = 4096 ctx/slot, Q8_0 KV cache, -fit auto-VRAM-fit, auto-sleeps GPU after 20min idle and reloads on next request in ~6s) - start via Desktop\\start-gemma4-mtp-server.bat first",
+          "limit": {
+            "context": 4096,
+            "output": 4096
+          }
         }
       }
     },

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -149,6 +149,17 @@ task freshness:regenerate
 task freshness:check
 ```
 
+## Schritt 4: Code Review Gate
+
+Vor dem PR-Merge: delegate an einen Review-Subagenten via `delegate()` oder nutze `gh-axi pr review` für eine automatische Code-Review-Prüfung. Behebe alle gefundenen Probleme.
+
+```bash
+# Autoren-Code-Review: delegate an explore-Subagenten
+delegate(prompt: "Review this PR's changes for bugs, security issues, and style. PR: $(gh-axi pr view --json url -q '.url')", agent: "explore")
+```
+
+Der User muss die Review-Ergebnisse bestätigen, bevor der PR gemergt wird.
+
 ## Schritt 5: PR erstellen
 
 Delegate to **`opencode-git-workflow` Steps 2–6** (SSOT):
@@ -167,17 +178,50 @@ bash scripts/devflow-ci-watch.sh "$TICKET_ID" "$PR_URL"
 
 ## Schritt 6: Auto-Merge wenn CI grün
 
+Phase-Chain-Gate (fail-closed):
 ```bash
 bash scripts/ticket.sh assert-phase-chain --id "$TICKET_ID"
+```
+
+Auto-Merge aktivieren (Voraussetzung: mindestens ein Implementierungs-Commit liegt auf dem Branch, nicht nur der Plan-Stage-Commit — T001899):
+```bash
 (cd "$MAIN_REPO" && gh-axi pr merge --auto --squash --delete-branch)
 ```
 
-## Schritt 6.4/6.5: Auf Merge warten + Ticket schließen
+## Schritt 6.4: Auf Merge warten (Poll-Schleife)
 
-Warte auf Merge (poll `gh-axi pr view`), dann:
+`gh-axi pr merge --auto` kehrt sofort zurück — der eigentliche Merge passiert asynchron.
+Warte, bis der Merge tatsächlich durch ist, bevor das Ticket geschlossen wird:
+
+```bash
+PR_NUM=$(gh-axi pr view --json number -q '.number')
+MAX_MERGE_WAIT_MIN="${MAX_MERGE_WAIT_MIN:-15}"
+WAIT_START=$(date +%s)
+
+echo "⏳ Warte auf Merge von PR #$PR_NUM (max ${MAX_MERGE_WAIT_MIN}min) ..."
+while true; do
+  MERGE_STATE=$(gh-axi pr view "$PR_NUM" --json mergeStateStatus,state -q '.state + "|" + .mergeStateStatus' 2>/dev/null || echo "UNKNOWN|UNKNOWN")
+  STATE="${MERGE_STATE%%|*}"
+  case "$STATE" in
+    MERGED) echo "✅ PR #$PR_NUM ist gemergt."; break ;;
+    CLOSED) echo "❌ PR #$PR_NUM wurde geschlossen ohne Merge." >&2; exit 2 ;;
+  esac
+  ELAPSED=$(( $(date +%s) - WAIT_START ))
+  if (( ELAPSED > MAX_MERGE_WAIT_MIN * 60 )); then
+    echo "❌ PR #$PR_NUM nach ${MAX_MERGE_WAIT_MIN}min nicht gemergt (state=$STATE)." >&2
+    exit 3
+  fi
+  sleep 15
+done
+```
+
+## Schritt 6.5: Ticket abschließen
+
+Merge = Abschluss (T001092). Ticket schließen:
 ```
 ticket-mcp: add_pr_link({ id: "$TICKET_ID", pr: "$PR_NUM" })
 ticket-mcp: transition_status({ id: "$TICKET_ID", status: "done", resolution: "shipped" })
+ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "deploy", state: "done", driver: "devflow", detail: "PR #$PR_NUM merged · done/shipped" })
 ```
 
 ## Schritt 7: Plan archivieren
@@ -197,6 +241,16 @@ git worktree remove .worktrees/<slug> --force
 git branch -D feature/<slug>
 ```
 
+## Schritt 8: Post-Merge Deploy & Verify
+
+Führe den Deployment-Schritt nur aus, wenn die geänderten Dateien deploy-pflichtige Bereiche betreffen:
+
+```bash
+bash scripts/devflow-post-merge-deploy.sh "$TICKET_ID"
+```
+
+**Deploy-Mapping (SSOT):** Pfad→Task-Tabelle und Pod-Verify-Schleife in `.claude/skills/references/deploy-routing.md`.
+
 ## Verwandte Skills
 
 | Skill | Beziehung |
@@ -205,6 +259,8 @@ git branch -D feature/<slug>
 | `opencode-git-workflow` | **SSOT für Commit/PR/Merge/Cleanup** |
 | `background-agents.ts` | Subagent-Routing (read-only vs write-capable) |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
+| `scripts/devflow-post-merge-deploy.sh` | Schritt 8 — Post-Merge Deploy |
+| `references/deploy-routing` | Deploy-Mapping (SSOT) |
 
 
 ## Framework mapping

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -66,11 +66,15 @@ Validiere lokal mit `jq`. Bei nicht erreichbaren Quellen: `risks[]`-Eintrag setz
 
 Wenn ein Design-Handoff existiert, lege Assets in `openspec/changes/<slug>/assets/` im main-Checkout an.
 
-#### Schritt A.3: Brainstorming
+#### Schritt A.3: Lavish-Board starten ⚡ PFLICHT — vor Brainstorming
 
-Starte strukturiertes Brainstorming mit dem User. Stelle Fragen als Plain-Text-Fragen im Chat (keine Tool-Fragen). Tracke Fortschritt mit einer Plain-Text-Checkliste im Reply. Verwende `lavish` (via `bash scripts/lavish-axi.sh`) für visuelle Boards.
+Erstelle `.lavish/<slug>-brainstorm.html` (Sections: Intent, Constraints, Trade-offs, Entscheidungen) und öffne es mit `npx -y lavish-axi .lavish/<slug>-brainstorm.html`. Dieses Board dient als visuelles Arbeitsblatt während des Brainstormings.
 
-#### Schritt A.4: OpenSpec-Change anlegen — AUF MAIN
+#### Schritt A.4: Brainstorming ⚡ IMMER
+
+Starte strukturiertes Brainstorming mit dem User. Nutze das `lavish`-Board aus A.3 für visuelle Dokumentation und strukturiertes Feedback. Tracke Fortschritt mit einer Plain-Text-Checkliste. Verwende einen read-only Subagenten (`delegate(prompt, agent)`) für Code-Exploration (Architektur/Code-Pfade).
+
+#### Schritt A.5: OpenSpec-Change anlegen — AUF MAIN
 
 ```bash
 # upstream OpenSpec CLI (preferred):
@@ -81,7 +85,7 @@ Starte strukturiertes Brainstorming mit dem User. Stelle Fragen als Plain-Text-F
 
 Übertrage Brainstorming-Output nach `openspec/changes/<slug>/proposal.md`. Der Implementierungsplan kommt in `openspec/changes/<slug>/tasks.md`.
 
-#### Schritt A.5: Ticket anlegen — VOR Plan-Schreibung ⚡
+#### Schritt A.6: Ticket anlegen — VOR Plan-Schreibung ⚡
 
 Erstelle das Ticket **jetzt** (nach dem Propose, vor dem Plan-Schreiben), damit die
 Ticket-ID für den Rest des Flows verfügbar ist und `stage_plan` sofort nach der


### PR DESCRIPTION
## Summary
- Fix llama.cpp MTP port in opencode.jsonc (8080 → 127.0.0.1:8091/v1)
- Fix default model key to match agent model keys (@262k suffix)
- Update Gemma4 description with full spec + context/output limits
- Add Code Review Gate, Wait-for-Merge Poll, and Post-Merge Deploy steps to opencode-flow-execute (aligns with dev-flow-execute)
- Make lavish board mandatory in opencode-flow-plan (aligns with dev-flow-plan)
- Fix step numbering in opencode-flow-plan

## Test Plan
- [ ] CI grün