### PR TITLE
fix(website): prevent invalidating synthetic e2e sessions in getSession [T000752]

### DIFF
--- a/website/src/lib/auth.test.ts
+++ b/website/src/lib/auth.test.ts
@@ -5,6 +5,40 @@ vi.mock('./logger', () => ({
   createRequestLogger: vi.fn(() => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() })),
 }));
 
+vi.mock('pg', () => {
+  const store = new Map<string, any>();
+  function MockPool() {
+    return {
+      query: vi.fn(async (sql: string, params?: any[]) => {
+        if (sql.includes('CREATE TABLE')) return { rows: [] };
+        if (sql.includes('INSERT INTO web_sessions')) {
+          store.set(params![0], JSON.parse(params![1]));
+          return { rows: [] };
+        }
+        if (sql.includes('SELECT data FROM web_sessions')) {
+          const data = store.get(params![0]);
+          return { rows: data ? [{ data }] : [] };
+        }
+        if (sql.includes('UPDATE web_sessions')) {
+          store.set(params![2], JSON.parse(params![0]));
+          return { rows: [] };
+        }
+        if (sql.includes('DELETE FROM web_sessions')) {
+          store.delete(params![0]);
+          return { rows: [] };
+        }
+        return { rows: [] };
+      }),
+    };
+  }
+  return {
+    default: {
+      Pool: MockPool,
+    },
+    Pool: MockPool,
+  };
+});
+
 const ORIGINAL_POCKET = process.env.POCKET_ID_FRONTEND_URL;
 const ORIGINAL_INTERNAL = process.env.POCKET_ID_URL;
 const ORIGINAL_SECRET = process.env.POCKET_ID_WEBSITE_SECRET;
@@ -104,6 +138,24 @@ describe('getSession (in-memory session lookup)', () => {
     const m = await loadModule();
     expect(await m.getSession('foo=bar')).toBeNull();
     expect(await m.getSession(null)).toBeNull();
+  });
+
+  it('retrieves synthetic/e2e sessions with empty tokens without attempting refresh', async () => {
+    const m = await loadModule();
+    const sessionId = await m.issueSession({
+      sub: 'test-id',
+      email: 'test@example.com',
+      name: 'Test User',
+      preferred_username: 'paddione',
+      realmRoles: ['admin'],
+      brand: null,
+      access_token: '',
+      refresh_token: '',
+      expires_at: Date.now() + 3600000,
+    });
+    const session = await m.getSession(`workspace_session=${sessionId}`);
+    expect(session).not.toBeNull();
+    expect(session?.preferred_username).toBe('paddione');
   });
 });
 

--- a/website/src/lib/auth.test.ts
+++ b/website/src/lib/auth.test.ts
@@ -6,25 +6,25 @@ vi.mock('./logger', () => ({
 }));
 
 vi.mock('pg', () => {
-  const store = new Map<string, any>();
+  const store = new Map<string, unknown>();
   function MockPool() {
     return {
-      query: vi.fn(async (sql: string, params?: any[]) => {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
         if (sql.includes('CREATE TABLE')) return { rows: [] };
         if (sql.includes('INSERT INTO web_sessions')) {
-          store.set(params![0], JSON.parse(params![1]));
+          store.set(String(params![0]), JSON.parse(String(params![1])));
           return { rows: [] };
         }
         if (sql.includes('SELECT data FROM web_sessions')) {
-          const data = store.get(params![0]);
+          const data = store.get(String(params![0]));
           return { rows: data ? [{ data }] : [] };
         }
         if (sql.includes('UPDATE web_sessions')) {
-          store.set(params![2], JSON.parse(params![0]));
+          store.set(String(params![2]), JSON.parse(String(params![0])));
           return { rows: [] };
         }
         if (sql.includes('DELETE FROM web_sessions')) {
-          store.delete(params![0]);
+          store.delete(String(params![0]));
           return { rows: [] };
         }
         return { rows: [] };

--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -234,9 +234,9 @@ export async function getSession(cookieHeader: string | null): Promise<UserSessi
     const ACCESS_TOKEN_BUFFER_MS = 60 * 1000;
     const accessClaims = decodeJwtPayload(session.access_token);
     const accessExpMs = typeof accessClaims?.exp === 'number' ? accessClaims.exp * 1000 : 0;
-    const accessExpired = accessExpMs - Date.now() < ACCESS_TOKEN_BUFFER_MS;
+    const accessExpired = accessExpMs > 0 && accessExpMs - Date.now() < ACCESS_TOKEN_BUFFER_MS;
     const webSessionExpiring = session.expires_at - Date.now() < ACCESS_TOKEN_BUFFER_MS;
-    if (accessExpired || webSessionExpiring) {
+    if (session.refresh_token && (accessExpired || webSessionExpiring)) {
       const refreshed = await refreshTokens(session.refresh_token);
       if (refreshed) {
         const newExpiry = Date.now() + SESSION_TTL_MS;


### PR DESCRIPTION
### Summary
Fixes E2E test failures caused by  prematurely invalidating synthetic/E2E sessions issued via .

### Root Cause
 inspected the JWT access token  claim to automatically refresh expired OIDC access tokens. Synthetic sessions generated for E2E tests have empty  and  strings ().  returned , causing  to evaluate to  and  to evaluate to . This triggered a token refresh attempt with an empty refresh token, which failed and deleted the session from PostgreSQL (), redirecting Playwright pages back to the login page and causing timeouts in .

### Fix
- Evaluates  only when .
- Attempts token refresh only when  is non-empty.
- Added unit test in  verifying synthetic/E2E session retrieval without token refresh.