### PR TITLE
fix(website): use X-API-KEY header for Pocket ID admin API [T003163]

### DIFF
--- a/tests/e2e/lib/health-assertions.ts
+++ b/tests/e2e/lib/health-assertions.ts
@@ -110,8 +110,9 @@ export async function assertReachable(
 /**
  * Assert that an authenticated endpoint is reachable.
  *
- * First checks that E2E_ADMIN_PASS is set. Then delegates to assertReachable.
- * Use for any test that requires admin authentication.
+ * First checks that CRON_SECRET is set (used as token for e2e-login).
+ * Then delegates to assertReachable. Use for any test that requires admin
+ * authentication against the live site.
  */
 export async function assertAuthenticatedReachable(
   request: APIRequestContext,
@@ -119,11 +120,11 @@ export async function assertAuthenticatedReachable(
   opts: ReachableOpts = {},
   testInfo?: TestInfo
 ): Promise<APIResponse> {
-  const adminPass = process.env.E2E_ADMIN_PASS;
-  if (!adminPass) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
     skipOrFail(
       testInfo,
-      `E2E_ADMIN_PASS not set — cannot reach authenticated endpoint: ${url}`
+      `CRON_SECRET not set — cannot reach authenticated endpoint: ${url}`
     );
   }
   return assertReachable(request, url, opts, testInfo);

--- a/website/src/lib/identity.ts
+++ b/website/src/lib/identity.ts
@@ -17,7 +17,9 @@ async function piApi(method: string, path: string, body?: unknown): Promise<Resp
   const res = await fetch(`${PI_URL}${path}`, {
     method,
     headers: {
-      Authorization: `Bearer ${PI_API_KEY}`,
+      // Pocket ID v2.9.0 requires X-API-KEY, not Authorization: Bearer
+      // (verified live, T001355 / pocket-id-client-seed.yaml).
+      'X-API-KEY': PI_API_KEY,
       'Content-Type': 'application/json',
     },
     body: body ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
## Summary
- Pocket ID v2.9.0 requires `X-API-KEY` header, not `Authorization: Bearer` (verified in pocket-id-client-seed.yaml)
- `listUsers()` in identity.ts used Bearer → always got 401 from Pocket ID
- This broke e2e-login endpoint (couldn't list users to find the user)
- Also updated assertAuthenticatedReachable to check CRON_SECRET instead of E2E_ADMIN_PASS

## Test Plan
- [ ] E2E PR smoke tests grün