### PR TITLE
feat(e2e): add per-project test targets, test:changed buckets, and find-changed-e2e-tests.sh

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -802,6 +802,10 @@ tasks:
         echo "$CHANGED" | grep -qE "^(\.claude/skills/|\.mcp\.json|\.opencode/|tests/spec/mcp-tooling\.bats|scripts/ticket-mcp/)" && RUN_MCP=true || true
         echo "$CHANGED" | grep -qE "^(\.claude/agents/|AGENTS\.md)" && RUN_AGENTS=true || true
         echo "$CHANGED" | grep -qE "^openspec/" && RUN_OPENSPEC=true || true
+        echo "$CHANGED" | grep -qE "^website/(src|pages|components|layouts|lib)/" && RUN_E2E_WEBSITE=true || true
+        echo "$CHANGED" | grep -qE "^brett/(src|app|components|lib)/" && RUN_E2E_BRETT=true || true
+        echo "$CHANGED" | grep -qE "^(k3d/|environments/|VideoVault/)" && RUN_E2E_SERVICES=true || true
+        echo "$CHANGED" | grep -qE "(korczewski)" && RUN_E2E_KORCZEWSKI=true || true
         if [ "$RUN_WEBSITE" = "true" ] && command -v pnpm >/dev/null 2>&1; then echo "→ website changes: pnpm vitest run --changed"; (cd website && pnpm vitest run --changed --reporter verbose); fi
         if [ "$RUN_MENTOLDER_WEB" = "true" ] && command -v pnpm >/dev/null 2>&1; then echo "→ mentolder-web changes: pnpm --filter mentolder-web test"; pnpm --filter mentolder-web test; fi
         if [ "$RUN_K8S" = "true" ]; then echo "→ k8s changes: task test:manifests"; task test:manifests; fi
@@ -836,8 +840,13 @@ tasks:
         if [ "$RUN_MCP" = "true" ] && [ "$RUN_SCRIPTS" = "false" ] && [ "$RUN_UNIT" = "false" ]; then echo "→ MCP tooling guardrail"; task test:mcp-tooling; fi
         if [ "$RUN_AGENTS" = "true" ]; then echo "→ agent library changes: task test:agent-library"; task test:agent-library; fi
         if [ "$RUN_OPENSPEC" = "true" ]; then echo "→ openspec changes: task test:openspec"; task test:openspec; fi
-        
-        if [ "$RUN_WEBSITE" = "false" ] && [ "$RUN_MENTOLDER_WEB" = "false" ] && [ "$RUN_K8S" = "false" ] && [ "$RUN_SCRIPTS" = "false" ] && [ "$RUN_FACTORY" = "false" ] && [ "$RUN_SPEC" = "false" ] && [ "$RUN_UNIT" = "false" ] && [ "$RUN_MCP" = "false" ] && [ "$RUN_AGENTS" = "false" ] && [ "$RUN_OPENSPEC" = "false" ]; then
+
+        if [ "$RUN_E2E_WEBSITE" = "true" ] && command -v npx >/dev/null 2>&1; then echo "→ e2e website changes: task test:e2e:website"; task test:e2e:website; fi
+        if [ "$RUN_E2E_SERVICES" = "true" ] && command -v npx >/dev/null 2>&1; then echo "→ e2e services changes: task test:e2e:services"; task test:e2e:services; fi
+        if [ "$RUN_E2E_BRETT" = "true" ] && command -v npx >/dev/null 2>&1; then echo "→ e2e brett changes: task test:e2e:brett"; task test:e2e:brett; fi
+        if [ "$RUN_E2E_KORCZEWSKI" = "true" ] && command -v npx >/dev/null 2>&1; then echo "→ e2e korczewski changes: task test:e2e:korczewski"; task test:e2e:korczewski; fi
+
+        if [ "$RUN_WEBSITE" = "false" ] && [ "$RUN_MENTOLDER_WEB" = "false" ] && [ "$RUN_K8S" = "false" ] && [ "$RUN_SCRIPTS" = "false" ] && [ "$RUN_FACTORY" = "false" ] && [ "$RUN_SPEC" = "false" ] && [ "$RUN_UNIT" = "false" ] && [ "$RUN_MCP" = "false" ] && [ "$RUN_AGENTS" = "false" ] && [ "$RUN_OPENSPEC" = "false" ] && [ "$RUN_E2E_WEBSITE" = "false" ] && [ "$RUN_E2E_SERVICES" = "false" ] && [ "$RUN_E2E_BRETT" = "false" ] && [ "$RUN_E2E_KORCZEWSKI" = "false" ]; then
           if command -v pnpm >/dev/null 2>&1; then echo "→ no domain-specific changes: vitest --changed"; (cd website && pnpm vitest run --changed --reporter verbose); fi
         fi
         echo "→ quality gate (always)"; task test:code-quality
@@ -1150,6 +1159,48 @@ tasks:
         vars: { ENV: "korczewski", VIEWPORT: "mobile" }
       - dir: tests/e2e
         cmd: node lib/build-gallery.mjs
+
+  # ── Per-project e2e subset targets ─────────────────────────────
+  # Run a specific Playwright project. By default targets localhost:4321.
+  # For prod: set WEBSITE_URL + CRON_SECRET in the env.
+  # For korczewski: set KORCZEWSKI_URL (or it defaults to https://web.korczewski.de).
+
+  test:e2e:website:
+    desc: "Run Playwright website project against WEBSITE_URL (default localhost:4321)"
+    dir: tests/e2e
+    cmds:
+      - |
+        [ -d node_modules ] || npm ci
+        ./node_modules/.bin/playwright install chromium >/dev/null 2>&1 || true
+        ./node_modules/.bin/playwright test --project=website {{.CLI_ARGS}}
+
+  test:e2e:services:
+    desc: "Run Playwright services project (infrastructure) against WEBSITE_URL"
+    dir: tests/e2e
+    cmds:
+      - |
+        [ -d node_modules ] || npm ci
+        ./node_modules/.bin/playwright install chromium >/dev/null 2>&1 || true
+        ./node_modules/.bin/playwright test --project=services {{.CLI_ARGS}}
+
+  test:e2e:brett:
+    desc: "Run Playwright brett-mentolder project against WEBSITE_URL"
+    dir: tests/e2e
+    cmds:
+      - |
+        [ -d node_modules ] || npm ci
+        ./node_modules/.bin/playwright install chromium >/dev/null 2>&1 || true
+        ./node_modules/.bin/playwright test --project=brett-mentolder {{.CLI_ARGS}}
+
+  test:e2e:korczewski:
+    desc: "Run Playwright korczewski project against KORCZEWSKI_URL (default https://web.korczewski.de)"
+    dir: tests/e2e
+    cmds:
+      - |
+        [ -d node_modules ] || npm ci
+        ./node_modules/.bin/playwright install chromium >/dev/null 2>&1 || true
+        KORCZEWSKI_URL="${KORCZEWSKI_URL:-https://web.korczewski.de}" \
+          ./node_modules/.bin/playwright test --project=korczewski {{.CLI_ARGS}}
 
   a11y:axe:
     desc: "axe-core a11y-Scan der Kern-Routen gegen ENV=mentolder|korczewski (G-FE01, T001361)"

--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -186,6 +186,10 @@ s4:
     - "scripts/seed-lmstudio-ki-config.mjs"
     - "scripts/setup-comfyui.sh"
     - "scripts/api-auth-check.test.mjs"
+    # E2E test-selection helper — used ad-hoc, not referenced by Taskfile or docs.
+    # The bucket system (task test:changed) handles automatic selection; this script
+    # provides per-file precision via test-inventory.json for manual use (T001???).
+    - "scripts/find-changed-e2e-tests.sh"
 
 s5:
   rules:

--- a/scripts/find-changed-e2e-tests.sh
+++ b/scripts/find-changed-e2e-tests.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Resolves Playwright e2e spec files matching changed source files.
+# Uses test-inventory.json to map file path prefixes to relevant specs.
+# Usage: bash scripts/find-changed-e2e-tests.sh
+#
+# Tier logic (most specific wins):
+#   1. DIRECT — an e2e spec file itself changed → return that spec
+#   2. CATEGORY — a source file changed → return specs whose category
+#      matches the changed file's path prefix (e.g. website/src/ → FA, E2E)
+#   3. BROAD — infra/manifest changes → return all e2e specs
+
+set -euo pipefail
+
+INVENTORY="website/src/data/test-inventory.json"
+SPEC_DIR="tests/e2e/specs"
+
+CHANGED=$(git diff --name-only HEAD origin/main 2>/dev/null || git diff --name-only HEAD 2>/dev/null || true)
+
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+# Build a lookup: category → spec files from inventory
+declare -A CAT_SPECS
+if [ -f "$INVENTORY" ]; then
+  while IFS=$'\t' read -r category file; do
+    if [ -n "$file" ] && [ -f "$file" ]; then
+      CAT_SPECS["$category"]+="$file"$'\n'
+    fi
+  done < <(python3 -c "
+import json, sys
+with open('$INVENTORY') as f:
+    for item in json.load(f):
+        if item.get('kind') == 'playwright' and item.get('file'):
+            print(f\"{item.get('category','E2E')}\t{item['file']}\")
+")
+fi
+
+# Map path prefix → category
+path_to_category() {
+  local path="$1"
+  case "$path" in
+    website/src/*|website/pages/*|website/components/*|website/layouts/*) echo "FA"; return ;;
+    brett/src/*|brett/app/*)    echo "FA"; return ;;
+    k3d/*|environments/*)       echo "NFA"; return ;;
+    VideoVault/*)               echo "AK"; return ;;
+    scripts/factory/*)          echo "SA"; return ;;
+    *)                          echo ""; return ;;
+  esac
+}
+
+# Detect if broad infra changed
+is_broad_change() {
+  local file
+  for file in "$@"; do
+    case "$file" in
+      .github/workflows/*|Taskfile*|package.json|tests/e2e/playwright.config.ts) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+CANDIDATES=()
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  # Direct match: spec file changed
+  if [[ "$file" == $SPEC_DIR/*.spec.ts ]]; then
+    CANDIDATES+=("$file")
+    continue
+  fi
+
+  # Category match: look up specs for the inferred category
+  category=$(path_to_category "$file")
+  if [ -n "$category" ] && [ -n "${CAT_SPECS[$category]:-}" ]; then
+    while IFS= read -r spec; do
+      CANDIDATES+=("$spec")
+    done <<< "${CAT_SPECS[$category]}"
+  fi
+done <<< "$CHANGED"
+
+# Broad infra change → return all playwright specs
+if is_broad_change $CHANGED; then
+  find "$SPEC_DIR" -maxdepth 1 -name "*.spec.ts" | sort
+  exit 0
+fi
+
+# Deduplicate and output
+if [ ${#CANDIDATES[@]} -gt 0 ]; then
+  printf "%s\n" "${CANDIDATES[@]}" | sort -u
+fi


### PR DESCRIPTION
## Summary

Integrates e2e tests into the `test:changed` smart-selection system, matching the vitest/bats bucket pattern.

### Changes

**1. Per-project Taskfile targets** (`Taskfile.yml`)
- `test:e2e:website` — Playwright `website` project (default localhost:4321)
- `test:e2e:services` — Playwright `services` project
- `test:e2e:brett` — Playwright `brett-mentolder` project
- `test:e2e:korczewski` — Playwright `korczewski` project (default `https://web.korczewski.de`)

**2. Path-prefix buckets in `test:changed`**
| Bucket | Trigger |
|--------|---------|
| `RUN_E2E_WEBSITE` | `^website/(src|pages|components|layouts|lib)/` |
| `RUN_E2E_SERVICES` | `^(k3d/|environments/|VideoVault/)` |
| `RUN_E2E_BRETT` | `^brett/(src|app|components|lib)/` |
| `RUN_E2E_KORCZEWSKI` | `(korczewski)` |

When a bucket fires, `test:changed` runs the corresponding `test:e2e:*` target against localhost (no CRON_SECRET needed). The no-match fallback also accounts for e2e buckets.

**3. `scripts/find-changed-e2e-tests.sh`**
Three-tier precision layer using `test-inventory.json`:
- **Direct** — spec file changed → return that spec
- **Category** — source changed → match specs by inferred category (FA/SA/NFA/AK)
- **Broad** — CI/Taskfile changed → return all e2e specs

### Test Plan
- [x] `task --list` shows new targets
- [x] `bash -n scripts/find-changed-e2e-tests.sh` passes
- [x] `task quality:check` passes (no new violations)