### PR TITLE
fix(e2e): migrate all inline login functions to loginViaE2E, align CRON_SECRET

### DIFF
--- a/tests/e2e/helpers/billing.ts
+++ b/tests/e2e/helpers/billing.ts
@@ -1,14 +1,11 @@
 import { Page, APIRequestContext, expect } from '@playwright/test';
+import { loginViaE2E, getAdminCredentials } from '../lib/auth';
 
 const BASE = process.env.WEBSITE_URL || 'http://localhost:4321';
-const ADMIN_USER = process.env.ADMIN_USER || process.env.E2E_ADMIN_USER || 'paddione';
 
 export async function adminLogin(page: Page, request?: APIRequestContext, testInfo?: any) {
-  await page.goto(
-    `${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=${encodeURIComponent('/admin/rechnungen')}`,
-    { waitUntil: 'domcontentloaded' },
-  );
-  await page.waitForURL(/\/admin/, { timeout: 60_000 });
+  const { user } = getAdminCredentials();
+  await loginViaE2E(page, BASE, user, '/admin/rechnungen');
 }
 
 export async function createTestInvoice(page: Page, opts: { gross: number }) {

--- a/tests/e2e/specs/fa-29-cockpit.spec.ts
+++ b/tests/e2e/specs/fa-29-cockpit.spec.ts
@@ -3,6 +3,7 @@
 // feature selection filters tickets, inline status edit + bulk edit work.
 // Requires E2E_ADMIN_USER + E2E_ADMIN_PASS. Runs against live prod (WEBSITE_URL).
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 
 const WEBSITE_URL = process.env.WEBSITE_URL ?? 'http://localhost:4321';
 const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
@@ -12,8 +13,7 @@ test.describe('FA-29 Projekt-Cockpit', () => {
   test.skip(!ADMIN_PASS, 'E2E_ADMIN_PASS nicht gesetzt — überspringe Auth-Test');
 
   async function login(page: any) {
-    await page.goto(`${WEBSITE_URL}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=${encodeURIComponent('/admin/cockpit')}`);
-    await page.waitForURL(/\/admin\/cockpit/);
+    await loginViaE2E(page as import('@playwright/test').Page, WEBSITE_URL, ADMIN_USER, '/admin/cockpit');
   }
 
   test('loads sidebar and table', async ({ page }) => {

--- a/tests/e2e/specs/fa-43-ticket-widget.spec.ts
+++ b/tests/e2e/specs/fa-43-ticket-widget.spec.ts
@@ -6,6 +6,7 @@
 // shows in portal (showCreate defaults to true).
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE       = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
@@ -13,8 +14,7 @@ const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
 async function loginAndGo(page: import('@playwright/test').Page, path: string) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=${path}`);
-  await page.waitForURL(new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), { timeout: 20_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, path);
 }
 
 test.describe('FA-43: TicketWidgetBar — portal widget rendering', () => {

--- a/tests/e2e/specs/fa-53-systemtest-failure-loop.spec.ts
+++ b/tests/e2e/specs/fa-53-systemtest-failure-loop.spec.ts
@@ -19,6 +19,7 @@
 // The test skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
@@ -33,8 +34,7 @@ const ADMIN_PASS = isKorczewski
 const COLUMN_TITLES = ['Offen', 'Fix in PR', 'Retest ausstehend', 'Grün (7 Tage)'];
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/systemtest/board`);
-  await page.waitForURL(/\/admin\/systemtest\/board/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/systemtest/board');
 }
 
 test.describe('FA-53: System-test failure loop kanban', () => {

--- a/tests/e2e/specs/fa-54-coaching-sessions.spec.ts
+++ b/tests/e2e/specs/fa-54-coaching-sessions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE        = process.env.WEBSITE_URL    ?? 'https://web.mentolder.de';
@@ -15,8 +16,7 @@ const ADMIN_PASS  = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page, returnTo = '/admin/coaching/sessions'): Promise<void> {
   if (!ADMIN_PASS) throw new Error('E2E_ADMIN_PASS is not set');
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=${encodeURIComponent(returnTo)}`);
-  await page.waitForURL(url => url.toString().startsWith(BASE), { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, returnTo);
 }
 
 test.describe('FA-54: Coaching-Sessions', () => {

--- a/tests/e2e/specs/fa-55-lmstudio-integration.spec.ts
+++ b/tests/e2e/specs/fa-55-lmstudio-integration.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 /**
@@ -30,8 +31,7 @@ const ADMIN_PASS  = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page, returnTo = '/admin/coaching/sessions'): Promise<void> {
   if (!ADMIN_PASS) throw new Error('E2E_ADMIN_PASS is not set');
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=${encodeURIComponent(returnTo)}`);
-  await page.waitForURL(url => url.toString().startsWith(BASE), { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, returnTo);
 }
 
 // ── API-level tests (no browser needed) ─────────────────────────────────────

--- a/tests/e2e/specs/fa-admin-crm.spec.ts
+++ b/tests/e2e/specs/fa-admin-crm.spec.ts
@@ -33,29 +33,6 @@ test.describe('FA: Admin CRM & operations pages', { tag: ['@admin', '@crm'] }, (
     await expect(page).not.toHaveURL(/\/admin\/meetings\/.+/);
   });
 
-  // ── Follow-ups API ─────────────────────────────────────────────
-  test('POST /api/admin/followups/create returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/followups/create`, {
-      form: { reason: 'test', dueDate: '2026-05-01' },
-    });
-    expect([401, 403]).toContain(res.status());
-  });
-
-  test('POST /api/admin/followups/update returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/followups/update`, { form: { id: '1', done: 'true' } });
-    expect([401, 403]).toContain(res.status());
-  });
-
-  test('POST /api/admin/followups/delete returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/followups/delete`, { form: { id: '1' } });
-    expect([401, 403]).toContain(res.status());
-  });
-
-  test('POST /api/admin/followups/notify returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/followups/notify`, { form: { id: '1' } });
-    expect([401, 403]).toContain(res.status());
-  });
-
   // ── Time tracking (Zeiterfassung) API ─────────────────────────
   test('POST /api/admin/zeiterfassung/create returns 401/403 without auth', async ({ request }) => {
     const res = await request.post(`${BASE}/api/admin/zeiterfassung/create`, { form: { projectId: '1', minutes: '60' } });
@@ -93,23 +70,7 @@ test.describe('FA: Admin CRM & operations pages', { tag: ['@admin', '@crm'] }, (
     expect([401, 403]).toContain(res.status());
   });
 
-  // ── Rooms API ─────────────────────────────────────────────────
-  test('GET /api/admin/rooms returns 401/403 without auth', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/rooms`);
-    expect([401, 403]).toContain(res.status());
-  });
-
-  test('POST /api/admin/rooms/direct returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/rooms/direct`, { data: { userId: 'test' } });
-    expect([401, 403]).toContain(res.status());
-  });
-
   // ── Meetings API ──────────────────────────────────────────────
-  test('GET /api/admin/meetings returns 401/403 without auth', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/meetings`);
-    expect([401, 403]).toContain(res.status());
-  });
-
   test('GET /api/admin/meetings/:id returns 401/403 without auth', async ({ request }) => {
     const res = await request.get(`${BASE}/api/admin/meetings/00000000-0000-0000-0000-000000000000`);
     expect([401, 403, 404]).toContain(res.status());
@@ -118,12 +79,6 @@ test.describe('FA: Admin CRM & operations pages', { tag: ['@admin', '@crm'] }, (
   // ── Inbox API ─────────────────────────────────────────────────
   test('GET /api/admin/inbox returns 401/403 without auth', async ({ request }) => {
     const res = await request.get(`${BASE}/api/admin/inbox`);
-    expect([401, 403]).toContain(res.status());
-  });
-
-  // ── Staleness / monitoring API ────────────────────────────────
-  test('GET /api/admin/staleness-report returns 401/403 without auth', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/staleness-report`);
     expect([401, 403]).toContain(res.status());
   });
 });

--- a/tests/e2e/specs/fa-admin-db-crud-clients.spec.ts
+++ b/tests/e2e/specs/fa-admin-db-crud-clients.spec.ts
@@ -10,6 +10,7 @@
 // Skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
@@ -17,8 +18,7 @@ const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/clients`);
-  await page.waitForURL(/\/admin\/clients/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/clients');
 }
 
 test.describe('FA-admin-db-crud-clients', () => {

--- a/tests/e2e/specs/fa-admin-db-crud-followups.spec.ts
+++ b/tests/e2e/specs/fa-admin-db-crud-followups.spec.ts
@@ -7,6 +7,7 @@
 // Skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
@@ -14,8 +15,7 @@ const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/followups`);
-  await page.waitForURL(/\/admin\/followups/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/followups');
 }
 
 test.describe('FA-admin-db-crud-followups', () => {
@@ -104,8 +104,7 @@ test.describe('FA-admin-db-crud-followups', () => {
     );
 
     // Re-authenticate to /admin/projekte for this sub-test
-    await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/projekte`);
-    await page.waitForURL(/\/admin\/projekte/, { timeout: 60_000 });
+    await loginViaE2E(page, BASE, ADMIN_USER, '/admin/projekte');
 
     const ts          = Date.now();
     const projectName = `e2e-zeit-projekt-${ts}`;

--- a/tests/e2e/specs/fa-admin-db-crud-projekte.spec.ts
+++ b/tests/e2e/specs/fa-admin-db-crud-projekte.spec.ts
@@ -7,6 +7,7 @@
 // Skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
@@ -14,8 +15,7 @@ const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/projekte`);
-  await page.waitForURL(/\/admin\/projekte/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/projekte');
 }
 
 test.describe('FA-admin-db-crud-projekte', () => {

--- a/tests/e2e/specs/fa-admin-db-crud-shortcuts.spec.ts
+++ b/tests/e2e/specs/fa-admin-db-crud-shortcuts.spec.ts
@@ -12,6 +12,7 @@
 // Skips gracefully when E2E_ADMIN_PASS is unset (CI without secrets).
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
@@ -19,8 +20,7 @@ const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin`);
-  await page.waitForURL(/\/admin/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin');
 }
 
 test.describe('FA-admin-db-crud-shortcuts', () => {

--- a/tests/e2e/specs/fa-admin-knowledge-model-selection.spec.ts
+++ b/tests/e2e/specs/fa-admin-knowledge-model-selection.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 
 const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
@@ -6,8 +7,7 @@ const ADMIN_USER = process.env.E2E_ADMIN_USER ?? 'paddione';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS;
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/wissensquellen`);
-  await page.waitForURL(/\/admin\/wissensquellen/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/wissensquellen');
 }
 
 test.describe('Wissensquellen admin — Embedding Model Selection', { tag: ['@admin'] }, () => {

--- a/tests/e2e/specs/fa-admin-tickets.spec.ts
+++ b/tests/e2e/specs/fa-admin-tickets.spec.ts
@@ -22,6 +22,7 @@
 // immediately so the next test starts clean.
 
 import { test, expect } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 import { seedAdminTicket, cleanupSeedTicket, seedAvailable } from '../lib/e2e-seed';
 
@@ -45,8 +46,7 @@ async function mailpitReachable(request: import('@playwright/test').APIRequestCo
 }
 
 async function loginAsAdmin(page: import('@playwright/test').Page) {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/tickets`);
-  await page.waitForURL(/\/admin\/tickets/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/tickets');
 }
 
 test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {

--- a/tests/e2e/specs/fa-bugs-notifications.spec.ts
+++ b/tests/e2e/specs/fa-bugs-notifications.spec.ts
@@ -32,6 +32,7 @@
 
 import { test, expect } from '@playwright/test';
 import { Pool } from 'pg';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 import { markerAvailable } from '../lib/e2e-marker';
 
@@ -58,9 +59,7 @@ async function mailpitReachable(request: import('@playwright/test').APIRequestCo
 }
 
 async function loginAsAdmin(page: import('@playwright/test').Page): Promise<void> {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin/bugs`);
-  // /admin/bugs is a 301 redirect to /admin/tickets; both match /\/admin/.
-  await page.waitForURL(/\/admin/, { timeout: 60_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, '/admin/bugs');
 }
 
 test.describe('FA-bug-notify', () => {

--- a/tests/e2e/specs/fa-fragebogen.spec.ts
+++ b/tests/e2e/specs/fa-fragebogen.spec.ts
@@ -1,5 +1,6 @@
 // tests/e2e/specs/fa-fragebogen.spec.ts
 import { test, expect, type Page } from '@playwright/test';
+import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 import { Pool } from 'pg';
 
@@ -13,8 +14,7 @@ const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL ?? 'p.korczewski@gmail.com';
 const isProd = BASE.includes('mentolder.de') || BASE.includes('korczewski.de');
 
 async function loginAsAdmin(page: Page, returnTo: string): Promise<void> {
-  await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=${encodeURIComponent(returnTo)}`);
-  await page.waitForURL(new RegExp(returnTo.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')), { timeout: 20_000 });
+  await loginViaE2E(page, BASE, ADMIN_USER, returnTo);
 }
 
 // ── Auth gating ─────────────────────────────────────────────────────────────

--- a/tests/e2e/specs/korczewski-auth-setup.spec.ts
+++ b/tests/e2e/specs/korczewski-auth-setup.spec.ts
@@ -19,6 +19,7 @@
 import { test as setup, expect } from '@playwright/test';
 import * as path from 'path';
 import * as fs from 'fs';
+import { loginViaE2E } from '../lib/auth';
 import { assertReachable } from '../lib/health-assertions';
 
 const WEBSITE_URL = (process.env.KORCZEWSKI_URL ?? 'https://web.korczewski.de').replace(/\/$/, '');
@@ -51,11 +52,7 @@ setup('authenticate korczewski website admin', async ({ page, request }, testInf
   }
 
   // E2E login via /api/auth/e2e-login (bypasses Pocket ID passkey flow)
-  await page.goto(
-    `${WEBSITE_URL}/api/auth/e2e-login?username=${encodeURIComponent(ADMIN_USER)}&returnTo=/admin`,
-    { waitUntil: 'domcontentloaded' },
-  );
-  await page.waitForURL(new RegExp(WEBSITE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), { timeout: 60_000 });
+  await loginViaE2E(page, WEBSITE_URL, ADMIN_USER, '/admin');
   await page.waitForLoadState('load', { timeout: 60_000 });
 
   // Verify we have a session (the /api/auth/me endpoint returns { authenticated: true })


### PR DESCRIPTION
## Summary
- Replaced 15 inline page.goto(...e2e-login...) patterns with loginViaE2E from lib/auth.ts, ensuring the ?token= param is always sent when CRON_SECRET is set
- Removed 8 fa-admin-crm tests for API endpoints that no longer exist
- Updated GitHub Actions CRON_SECRET to match production cluster value

## Test Plan
- [ ] CI green