### PR TITLE
chore(ops): Health-Goal-Scopes G-E2E/G-OPS/G-DB11 aufnehmen (E2E-Suite, Cluster-Runtime, Restore-Verify) [T002063]

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -31,11 +31,97 @@ Ein Ziel ohne reproduzierbaren Mess-Befehl ist kein Ziel, sondern ein Wunsch.
 Sofort angehen. Ticket-Erstellung ist **bewusst manuell** (`scripts/health-goals-update.sh
 --suggest-tickets`, dedupliziert gegen offene Tickets) — kein Ziel erzeugt automatisch ein Ticket.
 
+## G-E2E01 — Nightly-E2E-Erfolgsrate (e2e.yml, letzte 14 Läufe): 0 % → ≥ 90 %
+
+**Was:** Anteil erfolgreicher Läufe des nächtlichen Playwright-E2E-Workflows (`e2e.yml`,
+beide Brands auf fleet) über die letzten 14 Läufe. G-CI01–03 messen ausschließlich `ci.yml` —
+die E2E-Suite lief zum Aufnahme-Zeitpunkt **14/14 rot** (Auth-Token/CRON_SECRET-Drift, Fix
+in Arbeit auf `fix/e2e-auth-token-and-cron-secret`), ohne dass irgendein Goal es sichtbar
+machte. Genau diese Lücke schließt das Ziel.
+
+```bash
+gh run list --workflow e2e.yml --limit 14 --json conclusion \
+  | python3 -c "import json,sys; r=[x['conclusion'] for x in json.load(sys.stdin) if x.get('conclusion')]; print(round(100*sum(1 for c in r if c=='success')/len(r)) if r else 'n/a')"
+```
+
+> **A · Baseline:** 0 (0/14 grün, 2026-07-22) · **Target:** ≥ 90 · **Aufwand:** mittel · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002063 (Aufnahme; Suite-Fix läuft separat über `fix/e2e-auth-token-and-cron-secret`)
+
 ---
 
 # Priorität B — Offene Ziele {#prio-b}
 
 Im nächsten Sprint einplanen.
+
+## G-E2E02 — E2E-Testdaten-Leak in Prod (is_test_data-Rows): 2 → 0
+
+**Was:** Summe aller Rows mit `is_test_data=true` über sämtliche Basistabellen mit dieser
+Spalte, je Brand-DB. Playwright bracketet Testdaten via
+`/api/admin/systemtest/purge-all-test-data` (globalSetup + globalTeardown), aber ein
+abgebrochener Lauf oder ein Purge-Fehler (Präzedenz T001453) lässt Testdaten in Prod
+zurück. Baseline 2026-07-22: je 1 Row in `public.inbox_items` (mentolder und korczewski).
+Während eines aktiven Nightly-E2E-Laufs sind transiente Treffer erwartbar — Messzeitpunkt
+tagsüber. Korczewski via `HG_DB_NS=workspace-korczewski` messen.
+
+```sql
+SELECT COALESCE(sum((xpath('/row/c/text()', query_to_xml(format(
+  'SELECT count(*) AS c FROM %I.%I WHERE is_test_data', c.table_schema, c.table_name),
+  false, true, '')))[1]::text::int), 0)
+FROM information_schema.columns c
+JOIN information_schema.tables t ON t.table_schema=c.table_schema AND t.table_name=c.table_name
+WHERE c.column_name='is_test_data' AND t.table_type='BASE TABLE';
+```
+
+> **B · Baseline:** 2 (1 mentolder + 1 korczewski, jeweils public.inbox_items, 2026-07-22) · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002063
+
+## G-OPS01 — Pods nicht Running/Ready (fleet, beide Brand-Namespaces): 3 → 0
+
+**Was:** Zählt Pods in `workspace` + `workspace-korczewski`, deren Phase nicht
+Running/Succeeded ist oder deren Container nicht ready sind. Alle G-K8S-Goals prüfen nur
+Manifeste (YAML) — dieses Ziel schaut erstmals auf den Live-Zustand des Clusters.
+Baseline 2026-07-22: `workspace/livekit-egress-…` (Pending), `workspace/test-pod`
+(Failed — Debris), `workspace-korczewski/oauth2-proxy-terminal-…` (Pending).
+
+```bash
+python3 -c "
+import json,subprocess
+n=0
+for ns in ('workspace','workspace-korczewski'):
+    d=json.loads(subprocess.check_output(['kubectl','get','pods','-n',ns,'--context','fleet','-o','json']))
+    for p in d['items']:
+        ph=p['status'].get('phase')
+        if ph=='Succeeded': continue
+        cs=p['status'].get('containerStatuses',[])
+        if ph!='Running' or any(not c.get('ready') for c in cs): n+=1
+print(n)"
+```
+
+> **B · Baseline:** 3 (2026-07-22) · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002063
+
+## G-DB11 — Tage seit letztem erfolgreichem Restore-Verify: n/a → ≤ 30
+
+**Was:** G-DB04 misst nur das *Alter* des letzten Backups — ob ein Backup tatsächlich
+restaurierbar ist, prüft `bash scripts/backup-restore.sh verify <timestamp> <db>`
+(spielt das verschlüsselte Dump in eine Wegwerf-DB ein, zählt Tabellen, dropt sie).
+Der Verify-Job stempelt seit T002063 bei Erfolg den ConfigMap `recovery-verify-status`
+(`last_success`, ISO-UTC) im Workspace-Namespace; gemessen wird dessen Alter in Tagen.
+Ein Backup, das nie probeweise restauriert wurde, ist nach der eigenen Maxime dieses
+Dokuments kein Backup, sondern ein Wunsch.
+
+```bash
+ts=$(kubectl get configmap recovery-verify-status -n workspace --context fleet \
+  -o jsonpath='{.data.last_success}' 2>/dev/null)
+[ -n "$ts" ] && echo $(( ($(date -u +%s) - $(date -u -d "$ts" +%s)) / 86400 )) || echo n/a
+```
+
+**Erster Verify-Lauf (2026-07-22, Backup `20260722-000016`, website): FEHLGESCHLAGEN.**
+`pg_restore` bricht beim `CREATE INDEX chunks_embedding_hnsw` (pgvector HNSW auf
+`knowledge.chunks`) ab — `could not resize shared memory segment … 64000064 bytes: No space
+left on device`. Das shared-db-`/dev/shm` ist das 64M-k8s-Default; das website-Backup ist
+damit aktuell **nicht vollständig restaurierbar** → Bug **T002064**. Nebenbefund gefixt:
+der Verify-Job ließ bei Abbruch die Wegwerf-DB (`website_verify_781884`) zurück —
+cleanup-`trap` in `backup-restore-lib.sh` ergänzt, Leiche manuell gedroppt.
+
+> **B · Baseline:** n/a · **Target:** ≤ 30 · **Aufwand:** gering (monatlicher `verify`-Lauf, ~2–10 min Job-Laufzeit) · **Messzyklus:** monatlich · **Reproduzierbar:** ja · **Ticket:** T002063 · Verify-Blocker: **T002064** (shared-db /dev/shm)
 
 ## G-SIZE02 — Großdateien außerhalb Gate-Scope (>1000 Zeilen): 3 → ≤ 3
 
@@ -304,6 +390,8 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-BRAIN12** | Brain-Manifest-Gruppen ohne Treffer (Ingest-Drift) | 0 ✓ | 0 | `bash scripts/brain-ingest-worklist.sh >/dev/null 2>&1 \| stderr-Warnungen 'hat 0 Treffer' zählen` |
 | **G-BRAIN13** | Brain-Merge-Hook-Pfad-Parität (Trigger ↔ Handler) | 0 ✓ | 0 | `paths:-Globs in .github/workflows/brain-merge-hook.yml gegen brain-merge-hook.sh-SRC-Argumente (sym. Diff)` |
 | **G-BRAIN15** | Brain-Seed-Template-Lint grün | Exit 0 ✓ | Exit 0 | `bash templates/brain/scripts/lint-frontmatter.sh templates/brain && bash templates/brain/scripts/lint-wikilinks.sh templates/brain` |
+| **G-OPS02** | Container-Restarts <24h (fleet, beide Brands) | 1 ✓ | ≤ 3 | `kubectl get pods -o json` + Python-Filter `lastState.terminated.finishedAt` < 24h (health-goals-check.sh) |
+| **G-OPS03** | Live-TLS-Cert-Restlaufzeit (Tage, min beider Brands) | 37 ✓ | ≥ 14 | `echo \| openssl s_client -servername web.<brand>.de -connect …:443 \| openssl x509 -enddate -noout` (health-goals-check.sh, mit Retry gegen Multi-A-Record-Transienten) |
 
 ---
 
@@ -319,8 +407,8 @@ bash scripts/health-goals-check.sh --only=G-RH01,G-CQ02
 **Messzyklus:**
 - **Pro Merge (CI-Gate):** G-RH02/07, G-TEST02/04, G-CQ04, G-SEC01/02, G-K8S04, G-CFG01, G-CI02, G-GIT02, G-SPEC01
 - **Täglich:** G-RH06, G-CI02, G-DB04, G-GIT01, G-CI03
-- **Wöchentlich:** G-RH01/03, G-TEST01/03, G-SIZE03, G-CI01, G-CD01, G-CQ02/05, G-IMG01, G-K8S03, G-SPEC03, G-GIT03, G-FE03/04, G-DB01, G-DB03, G-DB06, G-DB08, G-DB09, G-DB10, G-SEC06, G-FE05, G-BRAIN12, G-BRAIN13, G-BRAIN15
-- **Monatlich/Quartal:** G-DEP02, G-SEC03/04, G-DOC02, G-FE01/02, G-BRAIN14, G-AGENTIC09
+- **Wöchentlich:** G-RH01/03, G-TEST01/03, G-SIZE03, G-CI01, G-CD01, G-CQ02/05, G-IMG01, G-K8S03, G-SPEC03, G-GIT03, G-FE03/04, G-DB01, G-DB03, G-DB06, G-DB08, G-DB09, G-DB10, G-SEC06, G-FE05, G-BRAIN12, G-BRAIN13, G-BRAIN15, G-E2E01, G-E2E02, G-OPS01, G-OPS02, G-OPS03
+- **Monatlich/Quartal:** G-DEP02, G-SEC03/04, G-DOC02, G-FE01/02, G-BRAIN14, G-AGENTIC09, G-DB11
 
 **Sprint-Highlights 2026-07-01:** G-CI01 erreicht Target (85 %→95 %, 19/20 grün) und wechselt von Prio A nach Prio C. G-RH03 (OpenSpec-BATS-Abdeckung 50 %→82 %) und G-DEP02 (Major-Deps 9→2) erreichen ihr Target und wechseln von Prio B nach Prio C. G-CQ01 erstmals gemessen: 0 astro-check-Fehler. G-CQ02 (explizite `any`) fällt weiter von 154 auf 8. G-GIT03 (Dateien >1MB) erreicht Target 7→6 per Policy-Ausschluss von `.codebase-memory/` (T001348) und wechselt von Prio A nach Prio C. G-SEC05-Messfehler dokumentiert: das Skript filtert nur eine von zwei GitHub-Actions-Bot-Mail-Varianten heraus, wodurch 4 Bot-Commits fälschlich als unsigniert zählen — echter Wert 0/50, Skript-Fix noch offen.
 
@@ -433,3 +521,21 @@ Target 90 — echte Optimierung ist bewusst nicht Teil dieses Chores; Follow-up-
 **Baseline-Update 2026-07-19 (T001950 — Live-Bestätigung nach Deploy):** G-FE05 **89→90 ✅ Target erreicht.** Nach Merge von PR #2948 (Auto-Deploy via `build-website.yml`, beide Brand-Jobs `Deploy Website (mentolder)`/`Deploy Website (korczewski)` grün) erneut 3× `npx @lhci/cli autorun --collect.numberOfRuns=3` gegen `https://web.mentolder.de` gemessen: Performance-Score konstant **90/100** über alle 3 Läufe (FCP 2.0s, LCP 3.0–3.1s). Live-HTML bestätigt den Fix: `sidekick-panels.css` wird per `<link rel="preload" as="style" onload="this.rel='stylesheet'">` + `<noscript>`-Fallback geladen, keine blockierende `<link rel="stylesheet">`-Variante mehr im `<head>`. G-FE05 wechselt von Prio B/A nach Prio C (Green Gate).
 
 **Baseline-Update 2026-07-21:** G-AGENTIC08 1→0 (toter Script-Pfad `scripts/openspec-validate.sh` in `openspec-propose/SKILL.md` zu `scripts/openspec.sh validate` korrigiert); G-DB04 1h→13h (Backup-Alter 13h, weiterhin im Target ≤26h); G-DEP04 2→0 (package.json engines korrigiert, Gate grün); G-CQ06 1→0 (@deprecated stripeServiceKey entfernt); G-CQ02 8→0 (any-Typen und comment-false-positives behoben); alle Prio-C-Gates grün via `scripts/health-goals-check.sh` verifiziert.
+
+**Baseline-Update 2026-07-22 (T002063 — neue Scopes E2E/OPS/Restore):** Drei neue Goal-Scopes
+aufgenommen, die die Laufzeit-Perspektive abdecken (bisher maßen nur die G-DB-Goals gegen
+Live-Systeme): **G-E2E01** Nightly-E2E-Erfolgsrate `e2e.yml` — Baseline **0 % (0/14 grün)**,
+direkte Prio A (aktive Verletzung; Fix läuft über `fix/e2e-auth-token-and-cron-secret`).
+**G-E2E02** E2E-Testdaten-Leak (is_test_data-Rows in Prod) — Baseline 2 (je 1×
+`public.inbox_items` in beiden Brand-DBs), Prio B. **G-OPS01** Pods nicht Running/Ready —
+Baseline 3 (`livekit-egress` Pending, `test-pod` Failed/Debris, `oauth2-proxy-terminal`
+Pending), Prio B. **G-OPS02** Container-Restarts <24h — 1 ≤ 3 ✓ (Green Gate). **G-OPS03**
+Live-TLS-Cert-Restlaufzeit — 37 Tage ≥ 14 ✓ (Green Gate; erste Messung gegen
+`web.korczewski.de` schlug transient fehl → Messung mit Retry). **G-DB11** Tage seit letztem
+Restore-Verify — n/a (Marker-ConfigMap `recovery-verify-status` wird ab jetzt von
+`backup-restore-lib.sh cmd_recovery_verify` bei Erfolg gestempelt; erster `verify`-Lauf
+ausstehend), Prio B. Alle sechs in `scripts/health-goals-check.sh` verdrahtet
+(kubectl/gh/openssl-Checks SKIPpen bei `--fast` oder fehlender Erreichbarkeit).
+Der erste G-DB11-Verify-Lauf schlug direkt fehl (shared-db `/dev/shm` 64M zu klein für den
+HNSW-Index-Build — website-Backup aktuell nicht vollständig restaurierbar, Bug **T002064**);
+Nebenbefund Wegwerf-DB-Leiche bei Job-Abbruch via cleanup-`trap` gefixt.

--- a/scripts/backup-restore-lib.sh
+++ b/scripts/backup-restore-lib.sh
@@ -87,6 +87,10 @@ spec:
               ENC="/backups/${TS}/${DB}.dump.enc"
               [ -f "\$ENC" ] || { echo "ERROR: \$ENC not found"; exit 1; }
               TMP=${DB}_verify_$$
+              # Cleanup auch bei pg_restore-Abbruch — sonst bleibt die Wegwerf-DB als
+              # Leiche auf shared-db zurück (Vorfall 2026-07-22: website_verify_781884)
+              cleanup() { PGPASSWORD="\$SHARED_DB_PASSWORD" dropdb -h shared-db -U postgres --if-exists "\$TMP"; rm -f /tmp/${DB}.dump; }
+              trap cleanup EXIT
               openssl enc -d -aes-256-cbc -pbkdf2 -in "\$ENC" -out /tmp/${DB}.dump -pass env:BACKUP_PASSPHRASE
               PGPASSWORD="\$SHARED_DB_PASSWORD" createdb -h shared-db -U postgres "\$TMP"
               PGPASSWORD="\$SHARED_DB_PASSWORD" pg_restore -h shared-db -U postgres -d "\$TMP" --no-owner --exit-on-error /tmp/${DB}.dump
@@ -117,6 +121,13 @@ YAML
     echo "    ✗ ${DB} dump FAILED to restore — backup is NOT trustworthy"; $KC logs -n "$NS" -l "job-name=${JOB}" --tail=50 2>/dev/null || true; exit 1
   fi
   $KC logs -n "$NS" -l "job-name=${JOB}" 2>/dev/null || true
+  # Erfolg persistent stempeln — Mess-Anker für Health-Goal G-DB11 (der Job selbst
+  # verschwindet nach ttlSecondsAfterFinished=600 und hinterlässt sonst keine Spur)
+  $KC create configmap recovery-verify-status -n "$NS" \
+    --from-literal=last_success="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --from-literal=db="$DB" --from-literal=backup_ts="$TS" \
+    --dry-run=client -o yaml | $KC apply -n "$NS" -f - >/dev/null \
+    || echo "    (Warnung: recovery-verify-status ConfigMap konnte nicht aktualisiert werden — G-DB11-Messung bleibt stale)"
 }
 
 cmd_recovery_browse() {

--- a/scripts/gen-goals-data.mjs
+++ b/scripts/gen-goals-data.mjs
@@ -54,10 +54,13 @@ const CATEGORY_MAP = {
   CFG: 'Konfiguration',
   DORA: 'CI/CD',
   FE: 'Frontend',
+  E2E: 'Test-Health',
+  OPS: 'Infrastruktur',
 };
 
 function categoryFor(id) {
-  const m = id.match(/^G-([A-Za-z]+)/);
+  // Non-greedy + \d*$ erlaubt Ziffern im Präfix selbst (G-E2E01 → "E2E", nicht "E")
+  const m = id.match(/^G-([A-Za-z][A-Za-z0-9]*?)\d*$/);
   return (m && CATEGORY_MAP[m[1]]) || 'Sonstige';
 }
 

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -117,6 +117,70 @@ db_backup_age_h() {
   now=$(date -u +%s)
   echo $(( (now - epoch) / 3600 ))
 }
+restore_verify_age_d() { # G-DB11 — Alter des recovery-verify-status-Stempels in Tagen
+  [ "$FAST" = 1 ] && { echo "-"; return; }
+  command -v kubectl >/dev/null 2>&1 || { echo "-"; return; }
+  local ts epoch
+  ts=$(kubectl get configmap recovery-verify-status -n "$DB_NS" --context "$DB_CTX" \
+         --request-timeout=5s -o jsonpath='{.data.last_success}' 2>/dev/null)
+  [ -n "$ts" ] || { echo "-"; return; }
+  epoch=$(date -u -d "$ts" +%s 2>/dev/null) || { echo "-"; return; }
+  echo $(( ($(date -u +%s) - epoch) / 86400 ))
+}
+
+# ── Cluster-Runtime-Mess-Helfer (read-only; SKIP bei --fast oder Cluster unerreichbar) ──
+OPS_CTX="${HG_OPS_CTX:-fleet}"; OPS_NS_LIST="${HG_OPS_NS:-workspace workspace-korczewski}"
+ops_kubectl_count() { # $1=not_ready|restarts_24h — zählt über alle OPS-Namespaces
+  [ "$FAST" = 1 ] && { echo "-"; return; }
+  command -v kubectl >/dev/null 2>&1 || { echo "-"; return; }
+  python3 - "$1" "$OPS_CTX" $OPS_NS_LIST <<'PY' 2>/dev/null || echo "-"
+import json,subprocess,sys,datetime
+mode,ctx=sys.argv[1],sys.argv[2]
+now=datetime.datetime.now(datetime.timezone.utc); n=0
+for ns in sys.argv[3:]:
+    d=json.loads(subprocess.check_output(
+        ["kubectl","get","pods","-n",ns,"--context",ctx,"--request-timeout=10s","-o","json"],
+        stderr=subprocess.DEVNULL))
+    for p in d["items"]:
+        ph=p["status"].get("phase")
+        cs=p["status"].get("containerStatuses",[])
+        if mode=="not_ready":
+            if ph=="Succeeded": continue
+            if ph!="Running" or any(not c.get("ready") for c in cs): n+=1
+        else:
+            for c in cs:
+                t=c.get("lastState",{}).get("terminated",{}).get("finishedAt")
+                if t and (now-datetime.datetime.fromisoformat(t.replace('Z','+00:00'))).total_seconds()<86400: n+=1
+print(n)
+PY
+}
+tls_min_days() { # G-OPS03 — min. Restlaufzeit über beide Brand-Frontends, 1 Retry pro Host
+  [ "$FAST" = 1 ] && { echo "-"; return; }
+  command -v openssl >/dev/null 2>&1 || { echo "-"; return; }
+  local d exp days try min=""
+  for d in ${HG_TLS_HOSTS:-web.mentolder.de web.korczewski.de}; do
+    exp=""
+    for try in 1 2; do # Retry: Multi-A-Record-Setups antworten transient nicht (2026-07-22)
+      exp=$(echo | timeout 10 openssl s_client -servername "$d" -connect "$d":443 2>/dev/null \
+              | openssl x509 -enddate -noout 2>/dev/null | cut -d= -f2)
+      [ -n "$exp" ] && break
+    done
+    [ -n "$exp" ] || { echo "-"; return; }
+    days=$(( ($(date -d "$exp" +%s) - $(date +%s)) / 86400 ))
+    if [ -z "$min" ] || [ "$days" -lt "$min" ]; then min=$days; fi
+  done
+  echo "${min:--}"
+}
+e2e_success_rate() { # G-E2E01 — %-Erfolgsrate der letzten 14 e2e.yml-Läufe
+  [ "$FAST" = 1 ] && { echo "-"; return; }
+  command -v gh >/dev/null 2>&1 || { echo "-"; return; }
+  local out; out=$(gh run list --workflow e2e.yml --limit 14 --json conclusion 2>/dev/null)
+  [ -n "$out" ] || { echo "-"; return; }
+  echo "$out" | python3 -c "
+import json,sys
+r=[x['conclusion'] for x in json.load(sys.stdin) if x.get('conclusion')]
+print(round(100*sum(1 for c in r if c=='success')/len(r)) if r else '-')" 2>/dev/null || echo "-"
+}
 
 [ "$QUIET" = 0 ] && printf "%sRepository-Health — reproduzierbare Ziele (.claude/lib/goals.md)%s\n\n" "$C_B" "$C_X"
 
@@ -283,6 +347,10 @@ row gate G-DB06 "$(db_scalar "SELECT
 + (SELECT count(*) FROM tickets.ticket_links l    WHERE l.from_id  IS NOT NULL AND NOT EXISTS (SELECT 1 FROM tickets.tickets t WHERE t.id=l.from_id));")" eq 0 "Orphan-Rows (ticket_plans/comments/links → tickets)"
 row gate G-DB04 "$(db_backup_age_h)" le 26 "Backup-Alter (h) seit letztem erfolgr. db-backup-Job — T001738"
 
+# ── Cluster-Runtime — GATES (G-OPS02/03; G-OPS01 ist Prio B → TARGET unten) ──
+row gate G-OPS02 "$(ops_kubectl_count restarts_24h)" le 3 "Container-Restarts <24h (fleet, beide Brand-Namespaces)"
+row gate G-OPS03 "$(tls_min_days)" ge 14 "Live-TLS-Cert-Restlaufzeit (Tage, min beider Brand-Frontends)"
+
 # ── TARGETS (Reduktionsziele in Arbeit) ────────────────────────────────────────
 [ "$QUIET" = 0 ] && printf "\n%sTARGETS (Reduktion)%s\n" "$C_B" "$C_X"
 
@@ -344,6 +412,12 @@ row target G-DB08 "$(db_scalar "SELECT count(*) FROM pg_stat_user_tables
       AND (seq_scan::numeric/NULLIF(seq_scan+idx_scan,0))>0.05;")" le 3 "Tabellen >10k Rows mit Seq-Scan-Anteil >5% (messen)"
 row target G-DB09 "$(db_scalar "SELECT count(*) FROM pg_stat_statements WHERE mean_exec_time > 1000 AND query NOT ILIKE 'COPY %'")" le 0 "Slow Queries in pg_stat_statements (mean_exec_time > 1s, exkl. Backup-COPY T001926)"
 row target G-DB10 "$(db_scalar "SELECT count(*) FROM pg_stat_user_indexes WHERE idx_scan = 0 AND indisready AND NOT indisprimary AND indexrelid NOT IN (SELECT conindid FROM pg_constraint WHERE contype='u')")" le 0 "Unused Indexes (idx_scan=0, exkl. PK/Unique)"
+row target G-DB11 "$(restore_verify_age_d)" le 30 "Tage seit letztem erfolgreichem Restore-Verify (recovery-verify-status)"
+
+# ── E2E-/OPS-TARGETS (T002063) ──
+row target G-E2E01 "$(e2e_success_rate)" ge 90 "Nightly-E2E-Erfolgsrate e2e.yml (%, letzte 14 Läufe)"
+row target G-E2E02 "$(db_scalar "SELECT COALESCE(sum((xpath('/row/c/text()', query_to_xml(format('SELECT count(*) AS c FROM %I.%I WHERE is_test_data', c.table_schema, c.table_name), false, true, '')))[1]::text::int), 0) FROM information_schema.columns c JOIN information_schema.tables t ON t.table_schema=c.table_schema AND t.table_name=c.table_name WHERE c.column_name='is_test_data' AND t.table_type='BASE TABLE'")" eq 0 "E2E-Testdaten-Leak (is_test_data=true Rows, Brand-DB via HG_DB_NS)"
+row target G-OPS01 "$(ops_kubectl_count not_ready)" le 0 "Pods nicht Running/Ready (fleet, beide Brand-Namespaces)"
 
 # ── CI-TARGETS ──
 row target G-CI03 "$(

--- a/website/src/lib/goals-data.generated.json
+++ b/website/src/lib/goals-data.generated.json
@@ -1,5 +1,65 @@
 [
   {
+    "id": "G-E2E01",
+    "title": "Nightly-E2E-Erfolgsrate (e2e.yml, letzte 14 Läufe)",
+    "category": "Test-Health",
+    "priority": "A",
+    "direction": "higher",
+    "baseline": 0,
+    "current": 0,
+    "target": 90,
+    "unit": "",
+    "status": "unknown",
+    "measurement": "gh run list --workflow e2e.yml --limit 14 --json conclusion \\\n  | python3 -c \"import json,sys; r=[x['conclusion'] for x in json.load(sys.stdin) if x.get('conclusion')]; print(round(100*sum(1 for c in r if c=='success')/len(r)) if r else 'n/a')\"",
+    "source": ".claude/lib/goals.md · G-E2E01",
+    "measured_at": "2026-07-22"
+  },
+  {
+    "id": "G-E2E02",
+    "title": "E2E-Testdaten-Leak in Prod (is_test_data-Rows)",
+    "category": "Test-Health",
+    "priority": "B",
+    "direction": "lower",
+    "baseline": 2,
+    "current": 2,
+    "target": 0,
+    "unit": "",
+    "status": "unknown",
+    "measurement": "SELECT COALESCE(sum((xpath('/row/c/text()', query_to_xml(format(\n  'SELECT count(*) AS c FROM %I.%I WHERE is_test_data', c.table_schema, c.table_name),\n  false, true, '')))[1]::text::int), 0)\nFROM information_schema.columns c\nJOIN information_schema.tables t ON t.table_schema=c.table_schema AND t.table_name=c.table_name\nWHERE c.column_name='is_test_data' AND t.table_type='BASE TABLE';",
+    "source": ".claude/lib/goals.md · G-E2E02",
+    "measured_at": "2026-07-22"
+  },
+  {
+    "id": "G-OPS01",
+    "title": "Pods nicht Running/Ready (fleet, beide Brand-Namespaces)",
+    "category": "Infrastruktur",
+    "priority": "B",
+    "direction": "lower",
+    "baseline": 3,
+    "current": 3,
+    "target": 0,
+    "unit": "",
+    "status": "unknown",
+    "measurement": "python3 -c \"\nimport json,subprocess\nn=0\nfor ns in ('workspace','workspace-korczewski'):\n    d=json.loads(subprocess.check_output(['kubectl','get','pods','-n',ns,'--context','fleet','-o','json']))\n    for p in d['items']:\n        ph=p['status'].get('phase')\n        if ph=='Succeeded': continue\n        cs=p['status'].get('containerStatuses',[])\n        if ph!='Running' or any(not c.get('ready') for c in cs): n+=1\nprint(n)\"",
+    "source": ".claude/lib/goals.md · G-OPS01",
+    "measured_at": "2026-07-22"
+  },
+  {
+    "id": "G-DB11",
+    "title": "Tage seit letztem erfolgreichem Restore-Verify",
+    "category": "Datenbank",
+    "priority": "B",
+    "direction": "lower",
+    "baseline": null,
+    "current": null,
+    "target": 30,
+    "unit": "",
+    "status": "unknown",
+    "measurement": "ts=$(kubectl get configmap recovery-verify-status -n workspace --context fleet \\\n  -o jsonpath='{.data.last_success}' 2>/dev/null)\n[ -n \"$ts\" ] && echo $(( ($(date -u +%s) - $(date -u -d \"$ts\" +%s)) / 86400 )) || echo n/a",
+    "source": ".claude/lib/goals.md · G-DB11",
+    "measured_at": "2026-07-22"
+  },
+  {
     "id": "G-SIZE02",
     "title": "Großdateien außerhalb Gate-Scope (>1000 Zeilen)",
     "category": "Code-Größe",
@@ -12,7 +72,7 @@
     "status": "unknown",
     "measurement": "git ls-files VideoVault .opencode | grep -E '\\.(ts|tsx|js|mjs|svelte|sh|py)$' \\\n  | grep -v node_modules \\\n  | while read -r f; do [ -L \"$f\" ] || echo \"$f\"; done \\\n  | xargs wc -l 2>/dev/null | grep -v ' total$' | awk '$1>1000' | wc -l",
     "source": ".claude/lib/goals.md · G-SIZE02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB01",
@@ -27,7 +87,7 @@
     "status": "unknown",
     "measurement": "WITH fk AS (\n  SELECT c.conrelid AS relid, c.conkey[1] AS col FROM pg_constraint c\n  JOIN pg_class t ON t.oid=c.conrelid JOIN pg_namespace n ON n.oid=t.relnamespace\n  WHERE c.contype='f' AND n.nspname NOT IN ('pg_catalog','information_schema') AND array_length(c.conkey,1)=1),\nidx AS (SELECT i.indrelid AS relid, i.indkey[0] AS col FROM pg_index i)\nSELECT count(*) FROM (SELECT relid,col FROM fk EXCEPT SELECT relid,col FROM idx) x;",
     "source": ".claude/lib/goals.md · G-DB01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB03",
@@ -42,7 +102,7 @@
     "status": "unknown",
     "measurement": "SELECT\n    (SELECT count(DISTINCT c.table_schema||'.'||c.table_name) FROM information_schema.columns c\n       JOIN information_schema.tables t ON t.table_schema=c.table_schema AND t.table_name=c.table_name\n       WHERE c.column_name='brand' AND c.table_schema NOT IN ('pg_catalog','information_schema') AND t.table_type='BASE TABLE')\n  - (SELECT count(DISTINCT conrelid) FROM pg_constraint\n       WHERE contype='c' AND pg_get_constraintdef(oid) ILIKE '%brand%' AND pg_get_constraintdef(oid) ILIKE '%mentolder%');",
     "source": ".claude/lib/goals.md · G-DB03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB10",
@@ -57,7 +117,7 @@
     "status": "unknown",
     "measurement": "db_scalar \"SELECT count(*) FROM pg_stat_user_indexes s JOIN pg_index i ON i.indexrelid = s.indexrelid WHERE s.idx_scan = 0 AND i.indisready AND NOT i.indisprimary AND s.indexrelid NOT IN (SELECT conindid FROM pg_constraint WHERE contype='u')\"",
     "source": ".claude/lib/goals.md · G-DB10",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SEC06",
@@ -72,7 +132,7 @@
     "status": "unknown",
     "measurement": "# Messung (lokal):\nbash scripts/trivy-scan.sh --json | jq '.total_critical, .total_high'\n# CI: advisory-only in .github/workflows/ci.yml (Security Scan Job)",
     "source": ".claude/lib/goals.md · G-SEC06",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-FE05",
@@ -87,7 +147,7 @@
     "status": "unknown",
     "measurement": "npx @lhci/cli autorun \\\n  --collect.url=https://web.mentolder.de \\\n  --collect.settings.chromeFlags='--headless --no-sandbox' \\\n  --assert.performance=0.9",
     "source": ".claude/lib/goals.md · G-FE05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-BRAIN14",
@@ -102,7 +162,7 @@
     "status": "unknown",
     "measurement": "bash scripts/brain-ingest-worklist.sh 2>/dev/null | python3 -c \"\nimport sys, json, hashlib\nstate=json.load(open('$HOME/.brain-ingest-state.json'))\ntodo=0\nfor line in sys.stdin:\n    path=line.split('\\t')[0].strip()\n    if not path: continue\n    st=state.get(path)\n    if not st or hashlib.sha256(open(path,'rb').read()).hexdigest()!=st['hash']: todo+=1\nprint(todo)\"",
     "source": ".claude/lib/goals.md · G-BRAIN14",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH01",
@@ -117,7 +177,7 @@
     "status": "unknown",
     "measurement": "python3 -c \"import json,sys; print(len(json.load(sys.stdin)))\" < docs/code-quality/baseline.json",
     "source": ".claude/lib/goals.md · G-RH01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH02",
@@ -132,7 +192,7 @@
     "status": "unknown",
     "measurement": "grep -r '@ts-ignore|@ts-expect-error' website/src --include='*.ts' | grep -v goals-data.ts | wc -l",
     "source": ".claude/lib/goals.md · G-RH02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH04",
@@ -147,7 +207,7 @@
     "status": "unknown",
     "measurement": "git for-each-ref ... refs/remotes/origin | while IFS='",
     "source": ".claude/lib/goals.md · G-RH04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH05",
@@ -162,7 +222,7 @@
     "status": "unknown",
     "measurement": "bash scripts/vda.sh oracle 'list plan_staged tickets'",
     "source": ".claude/lib/goals.md · G-RH05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH06",
@@ -177,7 +237,7 @@
     "status": "unknown",
     "measurement": "gh-axi issue list --label sentinel --state open --json createdAt",
     "source": ".claude/lib/goals.md · G-RH06",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH07",
@@ -192,7 +252,7 @@
     "status": "unknown",
     "measurement": "task freshness:check",
     "source": ".claude/lib/goals.md · G-RH07",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-TEST01",
@@ -207,7 +267,7 @@
     "status": "unknown",
     "measurement": "grep -rniE \"skip [\\\"']\" tests --include=*.bats | grep -ciE \"pending|todo|WP-|disabled\"",
     "source": ".claude/lib/goals.md · G-TEST01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-TEST02",
@@ -222,7 +282,7 @@
     "status": "unknown",
     "measurement": "grep -rnE '\\.only\\b' website/src --include='*.test.ts' | wc -l",
     "source": ".claude/lib/goals.md · G-TEST02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-TEST03",
@@ -237,7 +297,7 @@
     "status": "unknown",
     "measurement": "grep -rnE \"(describe|it|test)\\.(skip|todo)\\b\" website/src --include=\"*.ts\" | wc -l",
     "source": ".claude/lib/goals.md · G-TEST03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-TEST04",
@@ -252,7 +312,7 @@
     "status": "unknown",
     "measurement": "git status --porcelain website/src/data/test-inventory.json | wc -l",
     "source": ".claude/lib/goals.md · G-TEST04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ02",
@@ -267,7 +327,7 @@
     "status": "unknown",
     "measurement": "grep -rn ': any|<any>|as any' website/src --include=*.ts --include=*.svelte --include=*.astro | wc -l",
     "source": ".claude/lib/goals.md · G-CQ02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ04",
@@ -282,7 +342,7 @@
     "status": "unknown",
     "measurement": "grep -rnE '\\b(FIXME|HACK|XXX)\\b' ... | wc -l",
     "source": ".claude/lib/goals.md · G-CQ04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ05",
@@ -297,7 +357,7 @@
     "status": "unknown",
     "measurement": "grep -rnE \"\\bTODO\\b\" --include=*.ts ... website/src scripts tests k3d brett/src | wc -l",
     "source": ".claude/lib/goals.md · G-CQ05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ06",
@@ -312,7 +372,7 @@
     "status": "unknown",
     "measurement": "grep -rnE '@deprecated' website/src | wc -l",
     "source": ".claude/lib/goals.md · G-CQ06",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ07",
@@ -327,7 +387,7 @@
     "status": "unknown",
     "measurement": "python3 -c \"..S2-Gate..\" < docs/code-quality/baseline.json",
     "source": ".claude/lib/goals.md · G-CQ07",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ09",
@@ -342,7 +402,7 @@
     "status": "unknown",
     "measurement": "python3 -c \"..S3-Gate..\" < docs/code-quality/baseline.json",
     "source": ".claude/lib/goals.md · G-CQ09",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CQ10",
@@ -357,7 +417,7 @@
     "status": "unknown",
     "measurement": "python3 -c \"..S4-Gate..\" < docs/code-quality/baseline.json",
     "source": ".claude/lib/goals.md · G-CQ10",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SIZE03",
@@ -372,7 +432,7 @@
     "status": "unknown",
     "measurement": "wc -l < website/src/lib/website-db.ts",
     "source": ".claude/lib/goals.md · G-SIZE03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-GIT01",
@@ -387,7 +447,7 @@
     "status": "unknown",
     "measurement": "gh pr list --state open --json number,createdAt",
     "source": ".claude/lib/goals.md · G-GIT01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-GIT03",
@@ -402,7 +462,7 @@
     "status": "unknown",
     "measurement": "git ls-files -z | xargs -0 -I{} sh -c 'test -f \"{}\" && wc -c \"{}\"' 2>/dev/null | awk '$1>1048576{c++} END{print c+0}'` — T001902: `.claude/skills/unsloth/references/llms-full.md` entfernt (redundanter, von der Skill selbst nicht referenzierter GitBook-Volldump, überlappend mit `llms-txt.md`/`llms.md`). **Manuelle Entscheidung zu den 2 Nutzer-Assets** (`assets/grilling-brett-admin-panel/Brett Admin Panel.html`, `environments/korczewski/KERN Logo Design.html`): bleiben unangetastet — Löschen ist ohne Nutzerfreigabe riskant, LFS ist repo-weit als defekt dokumentiert (T001348), und beide Dateien machen nur 2 von 6 verbleibenden >1MB-Treffern aus (Target bereits ohne sie erreicht). Keine Gate-Scope-Ausnahme nötig; siehe T001902-Ticketkommentar.",
     "source": ".claude/lib/goals.md · G-GIT03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DEP01",
@@ -417,7 +477,7 @@
     "status": "unknown",
     "measurement": "cd website && pnpm audit --json 2>/dev/null | python3 -c \"...\"",
     "source": ".claude/lib/goals.md · G-DEP01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DEP03",
@@ -432,7 +492,7 @@
     "status": "unknown",
     "measurement": "grep -q \"npm ci\" website/Dockerfile && echo inkonsistent || echo ok",
     "source": ".claude/lib/goals.md · G-DEP03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DEP04",
@@ -447,7 +507,7 @@
     "status": "unknown",
     "measurement": "for p in package.json website/package.json ...; do python3 -c \"..engines..\"; done",
     "source": ".claude/lib/goals.md · G-DEP04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DEP05",
@@ -462,7 +522,7 @@
     "status": "unknown",
     "measurement": "gh pr list --state open --json author,labels | python3 -c \"..renovate..\"",
     "source": ".claude/lib/goals.md · G-DEP05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DEP02",
@@ -477,7 +537,7 @@
     "status": "unknown",
     "measurement": "cd website && pnpm outdated` (Major-Sprünge zählen: aktuell nur eslint-plugin-astro 1→2, knip 5→6)",
     "source": ".claude/lib/goals.md · G-DEP02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-IMG01",
@@ -492,12 +552,12 @@
     "status": "unknown",
     "measurement": "grep -rhE 'image:' k3d/ prod*/ | ... sort -u | awk -F'\\t' '{c[$1]++} END{...}'` (T001766 gefixt: Loki/Promtail-Digests nachgezogen; war Prio B)",
     "source": ".claude/lib/goals.md · G-IMG01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-K8S01",
     "title": "Deployments ohne Limits",
-    "category": "Sonstige",
+    "category": "Infrastruktur",
     "priority": "C",
     "direction": "lower",
     "baseline": null,
@@ -507,12 +567,12 @@
     "status": "unknown",
     "measurement": "python3 -c \"..resources.limits..\" k3d/*.yaml",
     "source": ".claude/lib/goals.md · G-K8S01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-K8S02",
     "title": "Deployments ohne readinessProbe",
-    "category": "Sonstige",
+    "category": "Infrastruktur",
     "priority": "C",
     "direction": "lower",
     "baseline": null,
@@ -522,12 +582,12 @@
     "status": "unknown",
     "measurement": "python3 -c \"..readinessProbe..\" k3d/*.yaml",
     "source": ".claude/lib/goals.md · G-K8S02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-K8S03",
     "title": "Deployments ohne securityContext",
-    "category": "Sonstige",
+    "category": "Infrastruktur",
     "priority": "C",
     "direction": "lower",
     "baseline": null,
@@ -537,12 +597,12 @@
     "status": "unknown",
     "measurement": "python3 -c \"..securityContext..\" k3d/*.yaml",
     "source": ".claude/lib/goals.md · G-K8S03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-K8S04",
     "title": "workspace:validate grün",
-    "category": "Sonstige",
+    "category": "Infrastruktur",
     "priority": "C",
     "direction": "lower",
     "baseline": null,
@@ -552,7 +612,7 @@
     "status": "unknown",
     "measurement": "task workspace:validate",
     "source": ".claude/lib/goals.md · G-K8S04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CFG01",
@@ -567,7 +627,7 @@
     "status": "unknown",
     "measurement": "task env:validate:all",
     "source": ".claude/lib/goals.md · G-CFG01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SEC01",
@@ -582,7 +642,7 @@
     "status": "unknown",
     "measurement": "grep -rn 'password.*=.*[^$]' k3d/*.yaml | grep -iv secretKeyRef | wc -l",
     "source": ".claude/lib/goals.md · G-SEC01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SEC02",
@@ -597,7 +657,7 @@
     "status": "unknown",
     "measurement": "bash scripts/git-crypt-guard.sh check-tracked",
     "source": ".claude/lib/goals.md · G-SEC02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SEC03",
@@ -612,7 +672,7 @@
     "status": "unknown",
     "measurement": "git log -1 --format='%at' -- environments/sealed-secrets/*.yaml | ...",
     "source": ".claude/lib/goals.md · G-SEC03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SEC04",
@@ -627,7 +687,7 @@
     "status": "unknown",
     "measurement": "openssl x509 -enddate -noout -in environments/certs/*.pem",
     "source": ".claude/lib/goals.md · G-SEC04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SEC05",
@@ -642,7 +702,7 @@
     "status": "unknown",
     "measurement": "git log -50 --pretty='%G? %ae' main | grep -v freshness-bot | grep -ciE 'github-actions\\[bot\\]",
     "source": ".claude/lib/goals.md · G-SEC05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SPEC01",
@@ -657,7 +717,7 @@
     "status": "unknown",
     "measurement": "bash scripts/openspec.sh validate",
     "source": ".claude/lib/goals.md · G-SPEC01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SPEC02",
@@ -672,7 +732,7 @@
     "status": "unknown",
     "measurement": "for d in openspec/changes/*/; do ... done",
     "source": ".claude/lib/goals.md · G-SPEC02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-SPEC03",
@@ -687,7 +747,7 @@
     "status": "unknown",
     "measurement": "for d in openspec/changes/*/; do [ -f \"$d/.ticket\" ] || m=$((m+1)); done",
     "source": ".claude/lib/goals.md · G-SPEC03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB06",
@@ -702,7 +762,7 @@
     "status": "unknown",
     "measurement": "db_scalar NOT-EXISTS-Summe (ticket_plans/comments/links → tickets)",
     "source": ".claude/lib/goals.md · G-DB06",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB09",
@@ -717,7 +777,7 @@
     "status": "unknown",
     "measurement": "db_scalar \"SELECT count(*) FROM pg_stat_statements WHERE mean_exec_time > 1000 AND query NOT ILIKE 'COPY %'\"` — T001926: Backup-COPY (pg_dump-intern) aus dem Mess-Scope ausgeschlossen",
     "source": ".claude/lib/goals.md · G-DB09",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DOC01",
@@ -732,7 +792,7 @@
     "status": "unknown",
     "measurement": "python3 scripts/check-links.py",
     "source": ".claude/lib/goals.md · G-DOC01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DOC02",
@@ -747,7 +807,7 @@
     "status": "unknown",
     "measurement": "wc -l < CLAUDE.md",
     "source": ".claude/lib/goals.md · G-DOC02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DOC03",
@@ -762,7 +822,7 @@
     "status": "unknown",
     "measurement": "for d in website brett scripts tests k3d; do ls \"$d\"/README* ... done",
     "source": ".claude/lib/goals.md · G-DOC03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DOC04",
@@ -777,7 +837,7 @@
     "status": "unknown",
     "measurement": "find docs -ipath '*adr*' -name '*.md' | wc -l",
     "source": ".claude/lib/goals.md · G-DOC04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DOC06",
@@ -792,7 +852,7 @@
     "status": "unknown",
     "measurement": "find .claude/skills docs/agent-guide -name SKILL.md -o -name README.md | wc -l",
     "source": ".claude/lib/goals.md · G-DOC06",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CI01",
@@ -807,7 +867,7 @@
     "status": "unknown",
     "measurement": "gh-axi run list --workflow ci.yml --branch main --limit 20 | grep -oE 'completed,(success|failure|cancelled)' | sort | uniq -c` (19/20, 1 cancelled)",
     "source": ".claude/lib/goals.md · G-CI01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CI02",
@@ -822,7 +882,7 @@
     "status": "unknown",
     "measurement": "gh-axi run list --workflow ci.yml --branch main --limit 5 | grep -c failure",
     "source": ".claude/lib/goals.md · G-CI02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CI03",
@@ -837,7 +897,7 @@
     "status": "unknown",
     "measurement": "gh run list --workflow ci.yml --branch main --limit 20 --json createdAt,updatedAt | python3 -c \"..p95..\"` (T001910: Messscript-Bug in `gh-axi run list --json` behoben, jetzt `gh` direkt)",
     "source": ".claude/lib/goals.md · G-CI03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-RH03",
@@ -852,7 +912,7 @@
     "status": "unknown",
     "measurement": "SPECS=$(ls openspec/specs/*.md | wc -l); BATS=$(ls tests/spec/*.bats | wc -l); echo \"$BATS/$SPECS\"",
     "source": ".claude/lib/goals.md · G-RH03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-CD02",
@@ -867,7 +927,7 @@
     "status": "unknown",
     "measurement": "gh-axi run list --workflow post-merge.yml --branch main --limit 15 | ...",
     "source": ".claude/lib/goals.md · G-CD02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DORA01",
@@ -882,7 +942,7 @@
     "status": "unknown",
     "measurement": "git log --since=\"4 weeks ago\" --first-parent --oneline main | wc -l",
     "source": ".claude/lib/goals.md · G-DORA01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DORA02",
@@ -897,7 +957,7 @@
     "status": "unknown",
     "measurement": "gh-axi api repos/{owner}/{repo}/pulls?...",
     "source": ".claude/lib/goals.md · G-DORA02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DORA03",
@@ -912,7 +972,7 @@
     "status": "unknown",
     "measurement": "git log --since=\"8 weeks ago\" --first-parent --oneline main | ...fix()/revert-Rate",
     "source": ".claude/lib/goals.md · G-DORA03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DORA04",
@@ -927,7 +987,7 @@
     "status": "unknown",
     "measurement": "git log --since=\"8 weeks ago\" --first-parent --format='%ct %s' main | grep -iE 'revert|hotfix'",
     "source": ".claude/lib/goals.md · G-DORA04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-FE03",
@@ -942,7 +1002,7 @@
     "status": "unknown",
     "measurement": "grep -rEn 'console\\.(error|warn)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' | grep -v 'browser-logger.ts' | grep -v 'logger.ts' | grep -v 'error-log-store.ts' | grep -v '\\.test\\.ts' | wc -l",
     "source": ".claude/lib/goals.md · G-FE03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-FE04",
@@ -957,7 +1017,7 @@
     "status": "unknown",
     "measurement": "grep -rEn 'console\\.(log|debug|info)' website/src --include='*.ts' --include='*.svelte' --include='*.astro' | grep -v 'browser-logger.ts' | grep -v '\\.test\\.ts' | wc -l",
     "source": ".claude/lib/goals.md · G-FE04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-GIT02",
@@ -972,7 +1032,7 @@
     "status": "unknown",
     "measurement": "git log --format=%s --no-merges -30 origin/main | grep -vcE '^(feat|fix|chore|...)'",
     "source": ".claude/lib/goals.md · G-GIT02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC02",
@@ -987,7 +1047,7 @@
     "status": "unknown",
     "measurement": "python3 <<'PY' ... norm/toks/fm/rows ... symmetric_difference",
     "source": ".claude/lib/goals.md · G-AGENTIC02",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC03",
@@ -1002,7 +1062,7 @@
     "status": "unknown",
     "measurement": "for f in .claude/agents/*.md; do name==basename && description present",
     "source": ".claude/lib/goals.md · G-AGENTIC03",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC04",
@@ -1017,7 +1077,7 @@
     "status": "unknown",
     "measurement": "awk '/test:changed/...' Taskfile.yml | grep -c .claude/agents + AGENTS + agent-library",
     "source": ".claude/lib/goals.md · G-AGENTIC04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC05",
@@ -1032,7 +1092,7 @@
     "status": "unknown",
     "measurement": "comm -3 <(ls agents/...) <(routing from validate.mjs) + <(registry from tools.yaml)",
     "source": ".claude/lib/goals.md · G-AGENTIC05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC06",
@@ -1047,7 +1107,7 @@
     "status": "unknown",
     "measurement": "claimed - real (Betrag)` via grep claim + `git ls-files -- .claude/skills | grep -c '/SKILL\\.md$'` (nur getrackte — market-cli-Installationen zählen nicht, T001783)",
     "source": ".claude/lib/goals.md · G-AGENTIC06",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC07",
@@ -1062,7 +1122,7 @@
     "status": "unknown",
     "measurement": "for SKILL.md in git ls-files; if description exist && zero refs in CLAUDE.md/AGENTS.md/OVERVIEW.md/other SKILL.md → count` (nur getrackte)",
     "source": ".claude/lib/goals.md · G-AGENTIC07",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC08",
@@ -1077,7 +1137,7 @@
     "status": "unknown",
     "measurement": "grep -rhoP '(?<![A-Za-z0-9_./-])scripts/...\\.(sh|mjs|py)' .claude/skills | sort -u | test -f",
     "source": ".claude/lib/goals.md · G-AGENTIC08",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC09",
@@ -1092,7 +1152,7 @@
     "status": "unknown",
     "measurement": "find .claude/skills -name SKILL.md -exec wc -l {} + | awk '$2!=\"total\"&&$1>500{c++} END{print c+0}'` — T001904: `dev-flow-plan` 508→479 Zeilen",
     "source": ".claude/lib/goals.md · G-AGENTIC09",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC11",
@@ -1107,7 +1167,7 @@
     "status": "unknown",
     "measurement": "comm -3 <(grep opencode-Liste | extract backtick-names) <(mcp_servers opencode.jsonc)",
     "source": ".claude/lib/goals.md · G-AGENTIC11",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC12",
@@ -1122,7 +1182,7 @@
     "status": "unknown",
     "measurement": "for s in $(mcp_servers .mcp.json); grep -q -- \"$s\" mcp-tool-guide.md",
     "source": ".claude/lib/goals.md · G-AGENTIC12",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC13",
@@ -1137,7 +1197,7 @@
     "status": "unknown",
     "measurement": "grep -rhoE 'mcp__...__|mcp-..._browser_' .claude/skills | gegen registrierte Server",
     "source": ".claude/lib/goals.md · G-AGENTIC13",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC14",
@@ -1152,7 +1212,7 @@
     "status": "unknown",
     "measurement": "python3 <<'PY' ... load both, sig() for common keys, count mismatches",
     "source": ".claude/lib/goals.md · G-AGENTIC14",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC15",
@@ -1167,7 +1227,7 @@
     "status": "unknown",
     "measurement": "grep -rhoE '/opsx[:-][a-z]+' in .claude/ .opencode/ .claude/skills vs valid command set",
     "source": ".claude/lib/goals.md · G-AGENTIC15",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC16",
@@ -1182,7 +1242,7 @@
     "status": "unknown",
     "measurement": "for each .claude/commands/opsx/*.md, compare normalized body with .opencode/opsx-$name.md",
     "source": ".claude/lib/goals.md · G-AGENTIC16",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC17",
@@ -1197,7 +1257,7 @@
     "status": "unknown",
     "measurement": "S4 command_globs gegen Referenzquellen; Config-Guard: ohne Config → 99",
     "source": ".claude/lib/goals.md · G-AGENTIC17",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC01",
@@ -1212,7 +1272,7 @@
     "status": "unknown",
     "measurement": "awk-Frontmatter-Check über .claude/agents/bachelorprojekt-{security,infra,db}.md",
     "source": ".claude/lib/goals.md · G-AGENTIC01",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-AGENTIC10",
@@ -1227,7 +1287,7 @@
     "status": "unknown",
     "measurement": "grep -rlE '^agent: <name>' .claude/skills --include=SKILL.md je Agent",
     "source": ".claude/lib/goals.md · G-AGENTIC10",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB04",
@@ -1242,7 +1302,7 @@
     "status": "unknown",
     "measurement": "db_scalar Backup-Alter (health-goals-check.sh); Regressionswache T001738",
     "source": ".claude/lib/goals.md · G-DB04",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-DB08",
@@ -1257,7 +1317,7 @@
     "status": "unknown",
     "measurement": "db_scalar pg_stat_user_tables seq_scan-Quote (health-goals-check.sh)",
     "source": ".claude/lib/goals.md · G-DB08",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-TEST05",
@@ -1272,7 +1332,7 @@
     "status": "unknown",
     "measurement": "cd website && pnpm vitest run --coverage` (in health-goals-check.sh, ohne --fast)",
     "source": ".claude/lib/goals.md · G-TEST05",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-BRAIN12",
@@ -1287,7 +1347,7 @@
     "status": "unknown",
     "measurement": "bash scripts/brain-ingest-worklist.sh >/dev/null 2>&1 | stderr-Warnungen 'hat 0 Treffer' zählen",
     "source": ".claude/lib/goals.md · G-BRAIN12",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-BRAIN13",
@@ -1302,7 +1362,7 @@
     "status": "unknown",
     "measurement": "paths:-Globs in .github/workflows/brain-merge-hook.yml gegen brain-merge-hook.sh-SRC-Argumente (sym. Diff)",
     "source": ".claude/lib/goals.md · G-BRAIN13",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
   },
   {
     "id": "G-BRAIN15",
@@ -1317,6 +1377,36 @@
     "status": "unknown",
     "measurement": "bash templates/brain/scripts/lint-frontmatter.sh templates/brain && bash templates/brain/scripts/lint-wikilinks.sh templates/brain",
     "source": ".claude/lib/goals.md · G-BRAIN15",
-    "measured_at": "2026-07-21"
+    "measured_at": "2026-07-22"
+  },
+  {
+    "id": "G-OPS02",
+    "title": "Container-Restarts <24h (fleet, beide Brands)",
+    "category": "Infrastruktur",
+    "priority": "C",
+    "direction": "lower",
+    "baseline": null,
+    "current": 1,
+    "target": 3,
+    "unit": "",
+    "status": "unknown",
+    "measurement": "kubectl get pods -o json` + Python-Filter `lastState.terminated.finishedAt` < 24h (health-goals-check.sh)",
+    "source": ".claude/lib/goals.md · G-OPS02",
+    "measured_at": "2026-07-22"
+  },
+  {
+    "id": "G-OPS03",
+    "title": "Live-TLS-Cert-Restlaufzeit (Tage, min beider Brands)",
+    "category": "Infrastruktur",
+    "priority": "C",
+    "direction": "higher",
+    "baseline": null,
+    "current": 37,
+    "target": 14,
+    "unit": "",
+    "status": "unknown",
+    "measurement": "echo | openssl s_client -servername web.<brand>.de -connect …:443 | openssl x509 -enddate -noout` (health-goals-check.sh, mit Retry gegen Multi-A-Record-Transienten)",
+    "source": ".claude/lib/goals.md · G-OPS03",
+    "measured_at": "2026-07-22"
   }
 ]


### PR DESCRIPTION
## Zusammenfassung

Drei neue Health-Goal-Scopes, die erstmals die **Laufzeit-Perspektive** abdecken (bisher maßen fast alle Goals repo-statisch):

| Goal | Prio | Baseline (2026-07-22) | Target |
|------|------|----------------------|--------|
| G-E2E01 Nightly-E2E-Erfolgsrate `e2e.yml` | **A** | **0 % (0/14 grün)** | ≥ 90 % |
| G-E2E02 E2E-Testdaten-Leak (is_test_data-Rows in Prod) | B | 2 (je 1× `public.inbox_items` pro Brand) | 0 |
| G-OPS01 Pods nicht Running/Ready (fleet, beide Brands) | B | 3 (inkl. `test-pod` Failed-Debris) | 0 |
| G-OPS02 Container-Restarts <24h | C ✓ | 1 | ≤ 3 |
| G-OPS03 Live-TLS-Cert-Restlaufzeit (min beider Brands) | C ✓ | 37 d | ≥ 14 d |
| G-DB11 Tage seit letztem Restore-Verify | B | n/a | ≤ 30 d |

## Änderungen
- `.claude/lib/goals.md`: 6 neue Goals + Baseline-Update-Block (SSOT)
- `scripts/health-goals-check.sh`: Mess-Helfer (kubectl/gh/openssl, SKIP bei `--fast`/Unerreichbarkeit) + 6 Rows — live verifiziert
- `scripts/backup-restore-lib.sh`: `cmd_recovery_verify` stempelt bei Erfolg ConfigMap `recovery-verify-status` (Mess-Anker G-DB11, Job hat TTL 600s) + cleanup-`trap` gegen Wegwerf-DB-Leichen
- `scripts/gen-goals-data.mjs`: `categoryFor`-Regex erlaubt Ziffern im Präfix (G-E2E01 → Kategorie Test-Health statt Sonstige); CATEGORY_MAP um E2E/OPS ergänzt

## Echte Funde während der Baseline-Messung
1. **Nightly-E2E 14/14 rot** — bestätigt die Lücke; Fix läuft separat (`fix/e2e-auth-token-and-cron-secret`).
2. **Restore-Verify schlägt fehl:** `pg_restore` bricht am HNSW-Index `knowledge.chunks_embedding_hnsw` ab — shared-db `/dev/shm` ist 64M-k8s-Default. Das website-Backup ist aktuell **nicht vollständig restaurierbar** → Bug **T002064**. Zurückgelassene Wegwerf-DB `website_verify_781884` manuell gedroppt.

## Verifikation
- `bash scripts/health-goals-check.sh --only=G-E2E01,G-E2E02,G-OPS01,G-OPS02,G-OPS03,G-DB11` — alle 6 messen korrekt (2 ✅, 3 🟡, 1 SKIP n/a)
- `task test:changed` grün, `task freshness:check` Exit 0, BATS `health-goals`/`repo-health-goals` 14/14 ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CwH6bnEkjuRoTg1VUYF1r