### PR TITLE
chore: consolidate local subagents into write-capable bonsai-27b

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -27,6 +27,22 @@
       // for OpenAI-compatible providers yet (github.com/anomalyco/opencode#6231).
       "models": {}
     },
+    "llama-bonsai-server": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "llama.cpp (Ternary-Bonsai-27B)",
+      "options": {
+        "baseURL": "http://127.0.0.1:8093/v1"
+      },
+      "models": {
+        "Ternary-Bonsai-27B-Q2_0.gguf": {
+          "name": "Ternary-Bonsai-27B (Q2_0, 130k ctx per slot)",
+          "limit": {
+            "context": 130000,
+            "output": 8192
+          }
+        }
+      }
+    },
     "lmstudio": {
       "models": {
         "qwen3.5-9b@q4_k_xl": {
@@ -89,41 +105,14 @@
     }
   },
   "agent": {
-    "qwen35-iq4": {
-      "description": "PREFERRED FIRST CHOICE for subagent delegation: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time). Try this first for subagent dispatch.",
+    "bonsai-27b": {
+      "description": "PRIMARY SUBAGENT: Ternary-Bonsai-27B (130k context per slot, up to 2 parallel slots via llama-server on port 8093)",
       "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
+      "model": "llama-bonsai-server/Ternary-Bonsai-27B-Q2_0.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#0EA5E9",
       "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
-    },
-    "qwen3-14b": {
-      "description": "Single-session implementation/planning agent: Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio",
-      "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#F59E0B",
-      "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
-    },
-    "qwen35": {
-      "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time)",
-      "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#22C55E",
-      "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
-    },
-    "qwen35-hq": {
-      "description": "Subagent using Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, MXFP4_MOE, 262k ctx) on LM Studio - serialized (1 at a time), use when max per-call context matters more than concurrency",
-      "mode": "subagent",
-      "model": "lmstudio/qwen3.6-14b-a3b-fablevibes@262k",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#16A34A",
-      "temperature": 0.2,
-      "permission": { "edit": "deny", "write": "deny", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
+      "permission": { "edit": "allow", "write": "allow", "bash": "deny", "webfetch": "deny", "websearch": "deny" }
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,7 @@ opencode uses the `background-agents.ts` plugin which reads agents from `agent-m
 
 | Agent | Model | Permissions | Use case |
 |-------|-------|-------------|----------|
-| `qwen35-iq4` | Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) | read-only | **Preferred first choice** for delegation |
-| `qwen35` | Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) | read-only | General subagent, 1 at a time |
-| `qwen35-hq` | Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) | read-only | When max per-call context matters |
-| `qwen3-14b` | Qwen3.6-14B-A3B FableVibes (14B-A3B MoE, Q4_K_M, 262k ctx) | read-only | Single-session planning |
+| `bonsai-27b` | Ternary-Bonsai-27B (Q2_0, 130k ctx per slot) | write-capable | **Preferred single choice** for delegation (up to 2 parallel slots on port 8093) |
 | `explore` | built-in | read-only | Fast codebase exploration |
 | `general` | built-in | read-only | General research tasks |
 


### PR DESCRIPTION
Consolidates subagents into a single write-capable `bonsai-27b` subagent backed by llama-server (Ternary-Bonsai-27B) running on port 8093 with 130k context per slot.