### PR TITLE
fix(infra): add missing required RECOVER_DOMAIN to brand envs [T002066]

### DIFF
--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -52,6 +52,7 @@ env_vars:
   MEDIAVIEWER_HOST: mediaviewer.korczewski.de
   VIDEOVAULT_DOMAIN: videovault.korczewski.de
   OTEL_DOMAIN: otel.korczewski.de
+  RECOVER_DOMAIN: recover.korczewski.de
   STREAM_DOMAIN: stream.korczewski.de
   NEXTCLOUD_DB_HOST: nextcloud-db.workspace-korczewski.svc.cluster.local
   WEBSITE_HOST: web.korczewski.de

--- a/environments/fleet-mentolder.yaml
+++ b/environments/fleet-mentolder.yaml
@@ -52,6 +52,7 @@ env_vars:
   MEDIAVIEWER_HOST: mediaviewer.mentolder.de
   VIDEOVAULT_DOMAIN: videovault.mentolder.de
   OTEL_DOMAIN: otel.mentolder.de
+  RECOVER_DOMAIN: recover.mentolder.de
   STREAM_DOMAIN: stream.mentolder.de
   NEXTCLOUD_DB_HOST: nextcloud-db.workspace.svc.cluster.local
   WEBSITE_HOST: web.mentolder.de

--- a/environments/korczewski.yaml
+++ b/environments/korczewski.yaml
@@ -50,6 +50,7 @@ env_vars:
   MEDIAVIEWER_HOST: mediaviewer.korczewski.de
   VIDEOVAULT_DOMAIN: videovault.korczewski.de
   OTEL_DOMAIN: otel.korczewski.de
+  RECOVER_DOMAIN: recover.korczewski.de
   STREAM_DOMAIN: stream.korczewski.de
   NEXTCLOUD_DB_HOST: nextcloud-db.workspace-korczewski.svc.cluster.local
   WEBSITE_HOST: web.korczewski.de

--- a/environments/mentolder.yaml
+++ b/environments/mentolder.yaml
@@ -48,6 +48,7 @@ env_vars:
   MEDIAVIEWER_HOST: mediaviewer.mentolder.de
   VIDEOVAULT_DOMAIN: videovault.mentolder.de
   OTEL_DOMAIN: otel.mentolder.de
+  RECOVER_DOMAIN: recover.mentolder.de
   STREAM_DOMAIN: stream.mentolder.de
   NEXTCLOUD_DB_HOST: nextcloud-db.workspace.svc.cluster.local
   WEBSITE_HOST: web.mentolder.de


### PR DESCRIPTION
## Zusammenfassung
`environments/schema.yaml` führt `RECOVER_DOMAIN` als `required: true`, aber nur `staging.yaml` definierte es — `env:validate` schlug für mentolder/korczewski fehl und blockierte damit **jeden** `workspace:deploy`/`feature:deploy` (entdeckt beim T002064-Post-Merge-Deploy).

## Fix
`RECOVER_DOMAIN: recover.<brand>.de` in `mentolder`/`korczewski`/`fleet-mentolder`/`fleet-korczewski` ergänzt (Platzierung analog `OTEL_DOMAIN`). `task env:validate:all` lokal grün (Exit 0).

Closes T002066

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CwH6bnEkjuRoTg1VUYF1r