### PR TITLE
fix(website): resolve 22 typecheck/lint warnings [vitest-cleanup]

### DIFF
--- a/website/knip.json
+++ b/website/knip.json
@@ -3,13 +3,9 @@
   "entry": [
     "src/pages/**/*.{astro,ts,js}",
     "src/middleware.{ts,js}",
-    "src/content/config.ts",
     "astro.config.{mjs,ts,js}"
   ],
   "project": [
     "src/**/*.{ts,tsx,js,mjs,svelte,astro}"
-  ],
-  "ignore": [
-    "src/**/*.generated.*"
   ]
 }

--- a/website/src/components/admin/TicketDetailSections.astro
+++ b/website/src/components/admin/TicketDetailSections.astro
@@ -58,7 +58,7 @@ const { ticket, timeline } = Astro.props;
   <TicketActivityTimeline client:load entries={timeline} />
 </div>
 
-<script define:vars={{ ticketId: ticket.id }}>
+<script is:inline define:vars={{ ticketId: ticket.id }}>
   document.querySelectorAll('.unlink-btn').forEach(btn => {
     btn.addEventListener('click', async () => {
       if (!confirm('Verknüpfung entfernen?')) return;

--- a/website/src/lib/claude-session-agent.ts
+++ b/website/src/lib/claude-session-agent.ts
@@ -107,7 +107,7 @@ export class ClaudeSessionAgent implements SessionAgent {
       { role: 'user', content: assembledUserPrompt },
     ];
 
-    const stream = await client.messages.stream({
+    const stream = client.messages.stream({
       model,
       max_tokens: kiConfig.maxTokens ?? 600,
       system: effectiveSystemPrompt,

--- a/website/src/lib/coaching-content.test.ts
+++ b/website/src/lib/coaching-content.test.ts
@@ -34,14 +34,14 @@ describe('getEffectiveCoaching', () => {
   });
 
   it('returns defaults when no service override exists', async () => {
-    mockGetServiceConfig.mockResolvedValue([]);
+    mockGetServiceConfig.mockReturnValue([]);
     const out = await getEffectiveCoaching('mentolder');
     expect(out.headline).toBe(DEFAULT.headline);
     expect(out.ctaHref).toBe('/termin');
   });
 
   it('returns defaults when the coaching slug is not present in the override list', async () => {
-    mockGetServiceConfig.mockResolvedValue([
+    mockGetServiceConfig.mockReturnValue([
       { slug: 'something-else', pageContent: { headline: 'X' } },
     ]);
     const out = await getEffectiveCoaching('mentolder');
@@ -49,7 +49,7 @@ describe('getEffectiveCoaching', () => {
   });
 
   it('applies headline, intro, forWhom, faq from the override when present', async () => {
-    mockGetServiceConfig.mockResolvedValue([
+    mockGetServiceConfig.mockReturnValue([
       {
         slug: 'coaching',
         pageContent: {
@@ -68,7 +68,7 @@ describe('getEffectiveCoaching', () => {
   });
 
   it('derives process steps from sections when sections is non-empty', async () => {
-    mockGetServiceConfig.mockResolvedValue([
+    mockGetServiceConfig.mockReturnValue([
       {
         slug: 'coaching',
         pageContent: {
@@ -87,7 +87,7 @@ describe('getEffectiveCoaching', () => {
   });
 
   it('falls back to defaults when sections is empty', async () => {
-    mockGetServiceConfig.mockResolvedValue([
+    mockGetServiceConfig.mockReturnValue([
       { slug: 'coaching', pageContent: { headline: 'X', sections: [] } },
     ]);
     const out = await getEffectiveCoaching('mentolder');
@@ -96,7 +96,7 @@ describe('getEffectiveCoaching', () => {
   });
 
   it('returns defaults when the DB call throws', async () => {
-    mockGetServiceConfig.mockRejectedValue(new Error('db down'));
+    mockGetServiceConfig.mockImplementation(() => { throw new Error('db down'); });
     const out = await getEffectiveCoaching('mentolder');
     expect(out.headline).toBe(DEFAULT.headline);
   });

--- a/website/src/lib/coaching-content.ts
+++ b/website/src/lib/coaching-content.ts
@@ -54,7 +54,7 @@ const DEFAULT_COACHING: CoachingContent = {
  */
 export async function getEffectiveCoaching(brand: string): Promise<CoachingContent> {
   try {
-    const overrides = await getServiceConfig(brand);
+    const overrides = getServiceConfig(brand);
     const svc = overrides?.find(o => o.slug === SLUG);
     const pc = svc?.pageContent;
 

--- a/website/src/lib/db-pool.ts
+++ b/website/src/lib/db-pool.ts
@@ -46,13 +46,6 @@ const poolConfig = {
 } as unknown as import('pg').PoolConfig;
 export const pool = new Pool(poolConfig);
 
-// Platform/ops-audit pool. This deliberately stays PER-BRAND (== pool).
-// An earlier attempt redirected korczewski -> the mentolder (workspace) DB to
-// centralize, but a korczewski website pod cannot reach shared-db.workspace
-// across namespaces in the fleet cluster (ClusterIP egress -> ECONNREFUSED),
-// which broke korczewski admin-ops. Each brand uses its own shared-db.
-export const platformPool = pool;
-
 // Schema initialisation must run ONCE per process, not on every request.
 // Running idempotent DDL (CREATE TABLE IF NOT EXISTS / ALTER ... ADD CONSTRAINT)
 // on the hot path races concurrent requests on the Postgres system catalog,

--- a/website/src/lib/einvoice/types.ts
+++ b/website/src/lib/einvoice/types.ts
@@ -10,14 +10,14 @@ const SellerConfigSchema = z.object({
   country: z.string().length(2),
   vatId: z.string().optional(),
   taxNumber: z.string().optional(),
-  contactEmail: z.string().email(),
+  contactEmail: z.email(),
   iban: z.string().min(15),
   bic: z.string().optional(),
 });
 
 const BuyerConfigSchema = z.object({
   name: z.string().min(1),
-  email: z.string().email(),
+  email: z.email(),
   address: z.string().optional(),
   postalCode: z.string().optional(),
   city: z.string().optional(),

--- a/website/src/lib/fuehrung-content.test.ts
+++ b/website/src/lib/fuehrung-content.test.ts
@@ -30,19 +30,19 @@ describe('getEffectiveFuehrung', () => {
   afterEach(() => mockGet.mockReset());
 
   it('returns defaults when no service override exists', async () => {
-    mockGet.mockResolvedValue([]);
+    mockGet.mockReturnValue([]);
     const out = await getEffectiveFuehrung('mentolder');
     expect(out.headline).toBe(DEFAULT.headline);
   });
 
   it('returns defaults when the fuehrung slug is not in the override list', async () => {
-    mockGet.mockResolvedValue([{ slug: 'other', pageContent: { headline: 'X' } }]);
+    mockGet.mockReturnValue([{ slug: 'other', pageContent: { headline: 'X' } }]);
     const out = await getEffectiveFuehrung('mentolder');
     expect(out.headline).toBe(DEFAULT.headline);
   });
 
   it('applies headline/intro/forWhom/faq from the override', async () => {
-    mockGet.mockResolvedValue([
+    mockGet.mockReturnValue([
       {
         slug: 'fuehrung-persoenlichkeit',
         pageContent: {
@@ -61,7 +61,7 @@ describe('getEffectiveFuehrung', () => {
   });
 
   it('derives process steps from sections when sections is non-empty', async () => {
-    mockGet.mockResolvedValue([
+    mockGet.mockReturnValue([
       {
         slug: 'fuehrung-persoenlichkeit',
         pageContent: {
@@ -78,7 +78,7 @@ describe('getEffectiveFuehrung', () => {
   });
 
   it('falls back to defaults when sections is empty', async () => {
-    mockGet.mockResolvedValue([
+    mockGet.mockReturnValue([
       { slug: 'fuehrung-persoenlichkeit', pageContent: { sections: [] } },
     ]);
     const out = await getEffectiveFuehrung('mentolder');
@@ -86,7 +86,7 @@ describe('getEffectiveFuehrung', () => {
   });
 
   it('returns defaults when DB throws', async () => {
-    mockGet.mockRejectedValue(new Error('boom'));
+    mockGet.mockImplementation(() => { throw new Error('boom'); });
     const out = await getEffectiveFuehrung('mentolder');
     expect(out.headline).toBe(DEFAULT.headline);
   });

--- a/website/src/lib/fuehrung-content.ts
+++ b/website/src/lib/fuehrung-content.ts
@@ -59,7 +59,7 @@ const DEFAULT_FUEHRUNG: FuehrungContent = {
  */
 export async function getEffectiveFuehrung(brand: string): Promise<FuehrungContent> {
   try {
-    const overrides = await getServiceConfig(brand);
+    const overrides = getServiceConfig(brand);
     const svc = overrides?.find(o => o.slug === SLUG);
     const staticSvc = config.services.find(s => s.slug === SLUG);
     const pc = svc?.pageContent;

--- a/website/src/lib/invoice-pdf.test.ts
+++ b/website/src/lib/invoice-pdf.test.ts
@@ -32,7 +32,7 @@ it('generates a non-empty PDF buffer', async () => {
     },
   });
   expect(buf.length).toBeGreaterThan(1000);
-  expect(buf.slice(0,4).toString()).toBe('%PDF');
+  expect(buf.subarray(0,4).toString()).toBe('%PDF');
 });
 
 it('includes reverse charge notice when supplyType is eu_b2b_services', async () => {
@@ -108,7 +108,7 @@ it('generates a Zahlungserinnerung (level 1, no fees) as a valid PDF', async () 
     customer: dunningCustomer,
     seller: dunningSeller,
   });
-  expect(buf.slice(0, 4).toString()).toBe('%PDF');
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
   const text = await extractText(buf);
   expect(text).toContain('ZAHLUNGSERINNERUNG');
 });
@@ -124,7 +124,7 @@ it('generates a Mahnung (level 2+) with fees and interest included in the total'
     customer: dunningCustomer,
     seller: { ...dunningSeller, email: undefined, phone: undefined },
   });
-  expect(buf.slice(0, 4).toString()).toBe('%PDF');
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
   const text = await extractText(buf);
   expect(text).toContain('MAHNUNG');
   // Mahngebühren/Verzugszinsen rows are only rendered when > 0
@@ -156,7 +156,7 @@ it('generateInvoicePdf covers optional fields: multi-line items, service period,
       outroText: 'Mit freundlichen Grüßen',
     },
   });
-  expect(buf.slice(0, 4).toString()).toBe('%PDF');
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
   const text = await extractText(buf);
   expect(text).toContain('Erika GmbH');
   expect(text).toContain('Reisekosten');
@@ -169,5 +169,5 @@ it('generateInvoicePdf renders a single service period date when no end date is 
     customer: { name: 'Max Mustermann', email: 'max@test.de', country: 'DE' },
     seller: dunningSeller,
   });
-  expect(buf.slice(0, 4).toString()).toBe('%PDF');
+  expect(buf.subarray(0, 4).toString()).toBe('%PDF');
 });

--- a/website/src/lib/website-db.ts
+++ b/website/src/lib/website-db.ts
@@ -52,7 +52,7 @@ import { isConflict as detectConflict, nextVersion as bumpVersion } from './admi
 // that imports these names from website-db.
 import { pool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
 export { pool, ensureSchemaOnce, __resetSchemaInitCacheForTests } from './db-pool';
-export { platformPool } from './db-pool';
+export { pool as platformPool } from './db-pool';
 import type { Pool, PoolClient } from 'pg';
 
 // listAllCustomers / listAdminUsers / getCustomerByEmail moved to

--- a/website/src/pages/admin/einstellungen/ordner-templates.astro
+++ b/website/src/pages/admin/einstellungen/ordner-templates.astro
@@ -1,8 +1,6 @@
 ---
 import AdminLayout from '../../../layouts/AdminLayout.astro';
 import AdminPageHeader from '../../../components/admin/ui/AdminPageHeader.svelte';
-import AdminCard from '../../../components/admin/ui/AdminCard.svelte';
-import AdminFormField from '../../../components/admin/ui/AdminFormField.svelte';
 import AdminEinstellungenTabs from '../../../components/AdminEinstellungenTabs.astro';
 import { getSession, getLoginUrl, isAdmin } from '../../../lib/auth';
 import { listTemplates } from '../../../lib/folder-templates-db';

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -355,7 +355,7 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
   <div id="replay-drawer-mount"></div>
 </AdminLayout>
 
-<script define:vars={{ assignmentId }}>
+<script is:inline define:vars={{ assignmentId }}>
   const notesEl = document.getElementById('coach-notes');
   const msgEl = document.getElementById('notes-msg');
 

--- a/website/src/pages/admin/projekte/[id].astro
+++ b/website/src/pages/admin/projekte/[id].astro
@@ -797,7 +797,7 @@ const tasksJson = JSON.stringify(allTasksFlat.map(t => ({
   </dialog>
 </AdminLayout>
 
-<script define:vars={{ spJson, tasksJson }}>
+<script is:inline define:vars={{ spJson, tasksJson }}>
   const subProjects = JSON.parse(spJson);
   const allTasks    = JSON.parse(tasksJson);
 

--- a/website/src/pages/admin/termine.astro
+++ b/website/src/pages/admin/termine.astro
@@ -87,7 +87,6 @@ for (const w of timeWindowsList) {
   windowsByDate.get(w.date)!.push(w);
 }
 
-const totalWindows = timeWindowsList.length;
 const upcomingBookings = bookings.filter(b => b.start >= now && b.status !== 'CANCELLED');
 const pastBookings = bookings.filter(b => b.start < now || b.status === 'CANCELLED');
 

--- a/website/src/pages/api/admin/coaching/save.ts
+++ b/website/src/pages/api/admin/coaching/save.ts
@@ -23,7 +23,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
 
   try {
     // Load existing service_config overrides
-    const existing = await getServiceConfig(BRAND) ?? [];
+    const existing = getServiceConfig(BRAND) ?? [];
     const staticSvc = config.services.find(s => s.slug === SLUG);
 
     // Build the pageContent from CoachingContent fields

--- a/website/src/pages/api/admin/components/[id].ts
+++ b/website/src/pages/api/admin/components/[id].ts
@@ -12,7 +12,7 @@ const PatchBody = z.object({
   area:     z.string().min(1).max(50).optional(),
   status:   z.enum(['active', 'inactive', 'deprecated']).optional(),
   cluster:  z.enum(['mentolder', 'korczewski', 'both']).optional(),
-  url:      z.string().url().nullable().optional(),
+  url:      z.url().nullable().optional(),
   hostname: z.string().max(100).nullable().optional(),
   notes:    z.string().max(500).nullable().optional(),
 });

--- a/website/src/pages/api/admin/components/index.ts
+++ b/website/src/pages/api/admin/components/index.ts
@@ -12,7 +12,7 @@ const CreateBody = z.object({
   area:     z.string().min(1).max(50),
   status:   z.enum(['active', 'inactive', 'deprecated']).optional(),
   cluster:  z.enum(['mentolder', 'korczewski', 'both']).optional(),
-  url:      z.string().url().nullable().optional(),
+  url:      z.url().nullable().optional(),
   hostname: z.string().max(100).nullable().optional(),
   notes:    z.string().max(500).nullable().optional(),
 });

--- a/website/src/pages/api/admin/fuehrung/save.ts
+++ b/website/src/pages/api/admin/fuehrung/save.ts
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
   }
 
   try {
-    const existing = await getServiceConfig(BRAND) ?? [];
+    const existing = getServiceConfig(BRAND) ?? [];
     const staticSvc = config.services.find(s => s.slug === SLUG);
 
     // Build pageContent from FuehrungContent

--- a/website/src/pages/poll/[id].astro
+++ b/website/src/pages/poll/[id].astro
@@ -93,7 +93,7 @@ const resultsUrl = `/poll/${id}/results`;
     )}
   </div>
 
-  <script define:vars={{ pollId: id, pollKind: poll?.kind ?? 'text', isLocked }}>
+  <script is:inline define:vars={{ pollId: id, pollKind: poll?.kind ?? 'text', isLocked }}>
     // Prevent duplicate submission in the same browser session
     if (!isLocked && sessionStorage.getItem('poll_submitted_' + pollId)) {
       const card = document.getElementById('card');

--- a/website/src/pages/portal/loslernen.astro
+++ b/website/src/pages/portal/loslernen.astro
@@ -128,7 +128,7 @@ const sortedThemes = [...themes].sort((a, b) => a.order - b.order);
     </div>
   </div>
 
-  <script define:vars={{ done: summary.done, total: summary.total }}>
+  <script is:inline define:vars={{ done: summary.done, total: summary.total }}>
     // (a) In-page CTA → open the Sidekick on the Agent-Anleitung + scroll the card.
     document.querySelectorAll('[data-jump-domid]').forEach((btn) => {
       btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

Resolves 22 astro check / TypeScript warnings across the website codebase. These are all safe, mechanical fixes with no behavior changes.

### Changes

| Category | Fix | Files |
|----------|-----|-------|
| **Unused imports** | Remove ,  (never used in template) |  |
| **Unused variable** | Remove  (declared, never read) |  |
| **Unnecessary `await`** |  is synchronous — remove `await` | , , 2 save endpoints |
| **Unnecessary `await`** | `client.messages.stream()` returns Stream directly | `claude-session-agent.ts` |
| **Deprecated API** | `buf.slice()` → `buf.subarray()` (Node.js deprecation) | `invoice-pdf.test.ts` |
| **Knip config** | Remove stale `ignore` entry (`src/**/*.generated.*`) and dead `entry` (`src/content/config.ts`) | `knip.json` |
| **Duplicate export** | Remove `platformPool` alias from `db-pool.ts`, re-export as `pool as platformPool` from `website-db.ts` | `db-pool.ts`, `website-db.ts` |
| **Astro `is:inline`** | Add `is:inline` to 5 `<script define:vars>` tags | `TicketDetailSections`, `fragebogen`, `projekte`, `poll`, `loslernen` |
| **Zod v4 deprecation** | `z.string().email()` → `z.email()`, `z.string().url()` → `z.url()` | `einvoice/types.ts`, `components/*.ts` |
| **Test mock alignment** | `mockResolvedValue` → `mockReturnValue` (matches sync API) | `coaching-content.test.ts`, `fuehrung-content.test.ts` |

### Results

- **astro check**: 105 → 83 warnings (22 fixed)
- **tsc --noEmit**: clean
- **vitest**: 2744 passed, 2 pre-existing failures in `identity.test.ts` (unrelated)

### Skipped (intentional)

- `getLoginUrl` unused-import warnings: false positive — function IS used in frontmatter but `astro check` doesn't track it correctly
- `parsed.error.flatten()` deprecation: changing would alter API response format
- `tseslint.config()` deprecation: minor, no functional impact
- `Layout.astro` `rel`/`onload` warnings: false positive — HTML attributes, not JS variables