### PR TITLE
chore(dev-flow): fail-visible openspec-embed wrapper for plan skills

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -329,8 +329,14 @@ lebt in `scripts/vda/ticket/stage-plan.sh` — `scripts/ticket.sh` bleibt unber�
 
 **Embedding-Index (Hybrid-Kontext-Transfer Teil 2):** Direkt nach dem Stage, vor
 Commit/Push, den Change nach pgvector indizieren, damit die Execute-/Factory-Phase
-ihn per factory-mcp `openspec_find_similar` abrufen kann:
-`node scripts/openspec-embed.mjs --slug <slug>`
+ihn per factory-mcp `openspec_find_similar` abrufen kann — über den **fail-visible
+Wrapper** (NICHT das nackte `openspec-embed.mjs`, das skippt bei fehlender Env still):
+`bash scripts/openspec-embed-local.sh <slug> "$(pwd)"`
+(2. Argument = Worktree-Root, in dem `openspec/changes/<slug>/` liegt. Der Wrapper
+löst SESSIONS_DATABASE_URL selbst per kubectl/port-forward auf, probt das
+TEI-Backend vorab und bricht mit Remediation-Hinweis ab statt still zu skippen.
+Exit ≠ 0 ⇒ Embedding fehlt — beheben, nicht ignorieren; Erfolgskriterium ist die
+Zeile `indexed slug='<slug>'`.)
 Fallback (ticket-mcp nicht erreichbar):
 ```bash
 # Falls TICKET_EXT_ID bereits gesetzt ist (von feature-intake oder User-Input),

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -158,7 +158,11 @@ Partial-Anzahl fürs Gang-Gating mitgeben (T002074) — via `set_plan_meta`, son
 `bash scripts/ticket.sh stage-plan --id "$TICKET_EXT_ID" --branch "feature/<slug>" --plan "openspec/changes/<slug>/tasks.md" --partials N`
 (N = Partials aus dem Manifest, 1..3; `--partials` lebt in `scripts/vda/ticket/stage-plan.sh`,
 `ticket.sh` bleibt unberührt). Danach den Change nach pgvector indizieren
-(Hybrid-Kontext-Transfer Teil 2): `node scripts/openspec-embed.mjs --slug <slug>`.
+(Hybrid-Kontext-Transfer Teil 2) — über den fail-visible Wrapper, NICHT das nackte
+`openspec-embed.mjs` (skippt bei fehlender Env still):
+`bash scripts/openspec-embed-local.sh <slug> "$(pwd)"` — Exit ≠ 0 ⇒ Embedding fehlt,
+beheben statt ignorieren (Erfolg = Ausgabe `indexed slug='<slug>'`; Wrapper löst
+DB-URL per kubectl auf und probt das TEI-Backend vorab).
 
 #### Schritt 5: Commit & Push — dann STOPP
 

--- a/scripts/openspec-embed-local.sh
+++ b/scripts/openspec-embed-local.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scripts/openspec-embed-local.sh — fail-visible wrapper around openspec-embed.mjs
+# for dev-flow-plan / opencode-flow-plan (Hybrid-Kontext-Transfer Teil 2).
+#
+# Problem: openspec-embed.mjs ist best-effort und skippt STILL, wenn
+# SESSIONS_DATABASE_URL fehlt oder das TEI-Embedding-Backend down ist — der
+# pgvector-Index (knowledge.chunks) bleibt dann leer und factory-mcp
+# `openspec_find_similar` findet den Change nicht (T002081/T002082-Vorfall).
+#
+# Dieser Wrapper macht den Schritt verlässlich:
+#   1. SESSIONS_DATABASE_URL: falls nicht gesetzt, per kubectl aus dem
+#      Website-Deployment gelesen (Literal-Env) und über einen temporären
+#      port-forward auf die Fleet-shared-db umgeschrieben. Die URL enthält
+#      Credentials und wird NIE ausgegeben.
+#   2. LLM_EMBED_URL: Default lokaler TEI-socat (127.0.0.1:8081), Fallback
+#      TEI-Docker direkt (127.0.0.1:9081). Vorab-Probe; bei totem Backend
+#      klare Remediation statt Silent-Skip.
+#   3. Ausgabe von openspec-embed.mjs wird geprüft: nur "indexed slug=" ist
+#      Erfolg (Exit 0). "skipping"/"failure" => Exit 1 mit Hinweis.
+#
+# Usage: bash scripts/openspec-embed-local.sh <slug> [<repo-root-mit-change>]
+#   <repo-root-mit-change>: optionaler Worktree-Pfad (OPENSPEC_EMBED_REPO),
+#   Default: Repo-Root dieses Checkouts.
+set -euo pipefail
+
+SLUG="${1:?usage: openspec-embed-local.sh <slug> [repo-root]}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+EMBED_REPO="${2:-$REPO_ROOT}"
+CTX="${FACTORY_CTX:-fleet}"
+
+PF_PID=""
+cleanup() { [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --- 1. Embedding-Backend proben (fail-fast, bevor wir die DB anfassen) -----
+probe_embed() {
+  curl -s --max-time 3 -o /dev/null -w '%{http_code}' \
+    -X POST "$1/v1/embeddings" -H 'Content-Type: application/json' \
+    -d '{"input":["ping"],"model":"bge-m3"}' 2>/dev/null || echo 000
+}
+EMBED_URL="${LLM_EMBED_URL:-http://127.0.0.1:8081}"
+if [[ "$(probe_embed "$EMBED_URL")" != "200" ]]; then
+  if [[ "$(probe_embed "http://127.0.0.1:9081")" == "200" ]]; then
+    EMBED_URL="http://127.0.0.1:9081"
+  else
+    cat >&2 <<'EOF'
+[openspec-embed-local] FEHLER: kein Embedding-Backend erreichbar (weder :8081 noch :9081).
+Remediation (WSL-Host, TEI läuft als Docker-Container — die systemd-Unit
+tei-embed.service scheitert unter Docker Desktop an "docker.service not found"):
+  docker rm -f tei-embed 2>/dev/null
+  docker run -d --name tei-embed -p 127.0.0.1:9081:80 \
+    -v /var/lib/llm/hf-cache:/data \
+    ghcr.io/huggingface/text-embeddings-inference:cpu-1.9 \
+    --model-id BAAI/bge-m3 --port 80 --max-client-batch-size 64 --max-batch-tokens 16384
+  # dann warten bis: curl -s http://127.0.0.1:9081/health -> 200
+EOF
+    exit 1
+  fi
+fi
+
+# --- 2. DB-URL beschaffen (nie ausgeben!) -----------------------------------
+DB_URL="${SESSIONS_DATABASE_URL:-${DATABASE_URL:-}}"
+if [[ -z "$DB_URL" ]]; then
+  RAW_URL="$(kubectl --context "$CTX" -n website get deploy website \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SESSIONS_DATABASE_URL")].value}' 2>/dev/null || true)"
+  if [[ -z "$RAW_URL" ]]; then
+    echo "[openspec-embed-local] FEHLER: SESSIONS_DATABASE_URL nicht gesetzt und nicht aus dem Cluster (--context $CTX) auflösbar." >&2
+    exit 1
+  fi
+  PF_PORT="${OPENSPEC_EMBED_PF_PORT:-15432}"
+  kubectl --context "$CTX" -n workspace port-forward svc/shared-db "${PF_PORT}:5432" >/dev/null 2>&1 &
+  PF_PID=$!
+  for _ in $(seq 1 10); do
+    (exec 3<>"/dev/tcp/127.0.0.1/${PF_PORT}") 2>/dev/null && { exec 3>&- 3<&-; break; } || sleep 1
+  done
+  DB_URL="$(printf '%s' "$RAW_URL" | sed -E "s#@[^/]+/#@127.0.0.1:${PF_PORT}/#")"
+fi
+
+# --- 3. Embed + fail-visible Auswertung -------------------------------------
+OUT="$(SESSIONS_DATABASE_URL="$DB_URL" LLM_EMBED_URL="$EMBED_URL" LLM_ENABLED=true \
+  OPENSPEC_EMBED_REPO="$EMBED_REPO" \
+  node "$REPO_ROOT/scripts/openspec-embed.mjs" --slug "$SLUG" 2>&1 || true)"
+# Credentials-sicher loggen (URLs rausfiltern)
+printf '%s\n' "$OUT" | grep -v '://' >&2 || true
+
+if printf '%s' "$OUT" | grep -q "indexed slug='"; then
+  exit 0
+fi
+echo "[openspec-embed-local] FEHLER: Embedding wurde NICHT indiziert (Output oben) — nicht still weitermachen." >&2
+exit 1


### PR DESCRIPTION
## Warum
Der Embedding-Schritt (Hybrid-Kontext-Transfer Teil 2) in dev-flow-plan/opencode-flow-plan rief das best-effort-Skript `openspec-embed.mjs` direkt auf — das skippt bei fehlender `SESSIONS_DATABASE_URL` oder totem TEI-Backend STILL (Exit 0). Ergebnis: T002081/T002082 wurden ohne pgvector-Index gestaged; `openspec_find_similar` hätte die Changes nie gefunden.

## Was
- Neu `scripts/openspec-embed-local.sh`: löst die DB-URL selbst auf (kubectl → Website-Deployment-Env + temporärer shared-db-Port-Forward, Credentials werden nie ausgegeben), probt das TEI-Backend vorab (:8081-socat, Fallback :9081), wertet die Ausgabe aus — nur `indexed slug='…'` ist Erfolg, sonst Exit 1 mit Remediation (inkl. Docker-Startkommando für den TEI-Container, dessen systemd-Unit unter Docker Desktop an `docker.service not found` scheitert).
- Beide Skill-Docs (`.claude/skills/dev-flow-plan`, `.opencode/skills/opencode-flow-plan`) rufen jetzt den Wrapper statt des nackten mjs auf und behandeln Exit ≠ 0 als zu behebenden Fehler.

Getestet: Wrapper end-to-end ohne vorgesetzte Env (kubectl-Auflösung + Port-Forward + TEI-Probe) → `indexed slug='local-llm-proxy': 13 chunks`; `task test:changed` + `task freshness:check` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ha7UcZ6k8PdEdukxN9tee4