### PR TITLE
chore(dev-flow): fix stale openspec-embed invocation in dev-flow-plan spec [T002084]

### DIFF
--- a/openspec/specs/dev-flow-plan.md
+++ b/openspec/specs/dev-flow-plan.md
@@ -289,9 +289,11 @@ The stage step SHALL persist the partial count on the ticket for gang gating:
 <path> --partials N` writes `slot_count = N` (validated 1..3, default 1) in the
 same staging query, implemented in `scripts/vda/ticket/stage-plan.sh` without
 growing `scripts/ticket.sh`. Immediately after staging and before commit/push,
-the skills SHALL run `node scripts/openspec-embed.mjs --slug <slug>` so the
-change is indexed into pgvector as the embedding-side context transfer for the
-execute/factory phase (retrieved via factory-mcp `openspec_find_similar`).
+the skills SHALL run `bash scripts/openspec-embed-local.sh <slug> "$(pwd)"`
+(the fail-visible wrapper — not the bare `openspec-embed.mjs`, which skips
+silently on missing env) so the change is indexed into pgvector as the
+embedding-side context transfer for the execute/factory phase (retrieved via
+factory-mcp `openspec_find_similar`).
 
 #### Scenario: Staging a three-partial plan sets slot_count
 
@@ -303,6 +305,6 @@ execute/factory phase (retrieved via factory-mcp `openspec_find_similar`).
 
 - **GIVEN** the plan was just staged
 - **WHEN** the skill continues to the commit step
-- **THEN** `node scripts/openspec-embed.mjs --slug <slug>` has been invoked for the change before the plan commit is pushed
+- **THEN** `bash scripts/openspec-embed-local.sh <slug> "$(pwd)"` has been invoked for the change before the plan commit is pushed
 
 <!-- merged from change delta dev-flow-plan.md (2c84896a552a) -->


### PR DESCRIPTION
## Summary
- The SSOT spec `openspec/specs/dev-flow-plan.md` still documented the bare `node scripts/openspec-embed.mjs --slug <slug>` invocation, but the skill was already switched to the fail-visible `openspec-embed-local.sh <slug> <repo-path>` wrapper by PR #3111.
- Discovered live during T002083 (FluxCD gitops) plan staging — a fresh reader following the spec's example hits "no SESSIONS_DATABASE_URL set" and has to rediscover the correct wrapper syntax by trial and error.
- Docs-only fix, no behavior change: sync the two spec examples to the wrapper's positional syntax and note why the bare `.mjs` is wrong (skips silently on missing env).

## Test plan
- [x] `task test:changed` — 52/52 pass
- [x] `task freshness:regenerate && task freshness:check` — clean, no unexpected diffs
- [x] `bash scripts/preflight-pr-scope.sh` — scope 'dev-flow' OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYzhJFYaE3Me7wbNz2szy2