### PR TITLE
chore(opencode): remove stale bonsai-27b/qwen35-iq4 refs, align on bonsai-8b [T002093]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -34,14 +34,10 @@
         "baseURL": "http://127.0.0.1:8093/v1"
       },
       "models": {
-        // 2026-07-22: 27B komplett entladen, KEIN Skript laedt es mehr - Port
-        // 8093 bedient jetzt in beiden Modi Ternary-Bonsai-8B: entweder
-        // start-bonsai-server.ps1 (2 Slots x 65536 = max Kontext pro Slot,
-        // gepaart mit Bonsai-Image) oder start-bonsai-parallel.ps1
-        // (VRAM-abhaengig viele Slots, kein Bild-Gen). Modell ist in beiden
-        // Faellen identisch, nur -np/-c unterscheiden sich.
+        // Ternary-Bonsai-8B on port 8093: up to 4 parallel slots x 65536 ctx
+        // each, combined KV cache. start-bonsai-parallel.ps1 configures -np 4.
         "Ternary-Bonsai-8B-Q2_0.gguf": {
-          "name": "Ternary-Bonsai-8B (Q2_0, 65k ctx/Slot)",
+          "name": "Ternary-Bonsai-8B (Q2_0, 4x65k parallel, combined KV)",
           "limit": {
             "context": 65536,
             "output": 8192
@@ -133,7 +129,7 @@
   },
   "agent": {
     "bonsai-8b": {
-      "description": "PRIMARY SUBAGENT (Quality-Modus, start-bonsai-server.ps1): Ternary-Bonsai-8B (65k context per slot, up to 2 parallel slots via llama-server on port 8093, paired with Bonsai-Image on the same GPU). 2026-07-22: replaces the former bonsai-27b agent - 27B is no longer loaded by any script.",
+      "description": "PRIMARY SUBAGENT: Ternary-Bonsai-8B (Q2_0, 65k ctx/slot, max 4 parallel slots via llama-server on port 8093, combined KV cache).",
       "mode": "subagent",
       "model": "llama-bonsai-server/Ternary-Bonsai-8B-Q2_0.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",

--- a/.opencode/skills/dev-flow/background-agents.ts
+++ b/.opencode/skills/dev-flow/background-agents.ts
@@ -1018,9 +1018,8 @@ class DelegationManager {
 		const resolvedResult = await this.resolveDelegationResult(delegation)
 		delegation.result = resolvedResult
 
-		// [T001978] Empty-output fallback removed 2026-07-22 — qwen35-iq4/hq agents
-		// deleted; bonsai-27b is the sole subagent. If it returns empty, treat as
-		// a normal completion (empty result) rather than retrying with a removed agent.
+		// [T001978] Empty-output fallback removed 2026-07-22. If bonsai-8b returns
+		// empty, treat as a normal completion rather than retrying.
 
 		if (resolvedResult.trim().length > 0) {
 			const metadata = await this.metadataGenerator(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Loaded via `.opencode/opencode.jsonc` (and its alias `.agents/settings.json`, which is a symlink to it) → `"instructions": ["AGENTS.md"]`. Comprehensive reference: `CLAUDE.md`.
 
-> **Subagent file layout:** `.claude/agents/bachelorprojekt-*.md` is the canonical source. `.agents/agents` is a directory symlink to `../.claude/agents` — **Claude Code only** reads these via its native `task` tool dispatch. **opencode does NOT read `.agents/agents/`** — it uses its own agent definitions in `.opencode/agent-models.jsonc` (local LLM subagents: `bonsai-27b`). Edit domain agents at `.claude/agents/<name>.md` (or its `.agents/agents/<name>.md` alias).
+> **Subagent file layout:** `.claude/agents/bachelorprojekt-*.md` is the canonical source. `.agents/agents` is a directory symlink to `../.claude/agents` — **Claude Code only** reads these via its native `task` tool dispatch. **opencode does NOT read `.agents/agents/`** — it uses its own agent definitions in `.opencode/agent-models.jsonc` (local LLM subagents: `bonsai-8b`). Edit domain agents at `.claude/agents/<name>.md` (or its `.agents/agents/<name>.md` alias).
 
 ## Agent Routing
 
@@ -27,11 +27,11 @@ opencode uses the `background-agents.ts` plugin which reads agents from `agent-m
 
 | Agent | Model | Permissions | Use case |
 |-------|-------|-------------|----------|
-| `bonsai-27b` | Ternary-Bonsai-27B (Q2_0, 130k ctx per slot) | write-capable | **Preferred single choice** for delegation (up to 2 parallel slots on port 8093) |
+| `bonsai-8b` | Ternary-Bonsai-8B (Q2_0, 65k ctx/slot, 4 parallel slots, combined KV) | write-capable | **Preferred single choice** for delegation (max 4 parallel, port 8093) |
 | `explore` | built-in | read-only | Fast codebase exploration |
 | `general` | built-in | read-only | General research tasks |
 
-Read-only agents use `delegate(prompt, agent)`. Write-capable work stays in the main session (no write-capable subagents defined).
+Read-only agents use `delegate(prompt, agent)`. Write-capable work (e.g. `bonsai-8b`) uses `task` with the agent name.
 
 ## Core Commands
 


### PR DESCRIPTION
## Summary

Remove all stale references to the deleted bonsai-27B model and qwen35-iq4/qwythos agents across config files. Align everything on the current `bonsai-8b` agent (Ternary-Bonsai-8B, Q2_0, 65k ctx/slot, 4 parallel slots, combined KV).

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Agent name `bonsai-27b` → `bonsai-8b`, specs updated to 4 parallel 65k ctx/slot combined KV |
| `.opencode/agent-models.jsonc` | Model comment + agent description cleaned of 27B references |
| `.opencode/skills/dev-flow/background-agents.ts` | Removed stale `bonsai-27b`/qwen35-iq4 comment |

## Out of scope (not in git)

- `~/.config/opencode/opencode.jsonc` — 27B comments cleaned locally
- `~/.config/opencode/plugins/background-agents.ts` — qwen35-iq4 routing → bonsai-8b

## Verification

```bash
rg -rn 'bonsai-27b|qwen35-iq4|qwen35-hq|qwythos-hq|Ternary-Bonsai-27B' AGENTS.md .opencode/ .claude/ CLAUDE.md
# Expected: no matches
```