### PR TITLE
chore(opencode): deny task tool for write-capable subagents [T002106]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -131,7 +131,7 @@
       "color": "#F59E0B",
       "temperature": 0.4,
       "steps": 4,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow" }
+      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
     },
     "bonsai-8b-2": {
       "description": "Write-capable subagent 2/3 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
@@ -141,7 +141,7 @@
       "color": "#F97316",
       "temperature": 0.4,
       "steps": 4,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow" }
+      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
     },
     "bonsai-8b-3": {
       "description": "Write-capable subagent 3/3 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
@@ -151,7 +151,7 @@
       "color": "#EA580C",
       "temperature": 0.4,
       "steps": 4,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow" }
+      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
     },
     // Eskalationsstufe fuer Parallel-Agenten (start-bonsai-parallel.ps1), NACH
     // lokaler Kontext-Kompaktierung/Retry und opencodes eigener Kompaktierung -
@@ -165,7 +165,7 @@
       "prompt": "{file:./prompts/deepseek-helper.md}",
       "color": "#F97316",
       "temperature": 0.3,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "webfetch": "deny", "websearch": "deny" }
+      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny", "webfetch": "deny", "websearch": "deny" }
     }
   }
 }


### PR DESCRIPTION
## Summary
- bonsai-8b-1/2/3 and deepseek-helper only overrode edit/write/bash in their permission block, silently inheriting the global `"task": "allow"` default from opencode.jsonc
- bonsai-8b used the inherited permission to try spawning a nested subagent while implementing T002072, tripping opencode's built-in subagent-nesting depth limit ("Subagent depth limit reached (1)") and repeatedly retrying instead of doing the work — burning its exclusive single-slot context
- Adds explicit `"task": "deny"` to all four write-capable subagent permission blocks

Ticket: T002106

## Test plan
- [ ] Config-only change (JSONC), no code path affected — validated by `task quality:check` in the pre-push hook (0 blocking violations)
- [ ] Re-dispatch a write-capable task to `bonsai-8b-1` and confirm no more depth-limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfFRwbZi2HmSmnYzd6YdRC