### PR TITLE
fix(infra): switch dev LLM_HOST_IP from Docker bridge to wg-mesh [T002109]

### DIFF
--- a/environments/dev.yaml
+++ b/environments/dev.yaml
@@ -21,7 +21,10 @@ env_vars:
   LLM_CODING_MODEL: "qwen/qwen3.5-9b"
   LLM_EMBED_MODEL: "text-embedding-bge-m3"
   LLM_EMBED_MODEL_NOMIC: "text-embedding-nomic-embed-text-v1.5"
-  LLM_HOST_IP: "172.17.0.1"
+  # wg-gpu-Adresse des WSL-Hosts — derselbe GPU-Peer, den die Prod-Envs adressieren.
+  # Docker-Bridge-Adressen funktionieren hier nicht: Docker Desktop fährt den Daemon in
+  # einer eigenen Distro, k3d vergibt pro Cluster ein zufälliges Subnetz. [T002109]
+  LLM_HOST_IP: "192.168.100.10"
   TURN_OVERLAY_IP: "172.17.0.1"
   TERMINAL_OVERLAY_IP: "172.17.0.1"
 

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -355,7 +355,7 @@ env_vars:
   - name: LLM_HOST_IP
     required: false
     default_dev: ""
-    description: "Mesh IP of the GPU host running TEI embed + LM Studio. Required when LLM_ENABLED=true. Empty in dev."
+    description: "Mesh IP of the GPU host running TEI embed + LM Studio. Required when LLM_ENABLED=true. The dev env sets this explicitly in environments/dev.yaml."
 
   - name: LLM_ENABLED
     required: true

--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -2,7 +2,7 @@
 # llm-gpu: external GPU peer — LM Studio + TEI
 #
 # LM Studio (Windows) läuft auf port 1234. K8s-Pods erreichen den Host
-# direkt via wg-mesh IP (prod) oder Docker-Bridge 172.17.0.1 (dev k3d).
+# direkt via wg-mesh IP (192.168.100.0/24). Docker-Bridge funktioniert im Dev
 # Kein socat nötig — Service-Port ist 1234 (kein Proxy-Port mehr).
 #
 # Modelle im LM Studio:
@@ -16,7 +16,7 @@
 #   llm-gateway-tei-embed  :8081  (bge-m3 via TEI, optional)
 #   llm-gateway-tei-rerank :8083  (bge-reranker-v2-m3 via TEI)
 #
-# ${LLM_HOST_IP}: 172.17.0.1 (dev k3d) | wg-mesh IP (prod fleet)
+# ${LLM_HOST_IP}: 192.168.100.10 (wg-mesh — dev + prod fleet)
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── LM Studio — alle Modelle auf port 1234 (Windows, kein socat) ─────────────

--- a/openspec/changes/k3d-dev-llm-bridge/design.md
+++ b/openspec/changes/k3d-dev-llm-bridge/design.md
@@ -1,0 +1,129 @@
+---
+ticket_id: T002109
+plan_ref: openspec/changes/k3d-dev-llm-bridge/tasks.md
+status: active
+date: 2026-07-23
+---
+
+# k3d-dev-llm-bridge — Design
+
+## Purpose
+
+Pods im lokalen k3d-Dev-Cluster (`korczewski`) können die LLM-Dienste auf dem WSL-Host nicht
+erreichen, weil `environments/dev.yaml` `LLM_HOST_IP` auf die Docker-Bridge `172.17.0.1`
+festnagelt. Diese Adresse existiert in dieser Umgebung nirgends: Docker Desktop fährt den Daemon in
+einer eigenen `docker-desktop`-WSL-Distro, k3d legt pro Cluster ein zufälliges Netz an (derzeit
+`172.21.0.0/16`), und in der Arbeits-Distro gibt es überhaupt kein `docker0`/`br-*`-Interface. Der
+Fix richtet `LLM_HOST_IP` im Dev auf dieselbe WireGuard-Mesh-Adresse aus, die Prod bereits nutzt,
+und verankert die Invariante in einem Regressionstest.
+
+---
+
+## Root-Cause-Analyse
+
+Die Ausgangsvermutung lautete auf drei unabhängige Defekte. Die Messung hat zwei davon widerlegt;
+festgehalten wird hier auch, was *nicht* zu ändern ist, damit spätere Sessions die verworfenen
+Pfade nicht erneut aufmachen.
+
+### RC1 — `LLM_HOST_IP` zeigt auf eine nicht existierende Bridge *(einzige Repo-Ursache)*
+
+`environments/dev.yaml:24` setzt `LLM_HOST_IP: "172.17.0.1"`. Über `Taskfile.llm.yml:40`
+(`envsubst '$LLM_HOST_IP' < k3d/llm-gpu.yaml`) landet dieser Wert in den `Endpoints`-Objekten von
+`llm-gateway-lmstudio` (1234), `llm-gateway-tei-embed` (8081) und `llm-gateway-tei-rerank` (8083).
+Alle drei zeigen damit ins Leere.
+
+Messung aus einem Pod heraus — jede Kombination aus `{172.21.0.1, 172.17.0.1}` × `{18235, 9081,
+8083}` liefert `unreachable`. `ip -4 -o addr show` in der Arbeits-Distro listet weder `docker0`
+noch ein `br-*`-Interface; die Container-Netze leben in der `docker-desktop`-Distro.
+
+### RC2 — NetworkPolicy *(kein Fix nötig — verworfen)*
+
+`allow-llm-gateway-egress` (`k3d/network-policies.yaml:114-140`) erlaubt Egress nach
+`192.168.100.0/24` und `10.13.14.0/24` auf den Ports 1234/8081/8083/8189. Für den Cluster-Pfad ist
+das **bereits korrekt**, sobald `LLM_HOST_IP` in `192.168.100.0/24` liegt. Eine dev-spezifische
+NetworkPolicy nach dem Muster von `k3d/network-policies-dev.yaml` (T001853) ist ausdrücklich
+**nicht** erforderlich.
+
+Der Port `18235` gehört bewusst *nicht* in diese Liste — siehe RC3.
+
+### RC3 — Loopback-Bindungen *(kein Fix nötig — verworfen)*
+
+Zwei Host-Dienste binden auf `127.0.0.1`, und das ist in beiden Fällen spezifikationskonform:
+
+- `scripts/llm-proxy/server.mjs:163` (`:18235`) — `openspec/specs/local-llm-proxy.md` definiert den
+  Proxy als **Host-internes** Werkzeug für Factory/opencode/`route-provider.sh`; alle Consumer
+  adressieren ihn als `http://127.0.0.1:18235`. Er ist kein Cluster-Egress-Ziel. Ihn auf ein
+  externes Interface zu binden, würde einen unauthentifizierten LLM-Proxy exponieren — unter WSL
+  `networkingMode=mirrored` sogar auf dem Windows-Netzstack.
+- `scripts/openspec-embed-local.sh:52` (`-p 127.0.0.1:9081:80`) — TEI-Container für den
+  OpenSpec-Embedding-Lauf, ebenfalls nur host-intern konsumiert.
+
+Die vom Cluster tatsächlich adressierten Dienste binden bereits erreichbar: `*:8081` (TEI-Embed,
+`/health` → 200) und `0.0.0.0:8083` (TEI-Rerank).
+
+### RC4 — Cluster ist eine Vor-T001853-Instanz *(Betriebszustand)*
+
+Der laufende Cluster nutzt API-Port `46435`; `k3d-config.yaml` pinnt seit T001853
+`kubeAPI.hostPort: "6445"`. Der Cluster wurde seit dem Fix nie neu erstellt. Kein Repo-Defekt, aber
+der Grund, warum die Verifikation eine Cluster-Neuanlage verlangt.
+
+---
+
+## Gewählter Ansatz: wg-Mesh-Adresse statt Docker-Bridge
+
+`LLM_HOST_IP` im Dev auf **`192.168.100.10`** setzen — die `wg-gpu`-Adresse des WSL-Hosts.
+
+Der Host ist selbst der GPU-Peer im WireGuard-Mesh: `ip addr` zeigt `eth3`/`wg-gpu` mit
+`192.168.100.10/32`, und `environments/mentolder.yaml`, `korczewski.yaml`,
+`fleet-mentolder.yaml`, `fleet-korczewski.yaml` verwenden exakt diese Adresse als `LLM_HOST_IP`.
+Dev erhält damit dieselbe Semantik wie Prod statt einer k3d-Sonderlocke.
+
+**Empirisch verifiziert** (Test-Listener auf `192.168.100.10:19999`):
+
+| Messung | Ergebnis |
+|---|---|
+| Host-Prozess bindet auf `192.168.100.10` | BIND-OK |
+| `docker run --network k3d-korczewski curl http://192.168.100.10:19999/` | **HTTP 200** |
+| dieselbe Anfrage gegen `192.168.65.254` (Docker-Desktop-Gateway) | `000` |
+
+### Verworfene Alternativen
+
+| Alternative | Grund für Verwerfung |
+|---|---|
+| Docker-Subnetz in `k3d-config.yaml` pinnen (`network:` + festes CIDR) | Das Gateway existierte nur in der `docker-desktop`-Distro; ein Host-Prozess könnte nicht darauf binden. Erzwingt zusätzlich eine Cluster-Neuanlage. |
+| `LLM_HOST_IP: auto` + Auflösung via `docker network inspect` in `env-resolve.sh` | Koppelt den Deploy an Docker-CLI-Zugriff und ist statisch kaum testbar — der Regressionstest könnte die Invariante nicht mehr prüfen. |
+| `host.k3d.internal` + `ExternalName`-Services | `host.k3d.internal` löst im Cluster nicht auf (gemessen). Würde zudem die Service-Topologie zwischen Dev und Prod divergieren lassen. |
+
+### Bewusst nicht Teil dieses Fixes
+
+- **LM Studio auf `:1234` läuft nicht.** Betriebszustand, kein Repo-Defekt. Nach dem Fix greift der
+  Endpoint, sobald LM Studio gestartet wird. TEI-Embed (8081) und -Rerank (8083) funktionieren
+  sofort.
+- **Netpol-Port `18235`**, **Bind-Adressen der Host-Tools** — siehe RC2/RC3.
+
+---
+
+## Risiken
+
+| Risiko | Abschätzung |
+|---|---|
+| `wg-gpu`-Interface ist beim Deploy nicht oben | Die Endpoints-Objekte werden trotzdem korrekt gerendert; die Verbindung schlägt erst zur Laufzeit fehl — dasselbe Verhalten wie in Prod. Kein Deploy-Blocker. |
+| Ein anderer Dev-Host hat nicht `192.168.100.10` | `environments/dev.yaml` beschreibt genau diese Maschine (WSL-Host = GPU-Peer). Weicht ein Setup ab, ist der Wert wie jede andere env-Variable zu überschreiben. |
+| Regression durch spätere „Aufräum"-Edits zurück auf eine Bridge-IP | Genau dagegen richtet sich der RED-Test: er verbietet Docker-Bridge-Adressen in `dev.yaml` explizit. |
+
+---
+
+## Verifikation
+
+1. **Statisch (CI):** BATS-Test in `tests/spec/llm-pipeline.bats` — `LLM_HOST_IP` in `dev.yaml`
+   liegt in `192.168.100.0/24` und ist keine Docker-Bridge-Adresse; die NetworkPolicy deckt dieses
+   CIDR ab.
+2. **Gerendert:** `envsubst` über `k3d/llm-gpu.yaml` erzeugt Endpoints mit `192.168.100.10`.
+3. **End-to-End (nach Merge, manuell):** `task cluster:create` (nimmt zugleich RC4 mit) +
+   `task workspace:deploy ENV=dev`, danach ein Pod gegen `llm-gateway-tei-embed:8081/health`.
+
+## Verwandte Tickets
+
+- **T002109** — dieses Ticket
+- **T001853** — k3d-Basis-Drift (done); lieferte `kubeAPI.hostPort`-Pin und `network-policies-dev.yaml`
+- **T002102** — Unified LLM Gateway (done); legte `:18235` als host-internen Proxy fest

--- a/openspec/changes/k3d-dev-llm-bridge/specs/llm-pipeline.md
+++ b/openspec/changes/k3d-dev-llm-bridge/specs/llm-pipeline.md
@@ -6,7 +6,7 @@ Update LLM_HOST_IP for the dev k3d environment from the unreachable Docker bridg
 (172.17.0.1) to the wg-mesh address (192.168.100.10) that all prod environments
 already use. Documentation fixes in k3d/llm-gpu.yaml and environments/schema.yaml.
 
-## CHANGED Requirements
+## MODIFIED Requirements
 
 ### Requirement: LLM-PIPELINE-001 — Dev LLM_HOST_IP is reachable from k3d pods
 

--- a/openspec/changes/k3d-dev-llm-bridge/specs/llm-pipeline.md
+++ b/openspec/changes/k3d-dev-llm-bridge/specs/llm-pipeline.md
@@ -1,0 +1,17 @@
+# llm-pipeline — Delta-Spec
+
+## Purpose
+
+Update LLM_HOST_IP for the dev k3d environment from the unreachable Docker bridge
+(172.17.0.1) to the wg-mesh address (192.168.100.10) that all prod environments
+already use. Documentation fixes in k3d/llm-gpu.yaml and environments/schema.yaml.
+
+## CHANGED Requirements
+
+### Requirement: LLM-PIPELINE-001 — Dev LLM_HOST_IP is reachable from k3d pods
+
+| | Before | After |
+|---|---|---|
+| Value | `172.17.0.1` (Docker bridge) | `192.168.100.10` (wg-mesh) |
+| Source | environments/dev.yaml:24 | environments/dev.yaml:24 |
+| Reachable | No — Docker Desktop daemon lives in separate distro; no `docker0` exists | Yes — empirically verified; same IP as all prod envs |

--- a/openspec/changes/k3d-dev-llm-bridge/tasks.md
+++ b/openspec/changes/k3d-dev-llm-bridge/tasks.md
@@ -1,0 +1,124 @@
+---
+title: "k3d-Dev-Cluster erreicht Host-LLM: LLM_HOST_IP auf wg-Mesh-Adresse umstellen"
+ticket_id: T002109
+domains: [infra, test]
+status: plan_staged
+---
+
+# k3d-dev-llm-bridge — Implementation Plan
+
+Pods im lokalen k3d-Dev-Cluster erreichen die LLM-Dienste auf dem WSL-Host nicht, weil
+`environments/dev.yaml` `LLM_HOST_IP` auf die Docker-Bridge `172.17.0.1` festnagelt — eine Adresse,
+die in dieser Umgebung nirgends existiert. Der Fix richtet den Wert auf die `wg-gpu`-Adresse
+`192.168.100.10` aus, die Prod bereits nutzt. Root-Cause-Analyse, Messwerte und die verworfenen
+Alternativen stehen in `openspec/changes/k3d-dev-llm-bridge/design.md`.
+
+Der Eingriff ist bewusst minimal: die NetworkPolicy deckt `192.168.100.0/24` bereits ab, und die
+Loopback-Bindungen von `llm-proxy` (`:18235`) und `tei-embed` (`:9081`) sind laut
+`openspec/specs/local-llm-proxy.md` beabsichtigt — beide bleiben unangetastet.
+
+<!-- vitest: kein neuer Test nötig, weil ausschließlich Config-/Manifest-Dateien und BATS
+     geändert werden — kein `.ts`/`.svelte`-Code im Scope. -->
+
+## File Structure
+
+| Datei | Art | S1 |
+|---|---|---|
+| `environments/dev.yaml` | geändert — `LLM_HOST_IP` auf wg-Mesh-Adresse | `.yaml`: kein S1-Limit in `gates.yaml` |
+| `environments/schema.yaml` | geändert — veraltete Beschreibung „Empty in dev" | `.yaml`: kein S1-Limit in `gates.yaml` |
+| `k3d/llm-gpu.yaml` | geändert — Kommentar-Doku nennt die falsche Dev-Adresse | `.yaml`: kein S1-Limit in `gates.yaml` |
+| `tests/spec/llm-pipeline.bats` | geändert — 4 Regressionstests (bereits im RED-Commit) | `.bats`: kein S1-Limit in `gates.yaml` |
+| `website/src/data/test-inventory.json` | generiert — via `task test:inventory` | generiert |
+
+Keine der Dateien ist in `docs/code-quality/baseline.json` gebaselined, und `gates.yaml → s1.limits`
+führt weder `.yaml` noch `.bats` — es gibt für diesen Plan folglich keine S1-Zeilenbudgets.
+
+---
+
+## Task 1 — RED-Zustand verifizieren
+
+Der Regressionstest liegt bereits im Stage-Commit (Fix-Pfad Schritt 3). Vor jeder Änderung muss er
+nachweislich aus dem richtigen Grund fehlschlagen.
+
+```bash
+npx --yes bats tests/spec/llm-pipeline.bats
+```
+
+**expected: FAIL** — genau diese drei Tests müssen rot sein:
+
+- `dev LLM_HOST_IP is not a Docker bridge address` → Meldung `LLM_HOST_IP=172.17.0.1 is a Docker
+  bridge address — unreachable from k3d pods`
+- `dev LLM_HOST_IP is inside the wg-mesh CIDR 192.168.100.0/24`
+- `dev LLM_HOST_IP matches the GPU-host address used by prod envs`
+
+Grün sein muss bereits `allow-llm-gateway-egress covers the CIDR that dev LLM_HOST_IP lives in` —
+das belegt, dass die NetworkPolicy nicht angefasst werden darf. Schlägt dieser vierte Test fehl,
+stimmt die Analyse nicht und der Plan ist zu stoppen.
+
+## Task 2 — `LLM_HOST_IP` in `environments/dev.yaml` korrigieren
+
+In `environments/dev.yaml` den Wert von `LLM_HOST_IP` von `"172.17.0.1"` auf `"192.168.100.10"`
+ändern und den Grund als Kommentar verankern, damit die Adresse nicht als versehentlich aus Prod
+kopiert gelesen wird:
+
+```yaml
+  # wg-gpu-Adresse des WSL-Hosts — derselbe GPU-Peer, den die Prod-Envs adressieren.
+  # Docker-Bridge-Adressen funktionieren hier nicht: Docker Desktop fährt den Daemon in
+  # einer eigenen Distro, k3d vergibt pro Cluster ein zufälliges Subnetz. [T002109]
+  LLM_HOST_IP: "192.168.100.10"
+```
+
+`TURN_OVERLAY_IP` und `TERMINAL_OVERLAY_IP` stehen in derselben Datei ebenfalls auf `172.17.0.1`.
+Sie gehören **nicht** in diesen Fix — sie adressieren coturn/Terminal, nicht den LLM-Pfad, sind
+nicht durch die Messung abgedeckt und würden den Scope unbelegt ausweiten. Wer sie prüfen will,
+braucht ein eigenes Ticket.
+
+## Task 3 — Veraltete Doku-Stellen zur Dev-Adresse korrigieren
+
+Zwei Stellen behaupten weiterhin die falsche Dev-Adresse und würden den Fix bei der nächsten
+Änderung wieder einkassieren:
+
+1. `k3d/llm-gpu.yaml` — der Kopfkommentar sagt `K8s-Pods erreichen den Host direkt via wg-mesh IP
+   (prod) oder Docker-Bridge 172.17.0.1 (dev k3d)` sowie `${LLM_HOST_IP}: 172.17.0.1 (dev k3d) |
+   wg-mesh IP (prod fleet)`. Beide Stellen auf die wg-Mesh-Adresse für **beide** Umgebungen
+   umschreiben.
+2. `environments/schema.yaml` — der `LLM_HOST_IP`-Eintrag beschreibt den Wert als `Empty in dev.`
+   Das trifft nicht mehr zu, da `dev.yaml` `LLM_ENABLED: "true"` setzt und damit eine erreichbare
+   Adresse braucht. Beschreibung entsprechend anpassen; `default_dev: ""` bleibt unverändert, weil
+   `dev.yaml` den Wert explizit setzt.
+
+Keine Brand-Domain-Literale einführen (S3) — es geht ausschließlich um IP-Adressen und Prosa.
+
+## Task 4 — Gerendertes Manifest prüfen
+
+Nachweisen, dass die Endpoints tatsächlich mit der neuen Adresse gerendert werden — die Änderung
+wirkt über `Taskfile.llm.yml:40` (`envsubst '$LLM_HOST_IP' < k3d/llm-gpu.yaml`), nicht direkt:
+
+```bash
+set -a && source <(bash scripts/env-resolve.sh dev) && set +a
+envsubst '$LLM_HOST_IP' < k3d/llm-gpu.yaml | grep -A2 'kind: Endpoints' | grep 'ip:'
+```
+
+Erwartung: **drei** `ip: 192.168.100.10`-Zeilen (lmstudio, tei-embed, tei-rerank) und keine
+verbliebene `172.`-Adresse. Zusätzlich `task workspace:validate` ausführen, da eine
+Manifest-Eingangsgröße geändert wurde.
+
+## Task 5 — Verifikation
+
+```bash
+npx --yes bats tests/spec/llm-pipeline.bats   # jetzt 10/10 grün
+task test:inventory                            # Test-Inventar nach BATS-Änderung regenerieren
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+
+`website/src/data/test-inventory.json` mitcommitten — der CI-Inventar-Check vergleicht gegen die
+committete Fassung und failt sonst.
+
+**End-to-End nach dem Merge** (nicht Teil der PR-Verifikation, da eine Cluster-Neuanlage nötig
+ist): `task cluster:create` — das nimmt zugleich RC4 mit, denn der laufende Cluster stammt noch aus
+der Zeit vor dem `kubeAPI.hostPort`-Pin aus T001853 — danach `task workspace:deploy ENV=dev` und
+ein Pod gegen `llm-gateway-tei-embed:8081/health`. Ein Treffer dort beweist die Kette
+Pod → NetworkPolicy → Endpoint → Host-TEI. Der `llm-gateway-lmstudio`-Endpoint bleibt so lange
+tot, bis LM Studio auf `:1234` gestartet wird — das ist Betriebszustand, kein Defekt dieses Fixes.

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -41,3 +41,44 @@ setup() {
 @test "knowledge-db.ts exists for pgvector operations" {
   [ -f "$REPO/website/src/lib/knowledge-db.ts" ]
 }
+
+# ── LLM_HOST_IP reachability from the k3d dev cluster [T002109] ────────
+#
+# The dev k3d cluster reaches the WSL host over the WireGuard mesh
+# (192.168.100.0/24), the same address prod already uses. Docker bridge
+# addresses do not work here: Docker Desktop runs its daemon in a separate
+# docker-desktop distro, so no docker0/br-* interface exists in the working
+# distro and k3d assigns a random per-cluster subnet.
+
+dev_llm_host_ip() {
+  grep -E '^\s*LLM_HOST_IP:' "$REPO/environments/dev.yaml" \
+    | head -1 | sed -E 's/.*:\s*"?([0-9.]+)"?.*/\1/'
+}
+
+@test "dev LLM_HOST_IP is not a Docker bridge address" {
+  local ip; ip="$(dev_llm_host_ip)"
+  [ -n "$ip" ]
+  # 172.16.0.0/12 covers docker0 (172.17.x) and every k3d-assigned subnet.
+  if [[ "$ip" =~ ^172\.(1[6-9]|2[0-9]|3[01])\. ]]; then
+    echo "LLM_HOST_IP=$ip is a Docker bridge address — unreachable from k3d pods" >&2
+    return 1
+  fi
+}
+
+@test "dev LLM_HOST_IP is inside the wg-mesh CIDR 192.168.100.0/24" {
+  local ip; ip="$(dev_llm_host_ip)"
+  [[ "$ip" =~ ^192\.168\.100\.[0-9]+$ ]]
+}
+
+@test "dev LLM_HOST_IP matches the GPU-host address used by prod envs" {
+  local dev prod
+  dev="$(dev_llm_host_ip)"
+  prod="$(grep -E '^\s*LLM_HOST_IP:' "$REPO/environments/mentolder.yaml" \
+    | head -1 | sed -E 's/.*:\s*"?([0-9.]+)"?.*/\1/')"
+  [ "$dev" = "$prod" ]
+}
+
+@test "allow-llm-gateway-egress covers the CIDR that dev LLM_HOST_IP lives in" {
+  run grep -q '192\.168\.100\.0/24' "$REPO/k3d/network-policies.yaml"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- Fix k3d dev cluster unable to reach host LLM services (TEI, LM Studio)
- `environments/dev.yaml`: LLM_HOST_IP changed from `172.17.0.1` (Docker bridge, unreachable from k3d pods) to `192.168.100.10` (wg-mesh, same address prod uses)
- `k3d/llm-gpu.yaml`: header comments updated to reflect the correct dev address
- `environments/schema.yaml`: LLM_HOST_IP description corrected ("Empty in dev" → "set explicitly in environments/dev.yaml")

## Root Cause
Docker Desktop runs the daemon in a separate `docker-desktop` WSL distro — no `docker0`/`br-*` interface exists in the working distro. k3d assigns random per-cluster subnets. The WireGuard mesh address `192.168.100.10` (wg-gpu) is already used by all prod environments and was empirically verified to be reachable from k3d pods.

## Test Plan
- [x] `npx bats tests/spec/llm-pipeline.bats` — 10/10 green
- [x] `envsubst` render: all three Endpoints produce `ip: 192.168.100.10`
- [x] RED test pre-verified: old `172.17.0.1` triggered 3 failures with expected error messages

## Design
See `openspec/changes/k3d-dev-llm-bridge/design.md` for root-cause analysis, measurements, and the three discarded alternatives (pinning k3d subnet, auto-resolve via Docker CLI, `host.k3d.internal`).

🤖 [T002109]