### PR TITLE
fix(scripts): GBNF-untaugliche Escapes aus Tool-Schemas entschaerfen [T002112]

### DIFF
--- a/scripts/llm-proxy/fixups.mjs
+++ b/scripts/llm-proxy/fixups.mjs
@@ -44,10 +44,86 @@ function normalizeBillingHeader(body) {
   return { ...body, system: [{ ...first, text: 'x-anthropic-billing-header: (normalized-for-cache);' }, ...rest] };
 }
 
+// llama.cpp baut aus JSON-Schema-"pattern" eine GBNF-Grammatik fuer constrained
+// tool-calling. GBNF kennt \- nicht (Regex schon, dort ist es ein redundantes
+// Escape) - trifft der Parser darauf, verwirft er die KOMPLETTE Grammatik:
+//   parse: error parsing grammar: unknown escape at \-A-Za-z0-9=, ()!])+) ...
+//   E failed to parse grammar
+// Der Slot startet dann ohne Grammatik, das Modell generiert Tool-Calls frei,
+// der Agent retryt - auf einem serialisierten Ein-Slot-Server der teuerste
+// denkbare Fehler. Quelle in freier Wildbahn: mcp-kubernetes liefert fuer
+// labelSelector/fieldSelector das Pattern [/_.\-A-Za-z0-9=, ()!] (T002112).
+//
+// Naiv \- durch - zu ersetzen waere falsch: aus [/_.\-A-Za-z0-9] wuerde
+// [/_.-A-Za-z0-9], wo .-A eine Range 0x2E-0x41 ist und /0123456789:;<=>?@
+// mitschluckt. Stattdessen wandert das Minus ans Klassenende, wo es unstrittig
+// literal ist.
+const warnedPatterns = new Set();
+
+/** @param {string} src @returns {string} */
+export function sanitizeGbnfPattern(src) {
+  if (typeof src !== 'string' || !src.includes('\\-')) return src;
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '\\') {
+      // Ausserhalb einer Zeichenklasse ist \- schlicht ein literales Minus.
+      if (src[i + 1] === '-') { out += '-'; i += 2; continue; }
+      out += c + (src[i + 1] ?? ''); i += 2; continue;
+    }
+    if (c !== '[') { out += c; i += 1; continue; }
+
+    let j = i + 1;
+    let head = '[';
+    if (src[j] === '^') { head += '^'; j += 1; }
+    if (src[j] === ']') { head += ']'; j += 1; } // ] direkt am Klassenanfang ist literal
+    let body = '';
+    let needsDash = false;
+    let closed = false;
+    while (j < src.length) {
+      const d = src[j];
+      if (d === '\\') {
+        if (src[j + 1] === '-') { needsDash = true; j += 2; continue; }
+        body += d + (src[j + 1] ?? ''); j += 2; continue;
+      }
+      if (d === ']') { closed = true; j += 1; break; }
+      body += d; j += 1;
+    }
+    // Unbalancierte Klasse: nicht raten, Rest unveraendert durchreichen.
+    if (!closed) { out += src.slice(i); return out; }
+    const dash = needsDash && !body.endsWith('-') ? '-' : '';
+    out += head + body + dash + ']';
+    i = j;
+  }
+  if (out !== src && !warnedPatterns.has(src)) {
+    warnedPatterns.add(src);
+    console.warn(`[fixups] GBNF-untaugliches Escape entschaerft: ${src} -> ${out}`);
+  }
+  return out;
+}
+
+function sanitizeSchemaTree(node) {
+  if (Array.isArray(node)) return node.map(sanitizeSchemaTree);
+  if (!node || typeof node !== 'object') return node;
+  const out = {};
+  for (const [k, v] of Object.entries(node)) {
+    out[k] = k === 'pattern' && typeof v === 'string' ? sanitizeGbnfPattern(v) : sanitizeSchemaTree(v);
+  }
+  return out;
+}
+
+/** @param {any} body @returns {any} */
+export function sanitizeToolSchemaPatterns(body) {
+  if (!Array.isArray(body?.tools)) return body;
+  return { ...body, tools: sanitizeSchemaTree(body.tools) };
+}
+
 export const FIXUPS = {
   'bonsai-system-role-fixup': bonsaiSystemRoleFixup,
   'flatten-content-blocks': flattenContentBlocks,
   'normalize-billing-header': normalizeBillingHeader,
+  'sanitize-tool-schema-patterns': sanitizeToolSchemaPatterns,
 };
 
 /** @param {string[]} names @param {any} body */

--- a/scripts/llm-proxy/server.mjs
+++ b/scripts/llm-proxy/server.mjs
@@ -3,7 +3,7 @@ import http from 'node:http';
 import { Readable } from 'node:stream';
 import { startRegistryPoll, getBackends, resolveApiKey } from './backends.mjs';
 import { startDiscovery, resolveModel, aggregateModels, getState } from './discovery.mjs';
-import { applyFixups } from './fixups.mjs';
+import { applyFixups, sanitizeToolSchemaPatterns } from './fixups.mjs';
 
 const PORT = Number(process.env.LLM_PROXY_PORT || 18235);
 const POLL_MS = 30_000;
@@ -115,7 +115,13 @@ async function proxyV1(req, res, subpath) {
   if (!routed) return sendJson(res, 503, { error: { code: 'no_backend', message: 'no healthy backend' } });
 
   const { backend, servedModel, substituted } = routed;
-  const budgetedBody = applyFixups(backend.fixups, await applyContextBudget(backend, body));
+  // sanitizeToolSchemaPatterns laeuft UNBEDINGT, nicht als benannter Fixup:
+  // ein GBNF-untaugliches Escape zerlegt die Tool-Call-Grammatik jedes
+  // llama.cpp-Backends (T002112). Ein Korrektheits-Fix, den man erst in
+  // llm_proxy_backends.fixups aktivieren muss, ist genau dann aus, wenn er
+  // gebraucht wird. Ohne betroffenes Pattern ist der Aufruf ein No-op.
+  const sanitized = sanitizeToolSchemaPatterns(body);
+  const budgetedBody = applyFixups(backend.fixups, await applyContextBudget(backend, sanitized));
   if (substituted) console.log(`[route] ${body.model} → ${backend.name}:${servedModel}`);
 
   const { run, queuedAt } = enqueue(backend.name, () => forwardToBackend(backend, servedModel, subpath, budgetedBody));

--- a/tests/spec/local-llm-proxy.bats
+++ b/tests/spec/local-llm-proxy.bats
@@ -114,3 +114,84 @@ _skip_if_no_db() {
   echo "$output" | grep -q '"baseUrl":"http://127.0.0.1:18235"'
   ! echo "$output" | grep -q ':8093'
 }
+
+# ── GBNF-Escape-Sanitizer (T002112) ───────────────────────────────────────────
+# mcp-kubernetes liefert JSON-Schema-"pattern" mit \- in einer Zeichenklasse.
+# In GBNF ist das kein gueltiges Escape -> llama.cpp verwirft die KOMPLETTE
+# Tool-Call-Grammatik ("unknown escape") und der Slot laeuft unconstrained.
+
+_sanitize() {  # $1 = pattern -> sanitisiertes Pattern auf stdout
+  node -e '
+    import("./scripts/llm-proxy/fixups.mjs").then(m => {
+      process.stdout.write(m.sanitizeGbnfPattern(process.argv[1]));
+    });
+  ' "$1" 2>/dev/null
+}
+
+@test "sanitizeGbnfPattern: \\- in Zeichenklasse wandert ans Klassenende" {
+  run _sanitize '^[/_.\-A-Za-z0-9=, ()!]+$'
+  [ "$status" -eq 0 ]
+  [ "$output" = '^[/_.A-Za-z0-9=, ()!-]+$' ]
+}
+
+@test "sanitizeGbnfPattern: erzeugt KEINE ungewollte Range (.-A)" {
+  run _sanitize '^[/_.\-A-Za-z0-9=, ()!]+$'
+  # Ein naives \- -> - haette '[/_.-A...' erzeugt: .-A waere eine Range 0x2E-0x41.
+  ! echo "$output" | grep -q '\.-A'
+}
+
+@test "sanitizeGbnfPattern: \\- ausserhalb einer Klasse wird zum Literal -" {
+  run _sanitize 'a\-b'
+  [ "$output" = 'a-b' ]
+}
+
+@test "sanitizeGbnfPattern: Pattern ohne \\- bleibt unveraendert" {
+  run _sanitize '^[a-z0-9-]+$'
+  [ "$output" = '^[a-z0-9-]+$' ]
+}
+
+@test "sanitizeGbnfPattern: andere Escapes bleiben erhalten" {
+  run _sanitize '^\d+\.\d+[\w\-]$'
+  [ "$output" = '^\d+\.\d+[\w-]$' ]
+}
+
+@test "sanitizeGbnfPattern: negierte Klasse behaelt ^ und bekommt - ans Ende" {
+  run _sanitize '[^\-a]'
+  [ "$output" = '[^a-]' ]
+}
+
+@test "sanitizeToolSchemaPatterns: patcht verschachtelte tools[].pattern" {
+  # node assertiert selbst und exit-codet - erspart das Escaping des
+  # Erwartungswerts durch bash/bats hindurch.
+  run node --input-type=module -e '
+    import assert from "node:assert";
+    import { sanitizeToolSchemaPatterns } from "./scripts/llm-proxy/fixups.mjs";
+    const BS = String.fromCharCode(92);
+    const pat = "^[/_." + BS + "-A-Za-z0-9=]+$";
+    const body = { tools: [{ type: "function", function: { name: "pods_list",
+      parameters: { type: "object", properties: {
+        labelSelector: { type: "string", pattern: pat } } } } }] };
+    const out = sanitizeToolSchemaPatterns(body);
+    const got = out.tools[0].function.parameters.properties.labelSelector.pattern;
+    assert.strictEqual(got, "^[/_.A-Za-z0-9=-]+$", "Pattern nicht korrekt entschaerft");
+    assert.strictEqual(body.tools[0].function.parameters.properties.labelSelector.pattern,
+      pat, "Original-Body wurde mutiert");
+  ' 2>/dev/null
+  [ "$status" -eq 0 ]
+}
+
+@test "sanitizeToolSchemaPatterns: Body ohne tools bleibt unangetastet" {
+  run node -e '
+    import("./scripts/llm-proxy/fixups.mjs").then(m => {
+      const body = { messages:[{role:"user",content:"hi"}] };
+      process.stdout.write(JSON.stringify(m.sanitizeToolSchemaPatterns(body)));
+    });
+  '
+  [ "$output" = '{"messages":[{"role":"user","content":"hi"}]}' ]
+}
+
+@test "server.mjs wendet den Sanitizer unbedingt an (nicht als DB-Opt-in)" {
+  # Ein Korrektheits-Fix, den man erst in llm_proxy_backends.fixups aktivieren
+  # muss, ist genau dann aus, wenn er gebraucht wird.
+  grep -q 'sanitizeToolSchemaPatterns' "${BATS_TEST_DIRNAME}/../../scripts/llm-proxy/server.mjs"
+}


### PR DESCRIPTION
## Problem

llama.cpp baut aus JSON-Schema-`pattern` eine GBNF-Grammatik für constrained tool-calling. GBNF kennt `\-` nicht — in Regex ist es ein (redundantes) Escape, im GBNF-Parser ein Fehler. Trifft er darauf, verwirft er die **komplette** Grammatik:

```
parse: error parsing grammar: unknown escape at \-A-Za-z0-9=, ()!])+) "\"" space
E failed to parse grammar
```

Der Slot startet dann **ohne** Grammatik — das Modell generiert Tool-Calls frei. Malformte Tool-Calls → Agent-Retry → der volle ~31k-Prompt nochmal. Auf einem serialisierten Ein-Slot-Server der teuerste denkbare Fehler. **35 Vorkommen** im Bonsai-Serverlog.

Quelle: `mcp-kubernetes` liefert das Pattern `[/_.\-A-Za-z0-9=, ()!]`. Betroffen sind 8 Regeln aus 5 Tools:

| Tool | Parameter |
|---|---|
| `pods_list`, `pods_list_in_namespace`, `resources_list` | `labelSelector`, `fieldSelector` |
| `nodes_top`, `pods_top` | `label_selector` |

`mcp-kubernetes` ist in `.opencode/opencode.jsonc` enabled — die Tools gehen in jeder Agent-Session mit raus.

## Lösung

Sanitizer in `scripts/llm-proxy/fixups.mjs`, angewendet in `server.mjs`.

**Warum nicht einfach `\-` → `-`:** Aus `[/_.\-A-Za-z0-9]` würde `[/_.-A-Za-z0-9]`, wo `.-A` plötzlich eine **Range** `0x2E`–`0x41` ist und `/0123456789:;<=>?@` mitschluckt. Der Sanitizer setzt das Minus stattdessen ans Klassenende, wo es unstrittig literal ist — semantikerhaltend. Ein eigener Test deckt genau diese Falle ab.

**Warum unbedingt statt als benannter Fixup:** Die Fixup-Liste kommt aus `llm_proxy_backends.fixups` (DB). Ein Korrektheits-Fix mit Opt-in ist genau dann aus, wenn er gebraucht wird. Ohne betroffenes Pattern ist der Aufruf ein No-op. Der Fixup ist zusätzlich unter `sanitize-tool-schema-patterns` registriert, falls er je explizit adressiert werden soll.

Der Sanitizer warnt einmal pro betroffenem Pattern auf stderr — stille Korrekturen wären hier das falsche Verhalten.

## Verifikation

**End-to-End gegen den laufenden llama.cpp-Server auf `:8093`** — dieselbe Tool-Definition, einmal mit kaputtem, einmal mit entschärftem Pattern:

| | `failed to parse grammar` |
|---|---|
| kaputtes Pattern `[/_.\-A-Za-z0-9=, ()!]` | **+1** |
| entschärftes Pattern `[/_.A-Za-z0-9=, ()!-]` | **+0** |

Weiter:
- `bats tests/spec/local-llm-proxy.bats` — **14/14 grün** (9 neue Tests)
- `task test:changed` — 52/52 grün
- `task freshness:regenerate` + `check` — EXIT=0
- `task test:inventory` — keine Diffs

## Kontext

Gefunden bei der Durchsatzanalyse zu T002111 (Bonsai-Server lief auf CPU statt GPU). Die Doku-Seite dieser Analyse steckt in #3146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL