### PR TITLE
fix(e2e): resolve E2E test failures and auth storageState path resolution [T002117]

### DIFF
--- a/tests/e2e/lib/auth.ts
+++ b/tests/e2e/lib/auth.ts
@@ -28,9 +28,26 @@ export async function loginViaE2E(
   const token = CRON_SECRET ? `&token=${encodeURIComponent(CRON_SECRET)}` : '';
   const url = `${cleanBase}/api/auth/e2e-login?username=${encodeURIComponent(user)}&returnTo=${encodeURIComponent(returnTo)}${token}`;
 
-  await page.goto(url, {
-    waitUntil: 'domcontentloaded',
-  });
+  let attempts = 0;
+  while (attempts < 3) {
+    try {
+      attempts++;
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+      break;
+    } catch (err: any) {
+      if (attempts >= 3) throw err;
+      await page.waitForTimeout(1000);
+    }
+  }
+
+  if (page.url().includes('/404')) {
+    // Retry with title-cased username variant (e.g. paddione -> Paddione)
+    const titleUser = user.charAt(0).toUpperCase() + user.slice(1);
+    if (titleUser !== user) {
+      const retryUrl = `${cleanBase}/api/auth/e2e-login?username=${encodeURIComponent(titleUser)}&returnTo=${encodeURIComponent(returnTo)}${token}`;
+      await page.goto(retryUrl, { waitUntil: 'domcontentloaded' });
+    }
+  }
 
   await page.waitForFunction(
     (expected: string) => window.location.pathname.startsWith(expected) || window.location.href.includes(expected),

--- a/tests/e2e/specs/fa-13-docs.spec.ts
+++ b/tests/e2e/specs/fa-13-docs.spec.ts
@@ -1,7 +1,14 @@
 import { test, expect } from '@playwright/test';
 
+const base = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+const defaultDocs = base.includes('mentolder.de')
+  ? 'https://docs.mentolder.de'
+  : base.includes('korczewski.de')
+  ? 'https://docs.korczewski.de'
+  : 'http://docs.localhost';
+
 const DOCS_URL = process.env.DOCS_URL
-  ?? (process.env.PROD_DOMAIN ? `https://docs.${process.env.PROD_DOMAIN}` : 'http://docs.localhost');
+  ?? (process.env.PROD_DOMAIN ? `https://docs.${process.env.PROD_DOMAIN}` : defaultDocs);
 
 /**
  * FA-13: Dokumentations-Service

--- a/tests/e2e/specs/fa-27-brett.spec.ts
+++ b/tests/e2e/specs/fa-27-brett.spec.ts
@@ -1,7 +1,14 @@
 import { test, expect } from '@playwright/test';
 
+const base = process.env.WEBSITE_URL ?? 'http://localhost:4321';
+const defaultBrett = base.includes('mentolder.de')
+  ? 'https://brett.mentolder.de'
+  : base.includes('korczewski.de')
+  ? 'https://brett.korczewski.de'
+  : 'http://brett.localhost';
+
 const BRETT_URL = process.env.BRETT_URL
-  ?? (process.env.PROD_DOMAIN ? `https://brett.${process.env.PROD_DOMAIN}` : 'http://brett.localhost');
+  ?? (process.env.PROD_DOMAIN ? `https://brett.${process.env.PROD_DOMAIN}` : defaultBrett);
 
 test.describe('FA-27: Systemisches Brett', { tag: ['@brett'] }, () => {
   // ── Unauthenticated probes (services project) ───────────────────────────

--- a/tests/e2e/specs/fa-48-factory-devflow.spec.ts
+++ b/tests/e2e/specs/fa-48-factory-devflow.spec.ts
@@ -32,6 +32,28 @@ function stubPayload(hall: HallItem[]) {
   };
 }
 
+async function gotoDevStatusWithStub(page: any, payload: any) {
+  await page.route('**/api/factory-floor', (route: any) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }),
+  );
+
+  await page.route('**/admin/pipeline*', async (route: any) => {
+    const response = await route.fetch();
+    let body = await response.text();
+    const payloadStr = JSON.stringify(payload);
+    // Replace initial: null or initial: {...} inside props attribute in Astro island
+    body = body.replace(/"initial":null/g, `"initial":${payloadStr}`);
+    body = body.replace(/"initial":\{.*?\}/g, `"initial":${payloadStr}`);
+    route.fulfill({ response, body });
+  });
+
+  await page.goto('/dev-status');
+}
+
 test.describe('FA-48: FactoryFloor devflow chip & CI badge', () => {
   test.beforeEach(async ({ page }) => {
     // Stub SSE endpoint to avoid real connection / error logs
@@ -39,12 +61,7 @@ test.describe('FA-48: FactoryFloor devflow chip & CI badge', () => {
   });
 
   test('T1: devflow workpiece hat data-driver="devflow" und kein goldenes bg', async ({ page }) => {
-    await page.route('**/api/factory-floor', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(
-        stubPayload([...FACTORY_HALL, ...DEVFLOW_HALL])
-      ) }),
-    );
-    await page.goto('/dev-status');
+    await gotoDevStatusWithStub(page, stubPayload([...FACTORY_HALL, ...DEVFLOW_HALL]));
     await expect(page.getByTestId('factory-floor')).toBeVisible();
 
     const devflowWps = page.getByTestId('floor-workpiece').filter({ hasText: 'T000582' });
@@ -56,12 +73,7 @@ test.describe('FA-48: FactoryFloor devflow chip & CI badge', () => {
   });
 
   test('T2: devflow workpiece im deploy-Phase zeigt CI-Badge mit ciStatus', async ({ page }) => {
-    await page.route('**/api/factory-floor', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(
-        stubPayload(DEVFLOW_HALL)
-      ) }),
-    );
-    await page.goto('/dev-status');
+    await gotoDevStatusWithStub(page, stubPayload(DEVFLOW_HALL));
 
     const badge = page.getByTestId('floor-ci-badge');
     await expect(badge).toBeVisible();
@@ -70,24 +82,14 @@ test.describe('FA-48: FactoryFloor devflow chip & CI badge', () => {
 
   test('T3: devflow workpiece ohne ciStatus zeigt kein CI-Badge', async ({ page }) => {
     // Nur die pending-devflow (ohne ciStatus)
-    await page.route('**/api/factory-floor', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(
-        stubPayload([DEVFLOW_HALL[1]]) // T000583, ciStatus=null
-      ) }),
-    );
-    await page.goto('/dev-status');
+    await gotoDevStatusWithStub(page, stubPayload([DEVFLOW_HALL[1]]));
 
     await expect(page.getByTestId('floor-workpiece').filter({ hasText: 'T000583' })).toBeVisible();
     await expect(page.getByTestId('floor-ci-badge')).toHaveCount(0);
   });
 
   test('T4: factory workpiece hat kein blue border / bg', async ({ page }) => {
-    await page.route('**/api/factory-floor', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(
-        stubPayload(FACTORY_HALL)
-      ) }),
-    );
-    await page.goto('/dev-status');
+    await gotoDevStatusWithStub(page, stubPayload(FACTORY_HALL));
 
     const wp = page.getByTestId('floor-workpiece').filter({ hasText: 'T000459' });
     await expect(wp).toHaveAttribute('data-driver', 'factory');
@@ -98,12 +100,7 @@ test.describe('FA-48: FactoryFloor devflow chip & CI badge', () => {
   });
 
   test('T5: devflow workpiece anzeige zeigt 👨‍💻 Emoji im Label', async ({ page }) => {
-    await page.route('**/api/factory-floor', (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(
-        stubPayload(DEVFLOW_HALL)
-      ) }),
-    );
-    await page.goto('/dev-status');
+    await gotoDevStatusWithStub(page, stubPayload(DEVFLOW_HALL));
 
     await expect(page.getByTestId('floor-workpiece').filter({ hasText: '👨‍💻' })).toBeVisible();
   });

--- a/tests/e2e/specs/mentolder-auth-setup.spec.ts
+++ b/tests/e2e/specs/mentolder-auth-setup.spec.ts
@@ -25,21 +25,30 @@ const ADMIN_PASS   = process.env.E2E_ADMIN_PASS ?? '';
 const USER         = process.env.E2E_USER ?? 'test-user';
 const USER_PASS    = process.env.E2E_USER_PASS ?? '';
 
-const AUTH_DIR           = path.join(__dirname, '..', '.auth');
-const ADMIN_STATE        = path.join(AUTH_DIR, 'mentolder-website-admin.json');
-const USER_STATE         = path.join(AUTH_DIR, 'mentolder-website-user.json');
+const ROOT_AUTH_DIR = path.resolve(process.cwd(), '.auth');
+const SPECS_AUTH_DIR = path.resolve(__dirname, '..', '.auth');
 
-function ensureAuthDir(): void {
-  if (!fs.existsSync(AUTH_DIR)) fs.mkdirSync(AUTH_DIR, { recursive: true });
+function saveStorageState(page: any, filename: string): void {
+  [ROOT_AUTH_DIR, SPECS_AUTH_DIR].forEach((dir) => {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, filename);
+    page.context().storageState({ path: target });
+  });
+}
+
+function writeEmptyState(filename: string): void {
+  [ROOT_AUTH_DIR, SPECS_AUTH_DIR].forEach((dir) => {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const target = path.join(dir, filename);
+    fs.writeFileSync(target, JSON.stringify({ cookies: [], origins: [] }));
+  });
 }
 
 // ── Admin login ──────────────────────────────────────────────────────────────
 setup('authenticate mentolder website admin', async ({ page, request }, testInfo) => {
-  ensureAuthDir();
-
   if (!ADMIN_PASS) {
     console.warn('[mentolder-setup] E2E_ADMIN_PASS not set — writing empty state (admin tests will use test.fixme)');
-    fs.writeFileSync(ADMIN_STATE, JSON.stringify({ cookies: [], origins: [] }));
+    writeEmptyState('mentolder-website-admin.json');
     return;
   }
 
@@ -48,28 +57,36 @@ setup('authenticate mentolder website admin', async ({ page, request }, testInfo
 
   await loginViaE2E(page, WEBSITE_URL, ADMIN_USER, '/admin');
 
-  const me = await verifySession(page.request, WEBSITE_URL);
+  const me = await page.evaluate(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/auth/me`);
+    if (!res.ok) return { authenticated: false };
+    return res.json();
+  }, WEBSITE_URL);
+
   expect(me.authenticated, 'mentolder website session should be authenticated').toBe(true);
 
-  await page.context().storageState({ path: ADMIN_STATE });
+  saveStorageState(page, 'mentolder-website-admin.json');
   console.log(`[mentolder-setup] saved mentolder-website-admin.json (user=${me.username})`);
 });
 
 // ── Portal user login ────────────────────────────────────────────────────────
 setup('authenticate mentolder portal user', async ({ page }) => {
-  ensureAuthDir();
-
   if (!USER_PASS) {
     console.log('[mentolder-setup] E2E_USER_PASS not set — skipping portal user state');
-    fs.writeFileSync(USER_STATE, JSON.stringify({ cookies: [], origins: [] }));
+    writeEmptyState('mentolder-website-user.json');
     return;
   }
 
   await loginViaE2E(page, WEBSITE_URL, USER, '/portal');
 
-  const me = await verifySession(page.request, WEBSITE_URL);
+  const me = await page.evaluate(async (baseUrl) => {
+    const res = await fetch(`${baseUrl}/api/auth/me`);
+    if (!res.ok) return { authenticated: false };
+    return res.json();
+  }, WEBSITE_URL);
+
   expect(me.authenticated, 'mentolder portal session should be authenticated').toBe(true);
 
-  await page.context().storageState({ path: USER_STATE });
+  saveStorageState(page, 'mentolder-website-user.json');
   console.log(`[mentolder-setup] saved mentolder-website-user.json (user=${me.username})`);
 });

--- a/website/src/components/FactoryFloor.svelte
+++ b/website/src/components/FactoryFloor.svelte
@@ -3,6 +3,7 @@
   import type { Phase } from '../lib/factory-floor-types';
   import { MOBILE_COL_INDEX } from './factory/MobileTabBar.svelte';
   export { MOBILE_COL_INDEX }; // eslint-disable-line no-import-assign
+  export const MOBILE_COL_COUNT = 11;
   export const STATIONS: { key: Phase; label: string }[] =
     PHASE_ORDER.map((key) => ({ key, label: key.charAt(0).toUpperCase() + key.slice(1) }));
 </script>
@@ -28,7 +29,7 @@
 
   let { initial }: { initial: FloorPayload | null } = $props();
 
-  const MOBILE_COL_COUNT = 11;
+  let isMobile = $state(false);
   let mobileColIndex = $state(0);
   let touchStartX = $state(0);
   $effect(() => {
@@ -41,9 +42,12 @@
   });
 
   onMount(() => {
-    const handler = (e: CustomEvent) => { if (e.detail) data = e.detail; };
-    window.addEventListener('floor-stub-update', handler as EventListener);
-    return () => window.removeEventListener('floor-stub-update', handler as EventListener);
+    const handler = (e: Event) => {
+      const customEvent = e as CustomEvent;
+      if (customEvent.detail) data = customEvent.detail;
+    };
+    window.addEventListener('floor-stub-update', handler);
+    return () => window.removeEventListener('floor-stub-update', handler);
   });
 
   function mobileNext() { if (mobileColIndex < MOBILE_COL_COUNT - 1) mobileColIndex++; }

--- a/website/src/components/FactoryFloor.svelte
+++ b/website/src/components/FactoryFloor.svelte
@@ -31,8 +31,6 @@
   const MOBILE_COL_COUNT = 11;
   let mobileColIndex = $state(0);
   let touchStartX = $state(0);
-  let isMobile = $state(false);
-
   $effect(() => {
     if (typeof window === 'undefined') return;
     const mq = window.matchMedia('(max-width: 767px)');
@@ -40,6 +38,12 @@
     const handler = (e: MediaQueryListEvent) => { isMobile = e.matches; };
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
+  });
+
+  onMount(() => {
+    const handler = (e: CustomEvent) => { if (e.detail) data = e.detail; };
+    window.addEventListener('floor-stub-update', handler as EventListener);
+    return () => window.removeEventListener('floor-stub-update', handler as EventListener);
   });
 
   function mobileNext() { if (mobileColIndex < MOBILE_COL_COUNT - 1) mobileColIndex++; }

--- a/website/src/lib/identity.test.ts
+++ b/website/src/lib/identity.test.ts
@@ -34,7 +34,7 @@ afterEach(() => {
 describe('createUser', () => {
   it('returns "exists" error when a user with the email is already present', async () => {
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify([{ id: 'u1', email: 'a@b.c' }]), { status: 200 })) as typeof fetch;
+      new Response(JSON.stringify({ data: [{ id: 'u1', email: 'a@b.c' }] }), { status: 200 })) as typeof fetch;
     const out = await createUser({ email: 'a@b.c', firstName: 'A', lastName: 'B' });
     expect(out).toEqual({ success: false, error: expect.stringMatching(/existiert/) });
   });
@@ -44,7 +44,7 @@ describe('createUser', () => {
     globalThis.fetch = (async (_url: unknown, _init?: RequestInit) => {
       callCount++;
       if (callCount === 1) {
-        return new Response('[]', { status: 200 });
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
       }
       return new Response('{}', { status: 201, headers: { Location: '/api/users/abc-123' } });
     }) as typeof fetch;
@@ -57,7 +57,7 @@ describe('createUser', () => {
     let callCount = 0;
     globalThis.fetch = (async () => {
       callCount++;
-      if (callCount === 1) return new Response('[]', { status: 200 });
+      if (callCount === 1) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       return new Response('forbidden', { status: 403 });
     }) as typeof fetch;
     const out = await createUser({ email: 'x@y.z', firstName: 'X', lastName: 'Y' });
@@ -91,7 +91,7 @@ describe('sendPasswordResetEmail', () => {
 describe('listUsers / getUserById / deleteUser / updateUser', () => {
   it('listUsers returns the parsed array', async () => {
     globalThis.fetch = (async () =>
-      new Response(JSON.stringify([{ id: 'u1', email: 'a@b.c' }]), { status: 200 })) as typeof fetch;
+      new Response(JSON.stringify({ data: [{ id: 'u1', email: 'a@b.c' }] }), { status: 200 })) as typeof fetch;
     const out = await listUsers();
     expect(out).toHaveLength(1);
     expect(out[0].id).toBe('u1');


### PR DESCRIPTION
Fixes E2E test failures across Playwright suites:
1. Fix POCKET_ID_URL in website deployment to resolve auth OIDC user lookup.
2. Ensure mentolder-auth-setup writes storageState to both root and specs auth directories.
3. Update loginViaE2E with transient network error retries and username casing fallback.
4. Dynamically derive service domains (docs.mentolder.de & brett.mentolder.de) when running against live environments.
5. Add event listener support in FactoryFloor component for E2E stub updates.

Ticket: T002117