### PR TITLE
fix(ci): post-merge render-artifact-Job braucht packages: write [T002118]

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -78,6 +78,16 @@ jobs:
     name: Render fleet artifact (GitOps)
     needs: [mark-awaiting, detect]
     if: vars.FLUX_ENABLED == 'true' && needs.detect.outputs.manifests_changed == 'true'
+    # render-fleet-artifact.yml verlangt packages: write (docker/login-action →
+    # ghcr). Ein via `uses:` aufgerufener Workflow darf nie mehr Rechte
+    # anfordern als der Aufrufer — sonst lehnt GitHub den GESAMTEN Workflow mit
+    # startup_failure ab, bevor auch nur ein Job startet. Diese Validierung
+    # laeuft VOR der if:-Auswertung, der Job muss dafuer also nicht einmal
+    # ausgefuehrt werden. Genau das passierte 37 Merges lang (T002118).
+    # Das Recht bleibt bewusst auf diesen Job begrenzt statt workflowweit.
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/render-fleet-artifact.yml
     secrets: inherit
 

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -524,3 +524,60 @@ PY
   [ "$status" -eq 0 ]
 }
 
+
+# T002118: Ein via `uses:` aufgerufener reusable workflow darf nie mehr Rechte
+# verlangen, als der aufrufende Job besitzt — sonst lehnt GitHub den GESAMTEN
+# Workflow mit startup_failure ab, bevor ein einziger Job startet. Die
+# Validierung laeuft VOR der if:-Auswertung, der Job muss also nicht einmal
+# ausgefuehrt werden. post-merge.yml war so 37 Merges lang tot (2026-07-22/23):
+# kein Ticket-Closure, kein deploy-legacy, 14 undeployte Manifest-Aenderungen.
+@test "T002118: jeder reusable-workflow-Aufruf deckt die Permissions des Callees" {
+  run python3 - "$REPO_ROOT" <<'PY'
+import glob, os, sys, yaml
+root = sys.argv[1]
+wf = os.path.join(root, ".github/workflows")
+RANK = {"none": 0, "read": 1, "write": 2}
+
+declared = {}
+for f in glob.glob(os.path.join(wf, "*.yml")):
+    try: declared[os.path.basename(f)] = (yaml.safe_load(open(f)) or {}).get("permissions") or {}
+    except Exception: pass
+
+bad = []
+for f in sorted(glob.glob(os.path.join(wf, "*.yml"))):
+    try: doc = yaml.safe_load(open(f)) or {}
+    except Exception: continue
+    top = doc.get("permissions")
+    for job, spec in (doc.get("jobs") or {}).items():
+        if not isinstance(spec, dict): continue
+        uses = spec.get("uses", "")
+        if not (isinstance(uses, str) and uses.startswith("./.github/workflows/")): continue
+        jobperm = spec.get("permissions")
+        # Ohne JEDEN expliziten permissions-Block greift der Repo-Default
+        # (hier: write). Statisch nicht pruefbar und nicht das Fehlerbild.
+        if top is None and jobperm is None: continue
+        have = {**(top or {}), **(jobperm or {})}
+        need = declared.get(os.path.basename(uses), {})
+        missing = {k: v for k, v in need.items()
+                   if RANK.get(have.get(k, "none"), 0) < RANK.get(v, 0)}
+        if missing:
+            bad.append(f"{os.path.basename(f)} job '{job}' -> {os.path.basename(uses)}: fehlt {missing}")
+
+if bad:
+    print("Permissions-Konflikt (fuehrt zu startup_failure):")
+    for b in bad: print("  " + b)
+    sys.exit(1)
+print("alle reusable-workflow-Aufrufe decken die Callee-Permissions")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "T002118: post-merge.yml render-artifact-Job gewaehrt packages: write" {
+  run python3 -c "
+import yaml,sys
+d=yaml.safe_load(open('$REPO_ROOT/.github/workflows/post-merge.yml'))
+p=(d['jobs']['render-artifact'].get('permissions') or {})
+sys.exit(0 if p.get('packages')=='write' else 1)
+"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

`post-merge.yml` schlägt seit **2026-07-22 14:47** bei jedem Push auf `main` mit `startup_failure` fehl — **37 Läufe in Folge**, kein einziger Job gestartet.

Der Workflow gewährt auf Workflow-Ebene nur `contents: read`, ruft aber `render-fleet-artifact.yml` via `uses:` auf, das zusätzlich `packages: write` verlangt (`docker/login-action` → ghcr). Ein aufgerufener reusable workflow darf nie mehr Rechte anfordern als der Aufrufer — GitHub lehnt sonst den **gesamten** Workflow ab.

Der fiese Teil: diese Validierung läuft **vor** der `if:`-Auswertung. Der `render-artifact`-Job wäre wegen `vars.FLUX_ENABLED` (gar nicht gesetzt) ohnehin übersprungen worden — der Workflow starb trotzdem.

Eingeführt mit #3115 (T002083, FluxCD GitOps). Letzter grüner Lauf: 2026-07-22 14:44.

## Folgen im Ausfallfenster

1. **„Merge = Abschluss" (T001092) war tot** — kein Ticket wurde automatisch geschlossen.
2. **Schwerwiegender: `deploy-legacy` lief nie.** Da `FLUX_ENABLED` nicht gesetzt ist, war das der aktive Deploy-Pfad. **14 gemergte Manifest-Änderungen wurden nie nach prod deployt:**
   - `environments/sealed-secrets/{dev,fleet-korczewski,fleet-mentolder,korczewski,mentolder,staging}.yaml`
   - `k3d/brett.yaml`, `k3d/kustomization.yaml`, `k3d/livekit-egress.yaml`, `k3d/llm-gpu.yaml`, `k3d/oauth2-proxy-brett.yaml`
   - `k3d/dev-stack/oauth2-proxy-{brainstorm,sessions}.yaml`, `prod-fleet/dev/kustomization.yaml`
3. Scout-Drift-Ratchet und `website:migrate`-Post-Steps liefen nicht.

## Änderung

`packages: write` wird **nur am aufrufenden Job** gewährt, nicht workflowweit — der Rest bleibt bei `contents: read`.

## Tests

Zwei Regressionstests in `tests/spec/ci-cd.bats`:

- ein **genereller Guard**, der für jeden `uses: ./.github/workflows/*`-Aufruf prüft, ob der aufrufende Job die Callee-Permissions abdeckt
- eine gezielte Assertion auf diesen Job

Der generelle Guard überspringt Aufrufer **ohne jeden** expliziten `permissions:`-Block — dort greift der Repo-Default (`write`), das ist statisch nicht prüfbar und nicht das Fehlerbild. `build-website.yml` und `build-brett.yml` rufen denselben Workflow auf, haben keinen Block und laufen deshalb grün (empirisch bestätigt).

Beide Tests gegengeprüft: **rot ohne den Fix, grün mit.**

## Verifikation

- `bats tests/spec/ci-cd.bats` — 58/58 grün
- `task test:changed` — 52/52 grün
- `task freshness:regenerate` + `check` — EXIT=0
- Permissions-Abgleich Caller/Callee programmatisch geprüft: kein Konflikt mehr

## Nacharbeit nach dem Merge

Die 14 aufgelaufenen Manifest-Änderungen brauchen einen einmaligen Deploy (`task workspace:deploy ENV=mentolder` / `ENV=korczewski`), und die im Fenster gemergten Tickets einen Status-Nachzug. Beides bewusst **nicht** in diesem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL