### PR TITLE
fix(scripts): Worktree-Canary prueft alle Branches und verifiziert die Reparatur [T002114]

### DIFF
--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -145,14 +145,26 @@ else
     echo "worktree-create: repo is git-crypt LOCKED — secrets left encrypted-at-rest in $WT_PATH" >&2
 fi
 
-# T001331/T001332: Post-checkout stale-smudge detection for BRANCH_EXISTS=1 path.
-# If the worktree was originally created in locked mode (smudge=cat) but the
-# main checkout now has a key, the checkout above ran with the stale smudge
-# filter — secrets are encrypted-at-rest in the worktree. Detect and fix.
+# T001331/T001332/T002114: Post-checkout stale-smudge detection.
+# If the checkout above ran with a broken or stale smudge filter, secrets are
+# encrypted-at-rest in the worktree. Detect and fix.
 # Also checks .claude/settings.json as fallback canary when .secrets dir is
 # empty — that file is git-crypt-managed and surfaces the same stale smudge. [T001332]
-if [ "$BRANCH_EXISTS" -eq 1 ] && [ -f "$KEY_SRC" ]; then
-  canary="$(find "$WT_PATH/environments/.secrets" -type f 2>/dev/null | head -1)"
+#
+# Runs for EVERY unlocked worktree, not just BRANCH_EXISTS=1 [T002114]. Die
+# alte Einschraenkung ging davon aus, dass nur wiederverwendete Worktrees einen
+# veralteten Filter erben koennen. Am 2026-07-23 kam der Defekt aber aus der
+# GETEILTEN .git/config des Hauptcheckouts (filter.git-crypt.clean/.smudge
+# standen dort auf LEEREN Strings) — damit trifft es auch frisch angelegte
+# Branches, und zwar lautlos: git ueberspringt den Filter dank stat-Cache, bis
+# irgendetwas einen git-crypt-Pfad anfasst. Danach stirbt jeder `git status`
+# mit "clean filter 'git-crypt' failed".
+if [ -f "$KEY_SRC" ]; then
+  # `|| canary=""` ist Pflicht: fehlt das Verzeichnis, gibt find 1 zurueck, und
+  # unter `set -o pipefail` reicht das die 1 durch head hindurch — die Zuweisung
+  # schluege fehl und `set -e` wuerde die Worktree-Erstellung abbrechen. Solange
+  # dieser Block auf BRANCH_EXISTS=1 beschraenkt war, fiel das nie auf. [T002114]
+  canary="$(find "$WT_PATH/environments/.secrets" -type f 2>/dev/null | head -1)" || canary=""
   if [ -z "$canary" ] && [ -f "$WT_PATH/.claude/settings.json" ]; then
     canary="$WT_PATH/.claude/settings.json"
   fi
@@ -167,7 +179,31 @@ if [ "$BRANCH_EXISTS" -eq 1 ] && [ -f "$KEY_SRC" ]; then
     git -C "$WT_PATH" config --worktree --unset filter.git-crypt.smudge 2>/dev/null || true
     git -C "$WT_PATH" config --worktree --unset filter.git-crypt.clean  2>/dev/null || true
     git -C "$WT_PATH" config --worktree filter.git-crypt.required true
-    git -C "$WT_PATH" checkout --force
+    # Non-fatal: schlaegt der Checkout am kaputten Filter fehl, soll die
+    # Diagnose unten laufen statt dass `set -e` mit einer nichtssagenden
+    # Rollback-Meldung abbricht. [T002114]
+    checkout_rc=0
+    git -C "$WT_PATH" checkout --force || checkout_rc=$?
+
+    # Nachpruefen statt hoffen [T002114]. Die Reparatur oben fasst nur
+    # worktree-lokale Config an — sitzt die Ursache in der geteilten
+    # .git/config, bleibt sie wirkungslos. Dann lieber laut abbrechen als
+    # einen Worktree zurueckgeben, der beim ersten `git status` explodiert
+    # (oder schlimmer: Klartext-Secrets stageable macht).
+    if [ "$checkout_rc" -ne 0 ] \
+       || bash "$(dirname "$0")/git-crypt-guard.sh" is-encrypted "$canary" 2>/dev/null; then
+      echo "worktree-create: FEHLER — Secrets sind nach der Reparatur immer noch verschluesselt." >&2
+      echo "  Canary: $canary" >&2
+      echo "  Wahrscheinliche Ursache: kaputte git-crypt-Filter in der GETEILTEN Config" >&2
+      echo "  ($COMMON_DIR/config). Pruefen mit:" >&2
+      echo "    git config --show-origin --get-regexp 'filter\\.git-crypt'" >&2
+      echo "  Erwartet: smudge='git-crypt smudge', clean='git-crypt clean', required=true." >&2
+      echo "  Leere Werte reparieren mit:" >&2
+      echo "    git config filter.git-crypt.smudge 'git-crypt smudge'" >&2
+      echo "    git config filter.git-crypt.clean  'git-crypt clean'" >&2
+      echo "    git config filter.git-crypt.required true" >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/tests/unit/worktree-create.bats
+++ b/tests/unit/worktree-create.bats
@@ -172,3 +172,65 @@ teardown() { rm -rf "$TMP"; }
   [ "$status" -ne 0 ]
   [ ! -d "$TMP/wt-smudge" ]
 }
+
+# ── T002114: leere git-crypt-Filter in der GETEILTEN .git/config ──────────────
+# Am 2026-07-23 standen filter.git-crypt.clean/.smudge im Hauptcheckout auf
+# LEEREN Strings. Folge: der Checkout entschluesselt nicht, die Secrets liegen
+# verschluesselt im Worktree — und weil git dank stat-Cache den Filter zunaechst
+# ueberspringt, faellt es erst auf, wenn irgendetwas einen git-crypt-Pfad
+# anfasst. Danach stirbt jeder `git status` mit "clean filter 'git-crypt' failed".
+# Die alte Reparaturlogik fasst nur worktree-lokale Config an, kann diesen Defekt
+# also gar nicht beheben — sie muss ihn erkennen und laut abbrechen.
+
+# Eigene Fixture: der HEAD-Blob traegt die ECHTE git-crypt-Magic, damit
+# git-crypt-guard.sh is-encrypted anschlaegt (das Fake-git-crypt der Suite oben
+# ist ein reiner Passthrough und erzeugt keine Magic).
+_setup_empty_filter_repo() {
+  BROKEN="$TMP/broken"
+  mkdir -p "$BROKEN/environments/.secrets"
+  git init -q -b main "$BROKEN"
+  git -C "$BROKEN" config user.email t@example.com
+  git -C "$BROKEN" config user.name  Tester
+  printf 'environments/.secrets/** filter=git-crypt diff=git-crypt\n' > "$BROKEN/.gitattributes"
+  # Blob mit der echten Magic \0GITCRYPT\0 committen, ohne aktiven Filter
+  printf '\000GITCRYPT\000BINARY-CIPHERTEXT' > "$BROKEN/environments/.secrets/test.yaml"
+  git -C "$BROKEN" add -A
+  git -C "$BROKEN" commit -qm init
+  # Key installieren -> das Skript nimmt den "unlocked"-Zweig
+  mkdir -p "$BROKEN/.git/git-crypt/keys"
+  printf 'FAKEKEY\n' > "$BROKEN/.git/git-crypt/keys/default"
+  # DER DEFEKT: leere Filter in der geteilten Config
+  git -C "$BROKEN" config filter.git-crypt.smudge ""
+  git -C "$BROKEN" config filter.git-crypt.clean  ""
+  git -C "$BROKEN" config filter.git-crypt.required false
+}
+
+@test "T002114: leere Filter in der geteilten Config -> Abbruch statt kaputtem Worktree" {
+  _setup_empty_filter_repo
+  run bash -c "cd '$BROKEN' && bash '$HELPER' fix/empty-filter '$TMP/wt-broken' HEAD"
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q 'immer noch verschluesselt'
+}
+
+@test "T002114: die Fehlermeldung nennt die geteilte Config als Ursache" {
+  _setup_empty_filter_repo
+  run bash -c "cd '$BROKEN' && bash '$HELPER' fix/empty-filter2 '$TMP/wt-broken2' HEAD"
+  [ "$status" -ne 0 ]
+  # muss auf die GETEILTE Config zeigen, nicht auf die worktree-lokale
+  echo "$output" | grep -qi 'geteilten Config'
+  echo "$output" | grep -q "filter.git-crypt.smudge 'git-crypt smudge'"
+}
+
+@test "T002114: der kaputte Worktree wird zurueckgerollt, nicht liegengelassen" {
+  _setup_empty_filter_repo
+  run bash -c "cd '$BROKEN' && bash '$HELPER' fix/empty-filter3 '$TMP/wt-broken3' HEAD"
+  [ "$status" -ne 0 ]
+  [ ! -d "$TMP/wt-broken3" ]
+}
+
+@test "T002114: die Canary-Pruefung laeuft auch fuer NEU angelegte Branches" {
+  # Vorher war sie auf BRANCH_EXISTS=1 beschraenkt — frische Branches (der
+  # Normalfall) liefen ungeprueft durch.
+  run grep -n 'BRANCH_EXISTS" -eq 1 \] && \[ -f "\$KEY_SRC"' "$HELPER"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Problem

`worktree-create.sh` lieferte lautlos kaputte Worktrees: git-crypt-Secrets lagen **verschlüsselt** im Arbeitsverzeichnis. Weil git dank stat-Cache den Filter zunächst überspringt, fiel es erst auf, als etwas einen git-crypt-Pfad anfasste — danach starb jeder `git status` mit `fatal: clean filter 'git-crypt' failed`.

**Die Ursache lag nicht in diesem Skript**, sondern in der geteilten `.git/config` des Hauptcheckouts: `filter.git-crypt.clean`/`.smudge` standen dort auf **leeren Strings** (lokal bereits repariert). Aber das Skript hat den Defekt weder erkannt noch gemeldet.

## Zwei Lücken

**1. Die stale-smudge-Erkennung war auf `BRANCH_EXISTS=1` beschränkt.** Sie ging davon aus, nur wiederverwendete Worktrees könnten einen veralteten Filter erben. Kommt der Defekt aus der geteilten Config, trifft es aber genauso frisch angelegte Branches — den Normalfall.

**2. Die Reparatur prüfte ihr eigenes Ergebnis nie.** Sie fasst nur worktree-lokale Config an und kann einen Defekt in der geteilten Config gar nicht beheben. Jetzt wird nachverifiziert: bleibt der Canary verschlüsselt (oder scheitert der Reparatur-Checkout), bricht das Skript mit `exit 1` ab und nennt die geteilte Config samt der drei `git config`-Befehle zur Behebung. Der halbe Worktree geht über den bestehenden Rollback-Trap weg.

Der Reparatur-Checkout musste dafür non-fatal werden — sonst reißt `set -e` das Skript vorher mit einer nichtssagenden Rollback-Meldung ab.

## Mitgefixt: ein latenter `pipefail`-Bug

```bash
canary="$(find "$WT_PATH/environments/.secrets" -type f 2>/dev/null | head -1)"
```

Fehlt das Verzeichnis, gibt `find` 1 zurück. `head` gibt 0 zurück — aber unter `set -o pipefail` wird der Pipeline-Status 1, die Zuweisung schlägt fehl, `set -e` bricht ab. Solange der Block hinter `BRANCH_EXISTS=1` lag, wurde er nie erreicht. **Ohne das Gate hätte er jede Worktree-Erstellung in einem Repo ohne `environments/.secrets` zerlegt** — in der Testsuite reproduziert, bevor `|| canary=""` ergänzt wurde.

## Tests

Vier neue Tests in `tests/unit/worktree-create.bats` mit eigener Fixture: HEAD-Blob mit **echter** git-crypt-Magic (`\0GITCRYPT\0`) plus leeren Filtern in der geteilten Config — der Vorfall exakt nachgestellt. Die vorhandene Fake-git-crypt-Fixture der Suite ist ein reiner Passthrough und erzeugt keine Magic, taugt dafür also nicht.

Geprüft werden: Abbruch, Aussagekraft der Meldung, Rollback, und dass das `BRANCH_EXISTS`-Gate weg ist.

**Suite: 14/14 grün** (vorher 10).

## Verifikation

- `bats tests/unit/worktree-create.bats` — 14/14
- `bash -n scripts/worktree-create.sh` — OK
- Realtest im echten Repo: Worktree angelegt, Secret entschlüsselt, `touch` + `git status` sauber
- `task freshness:regenerate` + `check` — EXIT=0

`task test:changed` zieht wegen der `scripts/`-Änderung ~1610 Tests und zeigt 38 Fehler in fremden Specs (`admin-token-consolidation`, `admin-ui-modal-drawer`, `health-goals` u. a.). Die sind **vorbestehend** — dieselben Dateien sind auf `main` genauso rot (4/3/2), `test:changed` wählt sie dort mangels Änderungen nur nicht aus. Nicht Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL