### PR TITLE
chore(ci): 'skills'-Scope registrieren, Header-Lint in den commit-msg-Hook [T002115]

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -28,3 +28,22 @@ if ! bash "$repo_root/scripts/check-commit-vs-diff.sh" "$1"; then
   echo "         'chore(plan):' for plan-only commits." >&2
   exit 1
 fi
+
+# Conventional-Commit-Header hier pruefen, nicht erst im pre-push [T002115].
+# pre-push validiert den ganzen Range und blockiert damit erst, wenn die Commits
+# schon stehen — ein unbekannter Scope kostet dann ein `git commit --amend` oder
+# ein interaktives Rebase. Hier abgefangen ist die Meldung sofort da und die
+# Nachricht noch aenderbar. pre-push bleibt als Backstop (faengt Commits, die
+# ohne installierte Hooks entstanden sind).
+# Bypass (nur im Notfall): SKIP_COMMIT_MSG_LINT=1 git commit ...
+if [[ "${SKIP_COMMIT_MSG_LINT:-0}" == "1" ]]; then
+  echo "⚠  commit-msg: SKIP_COMMIT_MSG_LINT=1 — bypassing conventional-commit check" >&2
+  exit 0
+fi
+
+if ! bash "$repo_root/scripts/validate-commit-msg.sh" message "$1"; then
+  echo "" >&2
+  echo "💡 Erlaubte Scopes: bash scripts/validate-commit-msg.sh scopes" >&2
+  echo "   Ticket-Scopes (T000123) und Health-Goal-Scopes (G-SIZE02) sind immer gueltig." >&2
+  exit 1
+fi

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -56,6 +56,7 @@ const NAMED_SCOPES = [
   'wg',
   'auto',
   'opencode',
+  'skills',
 ];
 
 const TICKET_SCOPE_RE = /^T\d{6}$/;

--- a/tests/spec/t001356-git02-conventional-commit.bats
+++ b/tests/spec/t001356-git02-conventional-commit.bats
@@ -146,3 +146,42 @@ teardown() {
   run "${BATS_TEST_DIRNAME}/../../scripts/register-scope.sh" "Not_Valid!"
   [ "$status" -ne 0 ]
 }
+
+# ── T002115: Header-Pruefung im commit-msg-Hook statt erst im pre-push ────────
+# pre-push validiert den ganzen Range und blockiert erst, wenn die Commits schon
+# stehen — ein unbekannter Scope kostet dann ein --amend oder ein interaktives
+# Rebase. Genau das passierte mit chore(skills): der Scope fehlte in
+# NAMED_SCOPES und die Ablehnung kam erst beim Push.
+
+HOOK="${BATS_TEST_DIRNAME}/../../.githooks/commit-msg"
+
+@test "T002115: 'skills' ist ein registrierter Scope" {
+  run bash "$SCRIPT" scopes
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx 'skills'
+}
+
+@test "T002115: commit-msg-Hook lehnt einen unbekannten Scope ab" {
+  echo "chore(bogusscope): test" > "$TMP_MSG"
+  run bash "$HOOK" "$TMP_MSG"
+  [ "$status" -eq 1 ]
+  echo "$output" | grep -q "unknown scope 'bogusscope'"
+}
+
+@test "T002115: commit-msg-Hook laesst chore(skills) durch" {
+  echo "chore(skills): Bonsai-Referenz aktualisieren" > "$TMP_MSG"
+  run bash "$HOOK" "$TMP_MSG"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002115: commit-msg-Hook nennt den Weg zur Scope-Liste" {
+  echo "chore(bogusscope): test" > "$TMP_MSG"
+  run bash "$HOOK" "$TMP_MSG"
+  echo "$output" | grep -q 'validate-commit-msg.sh scopes'
+}
+
+@test "T002115: SKIP_COMMIT_MSG_LINT=1 umgeht die Pruefung" {
+  echo "chore(bogusscope): test" > "$TMP_MSG"
+  SKIP_COMMIT_MSG_LINT=1 run bash "$HOOK" "$TMP_MSG"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Zwei Reibungspunkte aus der T002111/T002112-Aufarbeitung.

## 1. `skills` fehlte in den erlaubten Scopes

`.claude/skills/` ist ein etablierter, häufig geänderter Pfad — `skills` stand trotzdem nicht in `commitlint.config.cjs → NAMED_SCOPES`. Ein `chore(skills):`-Commit wurde abgelehnt:

```
✗ [31a5479d9] unknown scope 'skills'
✗ pre-push: Conventional Commit validation failed — push blocked
```

Ausweichscope war `docs`, was die Herkunft der Änderung verschleiert — Skill-Definitionen sind keine Projektdokumentation.

Registriert über `scripts/register-scope.sh` (die vorgesehene SSOT-Route), nicht von Hand — daher der Eintrag am Array-Ende.

## 2. Die Prüfung kam zu spät

Der Header-Lint lief bisher **nur** im `pre-push`-Hook. Der validiert den ganzen Range und blockiert damit erst, wenn die Commits schon stehen — ein unbekannter Scope kostet dann ein `git commit --amend` oder ein interaktives Rebase.

Jetzt prüft schon `.githooks/commit-msg` via `validate-commit-msg.sh message`: die Meldung kommt sofort, die Nachricht ist noch änderbar.

```
✗ unknown scope 'bogusscope': chore(bogusscope): test

💡 Erlaubte Scopes: bash scripts/validate-commit-msg.sh scopes
   Ticket-Scopes (T000123) und Health-Goal-Scopes (G-SIZE02) sind immer gueltig.
```

`pre-push` bleibt als Backstop für Commits, die ohne installierte Hooks entstanden sind. Bypass: `SKIP_COMMIT_MSG_LINT=1`, im Stil des bereits vorhandenen `SKIP_COMMIT_VS_DIFF`.

## Tests

Fünf neue Tests in `tests/spec/t001356-git02-conventional-commit.bats`: Scope registriert, Hook lehnt unbekannten Scope ab, lässt `chore(skills)` durch, nennt den Weg zur Scope-Liste, Bypass greift.

**Suite: 26/26 grün** (vorher 21).

## Verifikation

- `bats tests/spec/t001356-git02-conventional-commit.bats` — 26/26
- `bash -n .githooks/commit-msg` — OK
- Hook manuell gegen gültigen/ungültigen Scope und Bypass geprüft
- `task freshness:regenerate` + `check` — EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL