### PR TITLE
fix(ci): pnpm im post-merge-Job einrichten, Ticket-Closure entkoppeln [T002121]

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -146,6 +146,21 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      # `task website:migrate` ruft intern `pnpm --dir website db:migrate` auf.
+      # Ohne diese drei Schritte stirbt der Job mit
+      # '"pnpm": executable file not found in $PATH' (exit 127) — und riss
+      # damit auch "Mark ticket done" mit, das im selben Job liegt. [T002121]
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        with:
+          version: 10
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: website/pnpm-lock.yaml
+      - name: Install website dependencies
+        run: cd website && pnpm install --frozen-lockfile
       - name: Set up kubeconfig
         env:
           FLEET_KUBECONFIG: ${{ secrets.FLEET_KUBECONFIG }}
@@ -161,7 +176,11 @@ jobs:
 
       - name: Mark ticket done
         id: close
-        if: success()
+        # always() statt success(): Closure trackt laut T001092 den MERGE, nicht
+        # Prod-Live — der Deploy ist ausdruecklich entkoppelt. Eine
+        # fehlgeschlagene Migration darf das Ticket also nicht offen halten.
+        # Vorher riss jeder Fehler im Migrationsschritt die Closure mit. [T002121]
+        if: always()
         env:
           FLEET_KUBECONFIG: ${{ secrets.FLEET_KUBECONFIG }}
         run: |

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -581,3 +581,48 @@ sys.exit(0 if p.get('packages')=='write' else 1)
 "
   [ "$status" -eq 0 ]
 }
+
+# T002121: `task website:migrate` ruft intern `pnpm --dir website db:migrate`
+# auf. Ein Job, der den Task ohne pnpm-Setup startet, stirbt mit
+# '"pnpm": executable file not found in $PATH' (exit 127). In post-merge.yml
+# riss das zusaetzlich den Schritt "Mark ticket done" mit, der im selben Job
+# liegt — "Merge = Abschluss" (T001092) blieb dadurch kaputt, obwohl der
+# Workflow nach dem T002118-Fix wieder startete.
+@test "T002121: jeder Job mit 'task website:migrate' richtet pnpm ein" {
+  run python3 - "$REPO_ROOT" <<'PY'
+import glob, os, sys, yaml
+wf = os.path.join(sys.argv[1], ".github/workflows")
+bad = []
+for f in sorted(glob.glob(os.path.join(wf, "*.yml"))):
+    try: doc = yaml.safe_load(open(f)) or {}
+    except Exception: continue
+    for job, spec in (doc.get("jobs") or {}).items():
+        steps = spec.get("steps") if isinstance(spec, dict) else None
+        if not steps: continue
+        runs = " ".join(str(s.get("run", "")) for s in steps)
+        if "website:migrate" not in runs and "pnpm" not in runs: continue
+        if "website:migrate" not in runs: continue
+        uses = " ".join(str(s.get("uses", "")) for s in steps)
+        if "pnpm/action-setup" not in uses:
+            bad.append(f"{os.path.basename(f)} job '{job}'")
+if bad:
+    print("Jobs rufen 'task website:migrate' ohne pnpm/action-setup:")
+    for b in bad: print("  " + b)
+    sys.exit(1)
+print("alle website:migrate-Jobs richten pnpm ein")
+PY
+  [ "$status" -eq 0 ]
+}
+
+@test "T002121: 'Mark ticket done' haengt an always(), nicht an success()" {
+  # Closure trackt laut T001092 den MERGE, nicht Prod-Live. Eine
+  # fehlgeschlagene Migration darf das Ticket nicht offen halten.
+  run python3 -c "
+import yaml,sys
+d=yaml.safe_load(open('$REPO_ROOT/.github/workflows/post-merge.yml'))
+steps=d['jobs']['post-deploy-imperative']['steps']
+s=[x for x in steps if x.get('name')=='Mark ticket done']
+sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
+"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Folgeticket zu #3149 (T002118). Der Workflow **startet** jetzt wieder — `mark-awaiting` und `detect` laufen grün. Aber `post-deploy-imperative` stirbt sofort:

```
Port-forwarding shared-db (5432) and running website migrations...
"pnpm": executable file not found in $PATH
task: Failed to run task "website:migrate": exit status 127
```

## Zwei Probleme

**1. Kein pnpm im Job.** Er installiert nur `task` via `arduino/setup-task`, aber weder Node noch pnpm — `task website:migrate` ruft intern `pnpm --dir website db:migrate` auf. `pnpm/action-setup` + `actions/setup-node` + `pnpm install` ergänzt, identisch zum Muster in `ci.yml`.

**2. Die Ticket-Closure hing am Erfolg der Migration.** Der Schritt `Mark ticket done` liegt im *selben* Job unter `if: success()`. Jeder Fehler im Migrationsschritt riss ihn mit — „Merge = Abschluss" (T001092) blieb kaputt, obwohl der Workflow wieder startete.

Laut T001092 trackt Closure aber ausdrücklich den **Merge**, nicht Prod-Live; der Deploy ist entkoppelt. Der Schritt hängt jetzt an `always()`.

## Tests

Zwei Tests in `tests/spec/ci-cd.bats`:

- ein **genereller Guard**, der jeden Job mit `task website:migrate` auf ein pnpm-Setup prüft
- eine Assertion auf die `always()`-Bedingung

Beide gegengeprüft: **rot ohne den jeweiligen Fix, grün mit.** Suite: 60/60.

## Verifikation

- `bats tests/spec/ci-cd.bats` — 60/60
- `task freshness:regenerate` + `check` — EXIT=0
- YAML- und Jobstruktur-Prüfung: Schrittreihenfolge korrekt

## Bewusst offen gelassen

`post-deploy-imperative` hängt via `needs` an `render-artifact`/`deploy-legacy` und wird übersprungen, wenn ein Deploy fehlschlägt — dann bleibt die Closure trotz `always()` aus. Ein eigener Closure-Job wäre robuster, ist aber ein größerer Umbau und im Ticket vermerkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL