### PR TITLE
fix(infra): oauth2-proxy-brett prod-Patch auf --skip-auth-route (Singular) [T002122]

### DIFF
--- a/prod/patch-oauth2-proxy-brett-deployment.yaml
+++ b/prod/patch-oauth2-proxy-brett-deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - "--email-domain=*"
             - "--allowed-group=workspace-users"
             # T002068: allow unauthenticated access to data-free routes
-            - "--skip-auth-routes=GET=^/healthz$|GET=^/three\\.min\\.js$"
+            - "--skip-auth-route=GET=^/healthz$|GET=^/three\\.min\\.js$"
           env:
             - name: POCKET_ID_BRETT_SECRET
               valueFrom:

--- a/tests/spec/auth-sso.bats
+++ b/tests/spec/auth-sso.bats
@@ -89,3 +89,30 @@ _render_korczewski() {
 @test "orphaned templates/brain/prod-korczewski subtree is gone" {
   [ ! -d templates/brain/prod-korczewski ] || { echo "FAIL: templates/brain/prod-korczewski still exists"; return 1; }
 }
+# T002122: oauth2-proxy v7.9.0 kennt nur --skip-auth-route (Singular). Der
+# Plural laesst den Container mit "unknown flag" und der vollen Usage
+# aussteigen -> CrashLoopBackOff. In prod stand er im Overlay-Patch
+# (prod/patch-oauth2-proxy-brett-deployment.yaml), waehrend die Basis bereits
+# korrigiert war - das Patch ueberschreibt den args-Block, also gewann der
+# kaputte Flag. Folge: Flux konnte beide Brand-Kustomizations 15h lang nicht
+# reconcilen, weil das Deployment nie healthy wurde.
+#
+# Geprueft wird das GERENDERTE Overlay, nicht die Quelldateien - nur dort
+# zeigt sich, welcher Flag nach dem Patch-Merge tatsaechlich in prod landet.
+@test "T002122: gerendertes mentolder-Overlay nutzt kein --skip-auth-routes" {
+  run _render_mentolder
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q -- '--skip-auth-routes'
+}
+
+@test "T002122: gerendertes korczewski-Overlay nutzt kein --skip-auth-routes" {
+  run _render_korczewski
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q -- '--skip-auth-routes'
+}
+
+@test "T002122: oauth2-proxy-brett behaelt den healthz-Bypass (Singular)" {
+  run _render_mentolder
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q -- '--skip-auth-route=GET=\^/healthz'
+}


### PR DESCRIPTION
## Produktionsproblem

Flux reconciliert seit **15 Stunden** weder mentolder noch korczewski:

```
flux-mentolder    False  health check failed: stalled resources:
                         [Deployment/workspace/oauth2-proxy-brett status: 'Failed']
flux-korczewski   False  health check failed: stalled resources:
                         [Deployment/workspace-korczewski/oauth2-proxy-brett status: 'Failed']
```

## Ursache

`prod/patch-oauth2-proxy-brett-deployment.yaml` setzte das Flag im **Plural**. oauth2-proxy v7.9.0 kennt nur den Singular — der Container gibt `unknown flag: --skip-auth-routes` plus die volle Usage aus und beendet sich → CrashLoopBackOff (159 bzw. 176 Restarts).

Der Kern: **die Basis war längst korrigiert, das Overlay-Patch nicht.**

| Datei | Flag |
|---|---|
| `k3d/oauth2-proxy-brett.yaml` | `--skip-auth-route` ✅ |
| `prod/patch-oauth2-proxy-brett-deployment.yaml` | `--skip-auth-routes` ❌ |

Da das Patch den kompletten `args`-Block der Basis **ersetzt**, gewann der kaputte Flag in Produktion. `prod/patch-oauth2-proxy-mediaviewer-deployment.yaml` nutzt korrekt den Singular — ein isolierter Tippfehler, eingeführt mit #3096 (T002068).

## Auswirkung

Der Dienst war **nicht** down: das alte ReplicaSet lief mit 1/1 ready weiter und bediente `brett.mentolder.de` / `brett.korczewski.de`.

Aber der hängende Rollout blockierte die **gesamte** Flux-Reconciliation beider Brand-Kustomizations — kein Manifest-Change landete mehr in prod, über welchen Weg auch immer. `flux-platform`, `flux-sealed-secrets` und die beiden website-Kustomizations waren READY; nur die Brand-Kustomizations hingen.

## Tests

Drei Tests in `tests/spec/auth-sso.bats`. Sie prüfen das **gerenderte** `prod-fleet`-Overlay beider Brands, nicht die Quelldateien — nur dort zeigt sich, welcher Flag nach dem Patch-Merge tatsächlich in prod landet. Genau diese Unterscheidung ist der Kern des Bugs: ein Test gegen `k3d/` wäre grün gewesen, während prod crasht.

Alle drei gegengeprüft: **rot ohne den Fix, grün mit.**

## Verifikation

- `task workspace:validate` — EXIT=0, „Manifests are valid"
- `bats tests/spec/auth-sso.bats` — 13/13
- `task freshness:regenerate` + `check` — EXIT=0

## Nach dem Merge

Flux sollte die Brand-Kustomizations selbst wieder gesund ziehen, sobald das Artefakt neu gerendert ist. Achtung: `vars.FLUX_ENABLED` ist nicht gesetzt, der `render-artifact`-Job läuft also nie — das OCI-Artefakt ist seit dem Bootstrap unverändert. Das ist ein separates Problem und in T002122 vermerkt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL