### PR TITLE
feat(plans): pipeline-aware partial planning with factory dispatch [T002110]

### DIFF
--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -183,6 +183,41 @@ bash scripts/agent-lock.sh check ticket "$TICKET_ID" | head -1 | grep -q '^mine$
 Prüfe zusätzlich den Registry-Overlap für geteilte Hochfrequenz-Dateien (SSOT:
 [session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md)):
 
+## Schritt 1.4.5: Pipeline-Modus erkennen (T002110)
+
+Prüfe in der DB, ob das Ticket im Pipeline-Modus (Partial-Dispatch) gestaged wurde:
+
+```bash
+TICKET_STRUCT=$(./scripts/vda.sh ticket get --id "$TICKET_ID" 2>/dev/null || echo '{}')
+SLOT_COUNT=$(echo "$TICKET_STRUCT" | jq -r '.slot_count // 1')
+TICKET_STATUS=$(echo "$TICKET_STRUCT" | jq -r '.status // empty')
+echo "ℹ️  Ticket $TICKET_ID: status=$TICKET_STATUS, slot_count=$SLOT_COUNT"
+```
+
+- **slot_count > 1:** Pipeline-Modus — die Factory hat bereits mit der Arbeit begonnen (vom Planner enqueued). Warte auf vollständige Partial-Dispatches (siehe Schritt 2.1).
+- **slot_count = 1:** Single-Shot — normale sequentielle Ausführung.
+
+### Schritt 1.4.6: Pipeline-Modus — Auf Partial-Vollständigkeit warten
+
+Wenn `slot_count > 1` und Factory bereits läuft (`status == 'in_progress'`):
+
+```bash
+# Poll-Schleife: warte bis alle N Partials im Branch sichtbar sind
+for wait_min in $(seq 1 30); do
+  git fetch origin "$(git branch --show-current)"
+  PLAN_COUNT=$(grep -c '^| p[0-9]' "$PLAN_FILE" 2>/dev/null || echo 0)
+  if [ "$PLAN_COUNT" -ge "$SLOT_COUNT" ]; then
+    echo "✅ Alle $SLOT_COUNT Partials sind im Branch sichtbar."
+    break
+  fi
+  echo "⏳ Warte auf Partial $PLAN_COUNT/$SLOT_COUNT ..."
+  git pull --rebase origin "$(git branch --show-current)"
+  sleep 30
+done
+```
+
+Dann normal rebasen und alle Partials implementieren.
+
 ## Schritt 1.5: Ticket auf `in_progress` setzen und touched_files registrieren
 
 > **Optional:** Wenn der Plan via `dev-flow-plan` auf `plan_staged` steht, kannst du vor diesem

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -142,55 +142,120 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 Der Implementierungsplan wird **ausschließlich** in `openspec/changes/<slug>/tasks.md` geschrieben.
 #### Schritt A.6: Playwright-Projekt-Gate (optional)
 Falls neue E2E-Tests geplant sind, weise das passende Playwright-Projekt zu (siehe [dev-flow-gotchas](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md) für Zuordnungstabelle).
-### Phase B: Worktree anlegen + Artefakte übertragen
-#### Schritt B.1: Worktree anlegen
+### Phase B: Worktree anlegen + Branch pushen (Pipeline-Start)
+
+🚨 **Pipeline-Prinzip:** Der Branch und Worktree werden JETZT angelegt und gepusht,
+damit Partial-Pläne sofort in die Factory enqueued werden können, während der Planner
+weiterarbeitet. Die Factory beginnt mit der Ausführung eines Partials, sobald es
+enqueued ist — parallel zum Schreiben des nächsten Partials.
 
 > **Ticket-vor-Branch-Check (T001917, T002050):** Prüfe vor der Worktree-Anlage, ob bereits ein Ticket existiert oder in Schritt 4.5 ein neues angelegt wird. Ist `TICKET_EXT_ID` bekannt, benenne den Branch **immer** mit Ticket-ID-Suffix (z.B. `feature/<slug>-t002050` statt `feature/<slug>`). Falls noch kein Ticket existiert, erstelle das Ticket VOR der Worktree-Anlage (siehe Schritt 4.5), um dessen `TICKET_EXT_ID` direkt in den Branch-Namen aufzunehmen. Sonst schlägt `preflight-pr-scope.sh` beim PR fehl (PR-Titel-Ticket-ID ≠ Branch-Name) und der Branch muss nachträglich umbenannt werden.
 
-Erstelle den Worktree NACH dem Propose (niemals `.claude/worktrees/` verwenden!):
+#### Schritt B.1: Worktree anlegen (git-crypt-safe)
+
 ```bash
-# git-crypt-safe: creates the worktree, handles git-crypt, inits submodules
 bash scripts/worktree-create.sh feature/<slug>-t<id> .worktrees/<slug>
 
-# Doppelarbeit verhindern: Branch claimen (Session-Koordination [T000510]).
+# Branch claimen (Session-Koordination [T000510])
 bash scripts/agent-lock.sh claim branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
-  || { echo "🛑 Branch wird bereits von einer anderen Session bearbeitet — koordinieren oder anderen slug wählen."; exit 1; }
+  || { echo "🛑 Branch wird bereits von einer anderen Session bearbeitet."; exit 1; }
 
-# Ticket-Claim (Session-Koordination [T000510])
-if [[ -n "${TICKET_EXT_ID:-}" ]]; then
-  bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
-    --branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
-    || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet — koordinieren."; exit 1; }
-fi
+# Ticket-Claim
+bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
+  --branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
+  || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet."; exit 1; }
 ```
-#### Schritt B.2: Proposal-Artefakte in den Worktree verschieben
-Die Artefakte aus Phase A befinden sich noch im main-Checkout — jetzt in den frischen Worktree verschieben:
+
+#### Schritt B.2: Artefakte in den Worktree verschieben
+
 ```bash
 WT=".worktrees/<slug>"
-
-# OpenSpec-Change-Ordner (proposal.md, tasks.md, design.md, ggf. assets/) — der
-# ganze Ordner wandert mit, die Design-Spec (design.md) liegt schon darin (T002074);
-# KEIN separater Spec-mv mehr nötig.
 mkdir -p "${WT}/openspec/changes/"
 mv "${REPO_ROOT}/openspec/changes/<slug>" "${WT}/openspec/changes/<slug>"
-
-# Plan Intel Bundle (aus A.1.5) in den Change-Ordner verschieben (falls separat gehalten)
-[ -f "${REPO_ROOT}/intel.json" ] && \
-  mv "${REPO_ROOT}/intel.json" "${WT}/openspec/changes/<slug>/intel.json" 2>/dev/null || true
-
-# Lavish-Board (falls vorhanden)
-[ -f "${REPO_ROOT}/.lavish/<slug>-brainstorm.html" ] && \
-  mv "${REPO_ROOT}/.lavish/<slug>-brainstorm.html" "${WT}/.lavish/" 2>/dev/null || true
-
+[ -f "${REPO_ROOT}/intel.json" ] && mv "${REPO_ROOT}/intel.json" "${WT}/openspec/changes/<slug>/intel.json" 2>/dev/null || true
+[ -f "${REPO_ROOT}/.lavish/<slug>-brainstorm.html" ] && mv "${REPO_ROOT}/.lavish/<slug>-brainstorm.html" "${WT}/.lavish/" 2>/dev/null || true
 cd "${WT}"
 ```
-Schlüsseldateien ans Ticket hängen (falls Design-Bundle, Schritt A.2):
+
+#### Schritt B.3: Scaffold-Commit + Push (Branch ist live für Factory)
+
 ```bash
-bash scripts/ticket-attach.sh "$TICKET_UUID" \
-  "openspec/changes/<slug>/assets/intent.md" \
-  openspec/changes/<slug>/assets/new/*.svg
+git add openspec/changes/<slug>/
+git commit -m "chore(plans): scaffold <slug> branch [$TICKET_EXT_ID]"
+git push -u origin $(git branch --show-current)
 ```
-### Phase C: Im Worktree — Plan-Phase
+
+### Phase C: Im Worktree — Pipeline-Plan-Phase (Partial-Dispatch)
+
+#### Schritt C.1: Decompose — Partial-Manifest erstellen
+Erzeuge aus `intel.json` (`impact_files`) das **Partial-Manifest** — Partials mit disjunkten
+`target_files`-Listen; das **letzte Partial ist IMMER die Tests-Rolle** (`tests`) und trägt den
+STRUCT2-Failing-Test-Step. Keine Datei in zwei Partials (D1). Obergrenze 9 (`--partials`-Cap).
+
+#### Schritt C.2: Pipeline-Loop — Pro Partial: Plan → Stage → Enqueue → Factory
+
+Führe für **jedes Partial in Reihenfolge** aus (außer Tests-Partial, das erst am Ende):
+
+```
+FOR each partial pX (p1, p2, ...):
+  │
+  ├─► Schritt C.2a: Partial-Plan schreiben
+  │     Spawne Plan-Subagenten (Task-Tool) — Kontext: proposal.md, intel.json-Subset.
+  │     Schreibt `tasks.d/pX-<name>.md`.
+  │
+  ├─► Schritt C.2b: tasks.md-Index aktualisieren
+  │     Orchestrator schreibt/updated tasks.md mit Partial-Manifest + File Structure.
+  │
+  ├─► Schritt C.2c: Commit + Push
+  │     git add openspec/changes/<slug>/
+  │     git commit -m "chore(plans): add partial pX-<name> for <slug> [$TICKET_EXT_ID]"
+  │     git push origin feature/<slug>-t<id>
+  │
+  ├─► Schritt C.2d: Plan stagen (slot_count setzen)
+  │     bash scripts/ticket.sh stage-plan \
+  │       --id "$TICKET_EXT_ID" --branch "feature/<slug>-t<id>" \
+  │       --plan "openspec/changes/<slug>/tasks.md" --partials N
+  │
+  ├─► Schritt C.2e: Readiness-Flags setzen
+  │     ticket-mcp: set_readiness_flag({id, flag:"spec_skizziert", value:true})
+  │     ticket-mcp: set_readiness_flag({id, flag:"abhaengigkeiten_klar", value:true})
+  │     ticket-mcp: set_readiness_flag({id, flag:"offene_fragen_geklaert", value:true})
+  │     ticket-mcp: set_readiness_flag({id, flag:"aufwand_geschaetzt", value:true})
+  │
+  ├─► Schritt C.2f: In Factory enqueuen ⚡
+  │     ticket-mcp: enqueue_ticket({ id: "$TICKET_EXT_ID" })
+  │     # Factory startet SOFORT mit pX — Planner fährt parallel mit p(X+1) fort
+  │
+  └─► Nächstes Partial (oder STOPP wenn alle geschrieben)
+
+NACH dem letzten Partial (Tests):
+  ├─► Schritt C.3: Plan-Qualitäts-Gate  
+  │     bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md
+  │     bash scripts/openspec.sh validate
+  │
+  ├─► Schritt C.4: Pgvector-Index
+  │     bash scripts/openspec-embed-local.sh <slug> "$(pwd)"
+  │
+  └─► Schritt C.5: Finaler Commit + Push
+        git add openspec/changes/<slug>/
+        git commit -m "chore(plans): finalize <slug> plan [$TICKET_EXT_ID]"
+        git push origin $(git branch --show-current)
+```
+
+### Pipeline-Fluss (visuell)
+```
+Zeit │
+     │ Planner: [p1] → [p2] → [p3(Tests)] → fertig
+     │ Factory:  ╰─► p1 ╰─► p2 ╰─► p3
+     │           (parallel zum Planner!)
+     ▼
+```
+
+### Race-Condition-Schutz
+- **Slot-Gating:** `stage-plan --partials N` setzt `slot_count`. Factory dispatcht nur bis zu dieser Grenze.
+- **Plan-Staleness:** Wenn Factory schneller ist als Planner → Dispatcher pausiert (kein Ticket in backlog). Sobald nächstes Partial enqueued ist, läuft Tick weiter.
+- **Plan-Mutation:** Sobald ein Partial enqueued ist, darf der Planner es nicht mehr ändern.
+
 ### Schritt 3.7: Plan-Erstellung — zweistufig: Decompose → paralleler Fan-out (T002074)
 Die Plan-Phase ist **zweistufig**. Bei kleinen Änderungen bleibt es faktisch bei
 einem einzigen Partial (= klassischer Single-Plan, unten). Bei mehreren Subsystemen

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -130,9 +130,46 @@ ticket-mcp: transition_status({ id: "$TICKET_ID", status: "in_progress" })
 ticket-mcp: set_touched_files({ id: "$TICKET_ID", files: "<dateien aus plan>" })
 ```
 
+## Schritt 1.6: Pipeline-Modus erkennen
+
+Prüfe, ob das Ticket im Pipeline-Modus (Partial-Dispatch) oder Single-Shot gestaged wurde:
+
+```bash
+TICKET_STRUCT=$(./scripts/vda.sh ticket get --id "$TICKET_ID" --json 2>/dev/null || echo '{}')
+SLOT_COUNT=$(echo "$TICKET_STRUCT" | jq -r '.slot_count // 1')
+TICKET_STATUS=$(echo "$TICKET_STRUCT" | jq -r '.status // empty')
+echo "ℹ️  Ticket $TICKET_ID: status=$TICKET_STATUS, slot_count=$SLOT_COUNT"
+```
+
+- **slot_count > 1:** Pipeline-Modus — die Factory hat bereits mit der Arbeit begonnen (vom Planner enqueued). Warte auf vollständige Partial-Dispatches (siehe Schritt 2.1).
+- **slot_count = 1:** Single-Shot — normale sequentielle Ausführung.
+
 ## Schritt 2: Implementierung delegieren
 
-Implementiere in-context (oder delegiere an write-capable Subagent — siehe `background-agents.ts` Routing: write-capable agents nutzen opencodes native write-capable Delegation, nicht `delegate()`).
+### Schritt 2.1: Pipeline-Modus — Auf Partial-Vollständigkeit warten
+
+Wenn `slot_count > 1` und Factory bereits läuft (`status == 'in_progress'`):
+
+```bash
+# Poll-Schleife: warte bis alle N Partials committed sind (vom Planner)
+# oder der Planner fertig ist (letztes Partial ist Tests)
+for wait_min in $(seq 1 30); do
+  # Prüfe ob Branch neue Partials hat
+  git fetch origin "$(git branch --show-current)"
+  PLAN_COUNT=$(grep -c '^| p[0-9]' "$PLAN_FILE" 2>/dev/null || echo 0)
+  if [ "$PLAN_COUNT" -ge "$SLOT_COUNT" ]; then
+    echo "✅ Alle $SLOT_COUNT Partials sind im Branch sichtbar."
+    break
+  fi
+  echo "⏳ Warte auf Partial $PLAN_COUNT/$SLOT_COUNT ..."
+  git pull --rebase origin "$(git branch --show-current)"
+  sleep 30
+done
+```
+
+Dann normal rebasen und alle Partials in der richtigen Reihenfolge abarbeiten.
+
+### Schritt 2.2: Implementierung (Single-Shot oder nach Warte-Schleife)
 
 - Lies den Plan aus `$PLAN_FILE`
 - Lies `openspec/changes/<slug>/intel.json` für Typen-Wahrheit

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -98,10 +98,14 @@ ticket-mcp: create_ticket({ type: "task", brand: "mentolder", title: "<slug>", p
 Setze `TICKET_EXT_ID` (Feld 1) und `TICKET_UUID` (Feld 2) aus der Rückgabe.
 Claims: `agent-lock.sh claim ticket` + `claim branch` mit Label `opencode-flow-plan`.
 
-### Phase B: Worktree anlegen + Artefakte übertragen
-#### Schritt B.1: Worktree anlegen
+### Phase B: Worktree anlegen + Branch pushen (vor Plan-Schreibung)
 
-Da `worktree.ts`'s `worktree_create` keine git-crypt-Filter-Neutralisierung hat (bekannte Limitation — siehe opencode-git-workflow), immer das Wrapper-Skript verwenden:
+🚨 **Pipeline-Prinzip:** Der Branch und Worktree werden JETZT angelegt und gepusht,
+damit Partial-Pläne sofort in die Factory enqueued werden können, während der Planner
+weiterarbeitet. Die Factory beginnt mit der Ausführung eines Partials, sobald es
+enqueued ist — parallel zum Schreiben des nächsten Partials.
+
+#### Schritt B.1: Worktree anlegen
 
 ```bash
 bash scripts/worktree-create.sh feature/<slug> .worktrees/<slug>
@@ -117,64 +121,97 @@ mv "${REPO_ROOT}/openspec/changes/<slug>" "${WT}/openspec/changes/<slug>"
 cd "${WT}"
 ```
 
-### Phase C: Im Worktree — Plan-Phase
-#### Schritt 3.7: Plan-Erstellung — zweistufig: Decompose → Fan-out (T002074)
+#### Schritt B.3: Leeren Branch pushen (Grundlage für Factory-Dispatch)
 
-Die Plan-Phase ist **zweistufig** (symmetrisch zu `dev-flow-plan`):
+```bash
+git add openspec/changes/<slug>/
+git commit -m "chore(plans): scaffold <slug> branch [$TICKET_EXT_ID]"
+git push -u origin feature/<slug>
+```
 
-**(a) Decompose** — erzeuge aus `intel.json` (`impact_files`) das **Partial-Manifest**:
-1–3 Partials mit disjunkten `target_files`-Listen; das **letzte Partial ist IMMER die
+### Phase C: Im Worktree — Pipeline-Plan-Phase (Partial-Dispatch)
+
+#### Schritt C.1: Decompose — Partial-Manifest erstellen
+
+Erzeuge aus `intel.json` (`impact_files`) das **Partial-Manifest**:
+1–N Partials mit disjunkten `target_files`-Listen; das **letzte Partial ist IMMER die
 Tests-Rolle** (`tests`, trägt den STRUCT2-Failing-Test-Step). Faustregel: 1 Partial bei
 < 5 `impact_files` / einem Subsystem, sonst Schnitt nach Subsystem, Tests separat. Keine
 Datei in zwei Partials (D1 — `plan-lint.sh` erzwingt das im Partial-Modus).
 
-**(b) Fan-out** — N parallele Plan-Subagenten via `background-agents.ts`
-(`delegate(prompt, agent="explore")`, Ergebnis via `delegation_read(id)`; ohne Plugin
-inline). Kontext pro Subagent NUR: `openspec/changes/<slug>/proposal.md`, sein
-Manifest-Eintrag, `bash scripts/plan-intel-filter.sh <slug> <target_files...>`
-(deterministisch gefilterte `intel.json`) und die Plan-Quality-Gates. Jeder schreibt
-seine `openspec/changes/<slug>/tasks.d/pX-<name>.md`; der Orchestrator schreibt den
-`tasks.md`-Index mit `## Partials`-Manifest, `## File Structure` und finalem Verify-Task.
+#### Schritt C.2: Pipeline-Loop — Pro Partial: Plan → Stage → Enqueue → Factory
 
-Jeder Subagent MUSS die Spec + `openspec/changes/<slug>/intel.json`(-Subset) als Kontext erhalten und die Plan-Qualitäts-Gates einhalten: S1-Budget pro Datei, `plan-lint.sh`-Konformität (F1/F2/STRUCT1-3/P1), drei verify-Commands im letzten Task.
+Führe für **jedes Partial** in Reihenfolge aus (außer das letzte Tests-Partial, das erst
+nach allen anderen gestaged wird):
 
-#### Schritt 3.8: Plan-Qualitäts-Gate
+```
+FOR each partial pX (p1, p2, ...):
+  │
+  ├─► Schritt C.2a: Partial-Plan schreiben
+  │     Fan-out Subagent via `delegate(prompt, agent="explore")` — Kontext: proposal.md,
+  │     intel.json-Subset, Quality-Gates. Schreibt `tasks.d/pX-<name>.md`.
+  │
+  ├─► Schritt C.2b: tasks.md-Index aktualisieren
+  │     Der Orchestrator updated `tasks.md` mit dem neuen Partial-Eintrag im Manifest
+  │     und der aktualisierten File Structure.
+  │
+  ├─► Schritt C.2c: Commit + Push (Partial ist im Branch sichtbar)
+  │     git add openspec/changes/<slug>/
+  │     git commit -m "chore(plans): add partial pX-<name> for <slug> [$TICKET_EXT_ID]"
+  │     git push origin feature/<slug>
+  │
+  ├─► Schritt C.2d: Plan stagen (plan_staged + slot_count setzen)
+  │     bash scripts/ticket.sh stage-plan \
+  │       --id "$TICKET_EXT_ID" \
+  │       --branch "feature/<slug>" \
+  │       --plan "openspec/changes/<slug>/tasks.md" \
+  │       --partials N
+  │
+  ├─► Schritt C.2e: Readiness-Flags setzen (damit auto-enqueue greift)
+  │     ticket-mcp: set_readiness_flag({ id: "$TICKET_EXT_ID", flag: "spec_skizziert", value: true })
+  │     ticket-mcp: set_readiness_flag({ id: "$TICKET_EXT_ID", flag: "abhaengigkeiten_klar", value: true })
+  │     ticket-mcp: set_readiness_flag({ id: "$TICKET_EXT_ID", flag: "offene_fragen_geklaert", value: true })
+  │     ticket-mcp: set_readiness_flag({ id: "$TICKET_EXT_ID", flag: "aufwand_geschaetzt", value: true })
+  │
+  ├─► Schritt C.2f: In Factory enqueuen ⚡
+  │     ticket-mcp: enqueue_ticket({ id: "$TICKET_EXT_ID" })
+  │     # Factory dispatcher startet jetzt WORK an diesem Partial!
+  │     # Der Planner fährt parallel mit dem nächsten Partial fort.
+  │
+  └─► Nächstes Partial (oder STOPP wenn alle geschrieben)
 
-```bash
-bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md
-bash scripts/openspec.sh validate
+NACH dem letzten Partial (Tests):
+  ├─► Schritt C.3: Plan-Qualitäts-Gate
+  │     bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md
+  │     bash scripts/openspec.sh validate
+  │
+  ├─► Schritt C.4: Pgvector-Index aktualisieren
+  │     bash scripts/openspec-embed-local.sh <slug> "$(pwd)"
+  │
+  └─► Schritt C.5: Finaler Commit + Push
+        git add openspec/changes/<slug>/
+        git commit -m "chore(plans): finalize <slug> plan [$TICKET_EXT_ID]"
+        git push origin feature/<slug>
 ```
 
-#### Schritt 4: Plan stagen (Ticket existiert bereits aus Schritt A.5)
+### Pipeline-Fluss (visuell)
 
-Ticket-ID muss aus Schritt A.5 im Kontext sein (`$TICKET_EXT_ID`).
-Plan stagen — `stage_plan` setzt automatisch `status=plan_staged` und die
-`FACTORY-PLAN-REF`-Comment:
 ```
-ticket-mcp: stage_plan({ id: "$TICKET_EXT_ID", branch: "feature/<slug>", plan: "openspec/changes/<slug>/tasks.md" })
-```
-
-Partial-Anzahl fürs Gang-Gating mitgeben (T002074) — via `set_plan_meta`, sonst Fallback
-`bash scripts/ticket.sh stage-plan --id "$TICKET_EXT_ID" --branch "feature/<slug>" --plan "openspec/changes/<slug>/tasks.md" --partials N`
-(N = Partials aus dem Manifest, 1..3; `--partials` lebt in `scripts/vda/ticket/stage-plan.sh`,
-`ticket.sh` bleibt unberührt). Danach den Change nach pgvector indizieren
-(Hybrid-Kontext-Transfer Teil 2) — über den fail-visible Wrapper, NICHT das nackte
-`openspec-embed.mjs` (skippt bei fehlender Env still):
-`bash scripts/openspec-embed-local.sh <slug> "$(pwd)"` — Exit ≠ 0 ⇒ Embedding fehlt,
-beheben statt ignorieren (Erfolg = Ausgabe `indexed slug='<slug>'`; Wrapper löst
-DB-URL per kubectl auf und probt das TEI-Backend vorab).
-
-#### Schritt 5: Commit & Push — dann STOPP
-
-Pre-Commit Guard: nicht auf main, sauberer Status, Branch-Lock-Check.
-
-```bash
-git add openspec/changes/<slug>/
-git commit -m "chore(plans): stage <slug> for execution [$TICKET_EXT_ID]"
-git push -u origin $(git branch --show-current)
+Zeit │
+     │ Planner:      [p1 schreiben] → [p2 schreiben] → [p3(Tests) schreiben] → fertig
+     │ Factory:       ╰─► p1 ausführen ╰─► p2 ausführen ╰─► p3(Tests) ausführen
+     │                (parallel zum Planner!)       (parallel zum Planner!)
+     ▼
 ```
 
-**STOPP.** Branch, Spec und Plan sind committed und gepusht. Nächster Schritt: `opencode-flow-execute`.
+### Wichtig — Race-Condition-Schutz
+
+- **Slot-Gating:** `stage-plan --partials N` setzt `slot_count` in der DB. Der Factory-Dispatcher reserviert slots nur bis zu dieser Grenze und erzeugt keinen Leerlauf durch Überdispatch.
+- **Plan-Staleness:** Wenn die Factory ein Partial schneller abarbeitet als der Planner das nächste schreibt, pausiert der Dispatcher (kein Ticket in `plan_staged`/`backlog`). Sobald das nächste Partial enqueued ist, läuft der Tick weiter.
+- **Ticket-Status:** Während der Pipeline bleibt das Ticket `plan_staged` → `backlog` → `in_progress`. Der Planner muss vor jedem Enqueue prüfen, ob die Factory das Ticket bereits bearbeitet (`in_progress`) — dann kurz pausieren und warten.
+- **Plan-Mutation:** Sobald ein Partial enqueued ist, darf der Planner den Plan für dieses Partial NICHT mehr ändern (Factory hat bereits begonnen). Neue Erkenntnisse fließen via `design.md`-Updates in spätere Partials.
+
+### Fix-Pfad
 
 ## Fix-Pfad
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,9 @@ task workspace:validate                          # Kustomize dry-run
 ## Workflow Rules
 
 - Branches: `feature/*`, `fix/*`, `chore/*`, `docs/*`. All changes via PRs → squash-merge. No direct pushes to `main`.
-- `dev-flow-plan` (brainstorm→spec→plan→push) then `dev-flow-execute` (implement→PR→deploy).
-- CI gate: `task test:changed` + `task freshness:check` + `task workspace:validate`.
+- **Pipeline-Prinzip:** Planning-Agents (opencode-flow-plan) legen Worktree + Branch sofort an und enqueuen jedes Partial-Plan einzeln in die Factory, sobald es geschrieben ist. Die Factory beginnt mit der Ausführung, während der Planner das nächste Partial schreibt. Siehe `opencode-flow-plan` SKILL.md Phase B/C.
+- `dev-flow-plan` (brainstorm→spec→partial-plan→stage→enqueue→factory-executes→next-partial) dann `dev-flow-execute` (PR→deploy).
+- CI gate: `task test:changed` + `task freshness:check` + `task workspace:validate` — **vor** PR-Create lokal laufen lassen, nicht erst in CI.
 - **Merge = closure** (T001092): ticket closes on green auto-merge. Prod deploy is decoupled (push-based).
 
 ## Architecture (30-second view)


### PR DESCRIPTION
## Summary
Ändert den Planungs-Workflow so, dass Planning-Agents Worktree + Branch sofort anlegen,
Partial-Pläne einzeln schreiben und nach jedem Partial in die Factory enqueuen.
Die Factory beginnt mit der Ausführung, während der Planner das nächste Partial schreibt.

## Geänderte Dateien
- **opencode-flow-plan SKILL.md** — Phase B: Worktree/Branch vor Plan, Phase C: Pipeline-Loop mit Stage→Enqueue
- **opencode-flow-execute SKILL.md** — Pipeline-Modus-Erkennung (slot_count), Wait-Loop für Partials
- **dev-flow-plan SKILL.md** (Claude) — gleiche Pipeline-Änderungen
- **dev-flow-execute SKILL.md** (Claude) — gleiche Pipeline-Änderungen  
- **AGENTS.md** — Pipeline-Prinzip dokumentiert

## Pipeline-Fluss


## Test Plan
- [x] conventional commit OK
- [x] quality:check passed (0 new violations)

Closes T002110