### PR TITLE
fix(ci): pnpm auch im deploy-legacy-Job, Guard loest die Task-Kette auf [T002124]

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -116,6 +116,23 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # `task workspace:deploy` ruft INTERN `task website:migrate` auf
+      # (Taskfile.yml:2629/:2758), das wiederum `pnpm --dir website db:migrate`
+      # startet. Die pnpm-Abhaengigkeit ist hier also indirekt ueber die
+      # Task-Kette und im Workflow-Text nicht sichtbar — genau deshalb hat der
+      # Guard aus T002121 diesen Job uebersehen. [T002124]
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda  # v4.1.0
+        with:
+          version: 10
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+          cache-dependency-path: website/pnpm-lock.yaml
+      - name: Install website dependencies
+        run: cd website && pnpm install --frozen-lockfile
+
       - name: Set up kubeconfig
         env:
           FLEET_KUBECONFIG: ${{ secrets.FLEET_KUBECONFIG }}

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -588,29 +588,61 @@ sys.exit(0 if p.get('packages')=='write' else 1)
 # riss das zusaetzlich den Schritt "Mark ticket done" mit, der im selben Job
 # liegt — "Merge = Abschluss" (T001092) blieb dadurch kaputt, obwohl der
 # Workflow nach dem T002118-Fix wieder startete.
-@test "T002121: jeder Job mit 'task website:migrate' richtet pnpm ein" {
-  run python3 - "$REPO_ROOT" <<'PY'
-import glob, os, sys, yaml
-wf = os.path.join(sys.argv[1], ".github/workflows")
+@test "T002124: jeder Job, der (auch indirekt) pnpm braucht, richtet es ein" {
+  # Loest die Task-Kette aus Taskfile.yml auf statt nur Workflow-Text zu
+  # greppen. deploy-legacy ruft `task workspace:deploy`, das intern
+  # `task website:migrate` startet, das `pnpm` braucht — im Workflow steht
+  # davon nichts. Der urspruengliche Guard (T002121) suchte nur nach der
+  # woertlichen Nennung von website:migrate und uebersah den Job deshalb.
+  run python3 - "$REPO_ROOT" <<'PYEOF'
+import glob, os, re, sys, yaml
+
+root = sys.argv[1]
+taskfile = open(os.path.join(root, "Taskfile.yml"), encoding="utf-8").read()
+
+# Fixpunkt: welche Tasks ziehen (transitiv) website:migrate nach sich?
+needs_pnpm = {"website:migrate"}
+starts = [(m.group(1), m.start()) for m in re.finditer(r"^  ([a-z0-9:_-]+):\s*$", taskfile, re.M)]
+bodies = {}
+for i, (name, pos) in enumerate(starts):
+    endpos = starts[i + 1][1] if i + 1 < len(starts) else len(taskfile)
+    bodies[name] = taskfile[pos:endpos]
+
+changed = True
+while changed:
+    changed = False
+    for name, body in bodies.items():
+        if name in needs_pnpm:
+            continue
+        if any(re.search(r"task\s+" + re.escape(t) + r"\b", body) for t in needs_pnpm):
+            needs_pnpm.add(name)
+            changed = True
+
 bad = []
-for f in sorted(glob.glob(os.path.join(wf, "*.yml"))):
-    try: doc = yaml.safe_load(open(f)) or {}
-    except Exception: continue
+for f in sorted(glob.glob(os.path.join(root, ".github/workflows/*.yml"))):
+    try:
+        doc = yaml.safe_load(open(f, encoding="utf-8")) or {}
+    except Exception:
+        continue
     for job, spec in (doc.get("jobs") or {}).items():
         steps = spec.get("steps") if isinstance(spec, dict) else None
-        if not steps: continue
+        if not steps:
+            continue
         runs = " ".join(str(s.get("run", "")) for s in steps)
-        if "website:migrate" not in runs and "pnpm" not in runs: continue
-        if "website:migrate" not in runs: continue
+        hit = [t for t in needs_pnpm if re.search(r"task\s+" + re.escape(t) + r"\b", runs)]
+        if not hit:
+            continue
         uses = " ".join(str(s.get("uses", "")) for s in steps)
         if "pnpm/action-setup" not in uses:
-            bad.append(f"{os.path.basename(f)} job '{job}'")
+            bad.append(f"{os.path.basename(f)} job '{job}' ruft {sorted(hit)} ohne pnpm-Setup")
+
 if bad:
-    print("Jobs rufen 'task website:migrate' ohne pnpm/action-setup:")
-    for b in bad: print("  " + b)
+    print("Jobs brauchen pnpm (direkt oder ueber die Task-Kette), richten es aber nicht ein:")
+    for b in bad:
+        print("  " + b)
     sys.exit(1)
-print("alle website:migrate-Jobs richten pnpm ein")
-PY
+print(f"OK - {len(needs_pnpm)} pnpm-pflichtige Tasks geprueft")
+PYEOF
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Folgefehler zu #3153 (T002121). Der dortige Fix richtete pnpm nur im Job `post-deploy-imperative` ein. `deploy-legacy` hat dasselbe Problem und brach beim **ersten Lauf nach dem T002118-Fix** sofort ab:

```
Deploy workspace to mentolder
"pnpm": executable file not found in $PATH
task: Failed to run task "website:migrate": exit status 127
task: Failed to run task "workspace:deploy": exit status 201
```

`task workspace:deploy` ruft **intern** `task website:migrate` auf (`Taskfile.yml:2629/:2758`), das `pnpm --dir website db:migrate` startet. Die pnpm-Abhängigkeit ist hier indirekt über die Task-Kette und im Workflow-Text nicht sichtbar.

## Warum mein Guard aus T002121 das übersah

Er suchte Jobs, deren `run:`-Blöcke wörtlich `website:migrate` enthalten. `deploy-legacy` nennt aber nur `task workspace:deploy`. Der Guard war zu eng gefasst — er prüfte den Workflow-Text statt der tatsächlichen Abhängigkeit.

## Der Guard löst jetzt die Kette auf

Per Fixpunkt über `Taskfile.yml`: ausgehend von `website:migrate` wird jeder Task aufgenommen, der einen bereits markierten Task aufruft. Ergebnis — **4 statt 1** pnpm-pflichtige Tasks:

```
['env:init', 'website:deploy', 'website:migrate', 'workspace:deploy']
```

Jeder Workflow-Job, der einen davon startet, muss `pnpm/action-setup` haben.

## Verifikation

- Gegenprobe: **rot ohne den Fix, grün mit**
- `bats tests/spec/ci-cd.bats` — 60/60
- `task freshness:regenerate` + `check` — EXIT=0
- YAML-Validierung OK

## Kette bis hierher

| Ticket | Problem | Status |
|---|---|---|
| T002118 | `startup_failure` durch Permissions-Konflikt | ✅ #3149 |
| T002121 | `post-deploy-imperative` ohne pnpm | ✅ #3153 |
| **T002124** | **`deploy-legacy` ohne pnpm (indirekt)** | dieser PR |
| T002122 | `oauth2-proxy-brett` CrashLoop blockiert Flux | ✅ #3154, wartet auf Deploy |

Nach diesem Merge sollte `deploy-legacy` erstmals seit dem 2026-07-22 wieder durchlaufen und den T002122-Fix nach prod bringen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BjD7rpLEqqxVLKb2vMFrL