### PR TITLE
fix(ci): replace slow apt-based Trivy install with static binary install [T002134]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
     name: Security Scan
     if: github.event.action != 'edited'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -240,10 +240,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          sudo apt-get update && sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update && sudo apt-get install -y trivy
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
 
       - name: Trivy container image scan (pinned images)
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Replaced the slow/unreliable apt-based Trivy installation in CI (double apt-get update, GPG key setup, apt repo) with the official static binary install script (`curl | sh`)
- Reduced job timeout from 20→15 minutes since the apt overhead was the main culprit

## Why
The apt-based install was slow and unreliable — the previous "fix" doubled the job timeout from 10→20 minutes instead of addressing the root cause. The static binary install:
- Completes in seconds instead of minutes
- Doesn't depend on apt repository availability
- Is the officially recommended method (same as referenced in trivy-scan.sh's error message)

## Test Plan
- [ ] CI security-scan job passes

Closes T002134