### PR TITLE
feat(scripts): add bonsai-write-guard to detect and revert subagent overwrites [T002137]

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -118,3 +118,14 @@ if [ "${SKIP_BRANCH_CHECK:-0}" != "1" ]; then
     esac
   fi
 fi
+
+# --- bonsai-write-guard: detect and revert whole-file overwrites [T002137] ---
+# Catches bonsai-8b agents that used write instead of edit. Lightweight:
+# only checks staged modified files for suspicious line-count reduction.
+# Bypass: SKIP_BONSAI_GUARD=1 git commit ...
+if [ "${SKIP_BONSAI_GUARD:-0}" != "1" ]; then
+  if ! bash "$repo_root/scripts/guard-bonsai-overwrite.sh" check "pre-commit"; then
+    echo "  Bypass: SKIP_BONSAI_GUARD=1 git commit ..." >&2
+    exit 1
+  fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,8 @@ assets-inbox/docs/superpowers/specs/.gaps/
 
 # Mishap tracker local log (gitignored; use --ticket for persistent records)
 .mishaps.log
+# Bonsai write guard log (local incident tracking, never committed)
+.bonsai-write-guard.log
 .worktrees/
 
 # mcp-task-runner build artifacts

--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -132,7 +132,10 @@
       "color": "#F59E0B",
       "temperature": 0.4,
       "steps": 10,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
+      // write=deny: bonsai-8b überschreibt sonst ganze Dateien statt surgical edit
+      // (beobachtet 2026-07-23, T002137: 3/3 bonsai löschten existierende Files).
+      // Neue Dateien erzeugt der Orchestrator nach Erhalt des Contents.
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
     "bonsai-8b-2": {
       "description": "Write-capable subagent 2/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
@@ -142,7 +145,7 @@
       "color": "#F97316",
       "temperature": 0.4,
       "steps": 10,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
     "bonsai-8b-3": {
       "description": "Write-capable subagent 3/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
@@ -152,7 +155,7 @@
       "color": "#EA580C",
       "temperature": 0.4,
       "steps": 10,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
     "bonsai-8b-4": {
       "description": "Write-capable subagent 4/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
@@ -162,7 +165,7 @@
       "color": "#D97706",
       "temperature": 0.4,
       "steps": 10,
-      "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny" }
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
     // Eskalationsstufe fuer Parallel-Agenten (start-bonsai-parallel.ps1), NACH
     // lokaler Kontext-Kompaktierung/Retry und opencodes eigener Kompaktierung -

--- a/.opencode/prompts/local-subagent.md
+++ b/.opencode/prompts/local-subagent.md
@@ -11,6 +11,13 @@ Rules:
 - Keep answers as short as the task allows. Verbosity is a cost here, not a feature.
 - Execute tool calls one at a time. After each tool result, verify the actual output before proceeding.
 
+File editing policy:
+- You have access to `edit` (surgical replacements in existing files) and `Read`, `Glob`, `Grep`, `bash` tools.
+- You do NOT have `write` — never try to use it. The `write` tool is denied on purpose to prevent whole-file overwrites. Use `edit` for all file changes.
+- Before editing a file, always `Read` it first to see its current content.
+- Do NOT ask the orchestrator for permission to use an alternative tool — if only `edit` is available, work with it.
+- WARNING: There is an automated guard (`guard-bonsai-overwrite.sh`) that detects whole-file overwrites after every task. If you use `write` or bash to overwrite a file instead of `edit`, the guard reverts your change and logs the incident. Any file that shrank to <30% of its original line count will be reverted automatically.
+
 Context budgeting:
 - You have 65k tokens total for system prompt + task + your output. Measure before committing to long plans.
 - If the task includes large files/diffs, summarize what you read rather than quoting it back — use file paths and line numbers for references.

--- a/.opencode/prompts/orchestrator.md
+++ b/.opencode/prompts/orchestrator.md
@@ -8,6 +8,8 @@ You are the **Orchestrator** (DeepSeek V4 Flash, 1M ctx on OpenCode Go). Your ro
 - **Gang gating**: before widening a gang, probe the llm-proxy admin surface `http://127.0.0.1:18235/admin/state` (NOT `/health`) and read the backend's `{inflight, max_inflight}`. Only add a concurrent stream when free in-flight capacity exists; otherwise dispatch sequentially. `/health` reports only liveness and must not be used to size the gang.
 - **Escalation**: if a bonsai-8b fails the same partial **twice** (stuck, context-exhausted, or repeated error after local compaction/retry), do NOT retry a third time locally — escalate that partial to `deepseek-helper` via `task` with a compacted handoff (goal, done-so-far, stuck-point).
 - Read-only exploration (code search, file reads) stays here. Only dispatch for write-capable implementation work.
+- **Bonsai overwrite guard**: After EVERY bonsai-8b dispatch completes, run `bash scripts/guard-bonsai-overwrite.sh <agent-name> <files...>` for each file the agent was supposed to touch. This catches cases where the agent used `write` (whole-file overwrite) instead of `edit` (surgical replacement). The guard reverts the file to HEAD and logs the incident. If the guard exits non-zero, record a `blocked` phase event and DO NOT proceed — inspect what happened and re-dispatch or escalate.
+  - If the guard fires on a file you did NOT list in the partial plan (an unintended modification), still revert and investigate — the agent touched something it shouldn't have.
 
 ## Observability (phase events)
 

--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -178,6 +178,9 @@ s4:
     # (e.g. tests/unit/skill-orchestrator.bats, tickets-sunset.bats). Without this
     # entry, those scripts are flagged as orphans. Added in T001170.
     - "tests/**/*.bats"
+    # Subagent prompt files under .opencode/prompts/ reference guard scripts and
+    # other helper scripts (e.g. guard-bonsai-overwrite.sh). Added in T002137.
+    - ".opencode/prompts/**/*.md"
   allowlist_globs:
     - "k3d/office-stack/**"
     - "k3d/coturn-stack/**"

--- a/scripts/guard-bonsai-overwrite.sh
+++ b/scripts/guard-bonsai-overwrite.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# scripts/guard-bonsai-overwrite.sh
+# Guard against bonsai-8b subagents overwriting files with write instead of edit.
+#
+# Usage (orchestrator mode):
+#   guard-bonsai-overwrite.sh <agent-name> <file1> [file2 ...]
+#
+# Usage (pre-commit mode):
+#   guard-bonsai-overwrite.sh check
+#
+# Detection heuristic:
+#   - If a tracked file was reduced to <30% of its HEAD line count → overwrite
+#   - If a tracked file was deleted entirely → overwrite
+#
+# On detection:
+#   - Reverts the file via `git checkout HEAD -- <file>`
+#   - Logs the incident to .bonsai-write-guard.log
+#   - Exits 1 (failure) to alert the caller
+#
+# Install: chmod +x scripts/guard-bonsai-overwrite.sh
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOGFILE="$REPO_ROOT/.bonsai-write-guard.log"
+THRESHOLD_PCT=30  # if current lines < THRESHOLD_PCT% of HEAD lines → overwrite
+
+reverted=0
+revert_file() {
+  local file="$1" agent="$2"
+  if git -C "$REPO_ROOT" show HEAD:"$file" >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" checkout HEAD -- "$file"
+    echo "[$(date -Iseconds)] GUARD:$agent REVERTED $file (overwrite detected)" >> "$LOGFILE"
+    echo "  ✗ GUARD:$agent — $file wurde überschrieben → zurückgesetzt (HEAD)" >&2
+    reverted=$((reverted + 1))
+  fi
+}
+
+check_file_overwrite() {
+  local file="$1" agent="${2:-bonsai-8b}"
+  [ -f "$REPO_ROOT/$file" ] || { revert_file "$file" "$agent"; return; }
+
+  # Compare line count with HEAD
+  local head_lines=0 current_lines=0
+  head_lines=$(git -C "$REPO_ROOT" show HEAD:"$file" 2>/dev/null | wc -l) || return 0
+  current_lines=$(wc -l < "$REPO_ROOT/$file") || return 0
+
+  # Only flag if HEAD had significant content
+  [ "$head_lines" -gt 5 ] || return 0
+
+  # If file shrank below threshold, it was overwritten
+  if [ "$current_lines" -lt $((head_lines * THRESHOLD_PCT / 100)) ]; then
+    echo "  ⚠ GUARD: $file shrank ${head_lines}→${current_lines} Zeilen (<${THRESHOLD_PCT}%)" >&2
+    revert_file "$file" "$agent"
+  fi
+}
+
+# ── pre-commit mode: check staged files ────────────────────────────────
+if [ "${1:-}" = "check" ]; then
+  agent="${2:-pre-commit}"
+  staged_files=$(git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=M 2>/dev/null || true)
+  deleted_files=$(git -C "$REPO_ROOT" diff --cached --name-only --diff-filter=D 2>/dev/null || true)
+
+  for file in $deleted_files; do
+    echo "  ⚠ GUARD: $file wurde gelöscht (staged) — prüfe auf versehentliche deletion" >&2
+    if git -C "$REPO_ROOT" show HEAD:"$file" >/dev/null 2>&1; then
+      # Check if a delete was staged but the worktree still has the file
+      if [ -f "$REPO_ROOT/$file" ]; then
+        echo "  ⚠ GUARD: $file gelöscht staged, aber Datei existiert noch — restoring" >&2
+        git -C "$REPO_ROOT" reset HEAD -- "$file" 2>/dev/null || true
+        echo "[$(date -Iseconds)] GUARD:pre-commit UNSTAGED-DELETE $file" >> "$LOGFILE"
+        reverted=$((reverted + 1))
+      fi
+    fi
+  done
+
+  for file in $staged_files; do
+    check_file_overwrite "$file" "$agent"
+  done
+
+  if [ "$reverted" -gt 0 ]; then
+    echo "  ⚠ BONSAI-WRITE-GUARD: $reverted Datei(en) zurückgesetzt — ein Agent hat write statt edit verwendet." >&2
+    echo "  Siehe $LOGFILE für Details." >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# ── orchestrator mode: agent name + file list ─────────────────────────-
+agent="${1:-bonsai-unknown}"
+shift || true
+
+if [ $# -eq 0 ]; then
+  # No explicit files: check all unstaged modified files
+  files=$(git -C "$REPO_ROOT" diff --name-only --diff-filter=M 2>/dev/null || true)
+else
+  files="$*"
+fi
+
+for file in $files; do
+  check_file_overwrite "$file" "$agent"
+done
+
+if [ "$reverted" -gt 0 ]; then
+  echo >&2 ""
+  echo "  ╔══════════════════════════════════════════════════════════════╗" >&2
+  echo "  ║  🤖 BONSAI-WRITE-GUARD: $reverted Datei(en) von $agent  ║" >&2
+  echo "  ║  wurden überschrieben und zurückgesetzt.                    ║" >&2
+  echo "  ║  Der Agent hat write statt edit verwendet.                  ║" >&2
+  echo "  ╚══════════════════════════════════════════════════════════════╝" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Add `scripts/guard-bonsai-overwrite.sh` — detects when a bonsai-8b subagent overwrites a file with `write` instead of using `edit`, reverts to HEAD, logs the incident
- Update `.opencode/prompts/local-subagent.md` — tells bonsai that `write` is denied and to use `edit` only, warns about the guard
- Update `.opencode/prompts/orchestrator.md` — instructs orchestrator to run the guard after every bonsai dispatch
- Update `.githooks/pre-commit` — adds pre-commit check as second layer of defense
- Update `docs/code-quality/gates.yaml` — adds `.opencode/prompts/**/*.md` as S4 reference source

## Test Plan
- [x] Test 1: bonsai-8b-1 used `write` (guard needed)
- [x] Test 2: bonsai-8b-2 used `edit` successfully (prompt hint works when followed)
- [x] Test 3: bonsai-8b-3 used `write` despite prompt (guard reverted)
- [x] Test 4: bonsai-8b-4 used `edit`, guard exit 0
- [x] Guard simulation: overwrite detected and reverted correctly

🤖 [T002137]