### PR TITLE
chore(infra): retrigger fleet manifest render after Flux cutover [T002139]

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -86,6 +86,7 @@ data:
   # Arena (last-man-standing game server; same host on both brands — mentolder only)
   ARENA_WS_URL: "${ARENA_WS_URL}"
   # Site
+  # T002139: no-op touch to retrigger render-fleet-artifact.yml after FLUX_ENABLED cutover
   SITE_URL: "${WEBSITE_SITE_URL}"
   # CORS allowlist for the React SPA (react.<brand>); empty → fail-closed (no React app)
   REACT_APP_ORIGIN: "${REACT_APP_ORIGIN}"


### PR DESCRIPTION
## Summary
- FLUX_ENABLED was flipped `true` on 2026-07-23 17:12 UTC, but no push since then touched a path watched by `render-fleet-artifact.yml` (`k3d/**`, `prod-fleet/**`, `flux/clusters/**`, …).
- The cluster is therefore still pulling a 21h-old OCI artifact, rendered *before* today's envsubst fixes (b55c4f0b4, T002127/#3161).
- That stale artifact ships an unresolved `${WEBSITE_SITE_URL}` placeholder in `k3d/website.yaml`, so the website calls Pocket-ID's `/authorize` with a literal `${WEBSITE_SITE_URL}/api/auth/callback` redirect_uri → Pocket-ID rejects it with `400 invalid callback URL` → OIDC login broken on web.mentolder.de (likely korczewski too).
- This PR is a **comment-only, no-op touch** to `k3d/website.yaml` solely to hit the `push` trigger's path filter and produce a fresh, correctly-rendered artifact for Flux to reconcile. No functional/behavioral change.

Ref: T002139 (bug ticket documenting the discovered failure per the repo's bug-triage convention).

## Test plan
- [x] `task workspace:validate` — manifests valid
- [ ] After merge: confirm `render-fleet-artifact.yml` runs (not skipped) on this push
- [ ] Confirm `kubectl --context fleet get ocirepository -n flux-system flux-system` shows a new digest
- [ ] Confirm Pocket-ID OIDC login succeeds on web.mentolder.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)