### PR TITLE
fix(infra): make flux-render-artifact.sh actually run [T002146]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4666,7 +4666,7 @@ tasks:
   flux:render:
     desc: "Render fleet-Komponenten + Flux-CRs nach out/ (kein Apply)"
     cmds:
-      - bash scripts/flux-render-artifact.sh --out "{{.OUT | default \"out\"}}"
+      - bash scripts/flux-render-artifact.sh --out "{{.OUT | default "out"}}"
 
   flux:bootstrap:
     desc: "Einmalig: flux-operator via Helm + FluxInstance + Receiver/IngressRoute/ghcr-auth (imperativ)"

--- a/scripts/flux-render-artifact.sh
+++ b/scripts/flux-render-artifact.sh
@@ -43,8 +43,11 @@ render_component() {
   local rendered
   rendered="$(kustomize build "$overlay" --load-restrictor=LoadRestrictionsNone)"
   
+  # grep exits 1 when the overlay has no ${VAR} refs at all; that's a valid outcome
+  # (handled by the -z "$vars" branch below), not a script failure — || true keeps
+  # set -e from aborting on the "no matches" case.
   local vars
-  vars="$(grep -oE '\$\{[A-Za-z0-9_]+\}' <<<"$rendered" | tr -d '${}' | sort -u | tr '\n' ' ')"
+  vars="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$rendered" | tr -d '${}' | sort -u | tr '\n' ' ')" || true
   
   if [[ -z "$vars" ]]; then
     # No vars to substitute — write as-is
@@ -68,10 +71,10 @@ render_component() {
   # FAIL-CLOSED: after substitution, check for any remaining unsubstituted ${VAR}
   # references. If any exist, the build fails instead of silently shipping a broken
   # manifest with literal placeholders (secret-exposure risk / fail-open).
-  if grep -qE '\$\{[A-Za-z0-9_]+\}' "$out"; then
+  if grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$out"; then
     echo "ERROR: Unsubstituted variable references remain in $out after envsubst." >&2
     echo "       The following vars were not defined in the environment:" >&2
-    grep -oE '\$\{[A-Za-z0-9_]+\}' "$out" | sort -u >&2
+    grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$out" | sort -u >&2
     echo "       Ensure all referenced env vars are set or add them to the allowlist." >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- `task flux:render` (called by `render-fleet-artifact.yml`) never actually succeeded since it was introduced in T002083 — every run had been silently `skipped` by the `FLUX_ENABLED` gate until it flipped `true` today (see T002139), so nobody noticed until now.
- **Bug 1:** `Taskfile.yml` used `{{.OUT | default \"out\"}}` — backslash-escaped quotes that belong inside a YAML *double-quoted* scalar, but this cmd line is unquoted. go-task's template parser failed with `unexpected "\\" in operand` on every call.
- **Bug 2:** `render_component()`'s `vars="$(grep ... )"` isn't part of a `local` declaration, so under `set -e` a `grep` with zero matches (valid — some overlays have no `${VAR}` refs at all, e.g. `platform`) aborts the whole script silently, before reaching the "no vars, write as-is" branch.
- **Bug 3 (found while verifying the fix):** the var-name extraction regex `[A-Za-z0-9_]+` allowed a leading digit, so it matched embedded shell positional params like `${1}` in the korczewski DDNS script's `api_call()` function — a false positive that trips T002127's new fail-closed guard. Tightened to `[A-Za-z_][A-Za-z0-9_]*` per POSIX env-var naming.

## Test plan
- [x] `bash -n scripts/flux-render-artifact.sh`
- [x] `task flux:render --dry` — no template error
- [x] Full local run of all 5 overlays (`platform`, `dev`, `mentolder`, `korczewski`, `website-mentolder`, `website-korczewski`) — completes with exit 0, previously died on the very first overlay
- [x] Spot-checked `website-mentolder/website-mentolder.yaml`: `SITE_URL: "https://web.mentolder.de"` now correctly resolved (was the literal `${WEBSITE_SITE_URL}` breaking Pocket-ID OIDC login, T002139)
- [x] `task workspace:validate`
- [ ] After merge: confirm `render-fleet-artifact.yml` succeeds (not `failure`) and OCIRepository digest advances

Ref: T002146 (blocks T002139's live verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)