### PR TITLE
chore(infra): retrigger fleet manifest render, attempt 2 [T002139]

### DIFF
--- a/k3d/website.yaml
+++ b/k3d/website.yaml
@@ -87,6 +87,8 @@ data:
   ARENA_WS_URL: "${ARENA_WS_URL}"
   # Site
   # T002139: no-op touch to retrigger render-fleet-artifact.yml after FLUX_ENABLED cutover
+  # (retrigger attempt 2 — attempt 1 in #3171 failed because render-fleet-artifact.yml
+  # itself was broken; that's fixed now in T002146/#3172)
   SITE_URL: "${WEBSITE_SITE_URL}"
   # CORS allowlist for the React SPA (react.<brand>); empty → fail-closed (no React app)
   REACT_APP_ORIGIN: "${REACT_APP_ORIGIN}"


### PR DESCRIPTION
## Summary
Second retrigger attempt. The first (#3171) landed a push that hit render-fleet-artifact.yml's push trigger, but the run itself failed — not due to the stale-artifact fix's own change, but because the render pipeline had two pre-existing, never-before-exercised bugs (fixed in T002146/#3172, merged after #3171 but on paths not watched by the push trigger, so it didn't self-retrigger).

Both bugs are now fixed and verified with a full local end-to-end render of all 5 overlays. This PR is another no-op comment touch to `k3d/website.yaml`, solely to re-hit the path-filtered push trigger.

Ref: T002139.

## Test plan
- [x] `task workspace:validate`
- [ ] After merge: `render-fleet-artifact.yml` succeeds (not failure/skipped)
- [ ] `kubectl --context fleet get ocirepository -n flux-system flux-system` shows a new digest
- [ ] Pocket-ID OIDC login succeeds on web.mentolder.de

🤖 Generated with [Claude Code](https://claude.com/claude-code)