### PR TITLE
fix(infra): rename OCIRepository source to fleet-manifests, commit it to git [T002147]

### DIFF
--- a/flux/clusters/fleet/bootstrap/receiver.yaml
+++ b/flux/clusters/fleet/bootstrap/receiver.yaml
@@ -9,5 +9,5 @@ spec:
     name: flux-webhook-token
   resources:
     - kind: OCIRepository
-      name: flux-system
+      name: fleet-manifests
       namespace: flux-system

--- a/flux/clusters/fleet/ks-dev.yaml
+++ b/flux/clusters/fleet/ks-dev.yaml
@@ -11,7 +11,7 @@ spec:
     - name: flux-infra-controllers
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./dev
   prune: true
   wait: true

--- a/flux/clusters/fleet/ks-infra-controllers.yaml
+++ b/flux/clusters/fleet/ks-infra-controllers.yaml
@@ -12,7 +12,7 @@ spec:
     - name: flux-sealed-secrets-korczewski
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./platform
   prune: true
   wait: true

--- a/flux/clusters/fleet/ks-korczewski.yaml
+++ b/flux/clusters/fleet/ks-korczewski.yaml
@@ -11,7 +11,7 @@ spec:
     - name: flux-infra-controllers
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./korczewski
   prune: true
   wait: true

--- a/flux/clusters/fleet/ks-mentolder.yaml
+++ b/flux/clusters/fleet/ks-mentolder.yaml
@@ -11,7 +11,7 @@ spec:
     - name: flux-infra-controllers
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./mentolder
   prune: true
   wait: true

--- a/flux/clusters/fleet/ks-sealed-secrets.yaml
+++ b/flux/clusters/fleet/ks-sealed-secrets.yaml
@@ -9,7 +9,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./sealed-secrets/mentolder
   prune: false
   wait: true
@@ -25,7 +25,7 @@ spec:
   timeout: 5m
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./sealed-secrets/korczewski
   prune: false
   wait: true

--- a/flux/clusters/fleet/ks-website-korczewski.yaml
+++ b/flux/clusters/fleet/ks-website-korczewski.yaml
@@ -11,7 +11,7 @@ spec:
     - name: flux-infra-controllers
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./website-korczewski
   prune: true
   wait: true

--- a/flux/clusters/fleet/ks-website-mentolder.yaml
+++ b/flux/clusters/fleet/ks-website-mentolder.yaml
@@ -11,7 +11,7 @@ spec:
     - name: flux-infra-controllers
   sourceRef:
     kind: OCIRepository
-    name: flux-system
+    name: fleet-manifests
   path: ./website-mentolder
   prune: true
   wait: true

--- a/flux/clusters/fleet/oci-source.yaml
+++ b/flux/clusters/fleet/oci-source.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: fleet-manifests
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: oci://ghcr.io/paddione/fleet-manifests
+  ref:
+    tag: latest
+  secretRef:
+    name: ghcr-auth

--- a/tests/flux-validation.bats
+++ b/tests/flux-validation.bats
@@ -6,9 +6,15 @@
 # never actually deployed (source-watcher operator/CRDs never installed) and had
 # a broken sourceRef (FluxInstance.spec.sync.ref must be a string, not a map) that
 # left flux-system's self-management stuck since it was merged. T002147 reverted
-# the cluster CR layer to the OCIRepository/flux-system source that
-# render-fleet-artifact.yml (T002083) actually produces and that is verified
-# working end-to-end.
+# the cluster CR layer to the OCIRepository source that render-fleet-artifact.yml
+# (T002083) actually produces and that is verified working end-to-end.
+#
+# That source is named "fleet-manifests", not "flux-system": once the sync.ref fix
+# let FluxInstance actually manage its own top-level sync resource, it created a
+# GitRepository named "flux-system" (matching spec.sync.kind) and garbage-collected
+# the pre-existing, imperatively-created OCIRepository of the same name — which every
+# app Kustomization's sourceRef still pointed at. Recreating the OCIRepository under
+# a name FluxInstance doesn't also want to own avoids the collision permanently.
 
 setup() {
   cd "$(git rev-parse --show-toplevel)"
@@ -26,13 +32,34 @@ setup() {
   done
 }
 
-@test "Brand/website/dev Kustomizations use OCIRepository/flux-system source" {
+@test "Brand/website/dev Kustomizations use OCIRepository/fleet-manifests source" {
   for f in flux/clusters/fleet/ks-{mentolder,korczewski,website-mentolder,website-korczewski,dev}.yaml; do
     run grep -q "kind: OCIRepository" "$f"
     [ "$status" -eq 0 ]
-    run grep -q "name: flux-system" "$f"
+    run grep -q "name: fleet-manifests" "$f"
     [ "$status" -eq 0 ]
   done
+}
+
+@test "No sourceRef still points at the colliding flux-system OCIRepository name" {
+  run grep -A1 "kind: OCIRepository" flux/clusters/fleet/ks-*.yaml
+  [ "$status" -eq 0 ]
+  ! printf '%s\n' "$output" | grep -q "name: flux-system$"
+}
+
+@test "fleet-manifests OCIRepository is committed with GHCR pull credentials" {
+  [ -f flux/clusters/fleet/oci-source.yaml ]
+  run grep -q "name: fleet-manifests" flux/clusters/fleet/oci-source.yaml
+  [ "$status" -eq 0 ]
+  run grep -q "url: oci://ghcr.io/paddione/fleet-manifests" flux/clusters/fleet/oci-source.yaml
+  [ "$status" -eq 0 ]
+  run grep -q "name: ghcr-auth" flux/clusters/fleet/oci-source.yaml
+  [ "$status" -eq 0 ]
+}
+
+@test "Webhook receiver targets the renamed OCIRepository" {
+  run grep -q "name: fleet-manifests" flux/clusters/fleet/bootstrap/receiver.yaml
+  [ "$status" -eq 0 ]
 }
 
 @test "No ExternalArtifact sourceRef references remain in Kustomization CRDs" {


### PR DESCRIPTION
## Summary
Live fallout from the T002147 `FluxInstance.spec.sync.ref` fix (#3174): once FluxInstance could finally manage its own top-level sync resource, it created a `GitRepository` named `flux-system` (matching `spec.sync.kind`) and **garbage-collected the pre-existing `OCIRepository` of the same name** that `render-fleet-artifact.yml` pushes to and every app Kustomization's `sourceRef` pointed at. That `OCIRepository` was never committed to git — purely imperative from initial bootstrap — so nothing protected it.

This briefly broke `flux-dev`, `flux-infra-controllers`, and `flux-sealed-secrets-mentolder` (`OCIRepository ... not found`) in production. **Already restored live** via kubectl (recreate + `secretRef` patch + force-reconcile, verified `flux-website-mentolder`/`-korczewski` back to `Ready=True` and Pocket-ID login working end-to-end). This PR makes that fix permanent and git-managed so it isn't another orphaned imperative resource waiting to collide again.

- `flux/clusters/fleet/oci-source.yaml`: `OCIRepository` **fleet-manifests** (was implicit, now explicit + version-controlled), including the `ghcr-auth` secretRef the original resource needed but the live recreation initially omitted (hit a `401` until patched).
- All app Kustomizations' `sourceRef.name`: `flux-system` → `fleet-manifests`.
- `bootstrap/receiver.yaml`: webhook target updated to match.

`fleet-manifests` was chosen specifically because it's a name FluxInstance has no reason to ever claim for its own sync resource — this collision can't recur.

Ref: T002147.

## Test plan
- [x] `tests/flux-validation.bats` — 17/17 (3 new cases: renamed source, committed OCIRepository + secretRef, receiver target)
- [x] `task workspace:validate`
- [x] Already verified live before this commit: `flux-website-mentolder`/`-korczewski` `Ready=True`, `SITE_URL` correct, Pocket-ID `/authorize` returns 200
- [ ] After merge: confirm the git-committed state matches what's live (no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)