### PR TITLE
fix: [T002142] Fix G-AGENTIC02 Agent-Routing ↔ Frontmatter-Drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,12 +88,12 @@ The following sections contain detailed reference material. **Do not load them i
 
 | Signals | Agent |
 |---------|-------|
-| `website/`, Astro, Svelte, CSS, UI, frontend | `bachelorprojekt-website` |
-| pod, logs, crash, kubectl, GPU, Ollama, LiveKit | `bachelorprojekt-ops` |
-| k3d/, manifest, kustomize, overlay, Taskfile, deploy | `bachelorprojekt-infra` |
-| test, FA-*, SA-*, NFA-*, BATS, Playwright, factory | `bachelorprojekt-test` |
-| database, PostgreSQL, schema, query, backup | `bachelorprojekt-db` |
-| SealedSecret, Keycloak, OIDC, DSGVO, credentials | `bachelorprojekt-security` |
+| `website/`, Astro, Svelte, component, homepage, kore, mentolder brand, CSS, UI, frontend, design | `bachelorprojekt-website` |
+| pod, logs, status, restart, crash, health, kubectl, "what's wrong", "why is X failing", "is X running", llm:, GPU, Ollama, model, LiveKit | `bachelorprojekt-ops` |
+| k3d/, prod*/, manifest, kustomize, overlay, Taskfile, ENV=, environments/, deploy, workspace:setup | `bachelorprojekt-infra` |
+| test, FA-*, SA-*, NFA-*, AK-*, BATS, Playwright, runner.sh, "test failing", "test case", "write a test", factory:, autopilot, FA-SF | `bachelorprojekt-test` |
+| database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline, bachelorprojekt.features, v_timeline | `bachelorprojekt-db` |
+| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` |
 
 Dispatch: `bash scripts/plan-context.sh <role> --with-openspec` → prepend as `<active-plans>`.
 </details>

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -213,8 +213,8 @@ def fm(p):
     m=re.search(r'[Tt]riggers on:\s*(.*)',d); return toks(m.group(1)) if m else set()
 rows={}; seg=False
 for line in open('AGENTS.md').read().splitlines():
-    if re.match(r'^## Agent Routing',line): seg=True; continue
-    if seg and re.match(r'^## ',line): break
+    if re.match(r'^<summary>Claude Code Domain Agents',line): seg=True; continue
+    if seg and re.match(r'^</details>',line): break
     if seg:
         m=re.match(r'\|(.*?)\|\s*`(bachelorprojekt-[a-z]+)`\s*\|\s*$',line)
         if m: rows[m.group(2)]=toks(m.group(1))


### PR DESCRIPTION
Fixes G-AGENTIC02: Der health-goals-check-Parser verglich die falsche Tabelle in AGENTS.md (## Agent Routing statt <details>Claude Code Domain Agents</details>).

**Changes:**
- `scripts/health-goals-check.sh`: Parser zielt jetzt auf `<summary>Claude Code Domain Agents</summary>` – `</details>` Block
- `AGENTS.md`: Domain-Agents-Tabelle mit korrekten Trigger-Signalen abgeglichen

Closes T002142