### PR TITLE
fix: [T002136] Mishap-Bundle: test:changed, coverage-guard, branch naming docs

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -52,7 +52,7 @@ einen Cron-Job ein. **STOPP hier.**
 > **Ticket-vor-Branch-Check (T001917):** Bevor der Branch-Slug feststeht, prüfen ob für diese
 > Chore bereits ein Ticket existiert (`TICKET_EXT_ID` gesetzt oder in `./scripts/ticket.sh list`
 > auffindbar?). Existiert noch keines, **zuerst das Ticket anlegen** (Block in Schritt 1 unten)
-> und dessen ID sofort in den Branch-Slug aufnehmen (z.B. `chore/lighthouse-ci-token-t001913`
+> und dessen ID sofort in den Branch-Slug aufnehmen (z.B. `chore/lighthouse-ci-token-T001913`
 > statt `chore/lighthouse-ci-token`) — nicht erst nach dem Worktree. Sonst schlägt
 > `preflight-pr-scope.sh` beim PR fehl (PR-Titel-Ticket-ID ≠ Branch-Name) und der Branch muss
 > nachträglich umbenannt werden (Zeitverlust, siehe T001913).
@@ -83,7 +83,7 @@ bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label
 ```
 
 > Enthält `<slug>` eine wiederverwendete `TICKET_EXT_ID` (z.B. `T001869`), sollte deren Ticketnummer
-> im Slug vorkommen (z.B. `doc-cleanup-t001869`) — `preflight-pr-scope.sh` prüft das PR-Titel↔Branch-
+> im Slug vorkommen (z.B. `doc-cleanup-T001869`) — `preflight-pr-scope.sh` prüft das PR-Titel↔Branch-
 > Matching case-insensitiv (T001873), Groß-/Kleinschreibung im Slug spielt also keine Rolle.
 
 Claim-Semantik, main-checkout-Sonderfall (`claim main-checkout`) und Release:

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -149,20 +149,20 @@ damit Partial-Pläne sofort in die Factory enqueued werden können, während der
 weiterarbeitet. Die Factory beginnt mit der Ausführung eines Partials, sobald es
 enqueued ist — parallel zum Schreiben des nächsten Partials.
 
-> **Ticket-vor-Branch-Check (T001917, T002050):** Prüfe vor der Worktree-Anlage, ob bereits ein Ticket existiert oder in Schritt 4.5 ein neues angelegt wird. Ist `TICKET_EXT_ID` bekannt, benenne den Branch **immer** mit Ticket-ID-Suffix (z.B. `feature/<slug>-t002050` statt `feature/<slug>`). Falls noch kein Ticket existiert, erstelle das Ticket VOR der Worktree-Anlage (siehe Schritt 4.5), um dessen `TICKET_EXT_ID` direkt in den Branch-Namen aufzunehmen. Sonst schlägt `preflight-pr-scope.sh` beim PR fehl (PR-Titel-Ticket-ID ≠ Branch-Name) und der Branch muss nachträglich umbenannt werden.
+> **Ticket-vor-Branch-Check (T001917, T002050):** Prüfe vor der Worktree-Anlage, ob bereits ein Ticket existiert oder in Schritt 4.5 ein neues angelegt wird. Ist `TICKET_EXT_ID` bekannt, benenne den Branch **immer** mit Ticket-ID-Suffix (z.B. `feature/<slug>-T002050` statt `feature/<slug>`). Falls noch kein Ticket existiert, erstelle das Ticket VOR der Worktree-Anlage (siehe Schritt 4.5), um dessen `TICKET_EXT_ID` direkt in den Branch-Namen aufzunehmen. Sonst schlägt `preflight-pr-scope.sh` beim PR fehl (PR-Titel-Ticket-ID ≠ Branch-Name) und der Branch muss nachträglich umbenannt werden.
 
 #### Schritt B.1: Worktree anlegen (git-crypt-safe)
 
 ```bash
-bash scripts/worktree-create.sh feature/<slug>-t<id> .worktrees/<slug>
+bash scripts/worktree-create.sh feature/<slug>-T<id> .worktrees/<slug>
 
 # Branch claimen (Session-Koordination [T000510])
-bash scripts/agent-lock.sh claim branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
+bash scripts/agent-lock.sh claim branch "feature/<slug>-T<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
   || { echo "🛑 Branch wird bereits von einer anderen Session bearbeitet."; exit 1; }
 
 # Ticket-Claim
 bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
-  --branch "feature/<slug>-t<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
+  --branch "feature/<slug>-T<id>" --worktree ".worktrees/<slug>" --label dev-flow-plan \
   || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet."; exit 1; }
 ```
 
@@ -209,11 +209,11 @@ FOR each partial pX (p1, p2, ...):
   ├─► Schritt C.2c: Commit + Push
   │     git add openspec/changes/<slug>/
   │     git commit -m "chore(plans): add partial pX-<name> for <slug> [$TICKET_EXT_ID]"
-  │     git push origin feature/<slug>-t<id>
+  │     git push origin feature/<slug>-T<id>
   │
   ├─► Schritt C.2d: Plan stagen (slot_count setzen)
   │     bash scripts/ticket.sh stage-plan \
-  │       --id "$TICKET_EXT_ID" --branch "feature/<slug>-t<id>" \
+  │       --id "$TICKET_EXT_ID" --branch "feature/<slug>-T<id>" \
   │       --plan "openspec/changes/<slug>/tasks.md" --partials N
   │
   ├─► Schritt C.2e: Readiness-Flags setzen

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -790,7 +790,7 @@ tasks:
     cmds:
       - |
         set -e
-        CHANGED=$(git diff --name-only HEAD origin/main 2>/dev/null || git diff --name-only HEAD 2>/dev/null || true)
+        CHANGED=$( (git diff --name-only HEAD origin/main 2>/dev/null || git diff --name-only HEAD 2>/dev/null; git diff --name-only HEAD) | sort -u || true)
         RUN_WEBSITE=false; RUN_MENTOLDER_WEB=false; RUN_K8S=false; RUN_SCRIPTS=false; RUN_FACTORY=false; RUN_SPEC=false; RUN_UNIT=false; RUN_MCP=false; RUN_OPENSPEC=false; RUN_AGENTS=false
         echo "$CHANGED" | grep -qE "^website/" && RUN_WEBSITE=true || true
         echo "$CHANGED" | grep -qE "^mentolder-web/" && RUN_MENTOLDER_WEB=true || true

--- a/scripts/tests/unit-coverage-guard.sh
+++ b/scripts/tests/unit-coverage-guard.sh
@@ -15,7 +15,7 @@ cd "$ROOT"
 allowlist="tests/unit/.coverage-allowlist"
 missing=()
 
-for f in tests/unit/*.bats; do
+while IFS= read -r f; do
   b="$(basename "$f" .bats)"
   # Referenced by a test task (subtasks invoke `tests/unit/<name>.bats`)?
   if grep -qF "${b}.bats" Taskfile.yml; then
@@ -26,7 +26,7 @@ for f in tests/unit/*.bats; do
     continue
   fi
   missing+=("$b")
-done
+done < <(find tests/unit -maxdepth 1 -name '*.bats' | sort)
 
 if (( ${#missing[@]} > 0 )); then
   {


### PR DESCRIPTION
Fixes 3 accumulated mishaps:

**M1** — `test:changed` Working-Tree-Erkennung: CHANGED_FILES inkludiert jetzt `git diff HEAD`
**M2** — `unit-coverage-guard.sh`: Nutzt `find` statt Taskfile-Grep, entkoppelt von Doppel-Wiring
**M3** — Branch-Naming-Beispiele in dev-flow-chore/dev-flow-plan SKILL.md auf `-T000XXX` (uppercase) korrigiert

Closes T002136