### PR TITLE
fix(skills): repair G-AGENTIC06/07/08/09 gate violations [T002143]

### DIFF
--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Skills Overview
 
-36 project-local skills (35 in `.claude/skills/<name>/` + 1 in `.claude/skills/superpowers/using-git-worktrees/`) grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
+39 project-local skills (35 in `.claude/skills/<name>/` + 1 in `.claude/skills/superpowers/using-git-worktrees/`) grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
 
 > **Konsolidierung (2026-06-21):** 7 Infra/Ops-Skills wurden in `infra-ops` zusammengeführt (nur bei explizitem Bedarf aufrufen). `update-dependencies` läuft als biweekly Cloud-Routine (https://claude.ai/code/routines/trig_01GiuyN6KP5iMcVUSvBQMKyQ). Die archivierten SKILL.md-Dateien haben kein `description`-Feld mehr und triggern nicht auto-matisch.
 
@@ -99,6 +99,7 @@ unabhängiger Beweis ist. Stufen 3+4 prüfen andere Dimensionen (Review-Qualitä
 | [`website-specialist`](website-specialist/SKILL.md) | Astro/Svelte frontend development, component creation, page routing, content management, UI implementation. Dispatched as subagent via `bachelorprojekt-website`. |
 | [`host-node-networking`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/host-node-networking.html) | Host server provisioning (Hetzner, cloud-init, Rescue Mode resets), WireGuard mesh network topology ("netplan"), host UFW firewall ports, LiveKit WebRTC networking, and WSL OpenClaw local gateway setup. |
 | [`cluster-deployment`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/cluster-deployment.html) | Stand up a brand-new Kubernetes environment, deploy resources, diagnose cluster degraded state (gap analysis), or operate the dev.mentolder.de stack. Also covers cross-brand fleet operations: `task feature:*` fan-out, `feature:promote` smoke gate, SealedSecrets/Keycloak per-brand independence (Phase 5). |
+| [`gitops-cluster-debug`](gitops-cluster-debug/SKILL.md), [`gitops-knowledge`](gitops-knowledge/SKILL.md), [`gitops-repo-audit`](gitops-repo-audit/SKILL.md) | Flux CD GitOps — debug live clusters, generate manifests, audit repos. Dispatched as subagents. |
 
 ---
 

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -327,72 +327,7 @@ bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md
 ### Schritt 4: Plan prüfen & übernehmen
 Du behältst deinen vollen Brainstorming-Kontext: lies den vom Subagenten zurückgegebenen Plan und prüfe ihn gegen die im Brainstorming getroffenen Entscheidungen. Prüfe zusätzlich die Gate-Konformität (Checkliste in [plan-quality-gates](file:///home/patrick/Bachelorprojekt/.claude/skills/references/plan-quality-gates.md)): S1-Budgets gegen die **wirksame Schwelle** (Baseline-Wert falls gebaselined, sonst Limit) pro Datei notiert — und bei Budget≈0 ein echter Verkleinerungs-/Split-Schritt statt kosmetischem Zusammenziehen? Finaler Verifikations-Task enthält `task test:changed` + `task freshness:regenerate` + `task freshness:check`? Keine Brand-Domain-Literale in den Code-Snippets? Bei Lücken oder Abweichungen delegiere erneut (Schritt 3.7) mit konkreten Korrektur-Hinweisen. Erst wenn der Plan passt, weiter zu Schritt 4.5.
 ### Schritt 4.5: Ticket anlegen oder wiederverwenden
-Prüfe ob ein bestehendes Ticket-ID übergeben wurde (z.B. von `feature-intake`).
-**MCP-first** (`ticket-mcp`) — wenn noch kein `TICKET_EXT_ID` gesetzt ist, ein neues Ticket anlegen (Rückgabe-Parsing: MCP-Tool-Guide §ticket-mcp).
-> `mcp__ticket-mcp__create_ticket({ type: "task", brand: "mentolder", title: "Plan: <slug>", priority: "mittel", description: "Branch: feature/<slug>\nPlan: openspec/changes/<slug>/tasks.md\nSpec: openspec/changes/<slug>/design.md\n<grilling-ref>" })`
-Bei vorhandenem Ticket stattdessen die UUID lesen: `mcp__ticket-mcp__get_ticket({ id: "$TICKET_EXT_ID" })` → `.id` ist die UUID.
-Plan stagen (Branch + Plan-Pfad im Ticket verankern — SSOT für dev-flow-execute) — **MCP-first**:
-> `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "feature/<slug>", plan: "openspec/changes/<slug>/tasks.md" })`
-
-**Partial-Anzahl mitgeben (T002074):** Bei einem Multi-Partial-Plan die Slot-Zahl
-für das Gang-Gating durchreichen — MCP-seitig via `set_plan_meta`, sonst per Fallback
-`bash scripts/ticket.sh stage-plan --id "$TICKET_EXT_ID" --branch "feature/<slug>" --plan "openspec/changes/<slug>/tasks.md" --partials N`
-(N = Anzahl der Partials aus dem `## Partials`-Manifest, 1..9; Default 1). `--partials`
-lebt in `scripts/vda/ticket/stage-plan.sh` — `scripts/ticket.sh` bleibt unberührt.
-
-**Embedding-Index (Hybrid-Kontext-Transfer Teil 2):** Direkt nach dem Stage, vor
-Commit/Push, den Change nach pgvector indizieren, damit die Execute-/Factory-Phase
-ihn per factory-mcp `openspec_find_similar` abrufen kann — über den **fail-visible
-Wrapper** (NICHT das nackte `openspec-embed.mjs`, das skippt bei fehlender Env still):
-`bash scripts/openspec-embed-local.sh <slug> "$(pwd)"`
-(2. Argument = Worktree-Root, in dem `openspec/changes/<slug>/` liegt. Der Wrapper
-löst SESSIONS_DATABASE_URL selbst per kubectl/port-forward auf, probt das
-TEI-Backend vorab und bricht mit Remediation-Hinweis ab statt still zu skippen.
-Exit ≠ 0 ⇒ Embedding fehlt — beheben, nicht ignorieren; Erfolgskriterium ist die
-Zeile `indexed slug='<slug>'`.)
-Fallback (ticket-mcp nicht erreichbar):
-```bash
-# Falls TICKET_EXT_ID bereits gesetzt ist (von feature-intake oder User-Input),
-# wiederverwenden — kein neues Ticket erstellen.
-if [[ -z "${TICKET_EXT_ID:-}" ]]; then
-  # Kein bestehendes Ticket — neues erstellen
-  GRILLING_REF=""
-  if [[ -n "${GRILLING_TICKET_EXT_ID:-}" ]]; then
-    GRILLING_REF=$'\n'"Grilling-Ticket: ${GRILLING_TICKET_EXT_ID}"
-  fi
-
-  TICKET_RESULT=$(./scripts/ticket.sh create \
-    --type task \
-    --brand mentolder \
-    --title "Plan: <slug>" \
-    --priority mittel \
-    --description "Branch: feature/<slug>"$'\n'"Plan: openspec/changes/<slug>/tasks.md"$'\n'"Spec: openspec/changes/<slug>/design.md"$GRILLING_REF)
-
-  TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
-  TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
-else
-  # Bestehendes Ticket wiederverwenden — UUID für Attachments holen
-  TICKET_UUID=$(./scripts/ticket.sh get --id "$TICKET_EXT_ID" | jq -r '.id')
-  echo "✅ Wiederverwende bestehendes Ticket $TICKET_EXT_ID"
-fi
-
-# Plan stagen: Branch + Plan-Pfad im Ticket verankern (Single Source of Truth für dev-flow-execute).
-./scripts/ticket.sh stage-plan \
-  --id "$TICKET_EXT_ID" \
-  --branch "feature/<slug>" \
-  --plan "openspec/changes/<slug>/tasks.md"
-```
-Hänge gesammelte Assets mit `bash scripts/ticket-attach.sh "$TICKET_UUID" <pfade>` an.
-Ticket-Claim jetzt nachholen (Session-Koordination [T000510]) — der Feature-Pfad kennt
-die Ticket-ID erst ab hier; Schritt 5's Pre-Commit-Guard prüft ticket-scoped und braucht
-diesen Claim VOR dem Commit. Falls Schritt B.1 den Claim bereits gesetzt hat (Ticket-ID
-war vorab bekannt), ist ein erneuter Claim durch dieselbe Session ein no-op-Refresh
-(kein Fehler):
-```bash
-bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
-  --branch "$(git branch --show-current)" --worktree "$(pwd)" --label dev-flow-plan \
-  || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet — koordinieren."; exit 1; }
-```
+SSOT für Ticket-Anlage, Stage und Embedding: [ticket-stage-procedure](file:///home/patrick/Bachelorprojekt/.worktrees/agentic-skill-hygiene-T002143/.claude/skills/references/ticket-stage-procedure.md)
 ### Schritt 5: Commit & Push — dann STOPP
 **Pre-Commit Guard (PFLICHT — Schritt 5) [T001268]:**
 Bevor der plan-stage Commit läuft, MUSS der Operator verifizieren:

--- a/.claude/skills/gitops-repo-audit/SKILL.md
+++ b/.claude/skills/gitops-repo-audit/SKILL.md
@@ -28,7 +28,7 @@ Understand the repository before diving into specifics.
 
 1. Run the bundled discovery script to get a Kubernetes resource inventory:
    ```bash
-   scripts/discover.sh -d <repo-root>
+   .claude/skills/gitops-repo-audit/scripts/discover.sh -d <repo-root>
    ```
    The script wraps `flux-schema discover` and outputs JSON with a top-level `inventory`
    object (alongside `kind`/`apiVersion`/`$schema`) containing: a `summary` (file, resource,
@@ -50,7 +50,7 @@ the same machine must not overwrite each other's bundles. If tmp is not writable
 
 ```bash
 bundle="$(mktemp "${TMPDIR:-/tmp}/flux-audit-bundle.XXXXXX" 2>/dev/null || true)"
-scripts/validate.sh -d <repo-root> ${bundle:+-b "$bundle"}
+.claude/skills/gitops-repo-audit/scripts/validate.sh -d <repo-root> ${bundle:+-b "$bundle"}
 ```
 
 It validates every manifest and the rendered output of each Kustomize overlay,
@@ -68,7 +68,7 @@ Check for deprecated Flux API versions.
 
 1. Run the bundled check script:
    ```
-   scripts/check-deprecated.sh -d <repo-root>
+   .claude/skills/gitops-repo-audit/scripts/check-deprecated.sh -d <repo-root>
    ```
    The script runs `flux migrate -f . --dry-run` and outputs exact file paths,
    line numbers, resource kinds, and the required version migration for each

--- a/.claude/skills/references/ticket-stage-procedure.md
+++ b/.claude/skills/references/ticket-stage-procedure.md
@@ -1,0 +1,67 @@
+### Schritt 4.5: Ticket anlegen oder wiederverwenden
+Prüfe ob ein bestehendes Ticket-ID übergeben wurde (z.B. von `feature-intake`).
+**MCP-first** (`ticket-mcp`) — wenn noch kein `TICKET_EXT_ID` gesetzt ist, ein neues Ticket anlegen (Rückgabe-Parsing: MCP-Tool-Guide §ticket-mcp).
+> `mcp__ticket-mcp__create_ticket({ type: "task", brand: "mentolder", title: "Plan: <slug>", priority: "mittel", description: "Branch: feature/<slug>\nPlan: openspec/changes/<slug>/tasks.md\nSpec: openspec/changes/<slug>/design.md\n<grilling-ref>" })`
+Bei vorhandenem Ticket stattdessen die UUID lesen: `mcp__ticket-mcp__get_ticket({ id: "$TICKET_EXT_ID" })` → `.id` ist die UUID.
+Plan stagen (Branch + Plan-Pfad im Ticket verankern — SSOT für dev-flow-execute) — **MCP-first**:
+> `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "feature/<slug>", plan: "openspec/changes/<slug>/tasks.md" })`
+
+**Partial-Anzahl mitgeben (T002074):** Bei einem Multi-Partial-Plan die Slot-Zahl
+für das Gang-Gating durchreichen — MCP-seitig via `set_plan_meta`, sonst per Fallback
+`bash scripts/ticket.sh stage-plan --id "$TICKET_EXT_ID" --branch "feature/<slug>" --plan "openspec/changes/<slug>/tasks.md" --partials N`
+(N = Anzahl der Partials aus dem `## Partials`-Manifest, 1..9; Default 1). `--partials`
+lebt in `scripts/vda/ticket/stage-plan.sh` — `scripts/ticket.sh` bleibt unberührt.
+
+**Embedding-Index (Hybrid-Kontext-Transfer Teil 2):** Direkt nach dem Stage, vor
+Commit/Push, den Change nach pgvector indizieren, damit die Execute-/Factory-Phase
+ihn per factory-mcp `openspec_find_similar` abrufen kann — über den **fail-visible
+Wrapper** (NICHT das nackte `openspec-embed.mjs`, das skippt bei fehlender Env still):
+`bash scripts/openspec-embed-local.sh <slug> "$(pwd)"`
+(2. Argument = Worktree-Root, in dem `openspec/changes/<slug>/` liegt. Der Wrapper
+löst SESSIONS_DATABASE_URL selbst per kubectl/port-forward auf, probt das
+TEI-Backend vorab und bricht mit Remediation-Hinweis ab statt still zu skippen.
+Exit ≠ 0 ⇒ Embedding fehlt — beheben, nicht ignorieren; Erfolgskriterium ist die
+Zeile `indexed slug='<slug>'`.)
+Fallback (ticket-mcp nicht erreichbar):
+```bash
+# Falls TICKET_EXT_ID bereits gesetzt ist (von feature-intake oder User-Input),
+# wiederverwenden — kein neues Ticket erstellen.
+if [[ -z "${TICKET_EXT_ID:-}" ]]; then
+  # Kein bestehendes Ticket — neues erstellen
+  GRILLING_REF=""
+  if [[ -n "${GRILLING_TICKET_EXT_ID:-}" ]]; then
+    GRILLING_REF=$'\n'"Grilling-Ticket: ${GRILLING_TICKET_EXT_ID}"
+  fi
+
+  TICKET_RESULT=$(./scripts/ticket.sh create \
+    --type task \
+    --brand mentolder \
+    --title "Plan: <slug>" \
+    --priority mittel \
+    --description "Branch: feature/<slug>"$'\n'"Plan: openspec/changes/<slug>/tasks.md"$'\n'"Spec: openspec/changes/<slug>/design.md"$GRILLING_REF)
+
+  TICKET_EXT_ID=$(echo "$TICKET_RESULT" | cut -d'|' -f1)
+  TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
+else
+  # Bestehendes Ticket wiederverwenden — UUID für Attachments holen
+  TICKET_UUID=$(./scripts/ticket.sh get --id "$TICKET_EXT_ID" | jq -r '.id')
+  echo "✅ Wiederverwende bestehendes Ticket $TICKET_EXT_ID"
+fi
+
+# Plan stagen: Branch + Plan-Pfad im Ticket verankern (Single Source of Truth für dev-flow-execute).
+./scripts/ticket.sh stage-plan \
+  --id "$TICKET_EXT_ID" \
+  --branch "feature/<slug>" \
+  --plan "openspec/changes/<slug>/tasks.md"
+```
+Hänge gesammelte Assets mit `bash scripts/ticket-attach.sh "$TICKET_UUID" <pfade>` an.
+Ticket-Claim jetzt nachholen (Session-Koordination [T000510]) — der Feature-Pfad kennt
+die Ticket-ID erst ab hier; Schritt 5's Pre-Commit-Guard prüft ticket-scoped und braucht
+diesen Claim VOR dem Commit. Falls Schritt B.1 den Claim bereits gesetzt hat (Ticket-ID
+war vorab bekannt), ist ein erneuter Claim durch dieselbe Session ein no-op-Refresh
+(kein Fehler):
+```bash
+bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \
+  --branch "$(git branch --show-current)" --worktree "$(pwd)" --label dev-flow-plan \
+  || { echo "🛑 Ticket wird bereits von einer anderen Session bearbeitet — koordinieren."; exit 1; }
+```


### PR DESCRIPTION
## Summary
- G-AGENTIC06: OVERVIEW.md counter 36→39 (matches actual skill count)
- G-AGENTIC07: Added GitOps orphan skills row to OVERVIEW.md (gitops-cluster-debug, gitops-knowledge, gitops-repo-audit)
- G-AGENTIC08: Fixed dead script paths in gitops-repo-audit/SKILL.md (scripts/ → .claude/skills/gitops-repo-audit/scripts/)
- G-AGENTIC09: Trimmed dev-flow-plan/SKILL.md 523→458 lines by extracting ticket-stage-procedure reference

## Test Plan
- [ ] All four gates pass: G-AGENTIC06=39/39, G-AGENTIC07=0 orphans, G-AGENTIC08=0 dead, G-AGENTIC09=458≤495

🤖 [T002143]
