### PR TITLE
fix(infra): [T002152] correct unqualified POCKET_ID_URL in fleet overlays

### DIFF
--- a/environments/fleet-korczewski.yaml
+++ b/environments/fleet-korczewski.yaml
@@ -60,7 +60,7 @@ env_vars:
   WEBSITE_SITE_URL: "https://web.korczewski.de"
   POCKET_ID_FRONTEND_URL: "https://auth.korczewski.de"
   POCKET_ID_DOMAIN: "auth.korczewski.de"
-  POCKET_ID_URL: "http://pocket-id:1411"
+  POCKET_ID_URL: "http://pocket-id.workspace-korczewski.svc.cluster.local:1411"
   # System-test failure loop master kill-switch.
   SYSTEMTEST_LOOP_ENABLED: "true"
   LLM_HOST_IP: "192.168.100.10"

--- a/environments/fleet-mentolder.yaml
+++ b/environments/fleet-mentolder.yaml
@@ -60,7 +60,7 @@ env_vars:
   WEBSITE_SITE_URL: "https://web.mentolder.de"
   POCKET_ID_FRONTEND_URL: "https://auth.mentolder.de"
   POCKET_ID_DOMAIN: "auth.mentolder.de"
-  POCKET_ID_URL: "http://pocket-id:1411"
+  POCKET_ID_URL: "http://pocket-id.workspace.svc.cluster.local:1411"
   # System-test failure loop master kill-switch.
   SYSTEMTEST_LOOP_ENABLED: "true"
   LLM_HOST_IP: "192.168.100.10"


### PR DESCRIPTION
## Summary
- `environments/fleet-mentolder.yaml` and `environments/fleet-korczewski.yaml` set `POCKET_ID_URL` to the unqualified short name `http://pocket-id:1411`.
- `website` runs in its own namespace (`website` / `website-korczewski`) while `pocket-id` runs in `workspace` / `workspace-korczewski` — the short name never resolves cross-namespace.
- Every server-side OIDC call in the website login callback (token exchange, userinfo — `website/src/lib/auth.ts`) failed with `TypeError: fetch failed`, breaking website login for **both brands** while Pocket ID's own hosted login page kept working (separate public frontend URL, unaffected).
- Fix: use the namespace-qualified FQDN, matching the legacy (now-inactive) `mentolder.yaml`/`korczewski.yaml` and the code's own fallback default.

Ticket: T002152 (critical, both brands)

## Immediate mitigation (already live, pre-dates this PR)
`kubectl patch configmap website-config` in both namespaces + rollout restart, applied 2026-07-24 ~04:37 UTC as break-glass to restore login immediately. Verified via in-pod `fetch` to `/.well-known/openid-configuration` → 200 on both brands. This PR makes that fix GitOps-persistent so Flux doesn't revert it on the next reconcile.

## Test plan
- [x] `task workspace:validate` — manifests valid (dry-run apply clean)
- [x] Live verification: in-pod fetch to pocket-id OIDC discovery endpoint returns 200 on both `website` and `website-korczewski` pods after the live mitigation patch
- [ ] CI green
- [ ] After merge/Flux reconcile: confirm ConfigMap value survives reconciliation (no revert to short name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)