### PR TITLE
fix(infra): checksum/config im Flux-Pfad + pfadunabhängiger Hash [T002156]

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -193,12 +193,16 @@ jobs:
             exit 1
           fi
           SUBSTITUTED=$(envsubst "$(printf '$%s ' $VARS)" <<<"$RENDERED")
-          # T002154: Hash NACH envsubst ueber die eingesetzten WERTE bilden. Aendert
-          # sich z.B. POCKET_ID_URL, aendert sich der Hash und das Deployment rollt
-          # neu aus — ohne diese Annotation friert envFrom den alten Wert im Pod ein.
-          # Ein Kustomize-configMapGenerator-Hash waere wirkungslos, weil Kustomize
-          # nur den unsubstituierten Platzhalter sieht.
-          export WEBSITE_CONFIG_SHA="$(sha256sum <<<"$SUBSTITUTED" | cut -c1-16)"
+          # T002154/T002156: Hash NACH envsubst ueber den website-config-data-Block.
+          # Der gemeinsame Helper stellt sicher, dass dieser Job, der Taskfile-Pfad
+          # und der Flux-Renderer denselben Wert berechnen — bei pfadabhaengigen
+          # Hashes (z.B. ueber das ganze Manifest inkl. Image-Tag) wuerden sie sich
+          # gegenseitig ueberschreiben und bei jedem Reconcile neu ausrollen.
+          export WEBSITE_CONFIG_SHA="$(bash scripts/website-config-sha.sh <<<"$SUBSTITUTED")"
+          if [[ -z "$WEBSITE_CONFIG_SHA" ]]; then
+            echo "::error::website-config-sha.sh returned an empty checksum"
+            exit 1
+          fi
           SUBSTITUTED=$(envsubst '$WEBSITE_CONFIG_SHA' <<<"$SUBSTITUTED")
           if grep -qE '\$\{[A-Za-z0-9_]+\}' <<<"$SUBSTITUTED"; then
             echo "::error::unexpanded \${VAR} placeholders remain after envsubst:"
@@ -350,12 +354,16 @@ jobs:
             exit 1
           fi
           SUBSTITUTED=$(envsubst "$(printf '$%s ' $VARS)" <<<"$RENDERED")
-          # T002154: Hash NACH envsubst ueber die eingesetzten WERTE bilden. Aendert
-          # sich z.B. POCKET_ID_URL, aendert sich der Hash und das Deployment rollt
-          # neu aus — ohne diese Annotation friert envFrom den alten Wert im Pod ein.
-          # Ein Kustomize-configMapGenerator-Hash waere wirkungslos, weil Kustomize
-          # nur den unsubstituierten Platzhalter sieht.
-          export WEBSITE_CONFIG_SHA="$(sha256sum <<<"$SUBSTITUTED" | cut -c1-16)"
+          # T002154/T002156: Hash NACH envsubst ueber den website-config-data-Block.
+          # Der gemeinsame Helper stellt sicher, dass dieser Job, der Taskfile-Pfad
+          # und der Flux-Renderer denselben Wert berechnen — bei pfadabhaengigen
+          # Hashes (z.B. ueber das ganze Manifest inkl. Image-Tag) wuerden sie sich
+          # gegenseitig ueberschreiben und bei jedem Reconcile neu ausrollen.
+          export WEBSITE_CONFIG_SHA="$(bash scripts/website-config-sha.sh <<<"$SUBSTITUTED")"
+          if [[ -z "$WEBSITE_CONFIG_SHA" ]]; then
+            echo "::error::website-config-sha.sh returned an empty checksum"
+            exit 1
+          fi
           SUBSTITUTED=$(envsubst '$WEBSITE_CONFIG_SHA' <<<"$SUBSTITUTED")
           if grep -qE '\$\{[A-Za-z0-9_]+\}' <<<"$SUBSTITUTED"; then
             echo "::error::unexpanded \${VAR} placeholders remain after envsubst:"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3643,10 +3643,10 @@ tasks:
           POCKET_ID_FRONTEND_URL="${POCKET_ID_FRONTEND_URL:-http://id.localhost}" \
           POCKET_ID_URL="${POCKET_ID_URL:-http://pocket-id.${WORKSPACE_NAMESPACE:-workspace}.svc.cluster.local:1411}" \
           envsubst "\$WEBSITE_IMAGE \$BRAND_ID \$BRAND_NAME \$CONTACT_EMAIL \$CONTACT_NAME \$CONTACT_PHONE \$CONTACT_CITY \$LEGAL_STREET \$LEGAL_ZIP \$LEGAL_JOBTITLE \$LEGAL_UST_ID \$LEGAL_WEBSITE \$SMTP_FROM \$SMTP_USER \$SMTP_HOST \$SMTP_PORT \$SMTP_SECURE \$WEBSITE_HOST \$WEBSITE_SITE_URL \$REACT_APP_ORIGIN \$KEYCLOAK_FRONTEND_URL \$NEXTCLOUD_EXTERNAL_URL \$NEXTCLOUD_DB_HOST \$DOCS_URL \$AUTH_EXTERNAL_URL \$VAULT_EXTERNAL_URL \$BRAIN_EXTERNAL_URL \$WHITEBOARD_EXTERNAL_URL \$TRAEFIK_EXTERNAL_URL \$MAIL_EXTERNAL_URL \$BRETT_DOMAIN \$LIVEKIT_DOMAIN \$STREAM_DOMAIN \$PROD_DOMAIN \$CLUSTER_ENV \$WEBSITE_NAMESPACE \$WORKSPACE_NAMESPACE \$SYSTEMTEST_LOOP_ENABLED \$ARENA_WS_URL \$LLM_ENABLED \$LLM_RERANK_ENABLED \$LLM_ROUTER_URL \$LLM_EMBED_URL \$COMFY_HOST_IP \$COMFY_PORT \$RIGGER_HOST_IP \$RIGGER_PORT \$POCKET_ID_FRONTEND_URL \$POCKET_ID_URL \$PRIMARY_FRONTEND \$WEBSITE_PRIMARY_SERVICE" < k3d/website.yaml > "$_WEB_RENDER"
-          # T002154: checksum/config NACH envsubst bilden — der Hash muss ueber die
-          # eingesetzten WERTE laufen, nicht ueber Platzhalter. Ein Kustomize-
-          # configMapGenerator-Hash waere hier wirkungslos (siehe design.md D2).
-          WEBSITE_CONFIG_SHA="$(sha256sum < "$_WEB_RENDER" | cut -c1-16)" \
+          # T002154/T002156: checksum/config NACH envsubst aus dem website-config-
+          # data-Block bilden (gemeinsamer Helper — alle drei Render-Pfade muessen
+          # denselben Wert liefern, sonst ueberschreiben sie sich gegenseitig).
+          WEBSITE_CONFIG_SHA="$(bash scripts/website-config-sha.sh < "$_WEB_RENDER")" \
             envsubst "\$WEBSITE_CONFIG_SHA" < "$_WEB_RENDER" | kubectl ${CTX_ARG} apply -f -
           rm -f "$_WEB_RENDER"
           envsubst "\$WEBSITE_NAMESPACE" < k3d/website-seller-config.yaml | kubectl ${CTX_ARG} apply -f -
@@ -3679,9 +3679,9 @@ tasks:
             | envsubst "\$WEBSITE_IMAGE \$BRAND_ID \$BRAND_NAME \$CONTACT_EMAIL \$CONTACT_NAME \$CONTACT_PHONE \$CONTACT_CITY \$LEGAL_STREET \$LEGAL_ZIP \$LEGAL_JOBTITLE \$LEGAL_UST_ID \$LEGAL_WEBSITE \$SMTP_FROM \$SMTP_USER \$SMTP_HOST \$SMTP_PORT \$SMTP_SECURE \$WEBSITE_HOST \$WEBSITE_SITE_URL \$REACT_APP_ORIGIN \$KEYCLOAK_FRONTEND_URL \$NEXTCLOUD_EXTERNAL_URL \$NEXTCLOUD_DB_HOST \$DOCS_URL \$AUTH_EXTERNAL_URL \$VAULT_EXTERNAL_URL \$BRAIN_EXTERNAL_URL \$WHITEBOARD_EXTERNAL_URL \$TRAEFIK_EXTERNAL_URL \$MAIL_EXTERNAL_URL \$BRETT_DOMAIN \$LIVEKIT_DOMAIN \$STREAM_DOMAIN \$PROD_DOMAIN \$CLUSTER_ENV \$WEBSITE_NAMESPACE \$WORKSPACE_NAMESPACE \$SYSTEMTEST_LOOP_ENABLED \$ARENA_WS_URL \$LLM_ENABLED \$LLM_RERANK_ENABLED \$LLM_ROUTER_URL \$LLM_EMBED_URL \$COMFY_HOST_IP \$COMFY_PORT \$RIGGER_HOST_IP \$RIGGER_PORT \$POCKET_ID_FRONTEND_URL \$POCKET_ID_URL \$PRIMARY_FRONTEND \$WEBSITE_PRIMARY_SERVICE" \
             | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
             > "$_WEB_RENDER"
-          # T002154: siehe Dev-Zweig oben — Hash NACH envsubst, sonst reagiert die
-          # Annotation nicht auf Wertaenderungen und der Rollout bleibt aus.
-          WEBSITE_CONFIG_SHA="$(sha256sum < "$_WEB_RENDER" | cut -c1-16)" \
+          # T002154/T002156: siehe Dev-Zweig oben — Hash NACH envsubst ueber den
+          # website-config-data-Block, via gemeinsamem Helper.
+          WEBSITE_CONFIG_SHA="$(bash scripts/website-config-sha.sh < "$_WEB_RENDER")" \
             envsubst "\$WEBSITE_CONFIG_SHA" < "$_WEB_RENDER" \
             | kubectl ${CTX_ARG} apply --server-side --force-conflicts -f -
           rm -f "$_WEB_RENDER"

--- a/scripts/flux-render-artifact.sh
+++ b/scripts/flux-render-artifact.sh
@@ -48,7 +48,17 @@ render_component() {
   # set -e from aborting on the "no matches" case.
   local vars
   vars="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$rendered" | tr -d '${}' | sort -u | tr '\n' ' ')" || true
-  
+
+  # T002156: WEBSITE_CONFIG_SHA wird NICHT aus der Umgebung substituiert — der
+  # Wert entsteht erst aus dem fertig substituierten Manifest (siehe unten).
+  # Ohne diese Ausnahme setzt envsubst den ungesetzten Wert auf "" und die
+  # Annotation ist dauerhaft leer: genau so ging T002154 live kaputt.
+  local wants_config_sha=0
+  if [[ " $vars " == *" WEBSITE_CONFIG_SHA "* ]]; then
+    wants_config_sha=1
+    vars="$(tr ' ' '\n' <<<"$vars" | sed '/^WEBSITE_CONFIG_SHA$/d;/^$/d' | tr '\n' ' ')"
+  fi
+
   if [[ -z "$vars" ]]; then
     # No vars to substitute — write as-is
     echo "$rendered" > "$out"
@@ -67,6 +77,33 @@ render_component() {
     | envsubst "$envsubst_vars" \
     | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
     > "$out"
+
+  # T002156: checksum/config NACH envsubst aus dem website-config-data-Block
+  # bilden. Der gemeinsame Helper garantiert, dass alle drei Render-Pfade
+  # (dieser hier, Taskfile website:deploy, build-website.yml) denselben Wert
+  # berechnen — sonst ueberschreiben sie sich gegenseitig und loesen bei jedem
+  # Flux-Reconcile einen unnoetigen Rollout aus.
+  if (( wants_config_sha )); then
+    local config_sha
+    config_sha="$(WEBSITE_CONFIG_SHA="" "${SCRIPT_DIR}/website-config-sha.sh" < "$out")"
+    if [[ -z "$config_sha" ]]; then
+      echo "ERROR: website-config-sha.sh returned an empty checksum for $out." >&2
+      exit 1
+    fi
+    WEBSITE_CONFIG_SHA="$config_sha" envsubst '$WEBSITE_CONFIG_SHA' < "$out" > "${out}.tmp"
+    mv "${out}.tmp" "$out"
+  fi
+
+  # FAIL-CLOSED (T002156): eine LEER substituierte checksum/config ist genauso
+  # kaputt wie ein uebrig gebliebener Platzhalter — der Check unten faengt nur
+  # letzteres. `checksum/config: ""` bedeutet: die Annotation aendert sich nie,
+  # loest also nie einen Rollout aus, und ueberschreibt still den Wert, den ein
+  # anderer Render-Pfad gesetzt hat.
+  if grep -qE '^\s*checksum/config: *("")?\s*$' "$out"; then
+    echo "ERROR: checksum/config is empty in $out — the annotation would never" >&2
+    echo "       change and would silently override other render paths." >&2
+    exit 1
+  fi
 
   # FAIL-CLOSED: after substitution, check for any remaining unsubstituted ${VAR}
   # references. If any exist, the build fails instead of silently shipping a broken

--- a/scripts/website-config-sha.sh
+++ b/scripts/website-config-sha.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# website-config-sha.sh — Content-Hash der website-config-ConfigMap [T002156]
+#
+# Liest ein GERENDERTES (envsubst'd) Website-Manifest von stdin und gibt einen
+# 16-stelligen Hash ueber den `data`-Block der `website-config`-ConfigMap aus.
+# Der Wert wird als Pod-Template-Annotation `checksum/config` gesetzt und sorgt
+# dafuer, dass eine Config-Aenderung tatsaechlich einen Rollout ausloest:
+# `website-config` haengt per `envFrom` am Container, und envFrom-Werte werden
+# beim Containerstart eingefroren — ein ConfigMap-Update allein erreicht
+# laufende Pods nie (anders als ein gemountetes ConfigMap-Volume).
+#
+# WARUM NUR DER data-BLOCK (T002156):
+# T002154 hashte das gesamte gerenderte Manifest. Das enthaelt den Image-Tag,
+# der sich je Render-Pfad unterscheidet — die drei Pfade (Flux-Renderer,
+# Taskfile, build-website.yml) haetten fuer dieselbe Config verschiedene Hashes
+# berechnet und sich gegenseitig ueberschrieben, was bei jedem Reconcile einen
+# unnoetigen Rollout ausgeloest haette. Ueber den data-Block ist der Hash
+# pfadunabhaengig: gleiche Config => gleicher Hash, egal wer rendert.
+#
+# WARUM NACH envsubst:
+# Der Hash muss ueber die eingesetzten WERTE laufen. Ein Kustomize-
+# configMapGenerator-Suffix-Hash waere wirkungslos, weil Kustomize im Pfad
+# `kustomize build | envsubst` nur den unsubstituierten Platzhalter sieht.
+#
+# Verwendung:
+#   WEBSITE_CONFIG_SHA="$(bash scripts/website-config-sha.sh < rendered.yaml)"
+set -euo pipefail
+
+python3 -c '
+import sys, yaml, hashlib, json
+
+data = None
+for doc in yaml.safe_load_all(sys.stdin):
+    if not doc:
+        continue
+    if doc.get("kind") == "ConfigMap" and (doc.get("metadata") or {}).get("name") == "website-config":
+        data = doc.get("data") or {}
+        break
+
+if data is None:
+    sys.stderr.write(
+        "ERROR: no ConfigMap named website-config found in the rendered manifest.\n"
+        "       website-config-sha.sh expects a rendered website manifest on stdin.\n"
+    )
+    sys.exit(1)
+
+# sort_keys => stabil unabhaengig von der YAML-Schluesselreihenfolge
+payload = json.dumps(data, sort_keys=True, ensure_ascii=False)
+print(hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16])
+'

--- a/tests/spec/auth-sso.bats
+++ b/tests/spec/auth-sso.bats
@@ -181,3 +181,114 @@ _render_korczewski() {
     return 1
   }
 }
+
+# ── T002156: checksum/config muss in ALLEN Render-Pfaden echt gefuellt sein ────
+#
+# T002154 fuehrte die checksum/config-Annotation ein, deckte aber nur zwei der
+# DREI Render-Pfade ab. Der primaere Pfad ist pull-based via Flux:
+#   render-fleet-artifact.yml -> task flux:render -> scripts/flux-render-artifact.sh
+#   -> OCI-Artefakt -> Flux-Kustomization (interval 10m)
+# Der Flux-Renderer leitet seine envsubst-Liste dynamisch ab und substituierte
+# WEBSITE_CONFIG_SHA daher mit dem ungesetzten (= leeren) Wert. Live stand auf
+# beiden Brands {"checksum/config":""} — wirkungslos, und schlimmer: Flux drehte
+# den von build-website.yml gesetzten Hash alle 10 min auf "" zurueck.
+#
+# Zweiter Defekt: T002154 hashte das GESAMTE Manifest inkl. Image-Tag, der sich
+# je Pfad unterscheidet — die Pfade haetten sich gegenseitig ueberschrieben.
+# Gehasht wird deshalb nur der data-Block der website-config-ConfigMap.
+
+@test "T002156: website-config-sha Helper existiert und ist ausfuehrbar" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  [ -x "${repo_root}/scripts/website-config-sha.sh" ] || {
+    echo "FAIL: scripts/website-config-sha.sh fehlt oder ist nicht ausfuehrbar —"
+    echo "      ohne gemeinsamen Helper driftet die Hash-Logik zwischen den 3 Pfaden."
+    return 1
+  }
+}
+
+@test "T002156: Hash ignoriert den Image-Tag (pfadunabhaengig)" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  local helper="${repo_root}/scripts/website-config-sha.sh"
+  [ -x "$helper" ] || skip "Helper noch nicht vorhanden"
+
+  local base='apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: website-config
+data:
+  POCKET_ID_URL: "http://pocket-id.workspace.svc.cluster.local:1411"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: website
+spec:
+  template:
+    spec:
+      containers:
+        - name: website
+          image: ghcr.io/paddione/website:IMGTAG'
+
+  local a b
+  a="$(sed 's/IMGTAG/sha-aaaaaaa/' <<<"$base" | bash "$helper")"
+  b="$(sed 's/IMGTAG/sha-bbbbbbb/' <<<"$base" | bash "$helper")"
+  [ "$a" = "$b" ] || {
+    echo "FAIL: Hash haengt vom Image-Tag ab ($a != $b) — die Render-Pfade wuerden"
+    echo "      sich gegenseitig ueberschreiben und Rollouts ausloesen."
+    return 1
+  }
+  [ -n "$a" ] || { echo "FAIL: Hash ist leer"; return 1; }
+}
+
+@test "T002156: Hash reagiert auf eine geaenderte Config" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  local helper="${repo_root}/scripts/website-config-sha.sh"
+  [ -x "$helper" ] || skip "Helper noch nicht vorhanden"
+
+  local tmpl='apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: website-config
+data:
+  POCKET_ID_URL: "VALUE"'
+
+  local a b
+  a="$(sed 's|VALUE|http://pocket-id:1411|' <<<"$tmpl" | bash "$helper")"
+  b="$(sed 's|VALUE|http://pocket-id.workspace.svc.cluster.local:1411|' <<<"$tmpl" | bash "$helper")"
+  [ "$a" != "$b" ] || {
+    echo "FAIL: Hash aendert sich nicht bei geaenderter Config ($a) — kein Rollout-Trigger."
+    return 1
+  }
+}
+
+@test "T002156: Flux-Renderer setzt checksum/config (primaerer Deploy-Pfad)" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  grep -q 'WEBSITE_CONFIG_SHA' "${repo_root}/scripts/flux-render-artifact.sh" || {
+    echo "FAIL: scripts/flux-render-artifact.sh kennt WEBSITE_CONFIG_SHA nicht."
+    echo "      Das ist der PRIMAERE (pull-based) Deploy-Pfad — ohne ihn bleibt die"
+    echo "      Annotation leer und Flux ueberschreibt die anderen Pfade alle 10 min."
+    return 1
+  }
+}
+
+@test "T002156: Flux-Renderer lehnt eine leer substituierte checksum/config ab" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  grep -qE 'checksum/config: *""|checksum_config_empty|EMPTY_CHECKSUM' "${repo_root}/scripts/flux-render-artifact.sh" || {
+    echo "FAIL: Der fail-closed-Check prueft nur auf UEBRIG GEBLIEBENE \${VAR},"
+    echo "      nicht auf LEER substituierte — genau dadurch ging T002154 kaputt live."
+    return 1
+  }
+}
+
+@test "T002156: alle drei Render-Pfade nutzen den gemeinsamen Helper" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  local missing=""
+  grep -q 'website-config-sha.sh' "${repo_root}/scripts/flux-render-artifact.sh"        || missing="$missing flux-render-artifact.sh"
+  grep -q 'website-config-sha.sh' "${repo_root}/Taskfile.yml"                            || missing="$missing Taskfile.yml"
+  grep -q 'website-config-sha.sh' "${repo_root}/.github/workflows/build-website.yml"     || missing="$missing build-website.yml"
+  [ -z "$missing" ] || {
+    echo "FAIL: Pfade ohne gemeinsamen Helper:$missing"
+    echo "      Duplizierte Hash-Logik driftet (vgl. T001993 envsubst-Allowlist)."
+    return 1
+  }
+}


### PR DESCRIPTION
Folge-Fix zu #3199 (T002154). Aufgefallen durch Patricks Rückfrage direkt nach dem Merge: *„wir hatten doch pull-based per Flux eingerichtet oder nicht?"* — zu Recht.

## Was kaputt war

T002154 ging von **zwei** Render-Pfaden aus. Es sind **drei**, und der übersehene ist der primäre:

```
render-fleet-artifact.yml → task flux:render → scripts/flux-render-artifact.sh
  → OCI ghcr.io/paddione/fleet-manifests → Flux-Kustomization (interval 10m)
```

Live auf beiden Brands nach dem Merge:

```
kubectl -n website get deploy website -o jsonpath='{...annotations}'
  → {"checksum/config":""}
```

Der Flux-Renderer leitet seine envsubst-Liste dynamisch aus dem Manifest ab und hat `WEBSITE_CONFIG_SHA` mit dem ungesetzten — also leeren — Wert substituiert. Sein fail-closed-Check sucht nach *übrig gebliebenen* `${VAR}`, nicht nach *leer* substituierten; der Platzhalter rutschte durch.

**Zwei Folgen, die zweite wiegt schwerer:**
- Die Annotation ist konstant leer und löst nie einen Rollout aus — der D2-Teil von T002154 tut in Prod nichts.
- `build-website.yml` setzt bei jedem `website/**`-Push einen echten Hash, Flux dreht ihn 10 Minuten später auf `""` zurück → **ein zusätzlicher, sinnloser Rollout nach jedem Website-Push**. Das gab es vor T002154 nicht.

**Zweiter Defekt:** Der Hash lief über das *gesamte* Manifest inklusive Image-Tag, der sich je Pfad unterscheidet. Selbst ein reiner Flux-Nachzug hätte die Pfade weiter gegeneinander laufen lassen.

## Fix

Neuer gemeinsamer Helper `scripts/website-config-sha.sh` hasht **nur** den `data`-Block der `website-config`-ConfigMap (sortiert, damit stabil). Alle drei Pfade rufen ihn auf — eine Quelle statt drei Kopien. Das ist dieselbe Drift-Klasse, die euch bei der envsubst-Allowlist schon getroffen hat (T001993).

Zusätzlich lehnt der Flux-Renderer eine leer substituierte `checksum/config` jetzt explizit ab — genau dieser Fall ist an der bisherigen fail-closed-Prüfung vorbeigerutscht und hat den Defekt live gehen lassen.

## Verifikation

Echter `task flux:render`:

```
website-mentolder.yaml:255    checksum/config: "f48d5571a36441bc"
website-korczewski.yaml:255   checksum/config: "1051b84335145a74"
```

Und der Helper auf dem **fertigen** Artefakt liefert exakt dieselben Werte — der Hash ist **idempotent**, ein erneuter Render erzeugt kein Flapping.

- `bats tests/spec/auth-sso.bats` — 22/22 grün (6 neue)
- `task workspace:validate` · `task freshness:check` — Exit 0

## Nicht betroffen

Der D1-Teil von T002154 (POCKET_ID_URL-FQDN) wirkt und ist live verifiziert — das war die eigentliche Login-Ursache. Dieser PR betrifft ausschließlich den Rollout-Trigger.

Closes T002156