### PR TITLE
fix(ci): render-fleet-artifact triggert auf den Renderer selbst [T002157]

### DIFF
--- a/.github/workflows/render-fleet-artifact.yml
+++ b/.github/workflows/render-fleet-artifact.yml
@@ -12,6 +12,7 @@ on:
         required: false
         type: string
         default: ''
+  workflow_dispatch:
   push:
     branches: [main]
     paths:
@@ -22,6 +23,13 @@ on:
       - 'prod-korczewski/**'
       - 'environments/sealed-secrets/**'
       - 'flux/clusters/**'
+      # T002157: die Render-Logik selbst gehoert in die Trigger-Pfade. Ohne sie
+      # aendert ein Fix am Renderer das Artefakt NICHT — es bleibt stale, bis
+      # zufaellig ein Manifest angefasst wird, und Flux rollt weiter den alten
+      # Stand aus. Genau so blieb der T002156-Fix nach dem Merge wirkungslos.
+      - 'scripts/flux-render-artifact.sh'
+      - 'scripts/website-config-sha.sh'
+      - 'Taskfile.yml'
 
 concurrency:
   group: render-fleet-artifact-${{ github.ref }}

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -658,3 +658,35 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
 "
   [ "$status" -eq 0 ]
 }
+
+# ── T002157: render-fleet-artifact muss auf seine eigenen Eingaben triggern ────
+#
+# Der Workflow triggerte nur auf Manifest-Pfade (k3d/**, prod*/**, flux/clusters/**),
+# nicht auf scripts/** — obwohl scripts/flux-render-artifact.sh DER RENDERER ist.
+# Folge: T002156 aenderte die Render-Logik, das OCI-Artefakt wurde nie neu gebaut,
+# und Flux lieferte weiter den alten Stand mit leerer checksum/config aus. Ohne
+# workflow_dispatch gab es zudem keine Moeglichkeit, einen Rebuild anzustossen.
+
+@test "T002157: render-fleet-artifact triggert auf den Renderer selbst" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  local wf="${repo_root}/.github/workflows/render-fleet-artifact.yml"
+  local missing=""
+  for input in flux-render-artifact.sh website-config-sha.sh Taskfile.yml; do
+    grep -q "$input" "$wf" || missing="$missing $input"
+  done
+  [ -z "$missing" ] || {
+    echo "FAIL: render-fleet-artifact.yml triggert nicht auf:$missing"
+    echo "      Diese Dateien bestimmen den Inhalt des OCI-Artefakts — ohne Trigger"
+    echo "      bleibt das Artefakt stale und Flux rollt eine veraltete Version aus."
+    return 1
+  }
+}
+
+@test "T002157: render-fleet-artifact ist manuell ausloesbar" {
+  local repo_root; repo_root="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  grep -qE '^\s*workflow_dispatch:' "${repo_root}/.github/workflows/render-fleet-artifact.yml" || {
+    echo "FAIL: kein workflow_dispatch — ein Artefakt-Rebuild laesst sich nicht gezielt"
+    echo "      ausloesen, nur ueber einen Dummy-Commit in einem getriggerten Pfad."
+    return 1
+  }
+}


### PR DESCRIPTION
Macht den T002156-Fix (#3202) in Produktion überhaupt erst wirksam.

## Problem

Nach dem Merge von #3202 wurde das OCI-Artefakt **nicht** neu gebaut — der letzte `render-fleet-artifact`-Lauf stammte weiterhin von T002154. Flux lieferte damit unverändert den alten Stand mit `checksum/config: ""` aus.

Grund: Die Trigger-Pfade umfassen `k3d/**`, `prod*/**`, `environments/sealed-secrets/**`, `flux/clusters/**` — aber **nicht** `scripts/**`, obwohl `scripts/flux-render-artifact.sh` *der Renderer selbst* ist. Eine Änderung an der Render-Logik löst also keinen Rebuild aus; das Artefakt bleibt stale, bis zufällig jemand ein Manifest anfasst.

Zusätzlich fehlte `workflow_dispatch` — es gab **keinen** Weg, einen Rebuild gezielt anzustoßen.

## Fix

Trigger-Pfade um die Dateien ergänzt, die den Artefakt-Inhalt bestimmen (`flux-render-artifact.sh`, `website-config-sha.sh`, `Taskfile.yml`), plus `workflow_dispatch`. Bewusst gezielt statt `scripts/**` — sonst liefe der Workflow bei jeder beliebigen Skript-Änderung.

2 Regressionstests in `tests/spec/ci-cd.bats`.

## Einordnung

Vorbestehende Lücke, kein Defekt aus T002154/T002156 — nur dadurch sichtbar geworden, dass T002156 ausschließlich nicht-getriggerte Pfade berührt hat.

Closes T002157