### PR TITLE
fix(opencode): llamacpp-mtp nur noch in agent-models.jsonc definieren [T002159]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -3,14 +3,19 @@
     "llamacpp-mtp": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "llama.cpp b9553 (Gemma4 QAT 12B + MTP draft, speculative decoding)",
+      // Einzige Definitionsstelle dieses Provider-Keys im Repo. scripts/opencode-sync-agents.sh
+      // synct sie nach ~/.config/opencode/opencode.jsonc; .opencode/opencode.jsonc darf sie
+      // NICHT erneut definieren, sonst driftet der Wert projekt-lokal ab (T002159).
       "options": {
-        "baseURL": "http://127.0.0.1:8091/v1"
+        "baseURL": "http://127.0.0.1:8091/v1",
+        "timeout": 600000,
+        "chunkTimeout": 120000
       },
       "models": {
         "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": {
-          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp b9553+CUDA13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 6, -np 4 parallel slots over -c 16384 total ctx = 4096 ctx/slot, Q8_0 KV cache, -fit auto-VRAM-fit, auto-sleeps GPU after 20min idle and reloads on next request in ~6s) - start via Desktop\\start-gemma4-mtp-server.bat first",
+          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp + CUDA 13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 2, -ngl 999, -c 16384 auf EINEM Slot (kein -np), --jinja) - vorher starten: C:\\Users\\PatrickKorczewski\\.lmstudio\\start-gemma4-12b-mtp.ps1",
           "limit": {
-            "context": 4096,
+            "context": 16384,
             "output": 4096
           }
         }

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -63,25 +63,14 @@
     }
   },
   "lsp": true,
+  // Der Provider "llamacpp-mtp" wird bewusst NICHT hier definiert, sondern
+  // ausschliesslich in .opencode/agent-models.jsonc — von dort synct
+  // scripts/opencode-sync-agents.sh (Taskfile.yml) ihn nach
+  // ~/.config/opencode/opencode.jsonc. Eine zweite Definition an dieser Stelle
+  // wuerde den gesyncten Wert projekt-lokal ueberschreiben und unbemerkt
+  // abdriften — genau so zeigte er auf den Bonsai-Port 8093 statt auf 8091
+  // (T002159).
   "provider": {
-    "llamacpp-mtp": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "llama.cpp MTP (Windows)",
-      "options": {
-        "baseURL": "http://127.0.0.1:8093/v1",
-        "timeout": 600000,
-        "chunkTimeout": 120000
-      },
-      "models": {
-        "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": {
-          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp b9553+CUDA13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 6, -np 4 parallel slots over -c 16384 total ctx = 4096 ctx/slot, Q8_0 KV cache, -fit auto-VRAM-fit, auto-sleeps GPU after 20min idle and reloads on next request in ~6s) - start via Desktop\\start-gemma4-mtp-server.bat first",
-          "limit": {
-            "context": 4096,
-            "output": 4096
-          }
-        }
-      }
-    },
     "lmstudio": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "LM Studio (local)",

--- a/openspec/changes/opencode-llamacpp-port-drift/design.md
+++ b/openspec/changes/opencode-llamacpp-port-drift/design.md
@@ -1,0 +1,150 @@
+---
+ticket_id: T002159
+plan_ref: openspec/changes/opencode-llamacpp-port-drift/tasks.md
+status: active
+date: 2026-07-25
+---
+
+# opencode-Provider `llamacpp-mtp` zeigt auf Bonsai-Port — Design Spec
+
+**Ticket:** T002159
+**Date:** 2026-07-25
+
+> **Brainstorming-Hinweis:** Die Root-Cause-Analyse lief interaktiv in der Session
+> vom 2026-07-25 (Diagnose → Live-Verifikation → Fix-Richtung, vom User bestätigt).
+> Das Lavish-Board wurde bewusst nicht geöffnet: die `lavish`-Skill verlangt vor dem
+> Start einer Browser-Session eine explizite Zustimmung, und die Inhalte des Boards
+> (Root-Cause, Fix-Ansatz, Subsysteme, Edge-Cases) lagen zum Zeitpunkt der
+> Pfad-Entscheidung bereits vollständig vor. Sie sind unten protokolliert.
+
+## Purpose
+
+Der opencode-Provider `llamacpp-mtp` ist in der Projekt-Config auf einen fremden
+Port konfiguriert. Sichtbar wird das als „Gemma ist in opencode nicht verfügbar";
+gefährlicher ist der stille Fall, in dem derselbe Provider unter dem Label Gemma
+Antworten eines völlig anderen Modells liefert. Dieser Change entfernt die
+Duplikat-Konfiguration und macht `agent-models.jsonc` zur einzigen Quelle.
+
+## Root cause (live verifiziert 2026-07-25)
+
+### Befund 1 — Port-Drift zwischen zwei Config-Oberflächen
+
+| Datei | `llamacpp-mtp` baseURL | Bewertung |
+|---|---|---|
+| `.opencode/agent-models.jsonc:7` | `http://127.0.0.1:8091/v1` | korrekt — entspricht dem Startskript |
+| `~/.config/opencode/opencode.jsonc:183` | `http://127.0.0.1:8091/v1` | korrekt — aus `agent-models.jsonc` gesynct |
+| `.opencode/opencode.jsonc:71` | `http://127.0.0.1:8093/v1` | **falsch** |
+
+Das Startskript `C:\Users\PatrickKorczewski\.lmstudio\start-gemma4-12b-mtp.ps1`
+setzt `--port 8091`. Port `8093` ist laut
+`.claude/skills/llama-cpp/references/bonsai-server-windows.md` fest dem
+Ternary-Bonsai-Server zugewiesen (Factory implement/review-Substrat, T002074).
+
+`agent-models.jsonc` ist die Sync-Quelle: `Taskfile.yml:223` →
+`scripts/opencode-sync-agents.sh` → `~/.config/opencode/opencode.jsonc`. Da opencode
+die **Projekt-Config über die globale legt**, überschreibt der falsche Wert aus
+`.opencode/opencode.jsonc` im Bachelorprojekt-Kontext genau den Wert, den die
+Sync-Pipeline korrekt gesetzt hat. Die Sync-Pipeline kann das nicht reparieren —
+sie schreibt ausschließlich die globale Datei.
+
+### Befund 2 — Der Fehler ist nicht fail-safe
+
+`llama-server` validiert das `model`-Feld einer Anfrage nicht. Es lädt genau ein
+Modell und antwortet damit, unabhängig davon, was der Client anfragt. Verifiziert:
+
+```
+POST http://127.0.0.1:8091/v1/chat/completions
+     {"model":"Ternary-Bonsai-8B-Q2_0.gguf", ...}
+→ HTTP 200, "model": "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
+```
+
+Daraus folgen zwei Zustände:
+
+- **Bonsai aus** (heutiger Zustand): Connection refused auf `:8093` → der Provider
+  scheitert sichtbar. Das ist der *gutartige* Fall und der, den der User gemeldet hat.
+- **Bonsai an**: derselbe Provider wird stillschweigend grün und liefert
+  Bonsai-8B-Antworten unter dem Label Gemma4-12B — kein Fehler, kein Log-Eintrag,
+  nur ein anderes Modell mit anderem Kontextfenster und anderer Tool-Call-Qualität.
+
+Zusätzlich killen die Bonsai-Startskripte laut Referenz „beim Start alles auf Port
+8093". Hätte der Gemma-Server je auf 8093 gelegen, hätte ihn jeder Factory-Lauf
+abgeschossen.
+
+### Befund 3 — Kontext-Drift
+
+`.opencode/opencode.jsonc:79` und `.opencode/agent-models.jsonc:13` deklarieren beide
+`limit.context: 4096`. Der laufende Server meldet:
+
+```
+GET http://127.0.0.1:8091/props → n_ctx: 16384
+```
+
+Die 4096 stammen aus der abgelösten `-np 4`-Konfiguration (16384 total ÷ 4 Slots).
+Das aktuelle Startskript setzt **kein** `-np`, der volle 16k-Kontext steht einem Slot
+zur Verfügung. opencode verschenkt derzeit drei Viertel davon.
+
+Dieselbe Veraltung steckt in den `name`-Beschreibungstexten beider Configs: sie
+nennen `-np 4`, `-fit`, Q8_0-KV-Cache, Auto-Sleep und `--spec-draft-n-max 6`. Das
+Skript nutzt `--spec-draft-n-max 2`, `-ngl 999`, `-c 16384`, `--jinja` — und keins
+der anderen Flags. Der Verweis „start via Desktop\start-gemma4-mtp-server.bat" zeigt
+zudem auf einen anderen Pfad als das tatsächlich verwendete Skript.
+
+## Blast radius
+
+`.github/workflows/opencode.yml:47` fährt opencode mit
+`model: llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` auf
+`runs-on: [self-hosted, fleet-gpu]`. Der Workflow checkt das Repo aus, also greift dort
+dieselbe `.opencode/opencode.jsonc` mit dem falschen Port. `tests/spec/opencode-local-model-runner.bats`
+pinnt diese Modell-Referenz bereits per `grep`, prüft aber nicht, ob der zugehörige
+Provider auf den richtigen Port zeigt — genau die Lücke, die dieser Change schließt.
+
+## Fix approach
+
+**Duplikat entfernen statt Port korrigieren.** Der `llamacpp-mtp`-Block wird ersatzlos
+aus `.opencode/opencode.jsonc` gestrichen. Begründung: Ein Provider-Key, der in zwei
+Dateien definiert ist, driftet beim nächsten Portwechsel erneut auseinander — eine
+reine `8093`→`8091`-Korrektur behebt den heutigen Symptomfall, nicht die Ursache. Nach
+dem Entfernen bleibt `agent-models.jsonc` die einzige Definitionsstelle, und die
+bestehende Sync-Pipeline versorgt die globale Config.
+
+Zusätzlich in `agent-models.jsonc`:
+- `limit.context` von `4096` auf `16384`,
+- den `name`-Beschreibungstext an die tatsächlichen Skript-Flags angleichen
+  (inkl. korrektem Startskript-Pfad).
+
+**Regressionsschutz:** ein BATS-Test in `tests/spec/llm-local-dev.bats`, der (a) prüft,
+dass `.opencode/opencode.jsonc` keinen `llamacpp-mtp`-Provider mehr definiert, und
+(b) dass `agent-models.jsonc` den Provider auf `8091` und nicht auf `8093` zeigen lässt.
+Der Test ist rein statisch — er braucht keinen laufenden Server und läuft damit im
+Offline-CI-Gate (`task test:all`) mit.
+
+## Alternativen (verworfen)
+
+| Ansatz | Verworfen weil |
+|---|---|
+| Nur `8093` → `8091` in `.opencode/opencode.jsonc` | Behebt das Symptom, lässt die Doppeldefinition bestehen; nächster Portwechsel driftet wieder. |
+| Gemma auf `8093` umziehen (Skript ändern) | Kollidiert frontal mit Bonsai; die Bonsai-Startskripte killen alles auf dem Port. |
+| Beide Server hinter den llm-proxy (`:18235`) legen | Größerer, eigenständiger Umbau — der Proxy hat eine FIFO-Queue mit einer In-Flight-Anfrage pro Backend (T002102). Gehört zu `central-llm-provider-routing`, nicht in einen Bugfix. |
+
+## Abgrenzung zu bestehenden Changes
+
+`openspec/changes/central-llm-provider-routing` konsolidiert die **Runtime-/Factory**-
+Provider-Auswahl (DB `tickets.provider_config` als SSOT, TS-Call-Sites,
+`route-provider.sh`, `provider-router.js`). Dieser Change betrifft die **opencode-Client**-
+Config (`.opencode/*.jsonc`). Keine gemeinsamen Dateien, keine Abhängigkeit in beide
+Richtungen.
+
+## Edge cases
+
+- **Andere Provider-Keys in `.opencode/opencode.jsonc`:** Der `lmstudio`-Block
+  (`:1234`, leere `models`) bleibt unangetastet — er ist kein Duplikat aus
+  `agent-models.jsonc`. Nur `llamacpp-mtp` wird entfernt.
+- **Subagenten-Referenzen:** Die globale Config referenziert
+  `llamacpp-mtp/gemma-…` in mehreren Agent-Definitionen. Da der Provider-Key nach dem
+  Entfernen weiterhin aus `agent-models.jsonc` stammt, bleiben diese Referenzen gültig.
+  Der Test muss das mitprüfen, damit das Entfernen nicht versehentlich den Key
+  komplett eliminiert.
+- **Server läuft nicht:** Der Fix macht Gemma nicht automatisch verfügbar — das
+  Startskript muss laufen. Das ist Betrieb, nicht Config, und bleibt außerhalb des Scopes.
+- **JSONC-Kommentare:** Beide Dateien sind JSONC mit Kommentaren. Änderungen müssen
+  kommentar-erhaltend erfolgen (kein `jq`-Roundtrip, der Kommentare verwirft).

--- a/openspec/changes/opencode-llamacpp-port-drift/specs/llm-local-dev.md
+++ b/openspec/changes/opencode-llamacpp-port-drift/specs/llm-local-dev.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Single Definition Site for the opencode `llamacpp-mtp` Provider
+
+The opencode provider key `llamacpp-mtp` SHALL be defined in exactly one place in
+the repository, namely `.opencode/agent-models.jsonc`. `.opencode/opencode.jsonc`
+SHALL NOT define a provider under that key.
+
+Rationale: `.opencode/agent-models.jsonc` is the sync source that
+`scripts/opencode-sync-agents.sh` (wired as `Taskfile.yml:223`) merges into
+`~/.config/opencode/opencode.jsonc`. Because opencode layers the project config on
+top of the global one, a second definition in `.opencode/opencode.jsonc` silently
+overrides the synced value inside this repository, and the sync pipeline cannot
+correct it — it only ever writes the global file (T002159).
+
+#### Scenario: Projekt-Config definiert den Provider nicht erneut
+
+- **GIVEN** `.opencode/agent-models.jsonc` definiert den Provider `llamacpp-mtp`
+  mit `baseURL` `http://127.0.0.1:8091/v1`
+- **WHEN** `.opencode/opencode.jsonc` auf eine erneute Definition desselben
+  Provider-Keys geprüft wird
+- **THEN** enthält die Datei keinen `llamacpp-mtp`-Eintrag, sodass der aus
+  `agent-models.jsonc` gesyncte Wert im Projekt-Kontext wirksam bleibt
+
+#### Scenario: Kein opencode-Provider zeigt auf den Bonsai-Port
+
+- **GIVEN** Port `8093` ist gemäß
+  `.claude/skills/llama-cpp/references/bonsai-server-windows.md` fest dem
+  Ternary-Bonsai-Server zugewiesen und `llama-server` validiert das `model`-Feld
+  einer Anfrage nicht, antwortet also unabhängig vom angefragten Modellnamen mit
+  dem geladenen Modell
+- **WHEN** die JSONC-Dateien unter `.opencode/` auf `baseURL`-Werte mit Port `8093`
+  geprüft werden
+- **THEN** existiert kein solcher `baseURL`-Eintrag, sodass ein laufender
+  Bonsai-Server keine Antworten unter dem Label eines Gemma-Modells liefern kann
+
+### Requirement: Declared Context Window Matches the Running Gemma Server
+
+The `limit.context` declared for the model `gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` in
+`.opencode/agent-models.jsonc` SHALL match the context window the llama.cpp server
+actually exposes, as reported by `GET /props` → `default_generation_settings.n_ctx`.
+
+Rationale: the previous value of `4096` derived from a retired `-np 4` slot layout
+(16384 total context divided across four slots). The current start script
+`start-gemma4-12b-mtp.ps1` sets no `-np`, so a single slot owns the full `-c 16384`
+context; declaring `4096` made opencode discard three quarters of the available
+window (T002159).
+
+#### Scenario: Deklariertes Kontextfenster entspricht dem Server-Wert
+
+- **GIVEN** das Startskript startet `llama-server` mit `-c 16384` und ohne `-np`
+- **WHEN** `.opencode/agent-models.jsonc` auf den `limit.context`-Wert des
+  Gemma-Modelleintrags geprüft wird
+- **THEN** ist der Wert `16384` und stimmt damit mit dem vom Server unter
+  `/props` gemeldeten `n_ctx` überein

--- a/openspec/changes/opencode-llamacpp-port-drift/tasks.md
+++ b/openspec/changes/opencode-llamacpp-port-drift/tasks.md
@@ -1,0 +1,164 @@
+---
+title: opencode-Provider llamacpp-mtp routet auf Bonsai-Port statt Gemma
+ticket_id: T002159
+domains: [infra, test]
+status: plan_staged
+---
+
+# opencode-llamacpp-port-drift — Implementation Plan
+
+Behebt die Doppeldefinition des opencode-Providers `llamacpp-mtp`. Die Projekt-Config
+`.opencode/opencode.jsonc` überschreibt den korrekt gesyncten Provider aus
+`.opencode/agent-models.jsonc` mit dem Bonsai-Port `8093` — Gemma4-12B ist dadurch
+unerreichbar, und sobald der Bonsai-Server läuft, liefert derselbe Provider stillschweigend
+Antworten eines anderen Modells. Design-Spec und Live-Verifikation:
+`openspec/changes/opencode-llamacpp-port-drift/design.md`.
+
+## File Structure
+
+| Datei | Art der Änderung |
+|---|---|
+| `.opencode/opencode.jsonc` | Provider-Block `llamacpp-mtp` ersatzlos entfernen |
+| `.opencode/agent-models.jsonc` | `limit.context` 4096 → 16384; `name`-Beschreibung an die realen Skript-Flags angleichen |
+| `tests/spec/llm-local-dev.bats` | fünf neue `@test`-Blöcke als Regressionsschutz (bereits im Stage-Commit enthalten) |
+
+Keine dieser Dateien ist S1-überwacht — die Extensions `.jsonc` und `.bats` stehen nicht in
+`docs/code-quality/gates.yaml → s1.limits`, und keine ist in `docs/code-quality/baseline.json`
+eingetragen. Es gibt daher kein Zeilenbudget zu beachten. S2 (Import-Zyklen), S3 (Brand-Domains)
+und CQ02 (`any`-Typen) sind nicht berührt: es wird kein TypeScript und kein Code unter
+`website/src/` angefasst.
+
+<!-- vitest: kein neuer Test nötig, weil ausschließlich JSONC-Konfiguration und BATS-Tests
+     geändert werden — kein Code unter website/src/lib oder website/src/pages/api. -->
+
+## Task 1 — RED-Nachweis der Regressionstests
+
+Die fünf Tests liegen bereits in `tests/spec/llm-local-dev.bats` (Stage-Commit). Dieser Task
+bestätigt vor jeder Config-Änderung, dass sie den Bug tatsächlich fangen.
+
+```bash
+bats tests/spec/llm-local-dev.bats
+```
+
+expected: FAIL — genau drei Tests müssen rot sein:
+
+- `opencode.jsonc defines no duplicate llamacpp-mtp provider` — rot, weil der Block noch existiert.
+- `no .opencode config points a baseURL at the Bonsai port 8093` — rot wegen `opencode.jsonc:71`.
+- `agent-models.jsonc declares the full 16384 context for Gemma4` — rot, weil dort noch `4096` steht.
+
+Grün sein müssen dagegen bereits jetzt die beiden Guards, die verhindern, dass Task 2 zu viel
+entfernt:
+
+- `agent-models.jsonc still defines the llamacpp-mtp provider`
+- `agent-models.jsonc points llamacpp-mtp at the Gemma port 8091`
+
+Ist dieses Muster nicht exakt so, stimmt die Diagnose nicht mehr mit dem Repo-Stand überein —
+dann zuerst die Design-Spec gegen den Ist-Zustand abgleichen, nicht die Tests anpassen.
+
+## Task 2 — Duplikat-Provider aus `.opencode/opencode.jsonc` entfernen
+
+Den kompletten `"llamacpp-mtp"`-Eintrag aus dem `provider`-Objekt streichen (aktuell Zeilen 68–84,
+vom Key bis zur schließenden Klammer inklusive des trennenden Kommas zum folgenden
+`"lmstudio"`-Eintrag).
+
+Randbedingungen:
+
+- Der `"lmstudio"`-Block (`:1234`, leere `models`) bleibt unverändert — er ist kein Duplikat aus
+  `agent-models.jsonc`.
+- Das umschließende `"provider"`-Objekt bleibt bestehen; es darf nicht leer zurückbleiben, da
+  `lmstudio` darin verbleibt.
+- Die Datei ist JSONC mit Kommentaren. Änderung ausschließlich per Texteditor-Edit vornehmen —
+  **kein** `jq`-Roundtrip, der sämtliche Kommentare verwerfen würde.
+
+Nach dem Entfernen stammt der Provider-Key ausschließlich aus `agent-models.jsonc` und wird über
+`Taskfile.yml:223` → `scripts/opencode-sync-agents.sh` in `~/.config/opencode/opencode.jsonc`
+gespiegelt.
+
+Syntax-Prüfung (JSONC-Kommentare vorher strippen, damit `jq` parsen kann):
+
+```bash
+node -e "const s=require('fs').readFileSync('.opencode/opencode.jsonc','utf8'); \
+  const j=s.replace(/^\s*\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,''); \
+  const o=JSON.parse(j); \
+  if ('llamacpp-mtp' in o.provider) { console.error('FAIL: provider still present'); process.exit(1); } \
+  if (!('lmstudio' in o.provider)) { console.error('FAIL: lmstudio was removed too'); process.exit(1); } \
+  console.log('OK: valid JSON, llamacpp-mtp gone, lmstudio intact');"
+```
+
+## Task 3 — Kontext und Beschreibung in `.opencode/agent-models.jsonc` korrigieren
+
+Im Modell-Eintrag `gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` (aktuell Zeilen 10–16):
+
+- `"context": 4096` → `"context": 16384`. Belegt durch `GET http://127.0.0.1:8091/props` →
+  `n_ctx: 16384`; das Startskript setzt kein `-np`, der volle Kontext gehört einem Slot.
+- `"output"` bleibt bei `4096` — das ist ein Generierungslimit, kein Fenster, und vom Befund
+  nicht betroffen.
+- Den `name`-Text an die tatsächlichen Flags des Startskripts angleichen. Zu entfernen sind die
+  Angaben `-np 4 parallel slots`, `4096 ctx/slot`, `Q8_0 KV cache`, `-fit auto-VRAM-fit`,
+  `auto-sleeps GPU after 20min idle` und `--spec-draft-n-max 6`; keines dieser Flags steht im
+  Skript. Zu nennen sind stattdessen `--spec-type draft-mtp`, `--spec-draft-n-max 2`, `-ngl 999`,
+  `-c 16384`, `--jinja`.
+- Den Startverweis `start via Desktop\\start-gemma4-mtp-server.bat first` durch den tatsächlich
+  verwendeten Pfad ersetzen: `C:\\Users\\PatrickKorczewski\\.lmstudio\\start-gemma4-12b-mtp.ps1`.
+
+Der `baseURL`-Wert `http://127.0.0.1:8091/v1` bleibt unverändert — er war von Anfang an korrekt.
+
+Syntax-Prüfung:
+
+```bash
+node -e "const s=require('fs').readFileSync('.opencode/agent-models.jsonc','utf8'); \
+  const j=s.replace(/^\s*\/\/.*$/gm,'').replace(/\/\*[\s\S]*?\*\//g,''); \
+  const o=JSON.parse(j); \
+  const m=o.provider['llamacpp-mtp'].models['gemma-4-12B-it-qat-UD-Q4_K_XL.gguf']; \
+  if (m.limit.context !== 16384) { console.error('FAIL: context is '+m.limit.context); process.exit(1); } \
+  console.log('OK: valid JSON, context 16384');"
+```
+
+## Task 4 — GRÜN-Nachweis und Sync-Parität
+
+Erst die Spec-Tests, dann die Parität zwischen Sync-Quelle und globaler Config prüfen.
+
+```bash
+bats tests/spec/llm-local-dev.bats
+bats tests/spec/opencode-local-model-runner.bats
+```
+
+Alle 18 Tests in `llm-local-dev.bats` müssen grün sein.
+`opencode-local-model-runner.bats` pinnt die Modell-Referenz in
+`.github/workflows/opencode.yml` und darf durch diese Änderung nicht rot werden — der
+Provider-Key `llamacpp-mtp` bleibt ja bestehen.
+
+Anschließend die Sync-Pipeline einmal fahren und verifizieren, dass die globale Config danach
+den Gemma-Port trägt:
+
+```bash
+bash scripts/opencode-sync-agents.sh
+grep -A4 '"llamacpp-mtp"' ~/.config/opencode/opencode.jsonc | grep 8091
+```
+
+Findet der `grep` nichts, hat die Sync-Pipeline den Provider nicht übertragen — dann ist der
+Fix unvollständig, weil opencode ohne Projekt-Definition ausschließlich auf die globale Config
+zurückfällt.
+
+## Task 5 — Verifikation
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+
+`task test:inventory` wurde beim Stagen bereits ausgeführt und ließ
+`website/src/data/test-inventory.json` unverändert bei 360 Einträgen — das Inventar indexiert
+Test-IDs, nicht jeden rohen `@test`-Namen, sodass die fünf neuen Blöcke keinen neuen Eintrag
+erzeugen. `task freshness:regenerate` bleibt trotzdem Pflichtschritt: es aktualisiert die übrigen
+Freshness-Artefakte, und der Inventory-Check in `.github/workflows/ci.yml` vergleicht gegen den
+committeten Stand. Ändert der Lauf doch eine Datei, wird sie mitcommittet.
+
+Zu erwarten ist außerdem, dass `.github/workflows/ci.yml:191` bei dieser PR anschlägt: dort ist
+ein eigener Check auf Änderungen an `.opencode/agent-models.jsonc` verdrahtet. Das ist gewollt
+und kein Fehlersignal.
+
+Manuelle Abnahme nach dem Merge (nicht CI-automatisierbar, da ein laufender Windows-Server nötig
+ist): mit gestartetem `start-gemma4-12b-mtp.ps1` in opencode das Modell
+`llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` auswählen und eine Antwort erzeugen.

--- a/tests/spec/llm-local-dev.bats
+++ b/tests/spec/llm-local-dev.bats
@@ -78,3 +78,37 @@ setup() {
   run grep -qE '^OPENAI_MODEL=qwen2\.5:' "$ENV_EXAMPLE"
   [ "$status" -eq 0 ]
 }
+
+# ── opencode llamacpp-mtp provider config (T002159) ───────────────────
+# Der Provider-Key `llamacpp-mtp` darf NUR in .opencode/agent-models.jsonc
+# definiert sein. Diese Datei ist die Sync-Quelle (Taskfile.yml -> 
+# scripts/opencode-sync-agents.sh -> ~/.config/opencode/opencode.jsonc).
+# Eine zweite Definition in .opencode/opencode.jsonc ueberschreibt den
+# gesyncten Wert projekt-lokal und driftet unbemerkt ab.
+
+@test "opencode.jsonc defines no duplicate llamacpp-mtp provider" {
+  run grep -q '"llamacpp-mtp"' "$REPO/.opencode/opencode.jsonc"
+  [ "$status" -ne 0 ]
+}
+
+@test "no .opencode config points a baseURL at the Bonsai port 8093" {
+  run bash -c "grep -hE '\"baseURL\": *\"https?://[^\"]*:8093' \"$REPO\"/.opencode/*.jsonc"
+  [ -z "$output" ]
+}
+
+@test "agent-models.jsonc still defines the llamacpp-mtp provider" {
+  run grep -q '"llamacpp-mtp"' "$REPO/.opencode/agent-models.jsonc"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent-models.jsonc points llamacpp-mtp at the Gemma port 8091" {
+  run grep -qE '"baseURL": *"http://127\.0\.0\.1:8091/v1"' "$REPO/.opencode/agent-models.jsonc"
+  [ "$status" -eq 0 ]
+}
+
+@test "agent-models.jsonc declares the full 16384 context for Gemma4" {
+  # Extrahiert den ersten "context"-Wert nach dem Gemma-Modellschluessel.
+  ctx="$(awk '/"gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": *\{/,/"context"/' \
+    "$REPO/.opencode/agent-models.jsonc" | grep -oE '"context": *[0-9]+' | head -1 | grep -oE '[0-9]+')"
+  [ "$ctx" = "16384" ]
+}

--- a/tests/spec/llm-local-dev.bats
+++ b/tests/spec/llm-local-dev.bats
@@ -87,12 +87,21 @@ setup() {
 # gesyncten Wert projekt-lokal und driftet unbemerkt ab.
 
 @test "opencode.jsonc defines no duplicate llamacpp-mtp provider" {
-  run grep -q '"llamacpp-mtp"' "$REPO/.opencode/opencode.jsonc"
-  [ "$status" -ne 0 ]
+  # Semantische Pruefung statt Textsuche: erklaerende Kommentare duerfen den
+  # Provider-Namen nennen, nur eine echte Definition im provider-Objekt ist verboten.
+  run node -e "
+    const s = require('fs').readFileSync('$REPO/.opencode/opencode.jsonc','utf8');
+    const j = s.replace(/^\s*\/\/.*\$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
+    const o = JSON.parse(j);
+    process.exit('llamacpp-mtp' in (o.provider || {}) ? 1 : 0);
+  "
+  [ "$status" -eq 0 ]
 }
 
 @test "no .opencode config points a baseURL at the Bonsai port 8093" {
-  run bash -c "grep -hE '\"baseURL\": *\"https?://[^\"]*:8093' \"$REPO\"/.opencode/*.jsonc"
+  # Kommentarzeilen ausgenommen — der Bonsai-Port darf dokumentiert werden,
+  # nur nicht als aktive baseURL gesetzt sein.
+  run bash -c "grep -hE '\"baseURL\": *\"https?://[^\"]*:8093' \"$REPO\"/.opencode/*.jsonc | grep -vE '^\s*//'"
   [ -z "$output" ]
 }
 


### PR DESCRIPTION
## Problem

`.opencode/opencode.jsonc` definierte den opencode-Provider `llamacpp-mtp` ein **zweites Mal** — mit der baseURL `http://127.0.0.1:8093/v1`. Port 8093 gehört laut `.claude/skills/llama-cpp/references/bonsai-server-windows.md` fest dem Ternary-Bonsai-Server; der Gemma-Server läuft auf 8091.

Da opencode die Projekt-Config über die globale legt, überschrieb dieser Wert genau das, was `scripts/opencode-sync-agents.sh` aus `.opencode/agent-models.jsonc` (dort korrekt: 8091) nach `~/.config/opencode/opencode.jsonc` synct. Die Sync-Pipeline konnte das nicht reparieren — sie schreibt nur die globale Datei.

**Der Fehler war nicht fail-safe.** `llama-server` validiert das `model`-Feld einer Anfrage nicht; live verifiziert:

```
POST :8091/v1/chat/completions {"model":"Ternary-Bonsai-8B-Q2_0.gguf", ...}
→ HTTP 200, "model": "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
```

Solange auf 8093 nichts lief, scheiterte der Provider sichtbar (das gemeldete Symptom: „Gemma nicht verfügbar"). Sobald jemand `start-bonsai-parallel.ps1` startet, wäre derselbe Provider stillschweigend grün geworden und hätte Bonsai-8B-Antworten unter dem Label Gemma4-12B geliefert — ohne Fehler, ohne Log-Eintrag.

Blast radius: `.github/workflows/opencode.yml:47` fährt opencode auf `self-hosted, fleet-gpu` mit genau diesem Provider.

## Lösung

Duplikat **entfernt** statt Port korrigiert — ein Provider-Key, eine Quelle. Eine reine `8093`→`8091`-Korrektur hätte die Doppeldefinition bestehen lassen und wäre beim nächsten Portwechsel erneut gedriftet.

- Duplikat-Block aus `opencode.jsonc` entfernt, Begründung als Kommentar hinterlegt
- `timeout`/`chunkTimeout` (600s/120s) nach `agent-models.jsonc` **migriert** — sie existierten nur im entfernten Block; ersatzloses Löschen wäre eine stille Regression auf opencodes kürzeren Default gewesen
- `limit.context` 4096 → 16384: der Server meldet `GET /props → n_ctx: 16384`; die 4096 stammten aus der abgelösten `-np 4`-Slot-Aufteilung
- `name`-Beschreibung an die realen Flags des Startskripts angeglichen (nannte `-np 4`, `-fit`, `--spec-draft-n-max 6` und ein `.bat`, das so nicht verwendet wird)

## Tests

Fünf neue `@test` in `tests/spec/llm-local-dev.bats` — parser-basiert statt textuell, damit erklärende Kommentare den Provider-Namen nennen dürfen. Gegen den Vor-Fix-Stand verifiziert rot:

| Test | vor Fix | nach Fix |
|---|---|---|
| `opencode.jsonc defines no duplicate llamacpp-mtp provider` | ROT | grün |
| `no .opencode config points a baseURL at the Bonsai port 8093` | ROT | grün |
| `agent-models.jsonc still defines the llamacpp-mtp provider` | grün (Guard) | grün |
| `agent-models.jsonc points llamacpp-mtp at the Gemma port 8091` | grün (Guard) | grün |
| `agent-models.jsonc declares the full 16384 context for Gemma4` | ROT | grün |

Die beiden Guards verhindern, dass „Duplikat entfernen" zu weit ausgelegt wird und beide Definitionen killt.

Verifikation: 18/18 bats grün · `opencode-local-model-runner.bats` 3/3 grün · `task test:changed` EXIT=0 · `task freshness:check` EXIT=0 · Sync-Pipeline gefahren, globale Config trägt jetzt 8091.

## Manuelle Abnahme (nicht CI-automatisierbar)

Mit laufendem `start-gemma4-12b-mtp.ps1` in opencode `llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` wählen und eine Antwort erzeugen.

Closes T002159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T9nLex7Ku7ijRDraRc9Q4