### PR TITLE
fix(ci): mint Renovate token per run via GitHub App, exempt its PRs from blanket auto-merge [T002161]

### DIFF
--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -1,10 +1,20 @@
 name: Auto-enable Auto-Merge
 
-# Aktiviert Squash-Auto-Merge auf jeder neuen Nicht-Draft-PR gegen main.
+# Aktiviert Squash-Auto-Merge auf jeder neuen Nicht-Draft-PR gegen main, die
+# NICHT das Label `dependencies` trägt.
 # Der Merge selbst passiert erst, wenn alle Required-Checks grün sind und
 # Branch-Protection erfüllt ist — diese Action setzt nur das --auto-Flag,
 # das bislang manuell via `gh pr merge --auto` gesetzt werden musste.
 # Repo-Voraussetzung: allow_auto_merge ist aktiviert.
+#
+# `dependencies`-Label = Renovate-PR (T002161): Renovate setzt das Auto-Merge-Flag
+# dort selbst via platformAutomerge, aber NUR für Updates, die seine gestaffelte
+# Policy in renovate.json5 freigibt (patch + devDependencies). Ohne diese Ausnahme
+# würde das pauschale --auto jene Policy aushebeln — main verlangt keine Reviews,
+# ein major- oder produktiver minor-Bump ginge also ungeprüft nach main und über
+# Flux auf beide Prod-Brands. Die Ausnahme greift label-basiert, nicht über
+# pull_request.user.login: der App-Slug hängt am frei gewählten App-Namen und
+# wäre beim Umbenennen eine stille Bruchstelle.
 # E2E PR is intentionally not a required check — see scripts/gh-branch-protection.sh
 # and task gh:branch-protection:status. Required checks: Offline Tests (Manifests, Configs, Unit),
 # Security Scan, Brett TypeScript, Conventional Commits.
@@ -26,7 +36,10 @@ jobs:
   enable-automerge:
     name: Enable Auto-Merge
     # Drafts ausnehmen — "fertig, aber nicht mergen" bleibt über Draft-Status möglich.
-    if: github.event.pull_request.draft == false
+    # Renovate-PRs (Label `dependencies`) ausnehmen — Begründung im Dateikopf.
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,10 +3,21 @@ name: Renovate
 # Self-hosted Renovate dependency update bot.
 # Spec:  docs/superpowers/specs/2026-06-17-t000898-design.md
 # Plan:  docs/superpowers/plans/2026-06-17-t000898.md
-# Setup: A dedicated GitHub App token must be stored as repo secret RENOVATE_TOKEN.
-#        See PR description for setup steps. Without the secret, this workflow fails.
 #
-# First run: trigger manually via workflow_dispatch after setting RENOVATE_TOKEN.
+# Setup (T002161): TWO repo secrets are required — RENOVATE_APP_ID and
+#   RENOVATE_APP_PRIVATE_KEY. A GitHub App *installation* token expires after one
+#   hour and therefore CANNOT be stored as a static secret; the token is minted
+#   fresh on every run by the create-github-app-token step below. The App needs
+#   Contents: write, Pull requests: write, Metadata: read AND — because the
+#   github-actions manager runs with pinDigests: true and thus edits files under
+#   .github/workflows/ — Workflows: write. Without the Workflows permission
+#   GitHub rejects the push ("refusing to allow a GitHub App to create or update
+#   workflow ...") while npm and kubernetes bumps keep working, which reads as a
+#   partial, hard-to-diagnose failure.
+#
+# NOT the opencode.yml pattern: that workflow uses id-token: write, and the
+#   OIDC-to-installation-token exchange is a feature of the opencode action.
+#   renovatebot/github-action has no such exchange and expects a ready token.
 
 on:
   schedule:
@@ -28,9 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      # Required: Renovate opens/updates PRs and writes to branches.
-      contents: write
-      pull-requests: write
+      # Only the checkout needs GITHUB_TOKEN. Renovate's write access comes from
+      # the App installation token minted below, not from GITHUB_TOKEN — so no
+      # contents/pull-requests write here. No id-token either: there is no OIDC
+      # flow in this workflow.
+      contents: read
 
     steps:
       - name: Checkout repository
@@ -40,16 +53,31 @@ jobs:
           fetch-tags: false
           persist-credentials: false
 
+      - name: Create GitHub App token
+        # SHA-gepinnt (Supply-Chain: Action erhaelt den App Private Key).
+        # v3.2.0 (2026-07). Bump via Review / Renovate selbst; nie @latest
+        # fuer secret-tragende Third-Party-Actions.
+        #
+        # app-id ist in v3 deprecated ("Use 'client-id' instead."), funktioniert
+        # aber unveraendert — RENOVATE_APP_ID haelt die numerische App ID. Eine
+        # spaetere Migration braucht BEIDES: Secret-Wert auf die Client ID
+        # umstellen UND diesen Input auf client-id umbenennen.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       - name: Self-hosted Renovate
         # SHA-gepinnt (Supply-Chain: Action erhaelt RENOVATE_TOKEN).
         # v46.1.15 (2026-06). Bump via Review / Renovate selbst; nie @latest
         # fuer secret-tragende Third-Party-Actions.
         uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd  # v46.1.15
         env:
-          # Dedicated GitHub App installation token.
-          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+          # Freshly minted App installation token (1h TTL, revoked post-job).
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
           # Log level for debugging.
           LOG_LEVEL: ${{ vars.RENOVATE_LOG_LEVEL || 'info' }}
         with:
           configurationFile: renovate.json5
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}

--- a/openspec/changes/renovate-app-token/design.md
+++ b/openspec/changes/renovate-app-token/design.md
@@ -1,0 +1,184 @@
+---
+ticket_id: T002161
+plan_ref: openspec/changes/renovate-app-token/tasks.md
+status: active
+date: 2026-07-26
+---
+
+# Design: Renovate auf GitHub-App-Token umstellen
+
+**Ticket:** T002161
+**Typ:** fix (bug)
+**SSOT-Spec:** `openspec/specs/ci-cd.md`
+
+## Purpose
+
+Renovate hat seit seiner Einführung (T000898, gemergt 2026-06-17) **nie** funktioniert. Alle
+fünf Cron-Läufe (2026-06-22 bis 2026-07-20) brachen nach ~40 s ab. Folge: sämtliche von
+Renovate verwalteten Dependencies driften still — nachgewiesen an Vaultwarden, das seit
+2026-02-10 auf `1.35.3-alpine` steht, während Upstream bei `1.37.0` ist (2 Minors + 5 Patches,
+~5,5 Monate). Dieser Change macht Renovate funktionsfähig und schließt dabei eine zweite
+Lücke, die den Fix andernfalls gefährlich machen würde.
+
+## Root-Cause-Analyse
+
+### RC1 — Secret fehlt (unmittelbar)
+
+`RENOVATE_TOKEN` existiert nicht als Repo-Secret. `renovatebot/github-action` startet den
+Container, Renovate findet ein leeres Token und bricht bei der Platform-Authentifizierung ab.
+Kein Repo-Scan → deshalb auch nie ein Dependency-Dashboard-Issue, das den Ausfall sichtbar
+gemacht hätte.
+
+Der Workflow dokumentiert die Voraussetzung selbst (`renovate.yml:6-9`), inklusive
+*„First run: trigger manually via workflow_dispatch after setting RENOVATE_TOKEN"*. Dieser
+manuelle Post-Merge-Schritt wurde nie ausgeführt. Es gab **keine Regression** — das Feature
+war ab Tag eins tot.
+
+### RC2 — Die Anleitung ist strukturell unmöglich (der eigentliche Fix-Grund)
+
+Ein GitHub-App-**Installation**-Token hat **1 Stunde TTL**. Es kann nicht als statisches
+Repo-Secret hinterlegt werden. Hätte man die Anleitung 2026-06 wörtlich befolgt, wäre Renovate
+genau einen Lauf lang gelaufen und danach wieder still gestorben — mit demselben
+`docker … exit code 1`, aber nun mit dem trügerischen Beweis „das Secret ist doch gesetzt".
+
+Erschwerend verweist die T000898-Design-Spec
+(`docs/superpowers/specs/2026-06-17-t000898-design.md:30`) auf `opencode.yml` als
+App-Auth-Vorbild. Dieses Muster ist **nicht übertragbar**: `opencode.yml:30` nutzt
+`id-token: write`, und der OIDC→Installation-Token-Exchange ist ein Feature der Action
+`anomalyco/opencode/github`. `renovatebot/github-action` hat keinen solchen Exchange und
+erwartet einen fertigen Token.
+
+### RC3 — Automerge-Kollision (beim Brainstorming entdeckt, T002161-Scope)
+
+`auto-enable-automerge.yml` setzt `--auto --squash --delete-branch` auf **jeder** Nicht-Draft-PR
+gegen `main`. Branch-Protection auf `main` hat `reviews: null` — keine Review-Pflicht, nur
+7 Required Checks.
+
+Renovates `automerge: false` (für `major`, prod-`minor`, kubernetes-`major` in
+`renovate.json5:104-108` u. a.) bedeutet ausschließlich *„Renovate selbst merged nicht"*. Es
+verhindert nicht, dass ein anderer Workflow das Auto-Merge-Flag setzt. Die gestufte
+Automerge-Policy aus T000898 ist damit faktisch außer Kraft.
+
+Konkrete Konsequenz ohne Gegenmaßnahme: Beim ersten erfolgreichen Renovate-Lauf mergt der
+Vaultwarden-Bump `1.35.3 → 1.37.0` ohne Review durch und wird via Flux (10-min-Reconcile) auf
+**beide** Prod-Brands ausgerollt — bei einem Passwortmanager mit SSO-only/PKCE-Konfiguration.
+Genau der Fall, für den die Policy `automerge: false` vorsieht.
+
+## Fix-Ansatz
+
+### Trennung langlebiges Geheimnis ↔ kurzlebiger Token
+
+`actions/create-github-app-token` prägt bei **jedem** Run einen frischen Installation-Token
+aus zwei langlebigen Secrets. Der Private Key läuft nie ab, der Token lebt nur für den Job
+und wird im Post-Step automatisch revoked.
+
+- **Version:** v3.2.0, SHA-gepinnt auf `bcd2ba49218906704ab6c1aa796996da409d3eb1` — gemäß der
+  in `renovate.yml:44` dokumentierten Konvention für secret-tragende Third-Party-Actions
+  (*„nie @latest"*).
+- **Input `client-id:`**, **nicht** `app-id:` — letzteres ist in v3 deprecated
+  (`action.yml`: *„Use 'client-id' instead."*). Entsprechend heißt das Secret
+  `RENOVATE_APP_CLIENT_ID`.
+- **Output:** `steps.app-token.outputs.token`.
+- **Kein `owner`/`repositories`-Input** — Default ist das aktuelle Repository, was genau dem
+  Installationsumfang entspricht.
+
+### Job-Permissions minimieren
+
+Mit App-Token braucht der Job die Schreibrechte **nicht** mehr über `GITHUB_TOKEN`: sie kommen
+aus dem App-Token. `contents: read` genügt für den Checkout. `id-token: write` wird **nicht**
+gesetzt — es gibt keinen OIDC-Flow (siehe RC2).
+
+### App-Permissions (beim Anlegen im UI)
+
+| Permission | Level | Warum |
+|---|---|---|
+| Contents | Read and write | Renovate pusht Update-Branches |
+| Pull requests | Read and write | PRs öffnen/aktualisieren, Auto-Merge-Flag setzen |
+| **Workflows** | **Read and write** | **Pflicht**, sobald Renovate `.github/workflows/**` anfasst — und das tut es: `renovate.json5` hat einen `github-actions`-Manager mit `pinDigests: true`. Ohne diese Permission verweigert GitHub den Push (`refusing to allow a GitHub App to create or update workflow …`) — ein schwer deutbarer Teilausfall, bei dem npm-/k8s-Bumps funktionieren und nur Actions-Pins scheitern |
+| Metadata | Read-only | wird von GitHub automatisch gesetzt |
+
+Webhook deaktiviert (Renovate braucht keinen), Installation *Only on this account* → nur
+`Paddione/Bachelorprojekt`.
+
+### Automerge-Kollision auflösen (RC3)
+
+Label-basierte Ausnahme statt Bot-Namens-Prüfung — der App-Slug (und damit
+`pull_request.user.login`) hängt am frei gewählten App-Namen und wäre eine stille
+Bruchstelle beim Umbenennen:
+
+- `renovate.json5`: `labels: ["dependencies"]` + `platformAutomerge: true`
+- `auto-enable-automerge.yml`: überspringt PRs, die das Label `dependencies` tragen
+
+Damit setzt **Renovate selbst** das Auto-Merge-Flag — aber nur für PRs, die seine eigene
+Policy erlaubt (`patch` + `devDependencies`). `major`, prod-`minor` und kubernetes-`major`
+bleiben als offene Review-PRs stehen, exakt wie T000898 es spezifiziert hat.
+
+## Trade-offs & Abwägungen
+
+**`RENOVATE_TOKEN` env-Variable bleibt zusätzlich zum `token:`-Input gesetzt.** Die Action
+mappt `token:` intern auf `RENOVATE_TOKEN`; beides zu setzen ist redundant. Wir behalten es
+trotzdem, weil der funktionale Teil des Workflows so unverändert bleibt und nur der
+*Token-Wert* wechselt — das minimiert die Zahl der Variablen, an denen der erste
+Verifikations-Run scheitern kann. Aufräumen ist ein Chore für später, kein Fix-Scope.
+
+**Scope-Erweiterung auf `auto-enable-automerge.yml` + `renovate.json5` bewusst akzeptiert.**
+Alternative wäre gewesen, RC3 als Folgeticket zu führen. Verworfen: zwischen Merge dieses Fixes
+und dem Folge-Fix läge ein Fenster, in dem Renovate-PRs ungeprüft durchmergen — der Fix würde
+das Risiko erst erzeugen, das er zu vermeiden vorgibt. Beide Dateien sind kleine, klar
+abgegrenzte Eingriffe (je ein `if:`-Guard bzw. zwei Config-Keys).
+
+**Renovates `platformAutomerge` mit App-Token nicht vorab verifizierbar.** Der Kommentar in
+`auto-enable-automerge.yml:36-37` dokumentiert, dass `GITHUB_TOKEN` `enablePullRequestAutoMerge`
+nicht ausführen darf (*„Resource not accessible by integration"*) — daher dort ein PAT. Eine
+eigene App mit `pull-requests: write` sollte die Mutation ausführen dürfen. Falls nicht, lässt
+Renovate die PR schlicht offen — Komfortverlust, kein Sicherheitsproblem, und im
+Verifikations-Run sofort sichtbar. Kein Blocker.
+
+**Der Vaultwarden-Bump gehört nicht in diesen Change.** Er ist der *Beweis*, dass der Fix
+greift, und braucht wegen SSO-only/PKCE eine eigene Prüfung der Release Notes auf
+OIDC-Breaking-Changes. Als eigenes Ticket nach dem ersten grünen Renovate-Lauf.
+
+## Betroffene Dateien
+
+| Datei | Zeilen | S1-Budget | Änderung |
+|---|---|---|---|
+| `.github/workflows/renovate.yml` | 55 | **unbegrenzt** (`.yml` hat kein S1-Limit) | Token-Step + permissions + Kommentar-Korrektur |
+| `.github/workflows/auto-enable-automerge.yml` | 43 | **unbegrenzt** | `if:`-Guard für `dependencies`-Label |
+| `renovate.json5` | 156 | **unbegrenzt** (`.json5` hat kein S1-Limit) | `labels` + `platformAutomerge` |
+| `tests/spec/ci-cd.bats` | 740 | **unbegrenzt** (`.bats` hat kein S1-Limit) | 4 neue Assertions |
+
+S1-Limits (`docs/code-quality/gates.yaml:44-58`) gelten ausschließlich für Code-Extensions
+(`.ts`, `.sh`, `.py`, `.astro`, …). Keine der vier Dateien fällt darunter, keine ist in
+`docs/code-quality/baseline.json` gebaselined → kein Ratchet-Risiko, kein Split nötig.
+
+## Manueller Anteil (nicht automatisierbar)
+
+Patrick legt die GitHub App im UI an (Permissions s. o.), notiert die **Client ID**, generiert
+den Private Key, installiert die App auf `Paddione/Bachelorprojekt` und setzt:
+
+```bash
+gh secret set RENOVATE_APP_CLIENT_ID --body "<client-id>"
+gh secret set RENOVATE_APP_PRIVATE_KEY < <pfad>.private-key.pem
+```
+
+Der Workflow-Umbau hängt nur an den Secret-**Namen**, nicht an den Werten, und kann unabhängig
+davon gemergt werden. Renovate bleibt bis zum Setzen der Secrets schlafend (rote Cron-Läufe wie
+bisher) — kein zusätzliches Risiko durch die Reihenfolge.
+
+## Verifikation
+
+1. `tests/spec/ci-cd.bats` — die 4 neuen Assertions gehen von FAIL auf PASS.
+2. `task test:all` + `task freshness:check` grün.
+3. **Nach Merge und gesetzten Secrets:** `workflow_dispatch` triggern. Akzeptanz: Run grün,
+   und Renovate erzeugt das Dependency-Dashboard-Issue bzw. mindestens einen Update-PR — der
+   Vaultwarden-Bump `1.35.3 → 1.37.0` muss darunter sein.
+4. Gegenprobe zu RC3: die Vaultwarden-PR trägt das Label `dependencies` und hat **kein**
+   aktiviertes Auto-Merge (Minor auf eine Prod-Dependency → Review-PR).
+
+## Prozess-Lehre
+
+Die T000898-Abnahmekriterien (Spec-Zeilen 90-99) prüfen ausschließlich Artefakt-Existenz und
+Config-Korrektheit. Der manuelle Bootstrap-Schritt kommt in keinem AK vor — deshalb galt das
+Ticket bei grünem CI als shipped, obwohl die Funktion nie live war. **Bootstrap-abhängige
+Features brauchen ein AK, das Live-Funktion nachweist** (hier: „ein `workflow_dispatch`-Run ist
+grün"), nicht nur grünes CI. Genau diesen Nachweis führt Verifikationsschritt 3 ein.

--- a/openspec/changes/renovate-app-token/design.md
+++ b/openspec/changes/renovate-app-token/design.md
@@ -75,9 +75,11 @@ und wird im Post-Step automatisch revoked.
 - **Version:** v3.2.0, SHA-gepinnt auf `bcd2ba49218906704ab6c1aa796996da409d3eb1` — gemäß der
   in `renovate.yml:44` dokumentierten Konvention für secret-tragende Third-Party-Actions
   (*„nie @latest"*).
-- **Input `client-id:`**, **nicht** `app-id:` — letzteres ist in v3 deprecated
-  (`action.yml`: *„Use 'client-id' instead."*). Entsprechend heißt das Secret
-  `RENOVATE_APP_CLIENT_ID`.
+- **Input `app-id:`** mit dem Secret `RENOVATE_APP_ID`, das die **numerische App ID** hält.
+  `app-id` ist in v3 deprecated (`action.yml`: *„Use 'client-id' instead."*), funktioniert aber
+  unverändert. Eine Migration auf `client-id` braucht **beides**: den Secret-Wert auf die
+  Client ID umstellen *und* den Input umbenennen — deshalb hier bewusst in einem Schritt
+  belassen und als Kommentar im Workflow vermerkt.
 - **Output:** `steps.app-token.outputs.token`.
 - **Kein `owner`/`repositories`-Input** — Default ist das aktuelle Repository, was genau dem
   Installationsumfang entspricht.
@@ -153,11 +155,11 @@ S1-Limits (`docs/code-quality/gates.yaml:44-58`) gelten ausschließlich für Cod
 
 ## Manueller Anteil (nicht automatisierbar)
 
-Patrick legt die GitHub App im UI an (Permissions s. o.), notiert die **Client ID**, generiert
+Patrick legt die GitHub App im UI an (Permissions s. o.), notiert die **App ID**, generiert
 den Private Key, installiert die App auf `Paddione/Bachelorprojekt` und setzt:
 
 ```bash
-gh secret set RENOVATE_APP_CLIENT_ID --body "<client-id>"
+gh secret set RENOVATE_APP_ID --body "<app-id>"
 gh secret set RENOVATE_APP_PRIVATE_KEY < <pfad>.private-key.pem
 ```
 

--- a/openspec/changes/renovate-app-token/specs/ci-cd.md
+++ b/openspec/changes/renovate-app-token/specs/ci-cd.md
@@ -8,8 +8,8 @@ The system SHALL run self-hosted Renovate weekly (montags 07:00 UTC) to open PRs
 dependencies, authenticating via a **per-run minted GitHub App installation token** — never
 `GITHUB_TOKEN`, and never a statically stored installation token. Because a GitHub App
 installation token expires after one hour, the workflow SHALL mint a fresh token on every run
-using a SHA-pinned `actions/create-github-app-token` step whose `client-id` and `private-key`
-inputs read the long-lived secrets `RENOVATE_APP_CLIENT_ID` and `RENOVATE_APP_PRIVATE_KEY`. The
+using a SHA-pinned `actions/create-github-app-token` step whose `app-id` and `private-key`
+inputs read the long-lived secrets `RENOVATE_APP_ID` and `RENOVATE_APP_PRIVATE_KEY`. The
 App installation SHALL carry the `Workflows: write` permission in addition to Contents and
 Pull requests, because the `github-actions` manager with `pinDigests: true` modifies files under
 `.github/workflows/`.
@@ -30,7 +30,7 @@ Pull requests, because the `github-actions` manager with `pinDigests: true` modi
 
 #### Scenario: Fehlende App-Secrets sind als Ausfallursache erkennbar
 
-- **GIVEN** `RENOVATE_APP_CLIENT_ID` oder `RENOVATE_APP_PRIVATE_KEY` ist nicht gesetzt
+- **GIVEN** `RENOVATE_APP_ID` oder `RENOVATE_APP_PRIVATE_KEY` ist nicht gesetzt
 - **WHEN** der Workflow läuft
 - **THEN** schlägt der Token-Step fehl, bevor Renovate startet — der Fehler benennt das fehlende
   App-Credential statt eines undurchsichtigen `docker … exit code 1` aus dem Renovate-Container

--- a/openspec/changes/renovate-app-token/specs/ci-cd.md
+++ b/openspec/changes/renovate-app-token/specs/ci-cd.md
@@ -1,0 +1,82 @@
+# ci-cd — Delta (renovate-app-token, T002161)
+
+## MODIFIED Requirements
+
+### Requirement: Dependency-Update via Renovate (selbstgehostet)
+
+The system SHALL run self-hosted Renovate weekly (montags 07:00 UTC) to open PRs for outdated
+dependencies, authenticating via a **per-run minted GitHub App installation token** — never
+`GITHUB_TOKEN`, and never a statically stored installation token. Because a GitHub App
+installation token expires after one hour, the workflow SHALL mint a fresh token on every run
+using a SHA-pinned `actions/create-github-app-token` step whose `client-id` and `private-key`
+inputs read the long-lived secrets `RENOVATE_APP_CLIENT_ID` and `RENOVATE_APP_PRIVATE_KEY`. The
+App installation SHALL carry the `Workflows: write` permission in addition to Contents and
+Pull requests, because the `github-actions` manager with `pinDigests: true` modifies files under
+`.github/workflows/`.
+
+#### Scenario: Renovate öffnet Dependency-Update-PR
+
+- **GIVEN** eine neue Version von `actions/checkout` ist verfügbar
+- **WHEN** Renovate montags um 07:00 UTC läuft
+- **THEN** öffnet Renovate einen PR mit dem gepinnten SHA-Digest-Update gemäß `renovate.json5`
+
+#### Scenario: Token wird pro Run frisch geprägt
+
+- **GIVEN** der Renovate-Workflow startet (per Cron oder `workflow_dispatch`)
+- **WHEN** die Steps ausgeführt werden
+- **THEN** läuft ein SHA-gepinnter `actions/create-github-app-token`-Step vor dem Renovate-Step
+- **AND** `renovatebot/github-action` erhält den Token als `steps.<id>.outputs.token`
+- **AND** kein statisch hinterlegtes `secrets.RENOVATE_TOKEN` wird referenziert
+
+#### Scenario: Fehlende App-Secrets sind als Ausfallursache erkennbar
+
+- **GIVEN** `RENOVATE_APP_CLIENT_ID` oder `RENOVATE_APP_PRIVATE_KEY` ist nicht gesetzt
+- **WHEN** der Workflow läuft
+- **THEN** schlägt der Token-Step fehl, bevor Renovate startet — der Fehler benennt das fehlende
+  App-Credential statt eines undurchsichtigen `docker … exit code 1` aus dem Renovate-Container
+
+#### Scenario: Kein paralleler Renovate-Lauf
+
+- **GIVEN** ein Renovate-Run ist bereits aktiv
+- **WHEN** ein manueller `workflow_dispatch` getriggert wird
+- **THEN** verhindert `concurrency.cancel-in-progress: false` keinen Abbruch des laufenden Jobs —
+  der neue Run wartet oder startet je nach concurrency-Gruppe-Semantik
+
+### Requirement: Squash-Auto-Merge
+
+The system SHALL automatically enable squash-auto-merge on every non-draft PR against `main`
+that does **not** carry the `dependencies` label, as soon as it is opened or made ready for
+review, so that the PR merges itself once all required checks pass and branch protection is
+satisfied. PRs carrying the `dependencies` label are excluded because Renovate manages their
+auto-merge itself via `platformAutomerge`, gated by the staged policy in `renovate.json5`
+(`patch` and `devDependencies` only). Without this exclusion the blanket auto-merge would
+override that policy — `main` requires no reviews, so a `major` or production `minor` bump would
+merge unreviewed and reach both production brands through Flux reconciliation.
+
+#### Scenario: Auto-Merge wird bei PR-Öffnung aktiviert
+
+- **GIVEN** ein neuer nicht-Draft-PR gegen `main` ohne `dependencies`-Label wird geöffnet
+- **WHEN** der `auto-enable-automerge`-Workflow ausgelöst wird
+- **THEN** setzt `gh pr merge --auto --squash --delete-branch` das Auto-Merge-Flag via PAT (nicht GITHUB_TOKEN)
+
+#### Scenario: Draft-PRs werden ausgenommen
+
+- **GIVEN** ein PR wird als Draft geöffnet
+- **WHEN** der `auto-enable-automerge`-Workflow prüft `github.event.pull_request.draft`
+- **THEN** überspringt der Job den `enable-automerge`-Schritt — kein Auto-Merge-Flag gesetzt
+
+#### Scenario: Renovate-PRs werden per Label ausgenommen
+
+- **GIVEN** Renovate öffnet einen PR und labelt ihn gemäß `renovate.json5` mit `dependencies`
+- **WHEN** der `auto-enable-automerge`-Workflow seine `if:`-Bedingung auswertet
+- **THEN** überspringt der Job den `enable-automerge`-Schritt
+- **AND** die Ausnahme greift label-basiert, nicht über `pull_request.user.login` — der App-Slug
+  hängt am frei gewählten App-Namen und wäre eine stille Bruchstelle beim Umbenennen
+
+#### Scenario: Renovate setzt Auto-Merge nur im Rahmen seiner Policy
+
+- **GIVEN** `platformAutomerge: true` ist in `renovate.json5` gesetzt
+- **WHEN** Renovate einen `patch`- oder `devDependencies`-PR öffnet
+- **THEN** aktiviert Renovate selbst das Auto-Merge-Flag
+- **AND** bei `major`, produktiven `minor`- oder kubernetes-`major`-Updates bleibt der PR als
+  offener Review-PR ohne Auto-Merge stehen

--- a/openspec/changes/renovate-app-token/tasks.md
+++ b/openspec/changes/renovate-app-token/tasks.md
@@ -58,12 +58,15 @@ Schritte:
      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
      id: app-token
      with:
-       client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
+       app-id: ${{ secrets.RENOVATE_APP_ID }}
        private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
    ```
 
-   `client-id` statt `app-id`: letzteres ist in v3 deprecated (`action.yml`: *„Use 'client-id'
-   instead."*). Kein `owner`/`repositories`-Input — Default ist das aktuelle Repository.
+   `app-id` mit dem gesetzten Secret `RENOVATE_APP_ID` (hält die numerische App ID). Der Input
+   ist in v3 deprecated (`action.yml`: *„Use 'client-id' instead."*), funktioniert aber
+   unverändert; eine Migration auf `client-id` erfordert zusätzlich einen neuen Secret-Wert und
+   wird als Workflow-Kommentar vermerkt. Kein `owner`/`repositories`-Input — Default ist das
+   aktuelle Repository.
 
 2. Im Renovate-Step beide Token-Referenzen auf den Step-Output umstellen:
    `RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}` (env) und
@@ -76,7 +79,7 @@ Schritte:
 
 4. Header-Kommentar (Zeilen 6-9) korrigieren: statt *„a dedicated GitHub App token must be
    stored as repo secret RENOVATE_TOKEN"* die tatsächliche Anforderung dokumentieren — zwei
-   Secrets `RENOVATE_APP_CLIENT_ID` + `RENOVATE_APP_PRIVATE_KEY`, App-Permissions
+   Secrets `RENOVATE_APP_ID` + `RENOVATE_APP_PRIVATE_KEY`, App-Permissions
    Contents RW / Pull requests RW / **Workflows RW** / Metadata RO, und der Hinweis, dass ein
    Installation-Token 1 h TTL hat und deshalb nicht statisch hinterlegt werden kann.
 
@@ -128,12 +131,16 @@ bisher), also entsteht durch die Reihenfolge kein zusätzliches Risiko.
 1. App unter https://github.com/settings/apps/new anlegen: Webhook deaktiviert, Installation
    *Only on this account*, Permissions Contents RW / Pull requests RW / Workflows RW /
    Metadata RO.
-2. **Client ID** notieren, Private Key generieren, App auf `Paddione/Bachelorprojekt` installieren.
+2. **App ID** notieren, Private Key generieren, App auf `Paddione/Bachelorprojekt` installieren.
 3. Secrets setzen:
    ```bash
-   gh secret set RENOVATE_APP_CLIENT_ID --body "<client-id>"
+   gh secret set RENOVATE_APP_ID --body "<app-id>"
    gh secret set RENOVATE_APP_PRIVATE_KEY < <pfad>.private-key.pem
    ```
+
+**Status: erledigt** (2026-07-26). Beide Secrets sind gesetzt — `RENOVATE_APP_ID` (11:09 UTC)
+und `RENOVATE_APP_PRIVATE_KEY` (11:11 UTC), verifiziert via `gh secret list`. Der hinterlegte
+Wert ist die numerische App ID, weshalb Task 2 den Input `app-id` statt `client-id` verwendet.
 
 ## Task 6 — Verifikation
 

--- a/openspec/changes/renovate-app-token/tasks.md
+++ b/openspec/changes/renovate-app-token/tasks.md
@@ -1,0 +1,167 @@
+---
+title: Renovate auf GitHub-App-Token umstellen und Automerge-Kollision auflösen
+ticket_id: T002161
+domains: [ci, dependencies]
+status: plan_staged
+---
+
+# renovate-app-token — Implementation Plan
+
+Design-Spec: `openspec/changes/renovate-app-token/design.md`
+SSOT-Spec: `openspec/specs/ci-cd.md`
+
+## File Structure
+
+| Datei | Ist-Zeilen | S1-Budget |
+|---|---|---|
+| `.github/workflows/renovate.yml` | 55 | kein S1-Limit für `.yml` (gates.yaml → s1.limits listet nur Code-Extensions) |
+| `.github/workflows/auto-enable-automerge.yml` | 43 | kein S1-Limit für `.yml` |
+| `renovate.json5` | 156 | kein S1-Limit für `.json5` |
+| `tests/spec/ci-cd.bats` | 819 | kein S1-Limit für `.bats` |
+| `website/src/data/test-inventory.json` | generiert | regeneriert via `task test:inventory` |
+
+Keine der Dateien ist in `docs/code-quality/baseline.json` gebaselined, keine fällt unter eine
+Extension mit Zeilenlimit → kein Ratchet-Risiko, kein Split nötig.
+
+<!-- vitest: kein neuer Test nötig, weil ausschließlich CI-Workflows und Renovate-Config
+     geändert werden — kein Code unter website/src/lib/** oder website/src/pages/api/**. -->
+
+## Task 1 — RED-Nachweis: die fünf T002161-Assertions schlagen fehl
+
+Die Tests sind in `tests/spec/ci-cd.bats` bereits geschrieben (Fix-Pfad-Voraussetzung) und
+dokumentieren RC1–RC3 in ihren FAIL-Meldungen.
+
+```bash
+bats tests/spec/ci-cd.bats --filter "T002161"
+```
+
+**expected: FAIL** — alle fünf Assertions (`T002161-A` ×2, `-B`, `-C`, `-D`) melden `not ok`,
+weil `create-github-app-token` noch nicht eingebaut ist, `auto-enable-automerge.yml` keinen
+Label-Guard hat und `renovate.json5` weder `labels` noch `platformAutomerge` setzt.
+
+Nachgewiesener Ist-Zustand vor dem Fix: `1..5`, fünfmal `not ok`.
+
+## Task 2 — `renovate.yml` auf frisch geprägten App-Token umstellen
+
+Ziel: Der Workflow prägt pro Run einen frischen Installation-Token, statt ein statisches
+(und nicht existierendes) `RENOVATE_TOKEN` zu erwarten.
+
+Schritte:
+
+1. Neuen Step **vor** dem Renovate-Step einfügen, mit `id: app-token`:
+
+   ```yaml
+   - name: Create GitHub App token
+     # SHA-gepinnt (Supply-Chain: Action erhaelt den App Private Key).
+     # v3.2.0 (2026-07). Bump via Review / Renovate selbst; nie @latest
+     # fuer secret-tragende Third-Party-Actions.
+     uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+     id: app-token
+     with:
+       client-id: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
+       private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+   ```
+
+   `client-id` statt `app-id`: letzteres ist in v3 deprecated (`action.yml`: *„Use 'client-id'
+   instead."*). Kein `owner`/`repositories`-Input — Default ist das aktuelle Repository.
+
+2. Im Renovate-Step beide Token-Referenzen auf den Step-Output umstellen:
+   `RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}` (env) und
+   `token: ${{ steps.app-token.outputs.token }}` (with). Beides bleibt gesetzt, damit der
+   funktionale Teil unverändert ist und nur der Token-Wert wechselt.
+
+3. `permissions:` im Job auf `contents: read` reduzieren. Die Schreibrechte kommen aus dem
+   App-Token, nicht mehr aus `GITHUB_TOKEN`. `id-token: write` wird **nicht** gesetzt — es gibt
+   keinen OIDC-Flow.
+
+4. Header-Kommentar (Zeilen 6-9) korrigieren: statt *„a dedicated GitHub App token must be
+   stored as repo secret RENOVATE_TOKEN"* die tatsächliche Anforderung dokumentieren — zwei
+   Secrets `RENOVATE_APP_CLIENT_ID` + `RENOVATE_APP_PRIVATE_KEY`, App-Permissions
+   Contents RW / Pull requests RW / **Workflows RW** / Metadata RO, und der Hinweis, dass ein
+   Installation-Token 1 h TTL hat und deshalb nicht statisch hinterlegt werden kann.
+
+Akzeptanz: `bats tests/spec/ci-cd.bats --filter "T002161-A"` und `--filter "T002161-B"` sind grün.
+
+## Task 3 — `auto-enable-automerge.yml`: Renovate-PRs ausnehmen
+
+Ziel: Renovates gestufte Automerge-Policy wieder wirksam machen (RC3).
+
+Die `if:`-Bedingung des Jobs um einen Label-Guard erweitern:
+
+```yaml
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+```
+
+Label-basiert statt Bot-Name-basiert, weil `pull_request.user.login` am frei gewählten App-Namen
+hängt und beim Umbenennen still bricht. Kommentarblock am Dateikopf um den Grund ergänzen: PRs mit
+`dependencies`-Label setzen ihr Auto-Merge-Flag selbst über Renovate, gestaffelt nach der Policy
+in `renovate.json5`.
+
+Akzeptanz: `bats tests/spec/ci-cd.bats --filter "T002161-C"` ist grün.
+
+## Task 4 — `renovate.json5`: Label + `platformAutomerge`
+
+Zwei Top-Level-Keys ergänzen (mit Begründungskommentar, wie im Rest der Datei üblich):
+
+```json5
+  // PR-Label — auto-enable-automerge.yml nimmt PRs mit diesem Label aus, damit
+  // ausschliesslich die gestaffelte automerge-Policy unten greift (T002161).
+  "labels": ["dependencies"],
+
+  // Renovate setzt das GitHub-Auto-Merge-Flag selbst — aber nur fuer PRs, die
+  // die packageRules unten freigeben (patch + devDependencies).
+  "platformAutomerge": true,
+```
+
+Die `packageRules` bleiben unverändert — sie sind korrekt und waren nie das Problem.
+
+Akzeptanz: `bats tests/spec/ci-cd.bats --filter "T002161-D"` ist grün.
+
+## Task 5 — Manueller Anteil: GitHub App anlegen (Patrick, außerhalb der PR)
+
+Nicht automatisierbar, blockiert den Merge aber nicht — der Workflow-Umbau hängt nur an den
+Secret-*Namen*. Bis die Secrets gesetzt sind, bleibt Renovate schlafend (rote Cron-Läufe wie
+bisher), also entsteht durch die Reihenfolge kein zusätzliches Risiko.
+
+1. App unter https://github.com/settings/apps/new anlegen: Webhook deaktiviert, Installation
+   *Only on this account*, Permissions Contents RW / Pull requests RW / Workflows RW /
+   Metadata RO.
+2. **Client ID** notieren, Private Key generieren, App auf `Paddione/Bachelorprojekt` installieren.
+3. Secrets setzen:
+   ```bash
+   gh secret set RENOVATE_APP_CLIENT_ID --body "<client-id>"
+   gh secret set RENOVATE_APP_PRIVATE_KEY < <pfad>.private-key.pem
+   ```
+
+## Task 6 — Verifikation
+
+```bash
+bats tests/spec/ci-cd.bats --filter "T002161"   # 5/5 ok (RED aus Task 1 ist grün geworden)
+task test:inventory                              # Test-Inventar nach Test-Änderung regenerieren
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+
+`website/src/data/test-inventory.json` mit committen — der CI-Inventar-Check vergleicht gegen die
+committete Version und failt sonst.
+
+Nach Merge **und** gesetzten Secrets (Task 5) der eigentliche Live-Nachweis:
+
+```bash
+gh workflow run renovate.yml
+gh run list --workflow=renovate.yml --limit 1
+```
+
+Abnahme:
+- Der `workflow_dispatch`-Run ist **grün** (erster erfolgreiche Renovate-Lauf überhaupt).
+- Renovate erzeugt das Dependency-Dashboard-Issue bzw. mindestens einen Update-PR; der
+  Vaultwarden-Bump `1.35.3 → 1.37.0` ist darunter.
+- Gegenprobe zu RC3: Diese Vaultwarden-PR trägt das Label `dependencies` und hat **kein**
+  aktiviertes Auto-Merge (Minor auf eine Prod-Dependency → bleibt Review-PR).
+
+Der Vaultwarden-Bump selbst wird in dieser PR **nicht** durchgeführt — er ist der Beweis, dass
+der Fix greift, und braucht wegen der SSO-only/PKCE-Konfiguration eine eigene Prüfung der
+Release Notes auf OIDC-Breaking-Changes (Folgeticket).

--- a/renovate.json5
+++ b/renovate.json5
@@ -41,6 +41,17 @@
   // Renovate will use chore(deps): / fix(deps): prefixes.
   "semanticCommits": "enabled",
 
+  // PR label (T002161). auto-enable-automerge.yml skips PRs carrying this label,
+  // so the blanket "--auto on every non-draft PR" no longer overrides the staged
+  // automerge policy in packageRules below. Label-based rather than bot-name-based:
+  // the App slug depends on the freely chosen App name.
+  "labels": ["dependencies"],
+
+  // Renovate sets the GitHub auto-merge flag itself — but only on PRs its own
+  // packageRules release for automerge (patch + devDependencies). major, prod
+  // minor and kubernetes major stay open as review PRs.
+  "platformAutomerge": true,
+
   "packageRules": [
     // ── npm (pnpm workspaces) ─────────────────────────────────────────────
 

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -756,20 +756,26 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
     echo "FAIL: kein SHA-gepinnter actions/create-github-app-token-Step in renovate.yml."
     echo "      Ein GitHub-App-Installation-Token hat 1h TTL und kann NICHT als"
     echo "      statisches Repo-Secret hinterlegt werden — der Workflow muss pro Run"
-    echo "      einen frischen Token aus RENOVATE_APP_CLIENT_ID + RENOVATE_APP_PRIVATE_KEY"
+    echo "      einen frischen Token aus RENOVATE_APP_ID + RENOVATE_APP_PRIVATE_KEY"
     echo "      praegen. SHA-Pin ist Pflicht (Konvention renovate.yml: nie @latest fuer"
     echo "      secret-tragende Third-Party-Actions)."
     return 1
   }
 }
 
-@test "T002161-A: renovate.yml nutzt client-id (nicht das in v3 deprecated app-id)" {
+@test "T002161-A: renovate.yml liest die App-Identitaet aus RENOVATE_APP_ID" {
   local wf="$REPO_ROOT/.github/workflows/renovate.yml"
-  grep -qE '^\s+client-id:' "$wf" || {
-    echo "FAIL: create-github-app-token wird ohne client-id:-Input aufgerufen."
-    echo "      In v3 ist app-id: deprecated ('Use client-id instead.'), siehe"
-    echo "      action.yml der Action. Erwartet: client-id mit dem Secret"
-    echo "      RENOVATE_APP_CLIENT_ID."
+  grep -qE '^\s+app-id: \$\{\{ secrets\.RENOVATE_APP_ID \}\}' "$wf" || {
+    echo "FAIL: create-github-app-token wird nicht mit app-id aus dem Secret"
+    echo "      RENOVATE_APP_ID aufgerufen. Das gesetzte Repo-Secret haelt die"
+    echo "      numerische App ID, also ist app-id der passende Input — in v3 zwar"
+    echo "      deprecated ('Use client-id instead.'), aber funktionsfaehig. Eine"
+    echo "      Migration auf client-id braucht BEIDES: neuen Secret-Wert (Client ID)"
+    echo "      UND umbenannten Input."
+    return 1
+  }
+  grep -qE '^\s+private-key: \$\{\{ secrets\.RENOVATE_APP_PRIVATE_KEY \}\}' "$wf" || {
+    echo "FAIL: private-key liest nicht aus dem Secret RENOVATE_APP_PRIVATE_KEY."
     return 1
   }
 }

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -738,3 +738,82 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
     return 1
   }
 }
+
+# ── T002161: Renovate lief seit Einfuehrung nie (5/5 Cron-Runs failure).
+#    RC1: Repo-Secret RENOVATE_TOKEN existiert nicht.
+#    RC2: Die Anleitung in renovate.yml:6-9 ist strukturell unmoeglich — ein
+#         GitHub-App-Installation-Token hat 1h TTL und kann nicht als statisches
+#         Repo-Secret hinterlegt werden. Fix: actions/create-github-app-token
+#         praegt pro Run einen frischen Token aus App-Client-ID + Private Key.
+#    RC3: auto-enable-automerge.yml setzt --auto auf JEDER Nicht-Draft-PR und
+#         hebelt damit Renovates gestufte automerge-Policy aus (main hat
+#         reviews: null). Fix: label-basierte Ausnahme + platformAutomerge.
+#    Alle vier Tests sind erwartet: FAIL — der Fix ist noch nicht implementiert.
+
+@test "T002161-A: renovate.yml praegt den Token via create-github-app-token (SHA-gepinnt)" {
+  local wf="$REPO_ROOT/.github/workflows/renovate.yml"
+  grep -qE 'uses: actions/create-github-app-token@[0-9a-f]{40}' "$wf" || {
+    echo "FAIL: kein SHA-gepinnter actions/create-github-app-token-Step in renovate.yml."
+    echo "      Ein GitHub-App-Installation-Token hat 1h TTL und kann NICHT als"
+    echo "      statisches Repo-Secret hinterlegt werden — der Workflow muss pro Run"
+    echo "      einen frischen Token aus RENOVATE_APP_CLIENT_ID + RENOVATE_APP_PRIVATE_KEY"
+    echo "      praegen. SHA-Pin ist Pflicht (Konvention renovate.yml: nie @latest fuer"
+    echo "      secret-tragende Third-Party-Actions)."
+    return 1
+  }
+}
+
+@test "T002161-A: renovate.yml nutzt client-id (nicht das in v3 deprecated app-id)" {
+  local wf="$REPO_ROOT/.github/workflows/renovate.yml"
+  grep -qE '^\s+client-id:' "$wf" || {
+    echo "FAIL: create-github-app-token wird ohne client-id:-Input aufgerufen."
+    echo "      In v3 ist app-id: deprecated ('Use client-id instead.'), siehe"
+    echo "      action.yml der Action. Erwartet: client-id mit dem Secret"
+    echo "      RENOVATE_APP_CLIENT_ID."
+    return 1
+  }
+}
+
+@test "T002161-B: renovate.yml uebergibt den gepraegten App-Token, nicht ein statisches Secret" {
+  local wf="$REPO_ROOT/.github/workflows/renovate.yml"
+  grep -qE 'steps\.[a-z-]+\.outputs\.token' "$wf" || {
+    echo "FAIL: renovatebot/github-action bekommt keinen Token aus dem"
+    echo "      create-github-app-token-Step (steps.<id>.outputs.token)."
+    echo "      Ein direkt referenziertes secrets.RENOVATE_TOKEN ist leer (nie gesetzt)"
+    echo "      und laesst Renovate bei der Platform-Auth abbrechen — genau die"
+    echo "      Ursache der 5 fehlgeschlagenen Cron-Runs 2026-06-22..2026-07-20."
+    return 1
+  }
+}
+
+@test "T002161-C: auto-enable-automerge.yml nimmt Renovate-PRs (dependencies-Label) aus" {
+  local wf="$REPO_ROOT/.github/workflows/auto-enable-automerge.yml"
+  grep -q "labels.\*.name" "$wf" && grep -q "dependencies" "$wf" || {
+    echo "FAIL: auto-enable-automerge.yml prueft das dependencies-Label nicht."
+    echo "      Der Workflow setzt --auto --squash auf JEDER Nicht-Draft-PR gegen main,"
+    echo "      und main hat reviews: null (keine Review-Pflicht). Damit mergen auch"
+    echo "      Renovate-PRs durch, fuer die renovate.json5 bewusst automerge: false"
+    echo "      setzt (major, prod-minor, kubernetes-major) — z.B. ein Vaultwarden-"
+    echo "      Minor-Bump, der via Flux auf beide Prod-Brands ausgerollt wird."
+    echo "      Erwartet: label-basierter Guard (nicht Bot-Name — der haengt am"
+    echo "      frei waehlbaren App-Namen)."
+    return 1
+  }
+}
+
+@test "T002161-D: renovate.json5 labelt seine PRs und setzt platformAutomerge" {
+  local cfg="$REPO_ROOT/renovate.json5"
+  grep -qE '"labels"\s*:\s*\[' "$cfg" || {
+    echo "FAIL: renovate.json5 setzt kein labels: [...]. Ohne Label kann"
+    echo "      auto-enable-automerge.yml Renovate-PRs nicht von eigenen PRs"
+    echo "      unterscheiden (siehe T002161-C)."
+    return 1
+  }
+  grep -qE '"platformAutomerge"\s*:\s*true' "$cfg" || {
+    echo "FAIL: renovate.json5 setzt platformAutomerge nicht explizit auf true."
+    echo "      Sobald auto-enable-automerge.yml Renovate-PRs auslaesst, muss"
+    echo "      Renovate das Auto-Merge-Flag selbst setzen — aber nur fuer die PRs,"
+    echo "      die seine eigene Policy erlaubt (patch + devDependencies)."
+    return 1
+  }
+}


### PR DESCRIPTION
## Problem

Renovate has **never worked** since it was introduced in T000898 (merged 2026-06-17). All five cron runs failed after ~40s with an opaque `Error: The process '/usr/bin/docker' failed with exit code 1`:

```
2026-07-20  schedule  failure
2026-07-13  schedule  failure
2026-07-06  schedule  failure
2026-06-29  schedule  failure
2026-06-22  schedule  failure
```

No regression — the feature was dead from day one. The first failing run was the first cron after the merge.

## Root causes

**RC1 — the secret was never set.** `gh secret list | grep -i renovate` came back empty. `renovate.yml:9` documented the required manual `workflow_dispatch` bootstrap; it was never performed. Renovate aborted during platform auth, so it never scanned the repo and never opened the Dependency Dashboard issue that would have surfaced the outage.

**RC2 — the documented setup was structurally impossible.** A GitHub App *installation* token expires after one hour and cannot be stored as a static repo secret. Following `renovate.yml:6-9` verbatim would have bought exactly one successful run before dying the same way again — with the misleading evidence that "the secret is set". Additionally the T000898 design spec pointed at `opencode.yml` as the App-auth model; that pattern does not transfer, because `opencode.yml:30` relies on `id-token: write` and the OIDC-to-installation-token exchange is a feature of the `anomalyco/opencode/github` action. `renovatebot/github-action` has no such exchange.

**RC3 — auto-merge collision (found while brainstorming, folded into this PR).** `auto-enable-automerge.yml` set `--auto --squash` on *every* non-draft PR against `main`, and branch protection on `main` has `reviews: null`. Renovate's `automerge: false` only means "Renovate itself won't merge" — it does not stop another workflow from setting the flag. The staged policy from T000898 was therefore inert: the first Vaultwarden bump would have merged unreviewed and rolled out to **both** production brands via Flux, on a password manager with SSO-only/PKCE config.

## Changes

- **`.github/workflows/renovate.yml`** — mints a fresh installation token every run via SHA-pinned `actions/create-github-app-token@bcd2ba4` (v3.2.0), reading the long-lived secrets `RENOVATE_APP_ID` + `RENOVATE_APP_PRIVATE_KEY`. Job `permissions` reduced to `contents: read`; write access comes from the App token, and no `id-token` is requested. Header comment rewritten to state the real requirement, including the **`Workflows: write`** App permission — mandatory because the `github-actions` manager runs with `pinDigests: true` and thus edits files under `.github/workflows/`. Without it GitHub rejects the push while npm and kubernetes bumps keep working, which reads as a baffling partial failure.
- **`.github/workflows/auto-enable-automerge.yml`** — skips PRs labelled `dependencies`. Label-based rather than bot-name-based, since `pull_request.user.login` follows the freely chosen App name and would break silently on rename.
- **`renovate.json5`** — adds `labels: ["dependencies"]` and `platformAutomerge: true`. Renovate now sets the auto-merge flag itself, but only where its own `packageRules` allow it (`patch` + `devDependencies`). `major`, production `minor` and kubernetes `major` stay open as review PRs. `packageRules` themselves are untouched — they were always correct.
- **`tests/spec/ci-cd.bats`** — five assertions covering RC1–RC3, written first and confirmed red before the fix.

`app-id` vs `client-id`: the input is deprecated in v3 but functional. The existing secret holds the numeric App ID, so migrating to `client-id` would need both a new secret value and a renamed input — noted as a workflow comment rather than done half-way here.

## Verification

- `bats tests/spec/ci-cd.bats --filter T002161` — **5/5 ok** (all five were `not ok` before the fix).
- `task freshness:check` — **exit 0**, S1–S4 ratchet and baseline assertion green; no file touched here has a line limit (`.yml`/`.json5`/`.bats` are absent from `gates.yaml → s1.limits`) and none is baselined.
- `scripts/plan-lint.sh` PASS (0 hard, 0 warn), `task openspec:validate` 11/11.
- YAML and JSON5 both parse.

**Pre-existing failures, not caused by this PR:** `task test:changed` reports three red `T001994` assertions (`website:deploy` envsubst allowlist missing `WEBSITE_CONFIG_SHA`). Proven pre-existing by running the *unmodified* `origin/main` version of the test file — identical three failures. Cause is a separate change (T002156/T002154) that moved `WEBSITE_CONFIG_SHA` into its own `envsubst` call, which the test's allowlist extractor does not recognise. Filed separately; not fixed here to keep this PR scoped.

**Known limitation:** `tests/spec/ci-cd.bats` is not executed by any required check — `ci.yml` runs only `software-factory`, `agent-library` and `mcp-tooling` from `tests/spec/`. The five new assertions therefore guard via local `task test:changed`, not via CI. This is also why the T001994 breakage above went unnoticed on `main`.

## Post-merge — the actual live proof

Secrets are already set (`RENOVATE_APP_ID`, `RENOVATE_APP_PRIVATE_KEY`). After merge:

```bash
gh workflow run renovate.yml
```

Acceptance: the run is **green** (the first successful Renovate run ever), and Renovate produces the Dependency Dashboard issue or at least one update PR — with the Vaultwarden bump `1.35.3` → `1.37.0` among them. Counter-check for RC3: that PR carries the `dependencies` label and has auto-merge **off**, because a production `minor` must stay a review PR.

The Vaultwarden bump itself is deliberately out of scope — it is the acceptance evidence for this fix, and it needs its own review of the release notes for OIDC breaking changes.

Closes T002161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgAzbFpnCNq5NfyZAoPcLx