### PR TITLE
fix(assistant): show meta fields inline in sidekick log stream [T002168]

### DIFF
--- a/website/src/components/assistant/LogsSidekickView.svelte
+++ b/website/src/components/assistant/LogsSidekickView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte';
   import { logEntries, clearLog, filterEntries, type LogFilters } from '../../lib/logging/log-store';
-  import { levelClass, levelLabel } from '../../lib/logging/log-format';
+  import { levelClass, levelLabel, formatMetaInline } from '../../lib/logging/log-format';
   import { openServerLogStream, openPodLogStream, type StreamHandle } from '../../lib/logging/log-streams';
   import { postError, podLineToError, fetchErrorHistory } from '../../lib/logging/error-report.js';
   import { browserLogger } from '../../lib/browser-logger.js';
@@ -147,7 +147,7 @@
   {#if errorMode === 'live'}
     <div class="log-list" bind:this={logEl}>
       {#if !filtered.length}<p class="empty">Keine Logs</p>{/if}
-      {#each filtered as e}<div class="line {levelClass(e.level)}"><span class="ts">{new Date(e.ts).toLocaleTimeString('de-DE')}</span><span class="src-tag src-{e.source}">{SOURCE_LABEL[e.source]}</span><span class="msg">{e.message}</span></div>{/each}
+      {#each filtered as e}<div class="line {levelClass(e.level)}"><span class="ts">{new Date(e.ts).toLocaleTimeString('de-DE')}</span><span class="src-tag src-{e.source}">{SOURCE_LABEL[e.source]}</span><span class="msg">{e.message}{#if e.meta} <span class="meta">{formatMetaInline(e.meta)}</span>{/if}</span></div>{/each}
     </div>
   {:else if errorMode === 'history'}
     <div class="log-list" bind:this={logEl}>
@@ -191,6 +191,6 @@
 .link{background:none;border:none;color:#5b8def;cursor:pointer;text-decoration:underline}
 .log-list{flex:1;min-height:12rem;max-height:45vh;overflow-y:auto;background:rgba(0,0,0,.28);border:1px solid rgba(255,255,255,.08);border-radius:8px;padding:.5rem;font-family:var(--mono,monospace);font-size:.72rem;line-height:1.45}
 .empty{color:#6b7280;white-space:nowrap}.line{display:grid;grid-template-columns:auto auto 1fr;gap:.5rem;padding:.1rem;color:inherit}
-.ts{color:#6b7280}.src-tag{font-size:.62rem;text-transform:uppercase}.msg{min-width:0}
+.ts{color:#6b7280}.src-tag{font-size:.62rem;text-transform:uppercase}.msg{min-width:0}.meta{opacity:.55;font-size:.66rem}
 .count{font-size:.68rem;color:#6b7280;text-align:right;white-space:nowrap;margin-top:.3rem}
 </style>

--- a/website/src/lib/logging/log-format.test.ts
+++ b/website/src/lib/logging/log-format.test.ts
@@ -7,6 +7,7 @@ import {
   levelLabel,
   parsePinoLine,
   parsePodLine,
+  formatMetaInline,
 } from './log-format';
 
 describe('pinoLevelToLevel', () => {
@@ -72,5 +73,22 @@ describe('parsePodLine', () => {
   it('uses heuristic for plain pod stdout', () => {
     expect(parsePodLine('container started, no errors')).toMatchObject({ level: 'error', source: 'pod' });
     expect(parsePodLine('all good')).toMatchObject({ level: 'info', source: 'pod' });
+  });
+});
+
+describe('formatMetaInline', () => {
+  it('returns empty string for undefined/empty meta', () => {
+    expect(formatMetaInline(undefined)).toBe('');
+    expect(formatMetaInline({})).toBe('');
+  });
+
+  it('formats request.end meta with prioritised field order', () => {
+    const meta = { requestId: 'r1', statusCode: 200, durationMs: 42, method: 'GET', path: '/api/admin' };
+    expect(formatMetaInline(meta)).toBe('statusCode=200 method=GET path=/api/admin durationMs=42 requestId=r1');
+  });
+
+  it('sorts unknown fields alphabetically after prioritised ones', () => {
+    const meta = { statusCode: 500, foo: 'bar', alpha: 1, durationMs: 10 };
+    expect(formatMetaInline(meta)).toBe('statusCode=500 durationMs=10 alpha=1 foo=bar');
   });
 });

--- a/website/src/lib/logging/log-format.ts
+++ b/website/src/lib/logging/log-format.ts
@@ -66,6 +66,18 @@ export function parsePinoLine(raw: string, source: LogSource = 'server'): LogEnt
  * Pod container stdout — the website pod emits pino JSON, other pods emit plain
  * text. Try JSON first (→ real numeric level), otherwise heuristic text level.
  */
+const META_ORDER = ['statusCode', 'method', 'path', 'durationMs', 'requestId'];
+
+export function formatMetaInline(meta?: Record<string, unknown>): string {
+  if (!meta || Object.keys(meta).length === 0) return '';
+  const entries = Object.entries(meta);
+  const sorted = [
+    ...META_ORDER.filter(k => k in meta).map(k => [k, meta[k]] as const),
+    ...entries.filter(([k]) => !META_ORDER.includes(k)).sort(([a], [b]) => a.localeCompare(b)),
+  ];
+  return sorted.map(([k, v]) => `${k}=${typeof v === 'number' ? v : String(v)}`).join(' ');
+}
+
 export function parsePodLine(raw: string): LogEntry {
   const trimmed = raw.trim();
   if (trimmed.startsWith('{')) return parsePinoLine(trimmed, 'pod');

--- a/website/src/lib/logging/log-store.test.ts
+++ b/website/src/lib/logging/log-store.test.ts
@@ -76,4 +76,12 @@ describe('filterEntries', () => {
   it('returns nothing when all chips are off', () => {
     expect(filterEntries(entries, allFilters({ levels: new Set() }))).toHaveLength(0);
   });
+
+  it('filters by meta field content via text', () => {
+    const withMeta = entry({ message: 'request.end', meta: { statusCode: 500, path: '/api/admin' } });
+    const withoutMeta = entry({ message: 'request.end', meta: { statusCode: 200 } });
+    const out = filterEntries([withMeta, withoutMeta], allFilters({ text: '500' }));
+    expect(out).toHaveLength(1);
+    expect(out[0].meta?.statusCode).toBe(500);
+  });
 });

--- a/website/src/lib/logging/log-store.ts
+++ b/website/src/lib/logging/log-store.ts
@@ -39,7 +39,10 @@ export function filterEntries(entries: LogEntry[], f: LogFilters): LogEntry[] {
   return entries.filter((e) => {
     if (!f.levels.has(e.level)) return false;
     if (!f.sources.has(e.source)) return false;
-    if (t && !e.message.toLowerCase().includes(t)) return false;
+    if (t && !e.message.toLowerCase().includes(t)) {
+      const metaStr = e.meta ? JSON.stringify(e.meta).toLowerCase() : '';
+      if (!metaStr.includes(t)) return false;
+    }
     return true;
   });
 }


### PR DESCRIPTION
## Summary
- Sidekick-Logs zeigten nur den `msg`-Feldinhalt (z.B. `request.end`)
- Strukturierte meta-Felder wie `statusCode`, `durationMs`, `method`, `path`, `requestId` wurden nie angezeigt, obwohl sie im `LogEntry.meta` vorhanden sind
- `formatMetaInline()` formatiert meta als kompakte Key=Value-Zeile mit priorisierter Reihenfolge
- Textfilter durchsucht jetzt auch `meta` (man kann nach Status-Code oder Pfad filtern)

## Änderungen
- `website/src/lib/logging/log-format.ts`: Neue `formatMetaInline()` Funktion
- `website/src/components/assistant/LogsSidekickView.svelte`: Meta inline hinter message anzeigen
- `website/src/lib/logging/log-store.ts`: Textfilter erweitert um meta-Suche
- Tests für beide Änderungen

## Test Plan
- [x] 22/22 Tests grün (log-format + log-store)
- [x] Typecheck: 0 Errors
- [x] Lint: sauber

Vorher: `14:09:42 Server request.end`
Nachher: `14:09:42 Server request.end statusCode=200 method=GET path=/api/admin durationMs=42`

[T002168]