### PR TITLE
fix(ci): repair envsubst allowlist extractor and run ci-cd.bats in a required check [T002163]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,20 @@ jobs:
       - name: MCP tooling guardrail
         run: ./tests/unit/lib/bats-core/bin/bats tests/spec/mcp-tooling.bats
 
+      # T002163: ci-cd.bats holds the guards for post-merge serialisation, website
+      # deploy brand parity, Flux artifact rendering, freshness-regen and the
+      # envsubst allowlists — but ran in no required check, so it enforced nothing.
+      # Three T001994 assertions sat red on main for weeks and only surfaced during
+      # a local `task test:changed` on an unrelated PR. Same blind spot let
+      # openspec:validate go red on main (T002167). Guards that CI never executes
+      # are documentation, not gates.
+      # PyYAML is needed by the G-CD01 assertions, which parse build-website.yml.
+      - name: Install PyYAML for CI-CD guard assertions
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: CI/CD pipeline guardrail
+        run: ./tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd.bats
+
       - name: Agent setup replay reminder
         run: |
           changed=$(git diff --name-only origin/main...HEAD || true)

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -403,12 +403,18 @@ _taskfile_envsubst_list() { # $1 = task name (z.B. workspace:deploy)
   ' "$REPO_ROOT/Taskfile.yml" | grep -oE '\\\$[A-Z0-9_]+' | tr -d '\\$' | sort -u
 }
 
-# Inline-envsubst-Liste des website:deploy-Tasks (Zeilen mit $WEBSITE_IMAGE-Liste).
+# Inline-envsubst-Allowlist des website:deploy-Tasks — Union ueber ALLE
+# envsubst-Aufrufe des Tasks, nicht nur die grosse $WEBSITE_IMAGE-Liste.
+# Der Task substituiert in mehreren separaten Aufrufen (T002163): die Hauptliste,
+# je einen fuer $WEBSITE_CONFIG_SHA (T002154/T002156) und mehrere fuer
+# $WEBSITE_NAMESPACE. Ein Extraktor, der nur die Hauptliste liest, meldet die
+# uebrigen Variablen als "Drift", obwohl der Deploy sie korrekt substituiert —
+# genau dieses False Positive hielt drei T001994-Assertions dauerhaft rot.
 _website_deploy_list() {
   awk '
     $0 == "  website:deploy:" {in_task=1; next}
     in_task && /^  [a-zA-Z0-9:_-]+:$/ {exit}
-    in_task && /envsubst "\\\$WEBSITE_IMAGE/ {print}
+    in_task && /envsubst "/ {print}
   ' "$REPO_ROOT/Taskfile.yml" | grep -oE '\\\$[A-Z0-9_]+' | tr -d '\\$' | sort -u
 }
 
@@ -872,6 +878,45 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
     echo "      keine quay.io/keycloak-Image-Referenz mehr in den Manifesten. Eine"
     echo "      packageRule fuer ein nicht mehr vorhandenes Image ist toter Ballast"
     echo "      und suggeriert eine Komponente, die es nicht mehr gibt."
+    return 1
+  }
+}
+
+# ── T002163: Die drei website:deploy-Allowlist-Assertions (T001994) waren auf main
+#    dauerhaft rot — ein False Positive: _website_deploy_list() las nur den
+#    envsubst-Aufruf mit der grossen $WEBSITE_IMAGE-Liste und uebersah die
+#    separaten Aufrufe fuer $WEBSITE_CONFIG_SHA (T002154/T002156) und
+#    $WEBSITE_NAMESPACE. Aufgefallen ist es NICHT durch CI, sondern beim lokalen
+#    task test:changed eines voellig unbeteiligten PRs (T002161) — weil diese
+#    Datei in keinem Required Check lief. Beide Luecken werden hier geschlossen.
+
+@test "T002163: _website_deploy_list erfasst ALLE envsubst-Aufrufe des Tasks" {
+  local list; list="$(_website_deploy_list)"
+  # Die drei Variablen stammen aus drei verschiedenen envsubst-Aufrufen des
+  # website:deploy-Tasks. Fehlt eine, ist der Extraktor wieder zu eng gefasst
+  # und meldet korrekt substituierte Variablen als Allowlist-Drift.
+  for v in WEBSITE_IMAGE WEBSITE_CONFIG_SHA WEBSITE_NAMESPACE; do
+    grep -qx "$v" <<< "$list" || {
+      echo "FAIL: $v fehlt in der extrahierten website:deploy-Allowlist."
+      echo "      _website_deploy_list() muss die Union ueber alle envsubst-Aufrufe"
+      echo "      des Tasks bilden, nicht nur die \$WEBSITE_IMAGE-Hauptliste."
+      echo "      Extrahiert wurde:"; sed 's/^/        /' <<< "$list"
+      return 1
+    }
+  done
+}
+
+@test "T002163: ci.yml fuehrt tests/spec/ci-cd.bats in einem Required Check aus" {
+  local ci="$REPO_ROOT/.github/workflows/ci.yml"
+  grep -q 'tests/spec/ci-cd.bats' "$ci" || {
+    echo "FAIL: ci.yml ruft tests/spec/ci-cd.bats nicht auf."
+    echo "      Diese Datei enthaelt die Guards fuer post-merge-Serialisierung,"
+    echo "      Brand-Parity im Website-Deploy, Flux-Artefakt-Rendering,"
+    echo "      freshness-regen und die envsubst-Allowlists. Laeuft sie in keinem"
+    echo "      Required Check, verhindert sie nichts — sie faellt nur dem auf, der"
+    echo "      zufaellig lokal verifiziert. Genau so blieben drei rote T001994-"
+    echo "      Assertions und ein rotes openspec:validate (T002167) unentdeckt"
+    echo "      auf main liegen, bis der naechste PR darueber stolperte."
     return 1
   }
 }


### PR DESCRIPTION
Two defects with one shared root cause: **a guard file that CI never executed.**

## 1. The false positive

Three `T001994` assertions were red on `main` for weeks:

```
envsubst-Allowlist-Drift in prod-fleet/website-mentolder — fehlende Config-Vars: WEBSITE_CONFIG_SHA
```

`_website_deploy_list()` only matched the `envsubst` call carrying the large `$WEBSITE_IMAGE` list. But `website:deploy` substitutes across **six separate calls** — the two main lists plus dedicated ones for `$WEBSITE_CONFIG_SHA` (added by T002154/T002156) and several for `$WEBSITE_NAMESPACE`:

```
3645:  envsubst "\$WEBSITE_IMAGE \$BRAND_ID \$BRAND_NAME …"     ← only this was read
3650:  envsubst "\$WEBSITE_CONFIG_SHA" < "$_WEB_RENDER" | kubectl apply
3652:  envsubst "\$WEBSITE_NAMESPACE" < k3d/website-seller-config.yaml
3679:  … | envsubst "\$WEBSITE_IMAGE \$BRAND_ID …"              ← and this
3685:  envsubst "\$WEBSITE_CONFIG_SHA" < "$_WEB_RENDER"
3706:  envsubst "\$WEBSITE_NAMESPACE" < k3d/website-dev-secrets.yaml
```

The deploy substitutes those variables correctly — the guard just couldn't see it. The extractor now takes the **union over all `envsubst` calls** of the task (a one-word regex change), and a new assertion pins `WEBSITE_IMAGE`, `WEBSITE_CONFIG_SHA` and `WEBSITE_NAMESPACE` so the pattern cannot be narrowed again unnoticed.

## 2. Why nobody noticed — the part that actually matters

`tests/spec/ci-cd.bats` **ran in no required check at all.** `ci.yml` executed only `software-factory`, `agent-library` and `mcp-tooling` from `tests/spec/`, and the `BATS Unit + Quality Gates` job selects via `find-changed-tests.sh` in mode `unit`, which resolves to `tests/unit/` exclusively.

So all 75 assertions in this file enforced nothing — including the guards for post-merge serialisation, website-deploy brand parity, Flux artifact rendering, `freshness-regen` and the envsubst allowlists. **A guard CI never runs is documentation, not a gate.**

The consequences were not hypothetical:

- The three red `T001994` assertions surfaced only during a local `task test:changed` on a completely unrelated PR (#3214, T002161).
- The same blind spot let `openspec:validate` go red on `main` and block *every* PR until the next one tripped over it (T002167).

The file now runs in `Factory + OpenSpec + Guards`. **Order matters within this commit:** the extractor fix comes first, so wiring the file into CI cannot turn the pipeline red. PyYAML is installed explicitly because the `G-CD01` assertions parse `build-website.yml` with `yaml.safe_load`.

## Verification

- `bats tests/spec/ci-cd.bats` — **75/75 ok, 0 failures** (72/75 before, the three `T001994` ones red).
- `bats … --filter T002163` — 2/2 ok; the CI-wiring assertion was confirmed red before the `ci.yml` change.
- `task test:changed` — passes, no cancelled/skipped/todo.
- `task freshness:check` — exit 0.
- `ci.yml` parses as YAML, 9 jobs.

This PR is its own best test: if any of the 75 assertions misbehaves under CI conditions (missing `kubectl kustomize`, absent `website/node_modules`), the new `CI/CD pipeline guardrail` step will say so here rather than silently on `main`. The kustomize-dependent assertions `skip` defensively when rendering yields nothing, and the ESLint one skips without installed website deps.

Closes T002163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgAzbFpnCNq5NfyZAoPcLx