### PR TITLE
fix(website): thread request through all email call chains for E2E guard

### DIFF
--- a/tests/e2e/specs/fa-admin-tickets.spec.ts
+++ b/tests/e2e/specs/fa-admin-tickets.spec.ts
@@ -25,6 +25,7 @@ import { test, expect } from '@playwright/test';
 import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
 import { seedAdminTicket, cleanupSeedTicket, seedAvailable } from '../lib/e2e-seed';
+import { markerHeaders, markerAvailable } from '../lib/e2e-marker';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
 const MAILPIT    = process.env.MAILPIT_URL ?? 'http://localhost:8025';
@@ -54,6 +55,8 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
     test.skip(!seedAvailable(),
       'CRON_SECRET oder SESSIONS_DATABASE_URL fehlt — DB-Seed würde Prod-Tracker verschmutzen oder scheitern');
     test.skip(!ADMIN_PASS, 'E2E_ADMIN_PASS fehlt — Admin-Login nicht möglich');
+
+    const e2eHeaders = markerAvailable() ? markerHeaders()! : {};
 
     await assertAuthenticatedReachable(
       request,
@@ -92,14 +95,14 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
       // ── 4. Internal comment ──
       const internalRes = await page.request.post(
         `${BASE}/api/admin/tickets/${ticketUuid}/comments`,
-        { headers: { 'Content-Type': 'application/json' },
+        { headers: { 'Content-Type': 'application/json', ...e2eHeaders },
           data: JSON.stringify({ body: 'PR4 internal comment', visibility: 'internal' }) });
       expect(internalRes.ok()).toBeTruthy();
 
       // ── 5. Public comment → reporter mail ──
       const publicRes = await page.request.post(
         `${BASE}/api/admin/tickets/${ticketUuid}/comments`,
-        { headers: { 'Content-Type': 'application/json' },
+        { headers: { 'Content-Type': 'application/json', ...e2eHeaders },
           data: JSON.stringify({ body: 'PR4 public reply for the reporter', visibility: 'public' }) });
       expect(publicRes.ok()).toBeTruthy();
 
@@ -116,7 +119,7 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
       // ── 6. Transition to done → close-mail ──
       const transRes = await page.request.post(
         `${BASE}/api/admin/tickets/${ticketUuid}/transition`,
-        { headers: { 'Content-Type': 'application/json' },
+        { headers: { 'Content-Type': 'application/json', ...e2eHeaders },
           data: JSON.stringify({ status: 'done', resolution: 'fixed', note: 'PR4 done', noteVisibility: 'internal' }) });
       expect(transRes.ok()).toBeTruthy();
 

--- a/tests/e2e/specs/fa-bugs-notifications.spec.ts
+++ b/tests/e2e/specs/fa-bugs-notifications.spec.ts
@@ -34,7 +34,7 @@ import { test, expect } from '@playwright/test';
 import { Pool } from 'pg';
 import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
-import { markerAvailable } from '../lib/e2e-marker';
+import { markerAvailable, markerHeaders } from '../lib/e2e-marker';
 
 const BASE       = process.env.WEBSITE_URL ?? 'http://localhost:4321';
 const MAILPIT    = process.env.MAILPIT_URL  ?? 'http://localhost:8025';
@@ -122,9 +122,11 @@ test.describe('FA-bug-notify', () => {
 
     // ── Step 3: Resolve ticket via API with admin session cookies ───
     // Use page.request so Playwright sends the session cookies from the
-    // logged-in browser context.
+    // logged-in browser context. The X-E2E-Test + X-Cron-Secret headers
+    // tell the server to skip the real SMTP send (isE2ETestRequest guard).
+    const e2eHeaders = markerAvailable() ? markerHeaders()! : {};
     const resolveRes = await page.request.post(`${BASE}/api/admin/bugs/resolve`, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...e2eHeaders },
       data: JSON.stringify({
         ticketId,
         resolutionNote: 'fixed in E2E plan — Playwright FA-bug-notify',

--- a/tests/e2e/specs/fa-fragebogen.spec.ts
+++ b/tests/e2e/specs/fa-fragebogen.spec.ts
@@ -2,6 +2,7 @@
 import { test, expect, type Page } from '@playwright/test';
 import { loginViaE2E } from '../lib/auth';
 import { assertAuthenticatedReachable } from '../lib/health-assertions';
+import { markerHeaders, markerAvailable } from '../lib/e2e-marker';
 import { Pool } from 'pg';
 
 const BASE       = process.env.WEBSITE_URL         ?? 'http://localhost:4321';
@@ -163,9 +164,10 @@ test.describe('FA-Fragebogen: Fill flow', { tag: ['@fragebogen'] }, () => {
     const cookies = await page.context().cookies();
     const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ');
 
+    const e2eHeaders = markerAvailable() ? markerHeaders()! : {};
     const res = await request.post(`${BASE}/api/portal/questionnaires/${a}/submit`, {
       data: {},
-      headers: { Cookie: cookieHeader },
+      headers: { Cookie: cookieHeader, ...e2eHeaders },
     });
     expect(res.status()).toBe(200);
 
@@ -422,7 +424,9 @@ test.describe('FA-Fragebogen: Real-user handoff', { tag: ['@fragebogen'] }, () =
     // Log in as admin — page.request shares the browser context's cookies automatically
     await loginAsAdmin(page, '/admin/fragebogen');
 
+    const e2eHeaders = markerAvailable() ? markerHeaders()! : {};
     const res = await page.request.post(`${BASE}/api/admin/questionnaires/assign`, {
+      headers: { ...e2eHeaders },
       data: { templateId, keycloakUserId },
     });
     expect(res.status()).toBe(201);

--- a/website/src/lib/assistant/actions.ts
+++ b/website/src/lib/assistant/actions.ts
@@ -7,6 +7,7 @@ export interface ActionContext {
   preferredUsername?: string;
   email?: string;
   payload: Record<string, unknown>;
+  request?: Request;
 }
 
 export interface ActionDescriptor {

--- a/website/src/lib/assistant/actions/portal/bookSession.ts
+++ b/website/src/lib/assistant/actions/portal/bookSession.ts
@@ -50,7 +50,7 @@ registerAction({
     }
 
     // Send confirmation email — non-blocking (fire-and-forget on error)
-    sendBookingConfirmation({ to: ctx.email, name: ctx.email, start, end }).catch(() => {});
+    sendBookingConfirmation({ to: ctx.email, name: ctx.email, start, end }, ctx.request).catch(() => {});
 
     const startStr = start.toLocaleString('de-DE', {
       timeZone: 'Europe/Berlin',

--- a/website/src/lib/assistant/actions/portal/cancelSession.ts
+++ b/website/src/lib/assistant/actions/portal/cancelSession.ts
@@ -50,7 +50,7 @@ registerAction({
         to: ctx.email,
         name: ctx.email,
         start: bookingStart,
-      }).catch(() => {});
+      }, ctx.request).catch(() => {});
     }
 
     return {

--- a/website/src/lib/assistant/actions/portal/moveSession.ts
+++ b/website/src/lib/assistant/actions/portal/moveSession.ts
@@ -61,7 +61,7 @@ registerAction({
       name: ctx.email,
       newStart,
       newEnd,
-    }).catch(() => {});
+    }, ctx.request).catch(() => {});
 
     const newStartStr = newStart.toLocaleString('de-DE', {
       timeZone: 'Europe/Berlin',

--- a/website/src/lib/email.ts
+++ b/website/src/lib/email.ts
@@ -282,7 +282,7 @@ export async function sendBookingConfirmation(params: {
   name: string;
   start: Date;
   end: Date;
-}): Promise<boolean> {
+}, request?: Request): Promise<boolean> {
   const dateStr = formatDe(params.start);
   return sendEmail({
     to: params.to,
@@ -293,14 +293,14 @@ Ihr Termin am ${dateStr} ist bestätigt.
 
 Mit freundlichen Grüßen
 ${FROM_NAME}`,
-  });
+  }, request);
 }
 
 export async function sendCancellationNotification(params: {
   to: string;
   name: string;
   start: Date;
-}): Promise<boolean> {
+}, request?: Request): Promise<boolean> {
   const dateStr = formatDe(params.start);
   return sendEmail({
     to: params.to,
@@ -311,7 +311,7 @@ Ihr Termin am ${dateStr} wurde erfolgreich abgesagt.
 
 Mit freundlichen Grüßen
 ${FROM_NAME}`,
-  });
+  }, request);
 }
 
 export async function sendRescheduleNotification(params: {
@@ -319,7 +319,7 @@ export async function sendRescheduleNotification(params: {
   name: string;
   newStart: Date;
   newEnd: Date;
-}): Promise<boolean> {
+}, request?: Request): Promise<boolean> {
   const dateStr = formatDe(params.newStart);
   return sendEmail({
     to: params.to,
@@ -330,5 +330,5 @@ Ihr Termin wurde auf ${dateStr} verschoben.
 
 Mit freundlichen Grüßen
 ${FROM_NAME}`,
-  });
+  }, request);
 }

--- a/website/src/lib/tickets/admin.test.ts
+++ b/website/src/lib/tickets/admin.test.ts
@@ -430,7 +430,7 @@ describe('addComment', () => {
     expect(out).toEqual({ id: 12, emailSent: true });
     expect(sendPublicCommentEmail).toHaveBeenCalledWith({
       externalId: 'T1', reporterEmail: 'reporter@example.com', body: 'public reply',
-    });
+    }, undefined);
   });
 
   it('does not send an email for a public comment on a non-bug ticket type', async () => {
@@ -459,6 +459,7 @@ describe('addComment', () => {
     expect(out.emailSent).toBe(true);
     expect(sendPublicCommentEmail).toHaveBeenCalledWith(
       expect.objectContaining({ externalId: 'uuid-1' }),
+      undefined,
     );
   });
 });

--- a/website/src/lib/tickets/admin.ts
+++ b/website/src/lib/tickets/admin.ts
@@ -540,6 +540,7 @@ export async function addComment(p: {
   visibility: 'internal' | 'public';
   actor: { id?: string; label: string };
   kind?: 'comment' | 'status_change' | 'system';
+  request?: Request;
 }): Promise<{ id: number; emailSent: boolean }> {
   await initTicketsSchema();
   const guard = await pool.query<{ brand: string; reporter_email: string | null; external_id: string | null; type: string }>(
@@ -565,7 +566,7 @@ export async function addComment(p: {
       externalId: guard.rows[0].external_id ?? p.ticketId,
       reporterEmail: guard.rows[0].reporter_email,
       body: trimmed,
-    });
+    }, p.request);
   }
   return { id: r.rows[0].id, emailSent };
 }

--- a/website/src/lib/tickets/email-templates.ts
+++ b/website/src/lib/tickets/email-templates.ts
@@ -62,7 +62,7 @@ export async function sendPublicCommentEmail(p: {
   externalId: string;
   reporterEmail: string;
   body: string;
-}): Promise<boolean> {
+}, request?: Request): Promise<boolean> {
   const BRAND_NAME    = process.env.BRAND_NAME    ?? 'mentolder';
   const PROD_DOMAIN   = process.env.PROD_DOMAIN   ?? 'mentolder.de';
   const CONTACT_EMAIL = process.env.CONTACT_EMAIL ?? `info@${PROD_DOMAIN}`;
@@ -83,7 +83,7 @@ Antworten Sie einfach auf diese E-Mail, um zurückzuschreiben.
 
 Mit freundlichen Grüßen
 ${BRAND_NAME}`,
-    });
+    }, request);
     return true;
   } catch (err) {
     logger.error({ err }, '[sendPublicCommentEmail] failed');

--- a/website/src/lib/tickets/transition.ts
+++ b/website/src/lib/tickets/transition.ts
@@ -28,6 +28,7 @@ export interface TransitionParams {
   noteVisibility?: 'internal' | 'public';
   actor: { id?: string; label: string };
   prNumber?: number;
+  request?: Request;
 }
 
 export interface TransitionResult {
@@ -126,7 +127,7 @@ export async function transitionTicket(
         reporterEmail: after.reporter_email,
         resolution: after.resolution,
         note: p.noteVisibility === 'public' ? p.note : undefined,
-      });
+      }, p.request);
     }
 
     if (becomingDone) {

--- a/website/src/lib/website-core-db.ts
+++ b/website/src/lib/website-core-db.ts
@@ -196,7 +196,8 @@ async function ticketIdByExternal(externalId: string): Promise<string | null> {
 export async function resolveBugTicket(
   ticketId: string,
   resolutionNote: string,
-  actor: { id?: string; label: string } = { label: 'admin' }
+  actor: { id?: string; label: string } = { label: 'admin' },
+  request?: Request,
 ): Promise<void> {
   const id = await ticketIdByExternal(ticketId);
   if (!id) throw new Error(`bug ${ticketId} not found`);
@@ -204,6 +205,7 @@ export async function resolveBugTicket(
     status: 'done', resolution: 'fixed',
     note: resolutionNote, noteVisibility: 'public',
     actor,
+    request,
   });
 }
 

--- a/website/src/pages/api/admin/bugs/resolve.ts
+++ b/website/src/pages/api/admin/bugs/resolve.ts
@@ -48,7 +48,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
   }
 
   try {
-    await resolveBugTicket(ticketId, resolutionNote, { label: session.preferred_username });
+    await resolveBugTicket(ticketId, resolutionNote, { label: session.preferred_username }, request);
   } catch (err) {
     locals.requestLogger.error({ err }, '[bugs/resolve] DB error:');
     if (isJson) {

--- a/website/src/pages/api/admin/inbox/[id]/action.ts
+++ b/website/src/pages/api/admin/inbox/[id]/action.ts
@@ -216,7 +216,7 @@ export const POST: APIRoute = async ({ request, params , locals }) => {
         }
         const p = item.payload as { ticketId: string; reporterEmail: string; brand: string };
         await resolveBugTicket(p.ticketId, resolveNote,
-          { label: session.preferred_username });
+          { label: session.preferred_username }, request);
         // No manual sendEmail() here — transitionTicket() handles the close-mail.
         await updateInboxItemStatus(id, 'actioned', session.preferred_username);
         return new Response(JSON.stringify({ success: true }),

--- a/website/src/pages/api/admin/tickets/[id]/comments.ts
+++ b/website/src/pages/api/admin/tickets/[id]/comments.ts
@@ -29,6 +29,7 @@ export const POST: APIRoute = async ({ request, params }) => {
       body: text,
       visibility: body.visibility === 'public' ? 'public' : 'internal',
       actor: { label: session.preferred_username },
+      request,
     });
     return new Response(JSON.stringify({ ok: true, ...r }), {
       status: 200, headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/admin/tickets/[id]/transition.ts
+++ b/website/src/pages/api/admin/tickets/[id]/transition.ts
@@ -37,6 +37,7 @@ export const POST: APIRoute = async ({ request, params }) => {
       note:  typeof body.note  === 'string' ? body.note  : undefined,
       noteVisibility: body.noteVisibility === 'public' ? 'public' : 'internal',
       actor: { label: session.preferred_username },
+      request,
     });
     return new Response(JSON.stringify({ ok: true, result }), {
       status: 200, headers: { 'Content-Type': 'application/json' },

--- a/website/src/pages/api/assistant/execute.ts
+++ b/website/src/pages/api/assistant/execute.ts
@@ -22,7 +22,7 @@ export const POST: APIRoute = async ({ request , locals }) => {
   if (typeof actionId !== 'string' || !actionId) return json({ error: 'missing actionId' }, 400);
 
   try {
-    const result = await executeAction(actionId, { profile, userSub: session.sub, preferredUsername: session.preferred_username, payload: payload ?? {} });
+    const result = await executeAction(actionId, { profile, userSub: session.sub, preferredUsername: session.preferred_username, payload: payload ?? {}, request });
     return json({ result });
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'execute failed';


### PR DESCRIPTION
## Summary
- The `isE2ETestRequest()` guard in `email.ts` was bypassed in several code paths because the HTTP `request` object was not threaded through the call chain
- Affected paths: `sendPublicCommentEmail`, `transitionTicket` → `sendBugCloseEmail`, `resolveBugTicket`, and assistant actions (`bookSession`, `cancelSession`, `moveSession`)
- E2E tests (`fa-admin-tickets`, `fa-bugs-notifications`, `fa-fragebogen`) were missing the `X-E2E-Test` + `X-Cron-Secret` marker headers

## Changes

### Production code — thread `request` through all email call chains
- `email.ts`: `sendBookingConfirmation`, `sendCancellationNotification`, `sendRescheduleNotification` now accept optional `request`
- `email-templates.ts`: `sendPublicCommentEmail` now accepts optional `request` and passes it to `sendEmail`
- `admin.ts`: `addComment` accepts `request?` and forwards to `sendPublicCommentEmail`
- `transition.ts`: `TransitionParams.request?` forwarded to `sendBugCloseEmail`
- `website-core-db.ts`: `resolveBugTicket` accepts `request?` and forwards to `transitionTicket`
- `actions.ts`: `ActionContext.request?` added for assistant action handlers
- API route handlers (`comments.ts`, `transition.ts`, `bugs/resolve.ts`, `inbox/[id]/action.ts`, `assistant/execute.ts`) now pass `request` downstream
- Assistant handlers (`bookSession`, `cancelSession`, `moveSession`) pass `ctx.request` to email functions

### E2E tests — add marker headers to email-triggering API calls
- `fa-admin-tickets.spec.ts`: `e2eHeaders` on comment + transition POSTs
- `fa-bugs-notifications.spec.ts`: `e2eHeaders` on resolve POST
- `fa-fragebogen.spec.ts`: `e2eHeaders` on assign + submit POSTs

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 351 files, 2783 tests passed, 0 failures
- [x] Updated `admin.test.ts` assertions to expect the new `request` parameter