### PR TITLE
chore(docs): replace stale Keycloak references with Pocket ID across agent context [T002169]

### DIFF
--- a/.claude/agents/bachelorprojekt-db.md
+++ b/.claude/agents/bachelorprojekt-db.md
@@ -23,7 +23,7 @@ You are a database specialist for the Bachelorprojekt platform.
 
 ## Shared PostgreSQL instance
 - Service: `shared-db` (PostgreSQL 16)
-- Databases: `keycloak`, `nextcloud`, `vaultwarden`, `website`, `docuseal`
+- Databases: `pocket_id`, `nextcloud`, `vaultwarden`, `website`, `docuseal` (no `keycloak` DB — the platform migrated to Pocket ID, T002169)
 - Access: `task workspace:psql ENV=<env> -- <db>`
 - Port-forward to localhost:5432: `task workspace:port-forward ENV=<env>`
 

--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -31,7 +31,7 @@ You are an infrastructure specialist for the Bachelorprojekt Kubernetes platform
   - `fleet` alone — platform-level only (cert-manager, Traefik, sealed-secrets); overlay `prod-fleet/platform`.
 - Both brands at 26/26 pods. The standalone `mentolder` cluster was decommissioned; the standalone `korczewski` cluster was torn down earlier. The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for everything.
 - DNS for both `mentolder.de` and `korczewski.de` routes to the `fleet` cluster.
-- Each brand has its own `shared-db` instance, Keycloak realm, and SealedSecrets. Cross-cutting changes (DB password rotations, OIDC tweaks, schema migrations) must be applied to **both namespaces** explicitly (`workspace` and `workspace-korczewski`), via the `fleet` context.
+- Each brand has its own `shared-db` instance, Pocket ID instance, and SealedSecrets. Cross-cutting changes (DB password rotations, OIDC tweaks, schema migrations) must be applied to **both namespaces** explicitly (`workspace` and `workspace-korczewski`), via the `fleet` context.
 - Always use `WORKSPACE_NAMESPACE` env var; never hardcode `-n workspace`.
 - **Dev cluster:** `k3s-1` has been permanently **DECOMMISSIONED** (memory corruption 2026-05-31). Dev now runs via local k3d on the WSL host (Proxmox VM 10.0.0.26). Context `k3d-mentolder-dev`.
 

--- a/.claude/agents/bachelorprojekt-ops.md
+++ b/.claude/agents/bachelorprojekt-ops.md
@@ -41,7 +41,7 @@ Topology is fully consolidated ("Fleet Stage 3", complete as of 2026-05-31). The
 ## Key commands
 ```bash
 task workspace:status   ENV=<env>           # pod status, services, ingress, PVCs
-task workspace:logs     ENV=<env> -- <svc>  # tail logs (keycloak, nextcloud, website, etc.)
+task workspace:logs     ENV=<env> -- <svc>  # tail logs (pocket-id, nextcloud, website, etc.)
 task workspace:restart  ENV=<env> -- <svc>  # restart a specific service
 task livekit:status     ENV=<env>           # LiveKit pods + recording count
 task livekit:logs       ENV=<env>           # livekit-server logs

--- a/.claude/agents/bachelorprojekt-security.md
+++ b/.claude/agents/bachelorprojekt-security.md
@@ -1,9 +1,9 @@
 ---
 name: bachelorprojekt-security
 description: >
-  Use for SealedSecrets management, Keycloak realm configuration, OIDC setup, DSGVO
+  Use for SealedSecrets management, Pocket ID OIDC client configuration, OIDC setup, DSGVO
   compliance checks, and secret rotation in the Bachelorprojekt platform. Triggers on:
-  SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret.
+  SealedSecret, Pocket ID, OIDC client, DSGVO, credentials, rotate, certificate, secret.
 model: opus
 tools:
   - mcp_postgres_query
@@ -46,13 +46,27 @@ einzigen aktiven Prod-Dateien. Legacy-Dateien (`mentolder.yaml`, `korczewski.yam
 existieren nur als Referenz für den decommissionten Standalone-Cluster.
 Jeder neue Secret-Block muss in die fleet-Dateien (außer `legacy_only: true`).
 
-## Keycloak realm files
-- Dev: `k3d/realm-workspace-dev.json`
-- Prod mentolder: `prod-mentolder/realm-workspace-mentolder.json`
-- Prod korczewski (fleet cluster, ns `workspace-korczewski`): `prod-korczewski/realm-workspace-korczewski.json`
-- SSO consumers: Nextcloud, Vaultwarden, DocuSeal, Website, Claude Code (all OIDC via Keycloak). Note: Tracking pipeline was fully removed (PRs #788/#993) — Tracking is no longer an active SSO consumer.
+## Pocket ID OIDC clients
 
-> **Two brands, two of everything (Fleet Stage 3).** Both brands run on the unified `fleet` cluster (context `fleet`), each with its own SealedSecrets, Keycloak realm, and `shared-db` instance in its own namespace. Secret rotation and realm sync span both namespaces (`workspace` for mentolder, `workspace-korczewski` for korczewski) but always via `--context fleet`. The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for everything.
+**There are no realm JSON files.** The platform migrated from Keycloak to Pocket ID; no
+`realm-workspace-*.json` exists anymore, and no `quay.io/keycloak` image is referenced by any
+manifest. Anything describing realm exports is stale.
+
+- Provider: `k3d/pocket-id.yaml` (`ghcr.io/pocket-id/pocket-id`), own PostgreSQL instance.
+- Clients live in the DB (`pocket_id.oidc_clients`), provisioned by the `pocket-id-client-seed`
+  Job (`k3d/pocket-id-client-seed.yaml`) through the Pocket ID Admin REST API on **every**
+  `task workspace:deploy`. Hand-editing clients in the UI creates drift the next deploy
+  overwrites.
+- Secret write-back: generated client secrets go into `workspace-secrets`. The **website** client
+  additionally needs `website-secrets` in the `website` namespace (cross-namespace, T001435) —
+  RBAC for that is in `k3d/pocket-id-client-seed-website-rbac.yaml`.
+- SSO consumers (~20 seeded clients): website, nextcloud, vaultwarden, brett, docs, downloads,
+  grafana, mediaviewer, studio, videovault, brain, brainstorm, comfy, terminal, traefik, mail,
+  rustdesk-web, session-hub, recovery, claude-code. Services without native OIDC sit behind an
+  `oauth2-proxy` gate instead of talking to the provider directly. Note: the Tracking pipeline
+  was fully removed (PRs #788/#993) — Tracking is no longer an active SSO consumer.
+
+> **Two brands, two of everything (Fleet Stage 3).** Both brands run on the unified `fleet` cluster (context `fleet`), each with its own SealedSecrets, Pocket ID instance, and `shared-db` in its own namespace. Secret rotation and OIDC-client seeding span both namespaces (`workspace` for mentolder, `workspace-korczewski` for korczewski) but always via `--context fleet`. The old `mentolder` and `korczewski` kubeconfig contexts are DEAD — use `fleet` for everything.
 
 ## DSGVO compliance
 ```bash

--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -98,7 +98,7 @@ unabhängiger Beweis ist. Stufen 3+4 prüfen andere Dimensionen (Review-Qualitä
 |---|---|---|
 | [`website-specialist`](website-specialist/SKILL.md) | Astro/Svelte frontend development, component creation, page routing, content management, UI implementation. Dispatched as subagent via `bachelorprojekt-website`. |
 | [`host-node-networking`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/host-node-networking.html) | Host server provisioning (Hetzner, cloud-init, Rescue Mode resets), WireGuard mesh network topology ("netplan"), host UFW firewall ports, LiveKit WebRTC networking, and WSL OpenClaw local gateway setup. |
-| [`cluster-deployment`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/cluster-deployment.html) | Stand up a brand-new Kubernetes environment, deploy resources, diagnose cluster degraded state (gap analysis), or operate the dev.mentolder.de stack. Also covers cross-brand fleet operations: `task feature:*` fan-out, `feature:promote` smoke gate, SealedSecrets/Keycloak per-brand independence (Phase 5). |
+| [`cluster-deployment`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/cluster-deployment.html) | Stand up a brand-new Kubernetes environment, deploy resources, diagnose cluster degraded state (gap analysis), or operate the dev.mentolder.de stack. Also covers cross-brand fleet operations: `task feature:*` fan-out, `feature:promote` smoke gate, SealedSecrets/Pocket-ID per-brand independence (Phase 5). |
 | [`gitops-cluster-debug`](gitops-cluster-debug/SKILL.md), [`gitops-knowledge`](gitops-knowledge/SKILL.md), [`gitops-repo-audit`](gitops-repo-audit/SKILL.md) | Flux CD GitOps — debug live clusters, generate manifests, audit repos. Dispatched as subagents. |
 
 ---
@@ -108,8 +108,7 @@ unabhängiger Beweis ist. Stufen 3+4 prüfen andere Dimensionen (Review-Qualitä
 | Skill | When to use |
 |---|---|
 | [`secret-rotation`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/secret-rotation.html) | Rotate DB passwords, API keys, SealedSecrets keypair (post-reset), Claude Code tokens, or service credentials across both brands on the fleet cluster. |
-| [`keycloak-realm-sync`](https://github.com/Paddione/Bachelorprojekt/blob/main/k3d/docs-content-built/skills/keycloak-realm-sync.html) | Reconcile Keycloak realm JSON → push OIDC client changes, group mappings, mappers, SSO login fixes. |
-| [`security-specialist`](security-specialist/SKILL.md) | SealedSecrets lifecycle, Keycloak realm config, OIDC setup, DSGVO compliance, credential management. Dispatched as subagent via `bachelorprojekt-security`. |
+| [`security-specialist`](security-specialist/SKILL.md) | SealedSecrets lifecycle, Pocket ID OIDC client config, OIDC setup, DSGVO compliance, credential management. Dispatched as subagent via `bachelorprojekt-security`. |
 
 ---
 
@@ -220,7 +219,7 @@ graph TD
 | Cluster aufsetzen / Workspace deployen | `infra-ops` §1–2 | Produktions-Cluster + alle Services |
 | DB-Migration / Backup | `infra-ops` §7 + `dev-flow-execute` (Schema-Change) | Gemergte Migration |
 | Secret rotieren | `infra-ops` §6 | Rotierte Secrets |
-| Keycloak / SSO | `infra-ops` §4 | Reconcilter Realm |
+| Pocket ID / SSO | `infra-ops` §4 | Re-seed OIDC clients |
 | LLM / GPU | `infra-ops` §5 | GPU-Pipeline operativ |
 | Abhängigkeiten updaten | Biweekly Cloud-Routine (auto) | Aktualisierte Packages per PR |
 

--- a/.claude/skills/database-specialist/SKILL.md
+++ b/.claude/skills/database-specialist/SKILL.md
@@ -33,7 +33,7 @@ task workspace:psql ENV=<env> -- <database>
 task workspace:port-forward ENV=<env>
 
 # Schema introspection
-task workspace:psql ENV=mentolder -- keycloak -c "\d+"
+task workspace:psql ENV=mentolder -- pocket_id -c "\d+"
 ```
 
 ## Tracking schema (legacy)
@@ -55,8 +55,8 @@ task workspace:db:restore -- all <timestamp>          # restore all DBs from one
 2. Review with `EXPLAIN ANALYZE <query>` for performance impact
 3. Apply to both namespaces:
    ```bash
-   task workspace:psql ENV=mentolder -- keycloak -f scripts/db/migrations/XX-something.sql
-   task workspace:psql ENV=korczewski -- keycloak -f scripts/db/migrations/XX-something.sql
+   task workspace:psql ENV=mentolder -- pocket_id -f scripts/db/migrations/XX-something.sql
+   task workspace:psql ENV=korczewski -- pocket_id -f scripts/db/migrations/XX-something.sql
    ```
 
 ## Password drift warning
@@ -68,13 +68,13 @@ ALTER ROLE <username> PASSWORD '<new_password>';
 ## Performance troubleshooting
 ```bash
 # Find slow queries in pg_stat_statements
-task workspace:psql ENV=mentolder -- keycloak -c "SELECT query, calls, total_exec_time FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;"
+task workspace:psql ENV=mentolder -- pocket_id -c "SELECT query, calls, total_exec_time FROM pg_stat_statements ORDER BY total_exec_time DESC LIMIT 10;"
 
 # Explain plan for specific query
 EXPLAIN ANALYZE SELECT * FROM features WHERE id = $1;
 
 # Vacuum and analyze
-VACUUM ANALYZE keycloak;
+VACUUM ANALYZE oidc_clients;
 ```
 
 ## Autonomous operation

--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -73,7 +73,7 @@ BASE_URL="https://web.mentolder.de"   # anpassen falls nötig
 ### Credentials: korczewski-Projekt
 
 Das `korczewski`-Projekt verwendet einen dedizierten `test-admin`-User auf dem
-Korczewski-Keycloak. Das Passwort ist in `environments/.secrets/korczewski.yaml`
+Korczewski-Pocket-ID. Das Passwort ist in `environments/.secrets/korczewski.yaml`
 unter dem Key `E2E_TEST_ADMIN_PASSWORD` gespeichert. Siehe details in [dev-flow-gotchas](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-gotchas.md).
 
 ---

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -67,7 +67,7 @@ nicht kosmetisch Zeilen zusammenziehen.
 
 - **Header ≤ 100 Zeichen** (commitlint-Regel)
 - `type`: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`, `ci`
-- `scope`: betroffenes Modul / Verzeichnis (z. B. `website`, `k3d`, `scripts`, `keycloak`)
+- `scope`: betroffenes Modul / Verzeichnis (z. B. `website`, `k3d`, `scripts`, `pocket-id`)
 - `TICKET_EXT_ID`: z. B. `T001026` — **immer anhängen** wenn ein Ticket existiert
 - Body-Zeilen ebenfalls < 100 Zeichen
 
@@ -75,7 +75,7 @@ Beispiele:
 
 ```
 feat(website): add React mentolder rebuild [T001026]
-fix(keycloak): rotate stale oauth2-proxy secret [T000950]
+fix(pocket-id): rotate stale oauth2-proxy secret [T000950]
 chore(k3d): bump TEI embed port 9081 [T000978]
 ```
 

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -29,7 +29,7 @@ die `psql -c`-Aufrufe unten setzen diesen Helper voraus.
 ## Step 1 — Scope the Incident (< 2 min)
 
 Determine:
-1. **Affected Service:** Keycloak, Nextcloud, Website, Brett, Arena, Vaultwarden, Docs, LiveKit, or Shared-DB.
+1. **Affected Service:** Pocket ID, Nextcloud, Website, Brett, Arena, Vaultwarden, Docs, LiveKit, or Shared-DB.
 2. **Target Cluster:** `mentolder` brand (fleet cluster), `korczewski` brand (fleet cluster), or both.
 3. **Onset Time:** Since when has it been failing? Check git log or deployment status.
 4. **Blast Radius:** All users or a subset of features?

--- a/.claude/skills/infra-ops/SKILL.md
+++ b/.claude/skills/infra-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: infra-ops
-description: Explicit-invoke-only infrastructure runbook. DO NOT auto-trigger. Use when the user asks about: cluster setup or reset, workspace deploy, host node networking (Hetzner/WireGuard/UFW/LiveKit), Keycloak/SSO/OIDC realm sync, LLM pipeline and GPU host, secret/SealedSecret rotation, or database migrations and backup/restore.
+description: Explicit-invoke-only infrastructure runbook. DO NOT auto-trigger. Use when the user asks about: cluster setup or reset, workspace deploy, host node networking (Hetzner/WireGuard/UFW/LiveKit), Pocket ID/SSO/OIDC client seeding, LLM pipeline and GPU host, secret/SealedSecret rotation, or database migrations and backup/restore.
 agent: bachelorprojekt-infra
 ---
 
@@ -16,7 +16,7 @@ Sieben frühere Einzel-Skills sind hier konsolidiert. Nur bei explizitem Bedarf 
 | Neuen Cluster aufsetzen / Environment deployen | [§1 Cluster Deployment](#1--cluster-deployment) |
 | Workspace-Platform deployen (alle Services) | [§2 Workspace Deploy](#2--workspace-deploy) |
 | Host-Netzwerk, WireGuard, UFW, LiveKit, OpenClaw | [§3 Host Node Networking](#3--host-node-networking) |
-| Keycloak / SSO / OIDC Realm konfigurieren | [§4 Keycloak Realm Sync](#4--keycloak-realm-sync) |
+| Pocket ID / SSO / OIDC-Clients konfigurieren | [§4 Pocket ID OIDC Client Seeding](#4--pocket-id-oidc-client-seeding) |
 | LLM-Pipeline / GPU-Host / Embeddings | [§5 LLM Ops](#5--llm-ops) |
 | Secrets rotieren / SealedSecrets | [§6 Secret Rotation](#6--secret-rotation) |
 | DB-Migrationen / Backup / Restore | [§7 Database Ops](#7--database-ops) |
@@ -140,7 +140,7 @@ task workspace:post-setup ENV=<env>
 | Symptom | Fix |
 |---------|-----|
 | `user_oidc` not configured | `task workspace:post-setup ENV=<env>` nochmal |
-| OIDC login loop | `task keycloak:sync ENV=<env>` dann post-setup |
+| OIDC login loop | Seed-Job neu ausführen (§4 Phase 3), dann post-setup |
 ### Phase 3 — `workspace:talk-setup`
 Konfiguriert Talk-HPB-Signaling und CoTURN-Credentials.
 ```bash
@@ -156,14 +156,14 @@ task workspace:transcriber-setup ENV=<env>
 ```
 ### Phase 6 — Optional Provisioning
 ```bash
-task workspace:admin-users-setup ENV=<env>    # SSO-Admin-User in Keycloak
+task workspace:admin-users-setup ENV=<env>    # ⚠️ T002171: Skript nutzt noch KC_*-Variablen (Keycloak) — kann so nicht funktionieren
 task workspace:vaultwarden:seed ENV=<env>      # Secret-Templates
 task workspace:vaultwarden:seed-logs ENV=<env> # Logs prüfen
 ```
 ### Service Inventory
 | Service | Ingress | Deployed by |
 |---------|---------|-------------|
-| Keycloak | `auth.<domain>` | `workspace:deploy` |
+| Pocket ID | `auth.<domain>` | `workspace:deploy` |
 | Nextcloud | `files.<domain>` | `workspace:deploy` |
 | Vaultwarden | `vault.<domain>` | `workspace:deploy` |
 | DocuSeal | `sign.<domain>` | `workspace:deploy` |
@@ -220,47 +220,55 @@ task livekit:dns-pin ENV=mentolder APPLY=true
 | LiveKit ICE fails / Audio muted | DNS nicht auf pin-node; Chrome braucht User-Gesture |
 | OpenClaw 503 | Ollama auf `10.10.0.3` prüfen; WireGuard-Tunnel aktiv? |
 
-## §4 — Keycloak Realm Sync
+## §4 — Pocket ID OIDC Client Seeding
 
-Keycloak-Realm aus JSON reconcilen — OIDC-Clients, Gruppen, Mapper, SSO-Login-Fehler.
-### Realm JSON Locations
-| Env | File | Quelle |
-|-----|------|--------|
-| dev | `k3d/realm-workspace-dev.json` | ConfigMap `realm-template` |
-| prod base | `prod/realm-workspace-prod.json` | **Live SoT** — Pocket-ID OIDC via `pocket-id-client-seed` Job |
-| mentolder | `prod-mentolder/realm-workspace-mentolder.json` | `register-oidc-client.mjs` only |
-| korczewski | `prod-korczewski/realm-workspace-korczewski.json` | `register-oidc-client.mjs` only |
-> **Nie** Realm-State direkt im Keycloak-Admin-UI ändern ohne das JSON zu updaten — Sync überschreibt UI-Änderungen.
+OIDC-Clients reconcilen — Redirect-URIs, Client-Secrets, SSO-Login-Fehler.
+
+> **Es gibt keine Realm-JSONs und keinen `task keycloak:sync`** (T002169). Die Plattform ist von
+> Keycloak auf **Pocket ID** migriert: kein `realm-workspace-*.json` existiert mehr, und kein
+> `quay.io/keycloak`-Image wird von einem Manifest referenziert. Wer nach Realm-Dateien sucht oder
+> `task keycloak:sync` aufruft, läuft ins Leere.
+
+### Wo der Client-State lebt
+| Ebene | Ort |
+|-------|-----|
+| Provider | `k3d/pocket-id.yaml` (`ghcr.io/pocket-id/pocket-id`), eigene Postgres-Instanz |
+| Client-State | **DB** `pocket_id.oidc_clients` — keine Datei, kein Git-Artefakt |
+| Provisionierung | Job `pocket-id-client-seed` (`k3d/pocket-id-client-seed.yaml`) via Pocket-ID Admin REST API, läuft bei **jedem** `task workspace:deploy` |
+| Secret-Rückschreibung | `workspace-secrets`; der **website**-Client zusätzlich in `website-secrets` (andere Namespace, T001435 — RBAC: `k3d/pocket-id-client-seed-website-rbac.yaml`) |
+
+> **Nie** Clients direkt im Pocket-ID-Admin-UI anlegen/ändern — der nächste Deploy-Seed
+> überschreibt UI-Änderungen. Änderungen gehören in den Seed-Job.
+
 ### Phases
-> **Status-Reads MCP-first:** Pod-Status/Logs bevorzugt über `mcp__mcp-kubernetes__pods_list_in_namespace({ namespace: "workspace" })` / `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<keycloak-pod>" })` (read-only); die `task workspace:status`/`logs`-Aufrufe unten sind der Fallback. Mutations (`task secrets:sync`, `register-oidc-client.mjs`, deploys) bleiben unverändert.
+> **Status-Reads MCP-first:** Pod-Status/Logs bevorzugt über `mcp__mcp-kubernetes__pods_list_in_namespace({ namespace: "workspace" })` / `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<pocket-id-pod>" })` (read-only); die `task workspace:status`/`logs`-Aufrufe unten sind der Fallback. Mutations (`task secrets:sync`, deploys) bleiben unverändert.
 ```bash
-# Phase 1: Pre-sync check (Fallback — siehe MCP-first oben)
-task workspace:status ENV=<env>  # keycloak pod: 1/1 Running?
-task workspace:logs ENV=<env> -- keycloak
+# Phase 1: Pre-check (Fallback — siehe MCP-first oben)
+task workspace:status ENV=<env>  # pocket-id pod: 1/1 Running?
+task workspace:logs ENV=<env> -- pocket-id
 
-# Phase 2: Realm-JSON editieren (falls nötig)
-# Dann validieren:
-python3 -c "import json; json.load(open('prod/realm-workspace-prod.json'))" && echo "valid"
+# Phase 2: Seed-Job-Definition anpassen (falls Client-Config sich ändert)
+#   k3d/pocket-id-client-seed.yaml — Clients, Redirect-URIs, Secret-Keys
 
-# Phase 3: OIDC-Client-Seed (Pocket-ID)
-# Der pocket-id-client-seed Job wird beim workspace:deploy ausgeführt.
-# Manuelles Neustarten bei Änderungen an den OIDC-Client-Konfigurationen:
+# Phase 3: Seed neu ausführen
+# Der Job hat einen stabilen Namen und wird beim Deploy angelegt; zum Erzwingen löschen:
 kubectl --context fleet -n workspace delete job pocket-id-client-seed --ignore-not-found=true
 kubectl --context fleet -n workspace-korczewski delete job pocket-id-client-seed --ignore-not-found=true
+# danach: task workspace:deploy ENV=<brand>
 
-# Phase 4: OIDC Clients verifizieren (Pocket-ID Admin UI):
-# id.<domain>/admin → Applications → redirect URIs prüfen
+# Phase 4: Clients verifizieren (Pocket-ID Admin UI):
+# auth.<domain>/admin → Applications → Redirect-URIs prüfen
 
 # Phase 5: SSO-Flow testen (Browser, Inkognito)
 ```
 ### Troubleshooting
 | Error | Fix |
 |-------|-----|
-| `401 Unauthorized` | Admin-Credentials prüfen, Keycloak warten |
-| `409 Conflict` | Client existiert bereits — Script auf update prüfen |
-| Website login loop | `webOrigins` in `website`-Client prüfen |
+| `401 Unauthorized` | `POCKET_ID_API_KEY` in `workspace-secrets` prüfen; pocket-id-Pod ready? |
+| `409 Conflict` | Client existiert bereits — Seed-Skript muss auf update gehen, nicht create |
+| Website login loop | Redirect-URIs des `website`-Clients prüfen |
 | Nextcloud OIDC error | Client-Secret re-seal + redeploy; `secret-rotation` Skill |
-| "Invalid client secret" | `secret-rotation` Skill — Secrets neu alignen |
+| "Invalid client secret" | Klassiker (T001327): Seed generierte ein neues Secret, die App liest den alten Wert aus dem k8s-Secret → `secret-rotation` Skill, Secrets neu alignen |
 
 ## §5 — LLM Ops
 
@@ -367,11 +375,11 @@ task workspace:deploy ENV=mentolder && task workspace:deploy ENV=korczewski
 ### Verification
 Status-Reads — **MCP-first** (`mcp-kubernetes`, read-only):
 > `mcp__mcp-kubernetes__pods_list_in_namespace({ namespace: "workspace" })` — alle Pods 1/1 Running?
-> `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<keycloak|nextcloud|website>-pod" })`
+> `mcp__mcp-kubernetes__pods_log({ namespace: "workspace", name: "<pocket-id|nextcloud|website>-pod" })`
 Fallback (mcp-kubernetes nicht erreichbar):
 ```bash
 task workspace:status ENV=<env>
-task workspace:logs ENV=<env> -- keycloak
+task workspace:logs ENV=<env> -- pocket-id
 task workspace:logs ENV=<env> -- nextcloud
 task workspace:logs ENV=<env> -- website
 ```
@@ -467,7 +475,7 @@ Nach Abschluss aller Schritte `mishap-tracker` mit dem akkumulierten `MISHAP_LOG
 Diese Skills sind in `infra-ops` aufgegangen. Ihre Verzeichnisse und Referenz-Dateien bleiben erhalten:
 - `.claude/skills/cluster-deployment/` — Hetzner + Proxmox provisioning references
 - `.claude/skills/host-node-networking/` — WireGuard + OpenClaw references
-- `.claude/skills/keycloak-realm-sync/`
+- `k3d/pocket-id-client-seed.yaml` (Seed-Job; es gibt kein `keycloak-realm-sync`-Skill mehr)
 - `.claude/skills/llm-ops/`
 - `.claude/skills/secret-rotation/`
 - `.claude/skills/workspace-deploy/`

--- a/.claude/skills/operations-management/SKILL.md
+++ b/.claude/skills/operations-management/SKILL.md
@@ -25,7 +25,7 @@ Is a core service DOWN or DEGRADED right now?
 
 | Situation | Skill |
 |-----------|-------|
-| Keycloak/Nextcloud/Website/Brett/LiveKit/DB is down or crashing | `incident-response` |
+| Pocket ID/Nextcloud/Website/Brett/LiveKit/DB is down or crashing | `incident-response` |
 | Triage open tickets, mark AI-fixable or needs-human | `ticket-ops` |
 | Clean up stale worktrees and branches | `ticket-ops` |
 | Review & merge open PRs, close linked tickets | `ticket-ops` |

--- a/.claude/skills/security-specialist/SKILL.md
+++ b/.claude/skills/security-specialist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-specialist
-description: Use for SealedSecrets lifecycle, key generation/rotation, Keycloak realm configuration, OIDC setup, SSO integration testing, DSGVO compliance checks, and credential management in the Bachelorprojekt platform. Triggers on: sealed-secret generate rotate, keycloak realm create update, OIDC configure test, DSGVO audit, password rotation, certificate renewal.
+description: Use for SealedSecrets lifecycle, key generation/rotation, Pocket ID OIDC client configuration, OIDC setup, SSO integration testing, DSGVO compliance checks, and credential management in the Bachelorprojekt platform. Triggers on: sealed-secret generate rotate, pocket-id oidc client create update, OIDC configure test, DSGVO audit, password rotation, certificate renewal.
 agent: bachelorprojekt-security
 category: devflow
 ---
@@ -36,14 +36,22 @@ The unified **`fleet`** context serves both brands:
 - **mentolder brand**: namespace `workspace`, ENV `mentolder`
 - **korczewski brand**: namespace `workspace-korczewski`, ENV `korczewski`
 
-Each brand has its own SealedSecrets, Keycloak realm, and shared-db instance. Legacy standalone clusters (mentolder/korczewski contexts) are DECOMMISSIONED — use `fleet` for everything.
+Each brand has its own SealedSecrets, Pocket ID instance, and shared-db instance. Legacy standalone clusters (mentolder/korczewski contexts) are DECOMMISSIONED — use `fleet` for everything.
 
-## Keycloak realm files
-- Dev: `k3d/realm-workspace-dev.json`
-- Prod mentolder: `prod-mentolder/realm-workspace-mentolder.json`
-- Prod korczewski: `prod-korczewski/realm-workspace-korczewski.json`
+## Pocket ID OIDC clients
 
-All OIDC consumers (Nextcloud, Vaultwarden, DocuSeal, Website, Claude Code) authenticate via Keycloak. Tracking pipeline was removed (PRs #788/#993).
+**No realm JSON files exist** — the platform migrated from Keycloak to Pocket ID (T002169). Client
+state lives in the DB `pocket_id.oidc_clients` and is provisioned by the `pocket-id-client-seed`
+Job (`k3d/pocket-id-client-seed.yaml`) through the Pocket ID Admin REST API on every
+`task workspace:deploy`. Provider manifest: `k3d/pocket-id.yaml`, reachable at `auth.<domain>`.
+
+Client secrets are written back into `workspace-secrets`; the **website** client additionally into
+`website-secrets` in the `website` namespace (cross-namespace, T001435). Hand-editing clients in the
+Admin UI drifts and is overwritten by the next deploy.
+
+All OIDC consumers — around 20 seeded clients including Nextcloud, Vaultwarden, DocuSeal, Website,
+Brett, Grafana, Studio, Videovault and Claude Code — authenticate via Pocket ID; services without
+native OIDC sit behind an `oauth2-proxy` gate. Tracking pipeline was removed (PRs #788/#993).
 
 ## DSGVO compliance
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ The following sections contain detailed reference material. **Do not load them i
 | k3d/, prod*/, manifest, kustomize, overlay, Taskfile, ENV=, environments/, deploy, workspace:setup | `bachelorprojekt-infra` |
 | test, FA-*, SA-*, NFA-*, AK-*, BATS, Playwright, runner.sh, "test failing", "test case", "write a test", factory:, autopilot, FA-SF | `bachelorprojekt-test` |
 | database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline, bachelorprojekt.features, v_timeline | `bachelorprojekt-db` |
-| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` |
+| SealedSecret, Pocket ID, OIDC client, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` |
 
 Dispatch: `bash scripts/plan-context.sh <role> --with-openspec` → prepend as `<active-plans>`.
 </details>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Before responding to any request, check these signals and delegate to the named 
 | `k3d/`, `prod*/`, manifest, kustomize, overlay, Taskfile, `ENV=`, `environments/`, deploy, `workspace:setup` | `bachelorprojekt-infra` | `mcp-kubernetes` (localhost:18080) — nur Status-Checks (Claude-Code-only) |
 | test, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, `FA-SF`, BATS, Playwright, `runner.sh`, "test failing", "test case", "write a test", `factory:`, autopilot | `bachelorprojekt-test` | `mcp-postgres` (localhost:13001) — Ticket-Queries |
 | database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline, `bachelorprojekt.features`, `v_timeline` | `bachelorprojekt-db` | `mcp-postgres` (localhost:13001) |
-| SealedSecret, Keycloak realm, OIDC, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` | — |
+| SealedSecret, Pocket ID, OIDC client, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` | — |
 
 > **MCP-Server names in this table refer to Claude-Code-only SSE servers** configured in `.claude/skills/references/mcp-tool-guide.md`. The opencode runtime registers its MCP servers in `.opencode/opencode.jsonc`: `mcp-kubernetes`, `mcp-postgres`, `factory-mcp`, `codebase-memory-mcp`, `mcp-task-runner`, `ticket-mcp`, `task-master-ai`, `github-mcp`, `playwright`, `sequential-thinking`, `webresearch`, `docfork` (same `mcp-kubernetes` name as the table; `factory-mcp` is the HTTP factory server on `:13003`). If you are running in opencode, see the `MCP-Schnellweg` block below and the opencode config, not the table above.
 
@@ -66,7 +66,7 @@ Ein Ticket wird bei **grünem Auto-Merge nach `main` direkt geschlossen** (`done
 
 ## Project Overview
 
-**Workspace MVP** -- a Kubernetes-based self-hosted collaboration platform for small teams (bachelor thesis). Integrates a custom messaging system (chat, built into the Astro website), Nextcloud (files + video via Talk), Keycloak (SSO/OIDC), Collabora (office suite), Claude Code (AI), Vaultwarden (passwords), and supporting services. All data stays on-premises (DSGVO/GDPR by design).
+**Workspace MVP** -- a Kubernetes-based self-hosted collaboration platform for small teams (bachelor thesis). Integrates a custom messaging system (chat, built into the Astro website), Nextcloud (files + video via Talk), Pocket ID (SSO/OIDC), Collabora (office suite), Claude Code (AI), Vaultwarden (passwords), and supporting services. All data stays on-premises (DSGVO/GDPR by design).
 
 Prerequisites: Docker, k3d, kubectl, `task` (go-task).
 
@@ -98,7 +98,7 @@ Routes to local Ollama (at `localhost:11434`) → Opencode/OpenClaw `task-runner
 
 All services run as Kubernetes Deployments in the `workspace` namespace, fronted by Traefik (built-in k3s ingress). There is no docker-compose.
 
-Services: Traefik → Keycloak (OIDC), Nextcloud+Talk, Collabora, Talk-HPB+coturn+Janus, Vaultwarden, Whiteboard, Brett, Mailpit, Docs (oauth2-proxy), DocuSeal, Tracking, LiveKit+Ingress+Egress, Website (separate `website` ns). All except Website share `workspace` ns. Shared PostgreSQL 16 (`shared-db`). Keycloak provides SSO for Nextcloud, Vaultwarden, DocuSeal, Tracking, Website, Claude Code.
+Services: Traefik → Pocket ID (OIDC), Nextcloud+Talk, Collabora, Talk-HPB+coturn+Janus, Vaultwarden, Whiteboard, Brett, Mailpit, Docs (oauth2-proxy), DocuSeal, Tracking, LiveKit+Ingress+Egress, Website (separate `website` ns). All except Website share `workspace` ns. Shared PostgreSQL 16 (`shared-db`). Pocket ID provides SSO for Nextcloud, Vaultwarden, DocuSeal, Tracking, Website, Claude Code and the oauth2-proxy-gated services.
 
 ### Cluster Topology & Nodes (Fleet Stage 3 — FULLY CONSOLIDATED 2026-05-31)
 - **mentolder (BRAND)**: DNS for `mentolder.de` routes to the **`fleet`** cluster (pk-hetzner-4/6/8 IPs: 204.168.244.104/37.27.251.38/62.238.23.79). The mentolder-standalone cluster has been **DECOMMISSIONED** — all k3s software uninstalled from gekko-hetzner-2/3/4; those nodes joined fleet as workers. Use `ENV=mentolder` or `ENV=fleet-mentolder` (aliases) with context `fleet`, namespace `workspace`. Both the old `mentolder` and `korczewski` kubeconfig contexts are **DEAD**. `k3s-1` has been permanently **DECOMMISSIONED** (memory corruption 2026-05-31). Local development runs via k3d on the WSL host (context: `k3d-mentolder-dev`).
@@ -129,9 +129,9 @@ Services: Traefik → Keycloak (OIDC), Nextcloud+Talk, Collabora, Talk-HPB+cotur
 - **Per-env config**: `PROD_DOMAIN`, `BRAND_NAME`, `CONTACT_EMAIL`, `ENV_CONTEXT`, `ENV_OVERLAY`, SMTP, etc. live in `environments/<env>.yaml`. `scripts/env-resolve.sh` exports them; tasks then `envsubst` them into manifests.
 - **Prod secrets**: plaintext in `environments/.secrets/<env>.yaml` (git-crypt-encrypted at-rest, tracked) → `task env:seal ENV=<env>` → committed SealedSecret in `environments/sealed-secrets/<env>.yaml`. `workspace:deploy` applies the SealedSecret before manifests.
 - **Dev secrets**: `k3d/secrets.yaml` (dev values only — never commit real credentials). The `prod/` overlay strips this via `$patch: delete` so sealed secrets survive.
-- **Keycloak realm**: dev uses `k3d/realm-workspace-dev.json`; each prod overlay provides its own `realm-workspace-<env>.json`.
-- **Nextcloud OIDC**: `k3d/nextcloud-oidc-dev.php` (dev) / `prod/nextcloud-oidc-prod.php` (prod), both loaded as ConfigMap.
-- **SSO flow**: Keycloak is the OIDC provider; Nextcloud, Vaultwarden, DocuSeal, Tracking, the website, and Claude Code all authenticate through it.
+- **Pocket ID OIDC clients**: there are **no realm JSON files** — Pocket ID keeps its clients in its own PostgreSQL database (`pocket_id.oidc_clients`). They are provisioned by the `pocket-id-client-seed` Job (`k3d/pocket-id-client-seed.yaml`) via the Pocket ID Admin REST API on every `task workspace:deploy`. Client secrets are written back into `workspace-secrets` (and, for the website client only, additionally into `website-secrets` in the `website` namespace — see `k3d/pocket-id-client-seed-website-rbac.yaml`). Editing clients by hand in the UI causes drift the next deploy will overwrite.
+- **Nextcloud OIDC**: `k3d/nextcloud-oidc-dev.php` (dev) / `prod/nextcloud-oidc-prod.php` (prod), both loaded as ConfigMap. They point at Pocket ID (`oidc_login_provider_url` → `http://pocket-id:1411` in dev).
+- **SSO flow**: **Pocket ID** (`ghcr.io/pocket-id/pocket-id`, `k3d/pocket-id.yaml`) is the OIDC provider. Around 20 clients are seeded, including website, nextcloud, vaultwarden, brett, docs, downloads, grafana, mediaviewer, studio, videovault, brain, comfy, terminal, traefik, mail, rustdesk-web, session-hub and claude-code. Services without native OIDC sit behind an `oauth2-proxy` gate (20 manifests reference it) rather than talking to the provider directly.
 
 ## CI/CD
 


### PR DESCRIPTION
The platform migrated from Keycloak to Pocket ID, but the context **every agent loads at session start** still described Keycloak as a live component — including configuration files that do not exist.

## Verified absent before rewriting anything

| Claim in the docs | Reality |
|---|---|
| `k3d/realm-workspace-dev.json`, `prod-*/realm-workspace-*.json` | **no such files** |
| Keycloak container | **no `quay.io/keycloak` image** in any `k3d/` or `prod*/` manifest |
| `keycloak` database (in `bachelorprojekt-db.md`) | only `pocket_id` is created (`k3d/pocket-id.yaml`) |
| `task keycloak:sync` (infra-ops §4 told agents to run it) | **not in the Taskfile** |
| `.claude/skills/keycloak-realm-sync/` (OVERVIEW.md linked it) | **no such directory** — only a stale HTML artifact under `k3d/docs-content-built/` |

## Why this was not cosmetic

During T002165 the stale docs nearly caused the Keycloak `packageRule` in `renovate.json5` to be **migrated forward** instead of deleted — a rule for a component that no longer exists. Only an explicit correction from Patrick mid-turn prevented it.

The failure mode is general: an agent asked to "configure OIDC" would search for realm JSONs, find nothing, and model Keycloak concepts (realm exports, group mappers) onto a system that keeps its OIDC clients in a database. `infra-ops` §4 actively instructed it to run a task that does not exist.

## The actual architecture, as documented now

Every claim below was checked against the repo:

- **Provider**: `k3d/pocket-id.yaml` (`ghcr.io/pocket-id/pocket-id`), serving `auth.<domain>` — Pocket ID took over Keycloak's domain slot (`configmap-domains.yaml`: `POCKET_ID_DOMAIN: "auth.localhost"`, commented *"was Keycloak's slot"*). My first draft wrongly wrote `id.<domain>`; corrected after checking.
- **Client state**: the database `pocket_id.oidc_clients` — no file, no git artifact.
- **Provisioning**: the `pocket-id-client-seed` Job via the Pocket ID Admin REST API on *every* `task workspace:deploy`. Hand-editing in the Admin UI drifts and gets overwritten.
- **Secret write-back**: `workspace-secrets`, plus `website-secrets` cross-namespace for the website client (T001435, RBAC in `pocket-id-client-seed-website-rbac.yaml`).
- **~20 seeded clients**: website, nextcloud, vaultwarden, brett, docs, downloads, grafana, mediaviewer, studio, videovault, brain, brainstorm, comfy, terminal, traefik, mail, rustdesk-web, session-hub, recovery, claude-code. Services without native OIDC sit behind an `oauth2-proxy` gate.

## Files

`CLAUDE.md` (5 spots: Project Overview, Architecture, Configuration patterns, SSO flow, routing signals) · `AGENTS.md` (routing signals) · four `bachelorprojekt-*` agents · skills `OVERVIEW`, `infra-ops` (§4 rewritten end to end), `security-specialist`, `database-specialist`, `operations-management`, `incident-response`, `git-workflow`, `dev-flow-e2e`.

The security agent's `description:` frontmatter had to move **in lockstep** with the routing table — G-AGENTIC02 couples the two, and changing one alone would trip the drift guard.

## Deliberately out of scope

- **T002171** — `scripts/admin-users-setup.sh` still drives Keycloak through `KC_*` variables (`KC_INTERNAL_URL`, `KC_ADMIN_PASS`, `KC_NAMESPACE`, …). That is executable code, reached from `Taskfile.yml:2233` and actively recommended in deploy output and in the fresh-cluster runbook. A docs chore must not change deploy paths, so it is filed separately and marked with a warning at the call site.
- **`openspec/specs/`** — 25 files, ~300 mentions (`auth-sso.md` alone has 66). Specs are the behavioural SSOT; each mention needs a case-by-case call between *an active requirement that is now wrong* and *a historical statement that should stand*. Bulk-replacing there would corrupt requirements.
- **`.claude/skills/gitops-*`** — Keycloak appears only as a generic OIDC example ("Dex, Keycloak, Entra ID") in third-party plugin docs. Correct as-is.

## Verification

- `task freshness:check` — exit 0.
- `bats tests/spec/agent-library.bats` and `agentic-tooling-quality-goals.bats` — green (these are the guards coupling routing table ↔ agent frontmatter, and they run in CI).
- No unintended Keycloak references remain in `.claude/`, `CLAUDE.md` or `AGENTS.md`; the only occurrences left are explicit statements *documenting* the migration ("no realm JSON files exist", "no `keycloak` DB").

**Pre-existing failures, not from this PR:** `task test:changed` selects 132 spec files here (because `.claude/skills/**` changed) and reports 48 red. They cover secrets files, `livekit-egress`, `factory-tokens.css`, `AdminModal.svelte` — none of which this PR touches. The one that does touch a changed file, `HWS-8: AGENTS.md Skill Dispatch Protocol`, was confirmed red against the unmodified `main` version of `AGENTS.md`. Filed as **T002176** — it is the same class of decay that T002163 just fixed for `ci-cd.bats`: spec tests that no required check executes.

Closes T002169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgAzbFpnCNq5NfyZAoPcLx
