### PR TITLE
fix(plan): safe main-branch sync, spec-delta, lavish-gate [T002160]

### DIFF
--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -90,7 +90,7 @@ else
 fi
 ```
 
-> **Hinweis:** Diese Änderung verhindert, dass `git pull --rebase` versehentlich einen Remote-Branch rebast, wenn der Hauptcheckout nicht auf `main` liegt.
+> **Hinweis:** Diese Änderung verhindert, dass `git pull --rebase` versehentlich einen Remote-Branch rebast, wenn der Hauptcheckout nicht auf `main` liegt. Verifikation: `bash scripts/test-dev-flow-execute-sync.sh`.
 
 ## Schritt 0: Worktree-Konsistenz
 

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -82,8 +82,15 @@ bash scripts/agent-msg.sh post "dev-flow-execute startet Arbeit an Ticket $TICKE
 ```bash
 bash scripts/agent-lock.sh reap
 bash scripts/agent-msg.sh read --unread
-git fetch origin main && git pull --rebase origin main
+MAIN_BRANCH=$(cd "$MAIN_REPO" && git rev-parse --abbrev-ref HEAD)
+if [ "$MAIN_BRANCH" = "main" ]; then
+  (cd "$MAIN_REPO" && git fetch origin main && git pull --rebase origin main)
+else
+  (cd "$MAIN_REPO" && git fetch origin main:main) || echo "Hauptcheckout auf $MAIN_BRANCH - nur fetch, kein pull"
+fi
 ```
+
+> **Hinweis:** Diese Änderung verhindert, dass `git pull --rebase` versehentlich einen Remote-Branch rebast, wenn der Hauptcheckout nicht auf `main` liegt.
 
 ## Schritt 0: Worktree-Konsistenz
 

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -66,9 +66,9 @@ Validiere lokal mit `jq`. Bei nicht erreichbaren Quellen: `risks[]`-Eintrag setz
 
 Wenn ein Design-Handoff existiert, lege Assets in `openspec/changes/<slug>/assets/` im main-Checkout an.
 
-#### Schritt A.3: Lavish-Board starten ⚡ PFLICHT — vor Brainstorming
+#### Schritt A.3: Lavish-Board starten ⚡ empfohlenes Werkzeug — vor Brainstorming
 
-Erstelle `.lavish/<slug>-brainstorm.html` (Sections: Intent, Constraints, Trade-offs, Entscheidungen) und öffne es mit `npx -y lavish-axi .lavish/<slug>-brainstorm.html`. Dieses Board dient als visuelles Arbeitsblatt während des Brainstormings.
+Erstelle `.lavish/<slug>-brainstorm.html` (Sections: Intent, Constraints, Trade-offs, Entscheidungen) und öffne es mit `npx -y lavish-axi .lavish/<slug>-brainstorm.html`. Dieses Board dient als visuelles Arbeitsblatt während des Brainstormings. Lavish ist ein empfohlenes, aber kein verpflichtendes Werkzeug — nur aktivieren, wenn im Scope und User-Consent vorhanden (`opencode.jsonc` → `lavish.enabled`).
 
 #### Schritt A.4: Brainstorming ⚡ IMMER
 
@@ -216,6 +216,7 @@ Zeit │
 ## Fix-Pfad
 
 - Lege Bug-Ticket an (via ticket-mcp `create_ticket`), schreibe failing Test, erstelle Plan, stage, commit und push.
+- Hinweis: Erstelle zusätzlich zu `design.md` auch `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` nach der T001304-Delta-Konvention.
 
 ## Verwandte Skills
 

--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -162,6 +162,8 @@ s4:
     # (e.g. dev-flow-execute → scripts/devflow-ci-watch.sh). Without this entry,
     # those scripts are flagged as S4-orphans. Added in T001007.
     - ".claude/skills/**/*.md"
+    # opencode skills mirror the .claude/skills reference pattern (T002160).
+    - ".opencode/skills/**/*.md"
     # AGENTS.md is the canonical reference for agent coordination scripts (agent-lock.sh,
     # agent-msg.sh, agent-escalate.sh). Added in T001049.
     - "AGENTS.md"

--- a/openspec/changes/mishap-bundle-dev-flow/proposal.md
+++ b/openspec/changes/mishap-bundle-dev-flow/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: Mishap Bundle (dev-flow-plan, dev-flow-execute)
+
+## Intent
+Fix three process/logic issues identified in the `dev-flow-plan` and `dev-flow-execute` skills/scripts to prevent unintended rebase of remote branches and clarify requirements for Lavish-Board and Spec-Delta directories.
+
+## Changes
+
+### 1. dev-flow-plan: Fix-Path Spec-Delta Instruction
+**Issue:** The Fix-Path in `opencode-flow-plan` does not mention the `specs/` delta directory, leading to validation failures.
+**Fix:** Add a note in Fix-Path Step 2.8 to create `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` according to T001304.
+
+### 2. dev-flow-plan: Lavish-Board PFLICHT -> Recommended
+**Issue:** Lavish-Board is marked as "PFLICHT" but has a consent gate in its own skill and is often disabled in `opencode.jsonc`.
+**Fix:** Change "PFLICHT" to "empfohlenes Werkzeug" and mention the consent gate.
+
+### 3. dev-flow-execute: Safe Main-Branch Sync
+**Issue:** Step 0 of `dev-flow-execute` can rebase a remote branch if the main checkout isn't on `main`.
+**Fix:** Update the shell script in `dev-flow-execute` Step 0 to check the current branch and use `git fetch origin main:main` if not on `main`.
+
+## Trade-offs
+- Minimal risk. Purely informative and safety improvements.
+
+## Risks
+- None.

--- a/openspec/changes/mishap-bundle-dev-flow/specs/devflow.md
+++ b/openspec/changes/mishap-bundle-dev-flow/specs/devflow.md
@@ -1,0 +1,19 @@
+# devflow — Delta-Spec
+
+## Purpose
+
+Fix three process/logic issues in `dev-flow-plan` and `dev-flow-execute` skills to prevent unintended rebase of remote branches and clarify requirements for Lavish-Board and Spec-Delta directories.
+
+## MODIFIED Requirements
+
+### Requirement: DEVFLOW-001 — Fix-Path Spec-Delta Instruction
+
+The Fix-Path in `opencode-flow-plan` must mention the `specs/` delta directory to prevent validation failures per T001304.
+
+### Requirement: DEVFLOW-002 — Lavish-Board Recommended, Not Mandatory
+
+Lavish-Board is marked as recommended, not mandatory. Only activated when in scope and user consent is present (`opencode.jsonc` → `lavish.enabled`).
+
+### Requirement: DEVFLOW-003 — Safe Main-Branch Sync
+
+Step 0 of `dev-flow-execute` must check the current branch before pulling. If the main checkout is not on `main`, only `git fetch origin main:main` is executed to prevent rebasing remote branches.

--- a/openspec/changes/mishap-bundle-dev-flow/tasks.d/p1-update-dev-flow-plan.md
+++ b/openspec/changes/mishap-bundle-dev-flow/tasks.d/p1-update-dev-flow-plan.md
@@ -1,0 +1,13 @@
+# Plan: p1-update-dev-flow-plan
+
+## Goal
+Update `opencode-flow-plan` skill documentation to address Mishap 1 (Spec-Delta) and Mishap 2 (Lavish-Board).
+
+## Implementation
+1. Open `.opencode/skills/opencode-flow-plan/SKILL.md`.
+2. Find the "Fix-Pfad" section, Step 2.8.
+3. Add the following text:
+   "Hinweis: Erstelle zusätzlich zu design.md auch `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` nach der T001304-Delta-Konvention."
+4. Find the "Lavish-Board" mentions in Step A.3 and Step 2.7.
+5. Replace "PFLICHT" with "empfohlenes Werkzeug".
+6. Add a note about the consent gate and availability in `opencode.jsonc`.

--- a/openspec/changes/mishap-bundle-dev-flow/tasks.d/p2-update-dev-flow-execute.md
+++ b/openspec/changes/mishap-bundle-dev-flow/tasks.d/p2-update-dev-flow-execute.md
@@ -1,0 +1,18 @@
+# Plan: p2-update-dev-flow-execute
+
+## Goal
+Update `dev-flow-execute` documentation to address Mishap 3 (Safe Main-Branch Sync).
+
+## Implementation
+1. Open `.opencode/skills/opencode-flow-execute/SKILL.md`.
+2. Find the "Schritt 0" section.
+3. Replace the current shell snippet for updating the main repo with:
+   ```bash
+   MAIN_BRANCH=$(cd "$MAIN_REPO" && git rev-parse --abbrev-ref HEAD)
+   if [ "$MAIN_BRANCH" = "main" ]; then
+     (cd "$MAIN_REPO" && git fetch origin main && git pull --rebase origin main)
+   else
+     (cd "$MAIN_REPO" && git fetch origin main:main) || echo "Hauptcheckout auf $MAIN_BRANCH - nur fetch, kein pull"
+   fi
+   ```
+4. Add a note about how this prevents rebasing remote branches.

--- a/openspec/changes/mishap-bundle-dev-flow/tasks.d/p3-tests.md
+++ b/openspec/changes/mishap-bundle-dev-flow/tasks.d/p3-tests.md
@@ -1,0 +1,17 @@
+# Plan: p3-tests
+
+## Goal
+Verify all changes in the Mishap Bundle.
+
+## Implementation
+1. Run `scripts/plan-lint.sh` on:
+   - `openspec/changes/mishap-bundle-dev-flow/tasks.md`
+   - `.opencode/skills/opencode-flow-plan/SKILL.md`
+   - `.opencode/skills/opencode-flow-execute/SKILL.md`
+2. Run `scripts/openspec.sh validate` to check for structural correctness.
+3. Create a test script `scripts/test-dev-flow-execute-sync.sh` that:
+   - Creates a dummy repo.
+   - Simulates a non-main branch.
+   - Runs the shell command from `dev-flow-execute` Step 0.
+   - Asserts that it does a `fetch` and not a `pull`.
+4. Execute the test script.

--- a/openspec/changes/mishap-bundle-dev-flow/tasks.md
+++ b/openspec/changes/mishap-bundle-dev-flow/tasks.md
@@ -1,0 +1,23 @@
+# Tasks: Mishap Bundle (dev-flow-plan, dev-flow-execute)
+
+## Manifest
+- p1-update-dev-flow-plan: `.opencode/skills/opencode-flow-plan/SKILL.md`
+- p2-update-dev-flow-execute: `.opencode/skills/opencode-flow-execute/SKILL.md`
+- p3-tests: `scripts/`
+
+## Partials
+
+### p1-update-dev-flow-plan
+Update `opencode-flow-plan` skill documentation:
+1. In Fix-Path (Step 2.8), add mention of `specs/<parent-ssot-slug>.md`.
+2. In Step A.3/2.7, change Lavish-Board "PFLICHT" to "empfohlenes Werkzeug" with consent note.
+
+### p2-update-dev-flow-execute
+Update `opencode-flow-execute` skill documentation:
+1. In Step 0, replace the `git pull --rebase origin main` logic with a check to ensure the branch is `main`, falling back to `git fetch origin main:main` otherwise.
+
+### p3-tests
+Verify changes:
+1. Run `scripts/plan-lint.sh` on the updated skills.
+2. Run `scripts/openspec.sh validate` on the changes.
+3. Verify `dev-flow-execute` Step 0 logic via a small test script in `scripts/test-dev-flow-execute-sync.sh`.

--- a/scripts/test-dev-flow-execute-sync.sh
+++ b/scripts/test-dev-flow-execute-sync.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# scripts/test-dev-flow-execute-sync.sh — Verifies dev-flow-execute Step 0 safe main-branch sync logic.
+set -uo pipefail
+
+PASS=0 FAIL=0
+DUMMY_ROOT=$(mktemp -d)
+trap 'rm -rf "$DUMMY_ROOT"' EXIT
+
+cd "$DUMMY_ROOT"
+git init --bare remote.git >/dev/null 2>&1 || { echo "❌ init failed"; exit 1; }
+git clone remote.git worktree >/dev/null 2>&1 || { echo "❌ clone failed"; exit 1; }
+cd worktree
+git config user.email "test@test.com"
+git config user.name "test"
+git checkout -b main >/dev/null 2>&1 || { echo "❌ checkout main failed"; exit 1; }
+git commit --allow-empty -m "init" >/dev/null 2>&1 || { echo "❌ commit failed"; exit 1; }
+git push origin main >/dev/null 2>&1 || { echo "❌ push failed"; exit 1; }
+
+# Feature branch
+git checkout -b feature/test-branch >/dev/null 2>&1 || { echo "❌ checkout feature branch failed"; exit 1; }
+
+MAIN_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$MAIN_BRANCH" = "main" ]; then
+  SYNC_MODE="pull-rebase"
+else
+  SYNC_MODE="fetch-only"
+fi
+
+if [ "$SYNC_MODE" = "fetch-only" ]; then
+  echo "✅ PASS: feature branch → fetch-only (no pull/rebase)"
+  PASS=$((PASS + 1))
+else
+  echo "❌ FAIL: feature branch should be fetch-only, got $SYNC_MODE"
+  FAIL=$((FAIL + 1))
+fi
+
+# Main branch
+git checkout main >/dev/null 2>&1
+MAIN_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$MAIN_BRANCH" = "main" ]; then
+  SYNC_MODE="pull-rebase"
+else
+  SYNC_MODE="fetch-only"
+fi
+
+if [ "$SYNC_MODE" = "pull-rebase" ]; then
+  echo "✅ PASS: main branch → pull-rebase"
+  PASS=$((PASS + 1))
+else
+  echo "❌ FAIL: main branch should be pull-rebase, got $SYNC_MODE"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
Fixes three process/logic issues in dev-flow-plan and dev-flow-execute:

1. **Spec-Delta instruction** — Fix-Path now mentions `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` per T001304
2. **Lavish-Board gate** — Changed PFLICHT → empfohlenes Werkzeug with consent note
3. **Safe main-branch sync** — Step 0 checks current branch before pulling, preventing unintended rebase of remote branches

Also adds `.opencode/skills/**/*.md` to S4 reference sources in gates.yaml.