### PR TITLE
fix(ci): migrate renovate kubernetes manager from fileMatch to managerFilePatterns [T002170]

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -157,13 +157,22 @@
   ],
 
   // Kubernetes manager: scan image references in k3d and prod manifests.
+  // managerFilePatterns replaces the deprecated fileMatch (T002170) — it was the
+  // remaining item behind Renovate's "Config needs migrating" warning after
+  // T002165 handled matchPackagePatterns. Regexes are slash-wrapped, same as the
+  // matchPackageNames migration.
+  //
+  // NOTE: the kubernetes manager ships NO default patterns — without these it
+  // matches nothing at all and every k8s image silently stops being updated
+  // (Vaultwarden, Pocket ID, postgres, …). Verify against the Dependency
+  // Dashboard after changing them, not just against a green workflow run.
   "kubernetes": {
-    "fileMatch": [
-      "^k3d/.+\\.yaml$",
-      "^prod/.+\\.yaml$",
-      "^prod-mentolder/.+\\.yaml$",
-      "^prod-korczewski/.+\\.yaml$",
-      "^prod-fleet/.+\\.yaml$"
+    "managerFilePatterns": [
+      "/^k3d/.+\\.yaml$/",
+      "/^prod/.+\\.yaml$/",
+      "/^prod-mentolder/.+\\.yaml$/",
+      "/^prod-korczewski/.+\\.yaml$/",
+      "/^prod-fleet/.+\\.yaml$/"
     ],
     // pinDigests: automatically update @sha256 digests on every update.
     "pinDigests": true

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -920,3 +920,37 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
     return 1
   }
 }
+
+# ── T002170: Restposten der Renovate-Config-Migration. fileMatch ist deprecated
+#    und wurde durch managerFilePatterns ersetzt (slash-gekapselte Regexes, wie
+#    schon bei matchPackageNames in T002165). Wichtig: der kubernetes-Manager hat
+#    KEINE Default-Patterns — ohne diese Liste matcht er nichts und jedes k8s-Image
+#    hoert still auf, Updates zu bekommen.
+
+@test "T002170: renovate.json5 nutzt managerFilePatterns statt deprecated fileMatch" {
+  local cfg="$REPO_ROOT/renovate.json5"
+  ! grep -qE '"fileMatch"' "$cfg" || {
+    echo "FAIL: renovate.json5 verwendet noch den deprecated Key fileMatch."
+    echo "      Ersatz: managerFilePatterns mit slash-gekapselten Regexes,"
+    echo "      z.B. \"/^k3d/.+\\\\.yaml\$/\"."
+    return 1
+  }
+  grep -qE '"managerFilePatterns"' "$cfg" || {
+    echo "FAIL: kein managerFilePatterns im kubernetes-Manager."
+    echo "      Der Manager hat KEINE Default-Patterns — ohne Liste matcht er"
+    echo "      nichts und alle k8s-Images bleiben ungepflegt."
+    return 1
+  }
+}
+
+@test "T002170: kubernetes-managerFilePatterns deckt alle vier Manifest-Baeume ab" {
+  local cfg="$REPO_ROOT/renovate.json5"
+  for tree in k3d prod prod-mentolder prod-korczewski prod-fleet; do
+    grep -qE "\"/\^${tree}/" "$cfg" || {
+      echo "FAIL: kein managerFilePatterns-Eintrag fuer '${tree}/'."
+      echo "      Fehlt ein Baum, uebersieht Renovate dessen Images vollstaendig —"
+      echo "      ohne Fehlermeldung, der Run bleibt gruen."
+      return 1
+    }
+  done
+}


### PR DESCRIPTION
Last item behind Renovate's `Config needs migrating` warning — T002165 handled `matchPackagePatterns`, this is `fileMatch`.

## Change

```diff
   "kubernetes": {
-    "fileMatch": [
-      "^k3d/.+\\.yaml$",
+    "managerFilePatterns": [
+      "/^k3d/.+\\.yaml$/",
       …
```

All five manifest trees (`k3d/`, `prod/`, `prod-mentolder/`, `prod-korczewski/`, `prod-fleet/`), regexes slash-wrapped — the same shape as the `matchPackageNames` migration.

**Syntax verified against upstream docs, not guessed:** `docs/usage/configuration-options.md` states *"managerFilePatterns … replaces the legacy fileMatch"*, and `lib/modules/manager/kubernetes/readme.md` shows the slash-wrapped pattern form.

## Why this one deserves care

The kubernetes manager ships **no default file patterns**. Get the list wrong and it matches nothing — *silently*. Every k8s image would stop being updated (Vaultwarden, Pocket ID, postgres, redis, …) while the workflow keeps reporting success. That is the exact failure mode T002165 already taught us: a green run is not evidence of work.

Two consequences for this PR:
- The post-merge check is the **Dependency Dashboard content**, not the run conclusion.
- A second assertion pins all five trees individually, so dropping one is caught by a test rather than by a quiet gap in coverage months later.

## Verification

- `bats tests/spec/ci-cd.bats --filter T002170` — 2/2 ok. Both confirmed **red** against `main`'s `renovate.json5` first (by checking out just that file and re-running).
- `renovate.json5` parses as JSON5; `kubernetes.fileMatch` is gone, `managerFilePatterns` has 5 entries.
- `bats tests/spec/ci-cd.bats` — 77/77 ok, no regressions.
- `task freshness:check` — exit 0.

## Post-merge acceptance

```bash
gh workflow run renovate.yml
```

Then check Dashboard #3219 still lists k8s image updates — `vaultwarden/server`, `ghcr.io/pocket-id/pocket-id`, `postgres:16-alpine`, `redis:7.4-alpine` must all still appear. If the pattern migration broke matching, those entries vanish while the run stays green.

## Note on the sibling findings in T002170

The ticket bundled three items. The other two need no code change here:

- **Docker auth** — I had flagged this as the most relevant item, suspecting Docker Hub digest updates were silently incomplete. Checked against the Dashboard: **not the case.** `postgres`, `redis`, `pgvector`, `curl`, `nats`, `nginx` and `node` all get update entries. Renovate attempts authenticated access, finds no credentials, falls back to anonymous, and succeeds. The residual risk is anonymous rate limits, which are irrelevant at a weekly schedule. Correction recorded on the ticket — **no Docker Hub token needed.**
- **npm multi-lockfile deprecation** — a forward-looking warning about the six pnpm workspaces. Nothing breaks today; it needs a decision before a future Renovate major, not a change now.

Closes T002170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgAzbFpnCNq5NfyZAoPcLx