### PR TITLE
fix(ci): honour the documented empty-value contracts in the flux render path [T002174]

### DIFF
--- a/scripts/flux-render-artifact.sh
+++ b/scripts/flux-render-artifact.sh
@@ -35,6 +35,22 @@ done
 mkdir -p "${OUT_DIR}"
 OUT_DIR="$(cd "${OUT_DIR}" && pwd)"
 
+# T002174: environments/schema.yaml ist die autoritative Spezifikation und definiert für
+# einzelne optionale Variablen ein Verhalten im leeren Fall. Der Taskfile-Render-Pfad
+# implementiert diese Verträge (Taskfile.yml:2831, 2961, 3641), der Flux-Pfad tat es nicht
+# und substituierte stattdessen den leeren Wert — was aus "Default anwenden" ein kaputtes
+# Manifest machte (Endpoints rigger-gateway mit ip: "" ließ flux-mentolder dauerhaft rot
+# stehen, wodurch Flux den gesamten Satz darin nicht mehr applizierte).
+#
+# Bewusst KEIN generischer "leere Variable = Fehler"-Check: über die vier Overlays hinweg
+# gibt es dutzende legitim leerer ${VAR}-Referenzen — Shell-Variablen in ConfigMap-
+# Skriptblöcken, Grafana-Dashboard-Templates und Platzhalter, die aus SealedSecrets
+# stammen. Nur explizit spezifizierte Verträge gehören hierher.
+apply_schema_defaults() {
+  # schema.yaml:403 — "Defaults to COMFY_HOST_IP when empty."
+  export RIGGER_HOST_IP="${RIGGER_HOST_IP:-${COMFY_HOST_IP:-}}"
+}
+
 render_component() {
   local overlay="$1" out="$2"
   # Dynamically extract ALL ${VAR} references from kustomize output.
@@ -123,6 +139,7 @@ cd "$PROJECT_DIR"
 (
   set +u
   source scripts/env-resolve.sh fleet-mentolder 2>/dev/null
+  apply_schema_defaults
   if [[ -n "$WEBSITE_IMAGE_OVERRIDE" ]]; then export WEBSITE_IMAGE="$WEBSITE_IMAGE_OVERRIDE"; fi
   if [[ -n "$BRETT_IMAGE_OVERRIDE" ]]; then export BRETT_IMAGE="$BRETT_IMAGE_OVERRIDE"; fi
   mkdir -p "${OUT_DIR}/platform"
@@ -130,17 +147,47 @@ cd "$PROJECT_DIR"
 )
 
 # 1b. Dev (workspace-dev namespace)
+#
+# T002174: environments/schema.yaml:466 spezifiziert für DEV_DOMAIN
+# "Empty disables the dev stack." Der Renderer setzte den leeren Wert stattdessen
+# stumpf ein, wodurch k3d/dev-stack/dev-ingress.yaml als `host: "*."` und
+# `tls.hosts[0]: ""` im Artefakt landete. Beides ist für die Kubernetes-API ungültig,
+# die flux-dev-Kustomization scheiterte am Dry-Run — und Flux appliziert dann den
+# GESAMTEN Satz darin nicht mehr, nicht nur das kaputte Ingress.
+# Aus einer Abschaltung wurde so eine Fehlkonfiguration.
 (
   set +u
-  source scripts/env-resolve.sh dev 2>/dev/null || true
+  # Kein `|| true`: schlug env-resolve fehl, lief der Render mit leerer Umgebung
+  # weiter und schrieb ein Manifest voller leer substituierter Werte ins Artefakt.
+  if ! source scripts/env-resolve.sh dev 2>/dev/null; then
+    echo "ERROR: env-resolve.sh dev failed — refusing to render the dev stack with" >&2
+    echo "       an empty environment (would emit empty-substituted manifests)." >&2
+    exit 1
+  fi
   mkdir -p "${OUT_DIR}/dev"
-  render_component prod-fleet/dev "${OUT_DIR}/dev/dev.yaml"
+  if [[ -z "${DEV_DOMAIN:-}" ]]; then
+    # Leeres, gültiges Kustomize-Verzeichnis statt gar keines: die flux-dev
+    # Kustomization zeigt fest auf path=./dev mit prune=true. Fehlte das Verzeichnis,
+    # scheiterte sie an "path not found" — also wieder rot, nur mit anderem Text.
+    # So wird sie Ready, appliziert nichts und prunt einen etwaigen Altbestand sauber weg.
+    echo "flux-render: DEV_DOMAIN is empty — rendering an empty dev stack (schema.yaml contract)."
+    cat > "${OUT_DIR}/dev/kustomization.yaml" <<'EOF'
+# Rendered empty by scripts/flux-render-artifact.sh: DEV_DOMAIN is unset for this
+# environment, and environments/schema.yaml defines that as "Empty disables the dev stack".
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []
+EOF
+  else
+    render_component prod-fleet/dev "${OUT_DIR}/dev/dev.yaml"
+  fi
 )
 
 # 2. Mentolder
 (
   set +u
   source scripts/env-resolve.sh fleet-mentolder 2>/dev/null
+  apply_schema_defaults
   if [[ -n "$WEBSITE_IMAGE_OVERRIDE" ]]; then export WEBSITE_IMAGE="$WEBSITE_IMAGE_OVERRIDE"; fi
   if [[ -n "$BRETT_IMAGE_OVERRIDE" ]]; then export BRETT_IMAGE="$BRETT_IMAGE_OVERRIDE"; fi
   mkdir -p "${OUT_DIR}/mentolder"
@@ -151,6 +198,7 @@ cd "$PROJECT_DIR"
 (
   set +u
   source scripts/env-resolve.sh fleet-korczewski 2>/dev/null
+  apply_schema_defaults
   if [[ -n "$WEBSITE_IMAGE_OVERRIDE" ]]; then export WEBSITE_IMAGE="$WEBSITE_IMAGE_OVERRIDE"; fi
   if [[ -n "$BRETT_IMAGE_OVERRIDE" ]]; then export BRETT_IMAGE="$BRETT_IMAGE_OVERRIDE"; fi
   mkdir -p "${OUT_DIR}/korczewski"
@@ -161,6 +209,7 @@ cd "$PROJECT_DIR"
 (
   set +u
   source scripts/env-resolve.sh fleet-mentolder 2>/dev/null
+  apply_schema_defaults
   if [[ -n "$WEBSITE_IMAGE_OVERRIDE" ]]; then export WEBSITE_IMAGE="$WEBSITE_IMAGE_OVERRIDE"; fi
   if [[ -n "$BRETT_IMAGE_OVERRIDE" ]]; then export BRETT_IMAGE="$BRETT_IMAGE_OVERRIDE"; fi
   mkdir -p "${OUT_DIR}/website-mentolder"
@@ -171,6 +220,7 @@ cd "$PROJECT_DIR"
 (
   set +u
   source scripts/env-resolve.sh fleet-korczewski 2>/dev/null
+  apply_schema_defaults
   if [[ -n "$WEBSITE_IMAGE_OVERRIDE" ]]; then export WEBSITE_IMAGE="$WEBSITE_IMAGE_OVERRIDE"; fi
   if [[ -n "$BRETT_IMAGE_OVERRIDE" ]]; then export BRETT_IMAGE="$BRETT_IMAGE_OVERRIDE"; fi
   mkdir -p "${OUT_DIR}/website-korczewski"

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -954,3 +954,61 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
     }
   done
 }
+# --- T002174: flux-render-artifact.sh ignoriert die dokumentierte Leer-Semantik ---
+# environments/schema.yaml ist die autoritative Spezifikation und definiert fuer beide
+# betroffenen Variablen ein Verhalten fuer den leeren Fall:
+#   RIGGER_HOST_IP (schema.yaml:403) "Defaults to COMFY_HOST_IP when empty."
+#   DEV_DOMAIN     (schema.yaml:466) "Empty disables the dev stack."
+# Der Taskfile-Pfad implementiert den Rigger-Fallback (Taskfile.yml:2831/2961/3641),
+# der Flux-Renderer implementierte KEINEN der beiden Vertraege: er substituierte stumpf
+# den leeren Wert. Ergebnis auf fleet: Endpoints rigger-gateway mit ip:"" und Ingress
+# workspace-ingress-dev mit host:"*." — beide liessen ihre Flux-Kustomization dauerhaft
+# rot werden, wodurch Flux den GESAMTEN Satz darin nicht mehr applizierte.
+#
+# Kein generischer "leere Variable = Fehler"-Check: ueber alle vier Overlays gibt es
+# dutzende legitim leerer Referenzen (Shell-Vars in ConfigMap-Skripten, Grafana-Template-
+# Variablen, Secret-Platzhalter aus SealedSecrets). Geprueft wird der konkrete Vertrag.
+
+flux_render_script() {
+  echo "$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/flux-render-artifact.sh"
+}
+
+@test "T002174: flux-render implementiert den RIGGER_HOST_IP-auf-COMFY_HOST_IP-Fallback" {
+  S="$(flux_render_script)"
+  [ -f "$S" ]
+  grep -qE 'RIGGER_HOST_IP=.*RIGGER_HOST_IP:-.*COMFY_HOST_IP' "$S" || {
+    echo "FAIL: kein Fallback RIGGER_HOST_IP -> COMFY_HOST_IP in flux-render-artifact.sh."
+    echo "      schema.yaml:403 spezifiziert 'Defaults to COMFY_HOST_IP when empty';"
+    echo "      ohne den Fallback rendert prod/rigger-gpu.yaml Endpoints mit ip: \"\"."
+    return 1
+  }
+}
+
+@test "T002174: flux-render rendert den dev-Stack nicht, wenn DEV_DOMAIN leer ist" {
+  S="$(flux_render_script)"
+  [ -f "$S" ]
+  # schema.yaml:466 — "Empty disables the dev stack". Der Renderer muss den leeren Fall
+  # abfangen, statt host:"*." zu erzeugen.
+  grep -qE 'DEV_DOMAIN' "$S" || {
+    echo "FAIL: flux-render-artifact.sh prueft DEV_DOMAIN ueberhaupt nicht."
+    echo "      schema.yaml:466 spezifiziert 'Empty disables the dev stack'."
+    return 1
+  }
+  awk '/# 1b\. Dev/,/^\)/' "$S" | grep -qE '(-z .*DEV_DOMAIN|DEV_DOMAIN.*-z)' || {
+    echo "FAIL: der dev-Renderblock hat keinen Leer-Guard auf DEV_DOMAIN."
+    return 1
+  }
+}
+
+@test "T002174: der dev-Renderblock verschluckt env-resolve-Fehler nicht per '|| true'" {
+  S="$(flux_render_script)"
+  [ -f "$S" ]
+  # Schlug env-resolve fehl, lief der Render mit LEERER Umgebung weiter und schrieb
+  # ein Manifest voller leer substituierter Werte ins Artefakt.
+  awk '/# 1b\. Dev/,/^\)/' "$S" | grep -qE 'env-resolve\.sh dev.*\|\| true' && {
+    echo "FAIL: 'source scripts/env-resolve.sh dev ... || true' im dev-Renderblock —"
+    echo "      ein Fehlschlag rendert stillschweigend mit leerer Umgebung weiter."
+    return 1
+  }
+  return 0
+}


### PR DESCRIPTION
## Problem

Drei von acht Flux-Kustomizations auf `fleet` waren dauerhaft nicht Ready. **Solange eine Kustomization rot ist, appliziert Flux den gesamten Satz darin nicht** — auch die gesunden Ressourcen. Deshalb musste der Website-Deploy zu T002162 per `kubectl rollout restart` break-glass erfolgen.

```
flux-mentolder   Endpoints rigger-gateway:      subsets[0].addresses[0].ip  Invalid value: ""
flux-dev         Ingress workspace-ingress-dev: spec.rules[0].host          Invalid value: "*."
flux-korczewski  Service llm-gateway-embed:     spec.ports[1].name          Duplicate value: "http"
```

## Ursache 1+2 — dokumentierte Leer-Semantik nie implementiert

`environments/schema.yaml` ist die autoritative Spezifikation und definiert für beide betroffenen Variablen ein Verhalten für den leeren Fall:

| Variable | Spezifikation | Flux-Renderer tat |
|---|---|---|
| `RIGGER_HOST_IP` (`schema.yaml:403`) | *„Defaults to COMFY_HOST_IP when empty."* | substituierte leer → `ip: ""` |
| `DEV_DOMAIN` (`schema.yaml:466`) | *„Empty disables the dev stack."* | renderte trotzdem → `host: "*."` |

Der Taskfile-Pfad implementiert den Rigger-Fallback korrekt (`Taskfile.yml:2831/2961/3641`) — der Flux-Pfad keinen von beiden. **Das sind keine fehlenden Config-Werte, sondern nicht implementierte Vertragsklauseln.** Beim Dev-Stack besonders deutlich: „leer deaktiviert" wurde als „leer einsetzen" implementiert, was aus einer *Abschaltung* eine *Fehlkonfiguration* macht.

### Warum der bestehende fail-closed-Check nicht greift

Der Check prüft auf **übrig gebliebene** `${VAR}`-Platzhalter und ist für leer substituierte Werte blind. Das ist bekannt — der Block direkt darüber ist ein Spezial-Check exakt dieser Klasse für `checksum/config` (T002156), mit dem Kommentar:

> *„eine LEER substituierte checksum/config ist genauso kaputt wie ein uebrig gebliebener Platzhalter — der Check unten faengt nur letzteres."*

Die Fehlerklasse war also verstanden, aber nur für **eine einzige** Variable geschlossen.

### Warum kein generischer Leer-Check

Bewusst **kein** „leere Variable = Fehler". Eine Messung über alle vier Overlays zeigt dutzende legitim leerer `${VAR}`-Referenzen: Shell-Variablen in ConfigMap-Skriptblöcken (`$${API}`, `$${OUT}`, `$${STAMP}`), Grafana-Dashboard-Templates (`${cid}`, `${datasource}`, `${gen}`) und Platzhalter, die aus SealedSecrets stammen. Die Variablen *dürfen* leer sein — falsch war, was der Renderer daraus machte. `apply_schema_defaults()` implementiert deshalb nur explizit spezifizierte Verträge.

## Änderungen

- **`apply_schema_defaults()`** — implementiert den `RIGGER_HOST_IP` → `COMFY_HOST_IP`-Fallback, aufgerufen in allen fünf Render-Blöcken.
- **Dev-Block** rendert bei leerem `DEV_DOMAIN` ein *leeres, gültiges* Kustomize-Verzeichnis statt gar keines. Die `flux-dev`-Kustomization zeigt fest auf `path=./dev` mit `prune=true` und wäre sonst an „path not found" gescheitert — wieder rot, nur mit anderem Text. `workspace-dev` ist aktuell leer (0 Ressourcen), es geht nichts verloren.
- **`|| true` entfernt** hinter `source env-resolve.sh dev`: Schlug env-resolve fehl, lief der Render mit *leerer* Umgebung weiter und schrieb ein Manifest voller leer substituierter Werte ins Artefakt.

## Ursache 3 — SSA-Portkonflikt, im Cluster behoben

Das gerenderte Manifest war **korrekt** (genau ein Port `http/8095`). Der Konflikt entstand erst im Cluster:

```
live korczewski:   Port 8081  name=http  managedFields.manager = kubectl
live mentolder:    Port 8095            manager = kustomize-controller   <- korrekt
Repo + beide envs: Port 8095
```

`spec.ports` ist `listType: map` mit `listMapKey: port` — 8081 und 8095 sind verschiedene Schlüssel, also merged SSA sie *nebeneinander* statt zu ersetzen, und beide heißen `http`. Kein `kustomize build` hätte das je zeigen können. Der verwaiste, handverwaltete Service wurde direkt im Cluster entfernt (Backup unter `tmp/claude-scratch/`), damit Flux ihn mit dem korrekten Port neu anlegt — `LLM_EMBED_URL` zeigte ohnehin auf 8095, er war bereits funktionslos.

## Verifikation

- **3 neue BATS-Tests** in `tests/spec/ci-cd.bats`, vor dem Fix rot verifiziert
- **Render lokal:** `rigger-gateway` → `ip: "192.168.100.10"`, kein `host: "*."` mehr, `dev/` leer gerendert und `kustomize build` darauf liefert sauber nichts
- **`kubectl apply --server-side --dry-run=server`** gegen `fleet` über alle Overlays: keiner der drei Ursprungsfehler mehr; verbleibende Meldungen sind Test-Artefakte (immutable Jobs)
- **Live bestätigt:** nach dem Entfernen des Service ist der `llm-gateway-embed`-Fehler aus `flux-korczewski` verschwunden — dahinter kam der `rigger-gateway`-Fehler zum Vorschein, den dieser PR behebt
- `tests/spec/ci-cd.bats` 78/78 grün, identisch zu `main`

## Folge-Überlegung (nicht in diesem PR)

Der wirklich generische Schutz wäre eine **Server-Dry-Run-Validierung des gerenderten Artefakts** im Render-Schritt bzw. in CI. Das hätte alle drei Fehler gefunden — auch den SSA-Portkonflikt, den keine statische Prüfung sehen kann.

Closes T002174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1XLX54hMFRok66zAVbjuF
