### PR TITLE
chore(deps): update Docker images (patch/minor) [T000XXX]

### DIFF
--- a/k3d/admin-actions-cronjobs.yaml
+++ b/k3d/admin-actions-cronjobs.yaml
@@ -18,7 +18,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: psql
-              image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
+              image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
               resources:
                 requests:
                   cpu: "50m"
@@ -69,7 +69,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: psql
-              image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
+              image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
               resources:
                 requests:
                   cpu: "50m"
@@ -116,7 +116,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: sessions-purge
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               resources:
                 requests:
                   cpu: "50m"

--- a/k3d/clean-seed.yaml
+++ b/k3d/clean-seed.yaml
@@ -91,7 +91,7 @@ spec:
             limits:   { cpu: "100m", memory: "64Mi" }
       containers:
         - name: seed
-          image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+          image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/coturn-stack/coturn.yaml
+++ b/k3d/coturn-stack/coturn.yaml
@@ -35,7 +35,7 @@ spec:
         kubernetes.io/hostname: ${TURN_NODE}
       containers:
         - name: coturn
-          image: coturn/coturn:4.9-alpine@sha256:229f87ef2428336ca2f4b4967a961cc6ad7aceb79277bc51f5a179606228d45f
+          image: coturn/coturn:4.15-alpine@sha256:b73dfc469b30ee62ba6c0a1824c502e24438f15e49b5f2dec81fa10315410509
           imagePullPolicy: Always
           # TURN_SECRET is sourced from coturn-secrets at runtime so the
           # same manifests work with dev literals and production-rotated

--- a/k3d/cronjob-dunning-detection.yaml
+++ b/k3d/cronjob-dunning-detection.yaml
@@ -20,7 +20,7 @@ spec:
               type: RuntimeDefault
           containers:
           - name: detector
-            image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+            image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true

--- a/k3d/cronjob-monthly-billing.yaml
+++ b/k3d/cronjob-monthly-billing.yaml
@@ -22,7 +22,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/cronjob-scheduled-publish.yaml
+++ b/k3d/cronjob-scheduled-publish.yaml
@@ -23,7 +23,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: publish
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/cronjob-systemtest-cleanup.yaml
+++ b/k3d/cronjob-systemtest-cleanup.yaml
@@ -43,7 +43,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
@@ -99,7 +99,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
@@ -158,7 +158,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: trigger
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/dev-cluster/kube-vip-ds.yaml
+++ b/k3d/dev-cluster/kube-vip-ds.yaml
@@ -51,7 +51,7 @@ spec:
           value: 10.0.0.20
         - name: prometheus_server
           value: :2112
-        image: ghcr.io/kube-vip/kube-vip:v0.8.7@sha256:32829cc6f8630eba4e1b5e4df5bcbc34c767e70703d26e64a0f7317951c7b517
+        image: ghcr.io/kube-vip/kube-vip:v0.9.2@sha256:c6d4f3a3fc2b7e95a23a20a0b05b7c64b2e5620783c8fa69a9bac753f99cc8bc
         imagePullPolicy: IfNotPresent
         name: kube-vip
         resources:

--- a/k3d/dev-stack/oauth2-proxy-brainstorm.yaml
+++ b/k3d/dev-stack/oauth2-proxy-brainstorm.yaml
@@ -80,7 +80,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/dev-stack/oauth2-proxy-dev.yaml
+++ b/k3d/dev-stack/oauth2-proxy-dev.yaml
@@ -73,7 +73,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           args:
             - --config=/run/config/oauth2-extra.cfg
             - --provider=keycloak-oidc

--- a/k3d/dev-stack/oauth2-proxy-sessions.yaml
+++ b/k3d/dev-stack/oauth2-proxy-sessions.yaml
@@ -78,7 +78,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/dev-stack/sish.yaml
+++ b/k3d/dev-stack/sish.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: sish
-          image: antoniomika/sish:v2.22.1@sha256:7da476e26856961705b96b85c6d8b2c648cdf8c4d6992290c7a10d0dfd2d1e86
+          image: antoniomika/sish:v2.23.0@sha256:c03329d1b8182ac8a928c1b928174dc2621619b824d0dcb11f045d02761bb327
           args:
             - --domain=${PROD_DOMAIN}
             - --ssh-address=:2222

--- a/k3d/error-log-retention-cronjob.yaml
+++ b/k3d/error-log-retention-cronjob.yaml
@@ -22,7 +22,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: curl
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/mailpit.yaml
+++ b/k3d/mailpit.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mailpit
-          image: axllent/mailpit:v1.29@sha256:757f22b56c1da03570afdb3d259effe5091018008a81bbedc8158cee7e16fdbc
+          image: axllent/mailpit:v1.30@sha256:b868afa176bfd6cce2323ea316cd99ccad77915e51e595748f6d786700ecf109
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/monitoring/kube-prometheus-stack-rendered.yaml
+++ b/k3d/monitoring/kube-prometheus-stack-rendered.yaml
@@ -76690,7 +76690,7 @@ spec:
       serviceAccountName: monitoring-prometheus-node-exporter
       containers:
         - name: node-exporter
-          image: quay.io/prometheus/node-exporter:v1.11.1-distroless@sha256:6112664fd761bb964d8a2d3d0119d6c8402618a89edbb3a43c8f7b4090fb53c9
+          image: quay.io/prometheus/node-exporter:v1.12.1-distroless@sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0
           imagePullPolicy: IfNotPresent
           args:
             - --path.procfs=/host/proc
@@ -76922,7 +76922,7 @@ spec:
             - name: sc-datasources-volume
               mountPath: "/etc/grafana/provisioning/datasources"
         - name: grafana
-          image: "docker.io/grafana/grafana:13.0.1-security-01@sha256:2d1f9ae67c1778d33e291d4c3c759cd8b650e67491f02533499eb950e075eeb5"
+          image: "docker.io/grafana/grafana:13.1.1@sha256:7cb8c64c4d57a57e734073f3cc94620adb24a0acb929bd80ba9f14017e3a975b"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -77067,7 +77067,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpointslices,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         imagePullPolicy: IfNotPresent
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.0@sha256:6b2f0b6f2f86ac5b1aa883a033a8dd55bb96c16d191ec973393bdaadaddac914
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1@sha256:85108987d044b18a098126732f98602df408888c0f7d456241f5abefb9744bc1
         ports:
         - containerPort: 8080
           name: http
@@ -77342,7 +77342,7 @@ metadata:
     release: "monitoring"
     heritage: "Helm"
 spec:
-  image: "quay.io/prometheus/alertmanager:v0.32.2@sha256:b85533a2eb45865835315810315f6951331b2dbc8c93a6cf9a51e156a006a706"
+  image: "quay.io/prometheus/alertmanager:v0.33.1@sha256:9e082985f56f4c8c9f724e18f2288c6708f472e56a5286b8863d080434ea065d"
   imagePullPolicy: "IfNotPresent"
   version: "v0.32.2"
   replicas: 1
@@ -77413,7 +77413,7 @@ spec:
         port: http-web
         pathPrefix: "/"
         apiVersion: v2
-  image: "quay.io/prometheus/prometheus:v3.12.0-distroless@sha256:f39df5334dee301b885f77e0ff1159f5d8a43bf9db518f885544594799a1e3c2"
+  image: "quay.io/prometheus/prometheus:v3.13.1-distroless@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893"
   imagePullPolicy: "IfNotPresent"
   version: "v3.12.0-distroless"
   externalUrl: http://monitoring-prometheus.monitoring:9090
@@ -78175,7 +78175,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.3@sha256:8ce13c365c8e9ced0aad5ef350a53c50b7ca5817f99d856b9eec895db1056728
+          image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.5@sha256:d0e80b2f62fe43bb5e1b96adc692132fb4522e802f4cf673c09b1f94722b8cb6
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -78242,7 +78242,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.3@sha256:8ce13c365c8e9ced0aad5ef350a53c50b7ca5817f99d856b9eec895db1056728
+          image: ghcr.io/jkroepke/kube-webhook-certgen:1.8.5@sha256:d0e80b2f62fe43bb5e1b96adc692132fb4522e802f4cf673c09b1f94722b8cb6
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/k3d/monitoring/loki-rendered.yaml
+++ b/k3d/monitoring/loki-rendered.yaml
@@ -296,7 +296,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: loki
-          image: docker.io/grafana/loki:3.6.7@sha256:3c8fd3570dd9219951a60d3f919c7f31923d10baee578b77bc26c4a0b32d092d
+          image: docker.io/grafana/loki:3.7.4@sha256:87f0a067673756a3cede1bcbf0c74875f7df9b09fddb53e399d0c576f756cfcc
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/loki/config/config.yaml
@@ -345,7 +345,7 @@ spec:
               cpu: 100m
               memory: 256Mi
         - name: loki-sc-rules
-          image: quay.io/kiwigrid/k8s-sidecar:2.7.3@sha256:694950d736c8b532eba4006527ccbdac98fefc9f30b3346ba2de50b6cad91c94
+          image: quay.io/kiwigrid/k8s-sidecar:2.8.1@sha256:abb55b2165c60e8f97e473862c7a3123df6f67d44f592949577c29b8fb2df9d6
           imagePullPolicy: IfNotPresent
           env:
             - name: METHOD

--- a/k3d/monitoring/otel-collector.yaml
+++ b/k3d/monitoring/otel-collector.yaml
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:0.145.0@sha256:a7343f01869071ea3f4c5e1e97df1bb1b3c4d5c77247db80e053a80b9df530c4
+          image: otel/opentelemetry-collector-contrib:0.157.0@sha256:f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6
           args: ["--config=/etc/otel/config.yaml"]
           env:
             - name: FACTORY_OTLP_TOKEN

--- a/k3d/nextcloud-redis.yaml
+++ b/k3d/nextcloud-redis.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
+          image: redis:7.4-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
           imagePullPolicy: Always
           args:
             - redis-server

--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -97,7 +97,7 @@ spec:
             - name: app
               mountPath: /var/www/html
         - name: copy-php-conf
-          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
+          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
@@ -117,7 +117,7 @@ spec:
               mountPath: /php-conf-d
       containers:
         - name: nextcloud
-          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
+          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
           imagePullPolicy: Always
           securityContext:
             readOnlyRootFilesystem: false
@@ -255,7 +255,7 @@ spec:
               cpu: "2"
         # ── Cron sidecar: runs php cron.php every 5 min ───────────────
         - name: nextcloud-cron
-          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
+          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -328,7 +328,7 @@ spec:
         # zz-db.config.php resolves dbpassword via getenv('POSTGRES_PASSWORD'),
         # so this sidecar needs the same DB env as the main/cron containers.
         - name: notify-push
-          image: nextcloud:33-apache@sha256:476228e615088e7d2de4bd9a87187961dfbff1577a96ff07955ec35dbe18f3c9
+          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/notify-unread-cronjob.yaml
+++ b/k3d/notify-unread-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: notify
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/k3d/ntfy.yaml
+++ b/k3d/ntfy.yaml
@@ -31,7 +31,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: ntfy-init
-          image: binwiederhier/ntfy:v2.24.0@sha256:f8a9b104313b87cc24ae4f775f39e6328205b57dff6ede3eaf098a91e5d79f59
+          image: binwiederhier/ntfy:v2.26.3@sha256:081b53dbb20674fcfe05fdb4eb8af9036a2645ef979543d16f7f80803af467b1
           imagePullPolicy: Always
           command: ["/bin/sh", "-exc"]
           args:
@@ -81,7 +81,7 @@ spec:
               memory: 64Mi
       containers:
         - name: ntfy
-          image: binwiederhier/ntfy:v2.24.0@sha256:f8a9b104313b87cc24ae4f775f39e6328205b57dff6ede3eaf098a91e5d79f59
+          image: binwiederhier/ntfy:v2.26.3@sha256:081b53dbb20674fcfe05fdb4eb8af9036a2645ef979543d16f7f80803af467b1
           imagePullPolicy: Always
           command: ["ntfy", "serve"]
           securityContext:

--- a/k3d/oauth2-proxy-brain.yaml
+++ b/k3d/oauth2-proxy-brain.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-brett.yaml
+++ b/k3d/oauth2-proxy-brett.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-comfy.yaml
+++ b/k3d/oauth2-proxy-comfy.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-docs.yaml
+++ b/k3d/oauth2-proxy-docs.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-downloads.yaml
+++ b/k3d/oauth2-proxy-downloads.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-mailpit.yaml
+++ b/k3d/oauth2-proxy-mailpit.yaml
@@ -66,7 +66,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-mediaviewer.yaml
+++ b/k3d/oauth2-proxy-mediaviewer.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-rustdesk-web.yaml
+++ b/k3d/oauth2-proxy-rustdesk-web.yaml
@@ -54,7 +54,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-studio.yaml
+++ b/k3d/oauth2-proxy-studio.yaml
@@ -70,7 +70,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-terminal.yaml
+++ b/k3d/oauth2-proxy-terminal.yaml
@@ -55,7 +55,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-traefik.yaml
+++ b/k3d/oauth2-proxy-traefik.yaml
@@ -67,7 +67,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/oauth2-proxy-videovault.yaml
+++ b/k3d/oauth2-proxy-videovault.yaml
@@ -53,7 +53,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -99,7 +99,7 @@ spec:
             limits:   { cpu: "100m", memory: "64Mi" }
       containers:
         - name: seed
-          image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+          image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/pocket-id.yaml
+++ b/k3d/pocket-id.yaml
@@ -34,7 +34,7 @@ spec:
           # pg_isready checks actual PostgreSQL readiness (not just TCP open).
           # nc -z only verifies TCP — shared-db accepts connections before it
           # can serve queries, so pocket-id would crash on its 3-retry startup.
-          image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
+          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
           command: ['sh', '-c', 'until pg_isready -h shared-db -p 5432 -U pocket_id -d pocket_id -q; do echo "waiting for shared-db..."; sleep 2; done']
           securityContext:
             allowPrivilegeEscalation: false
@@ -53,7 +53,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: psql
-          image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
+          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -182,7 +182,7 @@ spec:
           # pg_isready checks actual PostgreSQL readiness (not just TCP open).
           # nc -z only verifies TCP — shared-db accepts connections before it
           # can serve queries, so pocket-id would crash on its 3-retry startup.
-          image: postgres:16-alpine@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
+          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
           command: ['sh', '-c', 'until pg_isready -h shared-db -p 5432 -U pocket_id -d pocket_id -q; do echo "waiting for shared-db..."; sleep 2; done']
           securityContext:
             allowPrivilegeEscalation: false
@@ -201,7 +201,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: pocket-id
-          image: ghcr.io/pocket-id/pocket-id:v2.9.0@sha256:a2a38a96699d7483d65b5849b015d954f294938306a03a9c0699bc5b79554e86
+          image: ghcr.io/pocket-id/pocket-id:v2.11.0@sha256:b7c37ab3044e53fd29b5f7295eebff5fdc0367dc043f36b41bcbe1815fcd965d
           imagePullPolicy: IfNotPresent
           # Retry wrapper (T002067): Pocket ID's Go binary only retries DB
           # connection 3 times (~9s) before exiting. shared-db uses

--- a/k3d/recovery-browser.yaml
+++ b/k3d/recovery-browser.yaml
@@ -35,7 +35,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: filebrowser
-          image: filebrowser/filebrowser:v2.63.5@sha256:aefb0c20de10ef8b617995ca5522479ad40d41e6386bd01946a345c6026ff31c  # pinned (was floating :v2) — see https://github.com/filebrowser/filebrowser/releases
+          image: filebrowser/filebrowser:v2.63.18@sha256:c4c627f687668c5a02ab410d8473712c77be7f1f0ea4f8d624d2a1392c495e76  # pinned (was floating :v2) — see https://github.com/filebrowser/filebrowser/releases
           imagePullPolicy: IfNotPresent
           args:
             - --noauth           # auth is handled by oauth2-proxy in front
@@ -139,7 +139,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           imagePullPolicy: Always
           args:
             - --config=/run/config/oauth2-extra.cfg

--- a/k3d/rustdesk-stack/hbbr.yaml
+++ b/k3d/rustdesk-stack/hbbr.yaml
@@ -28,7 +28,7 @@ spec:
         kubernetes.io/hostname: ${TURN_NODE}
       containers:
         - name: hbbr
-          image: rustdesk/rustdesk-server:1.1.15@sha256:10818ec05b179039c6660f4d8e74b303f0db2858bbad2b18e24992ea22d54cd6
+          image: rustdesk/rustdesk-server:1.1.16@sha256:8ecdab65deb7c84652a626380e31d11a8f1fbafd97916d57f95c20628f943c00
           imagePullPolicy: IfNotPresent
           command: ["hbbr"]
           workingDir: /root

--- a/k3d/rustdesk-stack/hbbs.yaml
+++ b/k3d/rustdesk-stack/hbbs.yaml
@@ -30,7 +30,7 @@ spec:
         kubernetes.io/hostname: ${TURN_NODE}
       containers:
         - name: hbbs
-          image: rustdesk/rustdesk-server:1.1.15@sha256:10818ec05b179039c6660f4d8e74b303f0db2858bbad2b18e24992ea22d54cd6
+          image: rustdesk/rustdesk-server:1.1.16@sha256:8ecdab65deb7c84652a626380e31d11a8f1fbafd97916d57f95c20628f943c00
           imagePullPolicy: IfNotPresent
           command: ["hbbs"]
           workingDir: /root

--- a/k3d/sealed-secrets-controller.yaml
+++ b/k3d/sealed-secrets-controller.yaml
@@ -70,7 +70,7 @@ spec:
       serviceAccountName: sealed-secrets-controller
       containers:
       - name: sealed-secrets-controller
-        image: docker.io/bitnami/sealed-secrets-controller:0.27.3@sha256:76f8c93c9e2e5450f90a416674f62ed9b9638b939561298f3218ed2a1cbe69d1
+        image: docker.io/bitnami/sealed-secrets-controller:0.38.4@sha256:ab8e4687a97fb097f30ca2f028222f779f231c224555ba05f43d172c61f84497
         imagePullPolicy: Always
         args:
         - --update-status

--- a/k3d/seed.yaml
+++ b/k3d/seed.yaml
@@ -91,7 +91,7 @@ spec:
             limits:   { cpu: "100m", memory: "64Mi" }
       containers:
         - name: seed
-          image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+          image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
+          image: nginx:1.31-alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
           ports:
             - containerPort: 80
           readinessProbe:

--- a/k3d/talk-hpb.yaml
+++ b/k3d/talk-hpb.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: nats
-          image: nats:2.12-alpine@sha256:2ca98656a279b2d88cfdf2b8c3f0d5d7f3941ae9dc2ab12ebaa92d83e0f4ccdb
+          image: nats:2.14-alpine@sha256:c11af972c99ae542de8925e6a7d9c533aa1eb039660420d2074beed6089b3bf0
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/vaultwarden.yaml
+++ b/k3d/vaultwarden.yaml
@@ -60,7 +60,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: vaultwarden
-          image: vaultwarden/server:1.35.3-alpine@sha256:c40957876ec13c1cb0d2b08f86e8f738e6d06f7460bad9cdae216cded174c10d
+          image: vaultwarden/server:1.36.0-alpine@sha256:d3531610b486905943706b235e97159331801c6856e1367a93a5905e2b40f204
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/prod-korczewski/ddns-updater.yaml
+++ b/prod-korczewski/ddns-updater.yaml
@@ -35,7 +35,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: updater
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               imagePullPolicy: IfNotPresent
               resources:
                 requests:

--- a/prod-korczewski/dev-db-refresh-cron.yaml
+++ b/prod-korczewski/dev-db-refresh-cron.yaml
@@ -35,7 +35,7 @@ spec:
             kubernetes.io/hostname: ${DEV_NODE}
           containers:
             - name: refresh
-              image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
+              image: pgvector/pgvector:0.8.5-pg16@sha256:1d533553fefe4f12e5d80c7b80622ba0c382abb5758856f52983d8789179f0fb
               command: [/bin/bash, /scripts/dev-db-refresh.sh]
               env:
                 # Destination: dev k3d Postgres via the k3d NodePort.

--- a/prod-korczewski/oauth2-proxy-dev.yaml
+++ b/prod-korczewski/oauth2-proxy-dev.yaml
@@ -62,7 +62,7 @@ spec:
               mountPath: /run/config
       containers:
         - name: oauth2-proxy
-          image: quay.io/oauth2-proxy/oauth2-proxy:v7.9.0@sha256:37c1570c0427e02fc7c947ef2c04e8995b8347b7abc9fcf1dbb4e376a4b221a7
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
           args:
             - --config=/run/config/oauth2-extra.cfg
             - --provider=keycloak-oidc

--- a/prod-mentolder/dev-db-refresh-cron.yaml
+++ b/prod-mentolder/dev-db-refresh-cron.yaml
@@ -37,7 +37,7 @@ spec:
             kubernetes.io/hostname: ${DEV_NODE}
           containers:
             - name: refresh
-              image: pgvector/pgvector:0.8.0-pg16@sha256:a132765ec351c65111b5b675928a3a0515a466a40f97277329db8b8209ad8bc9
+              image: pgvector/pgvector:0.8.5-pg16@sha256:1d533553fefe4f12e5d80c7b80622ba0c382abb5758856f52983d8789179f0fb
               command: [/bin/bash, /scripts/dev-db-refresh.sh]
               env:
                 # Destination: dev Postgres via the HA dev-cluster VIP LoadBalancer.

--- a/prod/reflector.yaml
+++ b/prod/reflector.yaml
@@ -52,7 +52,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: sync
-              image: curlimages/curl:8.7.1@sha256:25d29daeb9b14b89e2fa8cc17c70e4b188bca1466086907c2d9a4b56b59d8e21
+              image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
               imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary

Bump 22 container images across `k3d/` and `prod*/` manifests with patch and minor updates.

## Updated images

| Image | Old | New |
|-------|-----|-----|
| postgres:16-alpine | digest update | digest update |
| redis:7.4-alpine | digest update | digest update |
| nextcloud:33-apache | digest update | digest update |
| coturn/coturn | 4.9-alpine | 4.15-alpine |
| axllent/mailpit | v1.29 | v1.30 |
| nginx | 1.27-alpine | 1.31-alpine |
| nats | 2.12-alpine | 2.14-alpine |
| filebrowser/filebrowser | v2.63.5 | v2.63.18 |
| binwiederhier/ntfy | v2.24.0 | v2.26.3 |
| rustdesk/rustdesk-server | 1.1.15 | 1.1.16 |
| antoniomika/sish | v2.22.1 | v2.23.0 |
| vaultwarden/server | 1.35.3-alpine | 1.36.0-alpine |
| curlimages/curl | 8.7.1 | 8.21.0 |
| bitnami/sealed-secrets-controller | 0.27.3 | 0.38.4 |
| grafana/grafana | 13.0.1 | 13.1.1 |
| grafana/loki | 3.6.7 | 3.7.4 |
| grafana/promtail | 3.5.1 | 3.6.11 |
| otel/opentelemetry-collector-contrib | 0.145.0 | 0.157.0 |
| ghcr.io/jkroepke/kube-webhook-certgen | 1.8.3 | 1.8.5 |
| ghcr.io/kube-vip/kube-vip | v0.8.7 | v0.9.2 |
| ghcr.io/pocket-id/pocket-id | v2.9.0 | v2.11.0 |
| quay.io/* (prometheus stack, k8s-sidecar, oauth2-proxy) | various | various |
| registry.k8s.io/kube-state-metrics | v2.19.0 | v2.19.1 |
| pgvector/pgvector (prod-korczewski, prod-mentolder) | 0.8.0-pg16 | 0.8.5-pg16 |

## Scope

- 48 files changed across `k3d/`, `prod/`, `prod-korczewski/`, `prod-mentolder/`
- All images are SHA-pinned (digest verified via `crane digest`)
- No Dockerfile changes, no application code changes
- Ref: #3219