### PR TITLE
chore(deps): update Docker/K8s images to major versions [T000XXX]

### DIFF
--- a/VideoVault/Dockerfile
+++ b/VideoVault/Dockerfile
@@ -5,7 +5,7 @@
 # Base: node:20-bookworm-slim (native ffprobe + build-essential for canvas).
 
 # ── Build stage ───────────────────────────────────────────────
-FROM node:22-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 WORKDIR /app
 
 RUN apt-get update \
@@ -36,7 +36,7 @@ COPY VideoVault/drizzle.config.ts ./
 RUN npm run build
 
 # ── Runtime stage ─────────────────────────────────────────────
-FROM node:22-bookworm-slim AS runtime
+FROM node:24-bookworm-slim AS runtime
 WORKDIR /app
 
 RUN apt-get update \

--- a/brett/Dockerfile
+++ b/brett/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Stage 1: build Vite client bundle
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci
@@ -10,7 +10,7 @@ COPY vite.config.ts tsconfig.json tsconfig.client.json tsconfig.server.json ./
 RUN npm run build
 
 # Stage 2: runtime (tsx server + built client)
-FROM node:22-alpine
+FROM node:24-alpine
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev

--- a/docker/einvoice-sidecar/Dockerfile
+++ b/docker/einvoice-sidecar/Dockerfile
@@ -6,7 +6,7 @@ RUN mvn -B -q dependency:go-offline
 COPY src ./src
 RUN mvn -B -q -DskipTests package
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:25-jre
 WORKDIR /app
 COPY --from=build /src/target/einvoice-sidecar-1.0.0.jar app.jar
 EXPOSE 8080

--- a/k3d/dev-cluster/kube-vip-ds.yaml
+++ b/k3d/dev-cluster/kube-vip-ds.yaml
@@ -51,7 +51,7 @@ spec:
           value: 10.0.0.20
         - name: prometheus_server
           value: :2112
-        image: ghcr.io/kube-vip/kube-vip:v0.9.2@sha256:c6d4f3a3fc2b7e95a23a20a0b05b7c64b2e5620783c8fa69a9bac753f99cc8bc
+        image: ghcr.io/kube-vip/kube-vip:v1.2.1@sha256:49b77655f9f109bedc5eb25723bb0e4c57d8513ba33cc69c31be3f243eb2386d
         imagePullPolicy: IfNotPresent
         name: kube-vip
         resources:

--- a/k3d/nextcloud-redis.yaml
+++ b/k3d/nextcloud-redis.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.4-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
+          image: redis:8.0-alpine@sha256:5f61955be8ab2ccee9372b84ae4d4da2e2b156f87281e3f218544055e7ee04d4
           imagePullPolicy: Always
           args:
             - redis-server

--- a/k3d/nextcloud.yaml
+++ b/k3d/nextcloud.yaml
@@ -97,7 +97,7 @@ spec:
             - name: app
               mountPath: /var/www/html
         - name: copy-php-conf
-          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
+          image: nextcloud:34-apache@sha256:e93ccfc952c95f18175f3d297fb2f60c35070c05ca976050c250a9ddab793e75
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
@@ -117,7 +117,7 @@ spec:
               mountPath: /php-conf-d
       containers:
         - name: nextcloud
-          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
+          image: nextcloud:34-apache@sha256:e93ccfc952c95f18175f3d297fb2f60c35070c05ca976050c250a9ddab793e75
           imagePullPolicy: Always
           securityContext:
             readOnlyRootFilesystem: false
@@ -255,7 +255,7 @@ spec:
               cpu: "2"
         # ── Cron sidecar: runs php cron.php every 5 min ───────────────
         - name: nextcloud-cron
-          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
+          image: nextcloud:34-apache@sha256:e93ccfc952c95f18175f3d297fb2f60c35070c05ca976050c250a9ddab793e75
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false
@@ -328,7 +328,7 @@ spec:
         # zz-db.config.php resolves dbpassword via getenv('POSTGRES_PASSWORD'),
         # so this sidecar needs the same DB env as the main/cron containers.
         - name: notify-push
-          image: nextcloud:33-apache@sha256:2e0ba719164b092fe0629c6e36d154e39155403afaef895116bcc37e88a52f09
+          image: nextcloud:34-apache@sha256:e93ccfc952c95f18175f3d297fb2f60c35070c05ca976050c250a9ddab793e75
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/pocket-id.yaml
+++ b/k3d/pocket-id.yaml
@@ -34,7 +34,7 @@ spec:
           # pg_isready checks actual PostgreSQL readiness (not just TCP open).
           # nc -z only verifies TCP — shared-db accepts connections before it
           # can serve queries, so pocket-id would crash on its 3-retry startup.
-          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+          image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
           command: ['sh', '-c', 'until pg_isready -h shared-db -p 5432 -U pocket_id -d pocket_id -q; do echo "waiting for shared-db..."; sleep 2; done']
           securityContext:
             allowPrivilegeEscalation: false
@@ -53,7 +53,7 @@ spec:
               memory: "64Mi"
       containers:
         - name: psql
-          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+          image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
@@ -182,7 +182,7 @@ spec:
           # pg_isready checks actual PostgreSQL readiness (not just TCP open).
           # nc -z only verifies TCP — shared-db accepts connections before it
           # can serve queries, so pocket-id would crash on its 3-retry startup.
-          image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
+          image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
           command: ['sh', '-c', 'until pg_isready -h shared-db -p 5432 -U pocket_id -d pocket_id -q; do echo "waiting for shared-db..."; sleep 2; done']
           securityContext:
             allowPrivilegeEscalation: false

--- a/k3d/talk-transcriber/Dockerfile
+++ b/k3d/talk-transcriber/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         xvfb \

--- a/mediaviewer-widget/Dockerfile
+++ b/mediaviewer-widget/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # ── Build stage ───────────────────────────────────────────────
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 # Source-only Player-Package zuerst (wird per Alias konsumiert)
 COPY packages/videovault-player ./packages/videovault-player

--- a/mentolder-web/Dockerfile
+++ b/mentolder-web/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # ── Build stage ───────────────────────────────────────────────────
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@10 --activate

--- a/studio-server/Dockerfile
+++ b/studio-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 # Multi-stage: deps → build (tsc + vite) → runtime (node dist/index.js)
-ARG NODE_IMAGE=node:22-bookworm-slim
+ARG NODE_IMAGE=node:24-bookworm-slim
 
 FROM ${NODE_IMAGE} AS deps
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN npx tsc -p tsconfig.json && npx tsc -p tsconfig.web.json && npx vite build
 FROM ${NODE_IMAGE} AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
-# node user already exists in base image node:22
+# node user already exists in base image node:24
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./package.json

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
 # ── Build stage ───────────────────────────────────────────────────────────────
 # Build context is repo root so that tests/ can be copied into the runtime stage.
-FROM node:22-alpine AS build
+FROM node:24-alpine AS build
 WORKDIR /app
 
 # T001224/T001276: website migrated to pnpm — `website/package-lock.json` was
 # deleted, only `website/pnpm-lock.yaml` exists. Corepack is bundled with
-# node 22, so we enable pnpm@10 (matches `.github/workflows/ci.yml` +
+# node 24, so we enable pnpm@10 (matches `.github/workflows/ci.yml` +
 # `.github/workflows/build-mentolder-web.yml`).
 ENV PNPM_HOME=/pnpm
 ENV PATH=/pnpm:$PATH
@@ -32,7 +32,7 @@ RUN pnpm run build
 RUN pnpm install --prod
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 
 # Tools needed by test runner scripts


### PR DESCRIPTION
## Summary

Bump Docker and Kubernetes images to their latest major versions.

## Changes

| Component | Image | Old | New |
|-----------|-------|-----|-----|
| brett, VideoVault, mediaviewer, mentolder-web, website, studio-server | node | 22 | 24 |
| talk-transcriber | python | 3.11-slim | 3.14-slim |
| collabora | collabora/code | 25.04.9.4.1 | 26.04.2.3.1 |
| einvoice-sidecar | eclipse-temurin | 21-jre | 25-jre |
| pocket-id | postgres | 16-alpine | 18-alpine |
| nextcloud-redis | redis | 7.4-alpine | 8.0-alpine |
| nextcloud | nextcloud | 33-apache | 34-apache |
| dev-cluster | kube-vip | 0.9.2 | 1.2.1 |

## Notes

- **Major version bumps** — may require code/config changes
- Node 24 is the current LTS release line
- Postgres 18, Redis 8, Nextcloud 34 are major releases — test thoroughly
- Collabora 26 requires rebuild of custom image (UPSTREAM_TAG updated)
- All images pinned with SHA digests in K8s manifests
- Dockerfile syntax directive kept at `docker/dockerfile:1` (minimum required)
- Ref: #3219