### PR TITLE
fix(tickets): stop BATS test writing live x/y bug tickets [T002224]

### DIFF
--- a/scripts/vda/ticket/_ticket-core.sh
+++ b/scripts/vda/ticket/_ticket-core.sh
@@ -8,6 +8,25 @@
 : "${DB:=website}"
 USER="website"
 
+# [T002224] Fail-closed test guard. A BATS test that reaches this file must have
+# stubbed the cluster itself (the repo idiom: prepend a mock `kubectl` to PATH,
+# see tests/spec/feature-product-linking.bats). When it has not, the real
+# kubectl is still on PATH and every write lands in the LIVE ticket database.
+#
+# That is not hypothetical: tests/spec/t001582-mishap-bundle.bats tried to block
+# the cluster with PATH="/nonexistent-dir:$PATH" — which only *prepends* an empty
+# directory and leaves the real kubectl resolvable. The test wrote a real
+# `title=x, description=y` bug ticket on every suite run and produced ~130 rows
+# between 2026-07-03 and 2026-07-26 before anyone traced them back here.
+#
+# So under BATS we repoint CTX at a sentinel context that cannot resolve. A
+# stubbed kubectl ignores the value (mocks answer regardless of --context) and
+# keeps passing; the real kubectl finds no pod and _pgpod exits 1 with its normal
+# error. Set TICKET_TEST_DB_OK=1 to opt a test back into real cluster access.
+if [[ -n "${BATS_TEST_NAME:-}${BATS_VERSION:-}" && "${TICKET_TEST_DB_OK:-0}" != "1" ]]; then
+  CTX="bats-no-cluster-t002224"
+fi
+
 _pgpod() {
   local pod
   pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)

--- a/scripts/vda/ticket/create.sh
+++ b/scripts/vda/ticket/create.sh
@@ -40,6 +40,12 @@ main() {
         ;;
     esac
   fi
+  # [T002224] create was the only cluster-write path that never consulted the
+  # offline guard — every mutating subcommand in scripts/ticket.sh does (see
+  # update-status, add-comment, archive-plan, …). Callers that cannot reach a
+  # cluster therefore had no way to say so, which is why tests resorted to
+  # PATH tricks to fake it.
+  if _ticket_offline_skip "create" "--type" "$type" "--title" "$title"; then exit 0; fi
   local pod; pod=$(_pgpod)
   local parent_uuid=""
   if [[ -n "$product_id" ]]; then

--- a/tests/spec/t001582-mishap-bundle.bats
+++ b/tests/spec/t001582-mishap-bundle.bats
@@ -72,21 +72,73 @@ setup() {
 
 @test "T001582-M2: create.sh rejects an invalid --severity value before any DB access" {
   [ -f "$CREATE_SH" ]
-  run env PATH="/nonexistent-path-so-kubectl-cannot-be-found:$PATH" \
+  # [T002224] TICKET_OFFLINE=1 is the sanctioned way to keep a write off the
+  # cluster. The previous PATH="/nonexistent-…:$PATH" only prepended an empty
+  # directory and left the real kubectl resolvable — see the sibling test below.
+  run env TICKET_OFFLINE=1 \
     bash "$CREATE_SH" create --type bug --title "x" --description "y" --severity hoch
   [ "$status" -eq 2 ]
   [[ "$output" == *"critical"* && "$output" == *"major"* && "$output" == *"minor"* && "$output" == *"trivial"* ]]
+  # The severity check must still run ahead of the offline guard, so no
+  # "OFFLINE: skipped" may appear — the call is rejected on validation alone.
+  [[ "$output" != *"OFFLINE: skipped"* ]]
 }
 
 @test "T001582-M2: create.sh still allows an empty --severity (optional field)" {
   [ -f "$CREATE_SH" ]
-  # No --severity at all must never trip the new validation (it must only run
-  # when the flag is present with a non-matching value). We can't exercise a
-  # real DB write offline, so assert the validation step itself doesn't reject
-  # the call before reaching the (expected, offline) _pgpod failure.
-  run env PATH="/nonexistent-path-so-kubectl-cannot-be-found:$PATH" \
-    bash "$CREATE_SH" create --type bug --title "x" --description "y"
+  # No --severity at all must never trip the validation (it must only run when
+  # the flag is present with a non-matching value). Past the validation the call
+  # must stop at the offline guard and never touch the database.
+  #
+  # [T002224] This test used to write a real `title=x, description=y` bug ticket
+  # into the live database on every single suite run — ~130 rows accumulated
+  # between 2026-07-03 and 2026-07-26. The guard was
+  # PATH="/nonexistent-path-so-kubectl-cannot-be-found:$PATH", which prepends a
+  # directory that does not exist but keeps $PATH intact, so /usr/local/bin/kubectl
+  # stayed resolvable and create.sh reached _pgpod and INSERTed for real.
+  run env TICKET_OFFLINE=1 bash "$CREATE_SH" create --type bug --title "x" --description "y"
+  [ "$status" -eq 0 ]
   [[ "$output" != *"Invalid --severity"* ]]
+  [[ "$output" == *"OFFLINE: skipped create"* ]]
+}
+
+@test "T002224: create.sh honours TICKET_OFFLINE=1 and performs no cluster write" {
+  # Regression guard for the ~130 stray x/y tickets. A mock kubectl records any
+  # invocation; with TICKET_OFFLINE=1 the recorder must stay empty, proving
+  # create.sh short-circuits before _pgpod rather than relying on kubectl being
+  # absent from PATH.
+  local mockdir cap
+  mockdir="$(mktemp -d)"; cap="$mockdir/invoked"
+  cat > "$mockdir/kubectl" <<'MOCKEOF'
+#!/usr/bin/env bash
+echo "kubectl $*" >> "$CAP"
+echo "pod/shared-db-0"
+exit 0
+MOCKEOF
+  chmod +x "$mockdir/kubectl"
+  run env PATH="$mockdir:$PATH" CAP="$cap" TICKET_OFFLINE=1 \
+    bash "$CREATE_SH" create --type bug --title "x" --description "y"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OFFLINE: skipped create"* ]]
+  [ ! -s "$cap" ]
+  rm -rf "$mockdir"
+}
+
+@test "T002224: _ticket-core repoints CTX away from the live cluster under BATS" {
+  # Fail-closed backstop: even a future test that forgets TICKET_OFFLINE must not
+  # reach the real cluster. Under BATS (and without TICKET_TEST_DB_OK=1) the
+  # sourced core rewrites CTX to a sentinel that cannot resolve.
+  run bash -c "source '$REPO/scripts/vda/ticket/_ticket-core.sh'; echo \"\$CTX\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "bats-no-cluster-t002224" ]]
+  [[ "$output" != "fleet" ]]
+}
+
+@test "T002224: TICKET_TEST_DB_OK=1 opts a test back into the configured context" {
+  run env TICKET_TEST_DB_OK=1 TICKET_CTX=fleet \
+    bash -c "source '$REPO/scripts/vda/ticket/_ticket-core.sh'; echo \"\$CTX\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == "fleet" ]]
 }
 
 @test "T001582-M2: ticket.sh usage text lists the valid --severity enum values" {


### PR DESCRIPTION
## Problem

`tests/spec/t001582-mishap-bundle.bats` wrote a **real** bug ticket into the live database on every suite run. 127 rows accumulated between 2026-07-03 and 2026-07-26, all `type=bug`, `title=x`, `description=y`, `is_test_data=false` — indistinguishable from genuine user bug reports and invisible to the T001453 test-data purge, which filters on `is_test_data`.

Five prior ticket-ops runs (15.07., 21.07., 23.07., and twice on 26.07.) closed these as `obsolete` without ever finding the source. During the 17:15 run on 26.07. four were closed while four new ones appeared.

## Root cause

The test intended to block cluster access:

```bash
run env PATH="/nonexistent-path-so-kubectl-cannot-be-found:$PATH" \
  bash "$CREATE_SH" create --type bug --title "x" --description "y"
```

This only *prepends* a non-existent directory and leaves `$PATH` fully intact:

```
$ env PATH="/nonexistent-path-so-kubectl-cannot-be-found:$PATH" command -v kubectl
/usr/local/bin/kubectl
```

So `create.sh:43` reached `_pgpod` and performed a real INSERT. The test asserted only `[[ "$output" != *"Invalid --severity"* ]]` — **no exit-status check** — so the successful write never surfaced as a failure.

Attribution is column-exact: `create.sh` defaults (`brand=mentolder`, `status=triage`, `priority=mittel`, `severity=NULL`, `areas=NULL`, `attention_mode=auto`, `is_test_data=false`) match the stray rows in every field, including the `NULL` `reporter_email`/`url` that rule out all three web endpoints.

The hypothesis recorded in T002224 (`/api/bug-report` via `fa-26-bug-report-form.spec.ts`) is **disproven**: that endpoint requires `email` + `category` and writes `reporter_email`/`url`, and `insertBugTicket` sets `title = description.slice(0,200)` so title and description would be identical. `POST /api/admin/tickets` rejects `type='bug'` outright.

This file is the sole offender — the other ~15 BATS tests that route through `_pgpod` correctly shadow `kubectl` with a mock prepended to `PATH`.

## Fix

Three layers, smallest to broadest:

1. **`create.sh` honours `TICKET_OFFLINE=1`.** It was the only cluster-write path that never consulted `_ticket_offline_skip` — every mutating subcommand in `ticket.sh` already does. Callers unable to reach a cluster had no supported way to say so, which is *why* the test resorted to a PATH trick.

2. **`_ticket-core.sh` repoints `CTX` under BATS** to a sentinel context unless `TICKET_TEST_DB_OK=1`. Fail-closed backstop for any future test that forgets. A stubbed `kubectl` ignores `--context` and keeps passing; a real one finds no pod and `_pgpod` exits 1 with its existing error. Chosen over a hard `exit` precisely so the ~15 legitimate mock-based tests need no changes.

3. **The two `T001582-M2` tests use `TICKET_OFFLINE=1` and now assert the exit status.** Plus two new regression tests: one proves via a recording mock `kubectl` that no cluster call happens at all, one pins the `CTX` guard in both directions.

## Verification

| Suite | Result |
|---|---|
| `tests/spec/t001582-mishap-bundle.bats` | 10/10 ok |
| `feature-product-linking` + `dev-flow-plan-ticket-sh-mishaps` + `ticket-mcp` | 49/49 ok, 0 failures |
| `ticket-create`, `vda-ticket-smoke`, `ticket-external-id-sequence`, `mishap-tracker`, `ticket-system` | 28/28 ok |
| `task test:all` | 1723 ok |
| `task freshness:check` | pass |

Row count for `title='x' AND description='y'` held at **127 across every single run** — before the fix each run added one.

`task test:changed` fails locally with `Cannot find module .../vitest/vitest.mjs`. This reproduces identically on clean `main` (exit 201) and is a missing local `pnpm install`, not a regression from this change.

## Follow-ups (not in this PR)

- Cleanup of the 127 legacy rows — tracked in T002224 step 5, being handled separately in the same ticket-ops run.
- `task test:changed` classifies a `scripts/`-only diff as "website changes" (`RUN_WEBSITE=true` even on a clean tree). Latent, out of scope here.

Closes T002224 steps 1–4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JA9qyiTbqvcKe3gX83WDe
