### PR TITLE
fix(infra): unfreeze prod GitOps — accept YAML 1.1 value-key in render gate [T002236]

### DIFF
--- a/scripts/flux-render-artifact.sh
+++ b/scripts/flux-render-artifact.sh
@@ -290,6 +290,28 @@ for tree_dir in "${OUT_DIR}/mentolder" "${OUT_DIR}/korczewski" "${OUT_DIR}/mento
   # Check the file is valid multi-document YAML with apiVersion on each doc
   if python3 -c "
 import yaml, sys
+
+# [T002236] Upstream CRDs carry YAML 1.1 value-key scalars that PyYAML's
+# SafeLoader has no constructor for. The kube-prometheus-stack AlertManager
+# matchType enum is one: a bare '=' among quoted operators.
+#
+#     enum:
+#     - '!='
+#     - =        <-- tag:yaml.org,2002:value
+#     - =~
+#     - '!~'
+#
+# Go-YAML — what kubectl, kustomize and Flux actually parse with — reads this
+# without complaint, so the manifest is correct and must not be reformatted;
+# it is vendored upstream content, not hand-written YAML. Only this validator
+# rejected it, and because the gate is fail-closed it aborted the artifact push
+# for BOTH brands on every main push from 2026-07-26 18:19 onward, silently
+# freezing prod at the last good artifact.
+#
+# Treat the tag as the plain scalar it is and keep the rest of the gate strict.
+yaml.SafeLoader.add_constructor(
+    'tag:yaml.org,2002:value', lambda loader, node: loader.construct_scalar(node))
+
 with open('${manifest}') as f:
     docs = list(yaml.safe_load_all(f))
 if not docs:

--- a/tests/spec/workspace-deploy.bats
+++ b/tests/spec/workspace-deploy.bats
@@ -282,6 +282,72 @@ FLUX_CLUSTER_DIR="${PROJECT_DIR}/flux/clusters/fleet"
   [ "$status" -eq 0 ]
 }
 
+@test "T002236: flux-render-artifact.sh validation gate accepts YAML 1.1 value-key scalars" {
+  # Regression guard. The gate added in T002207 used a bare yaml.safe_load_all,
+  # which has no constructor for tag:yaml.org,2002:value — the unquoted `=` in the
+  # vendored kube-prometheus-stack AlertManager matchType enum. Because the gate is
+  # fail-closed, every main push from 2026-07-26 18:19 aborted the artifact push for
+  # both brands and silently froze prod at the last good artifact.
+  #
+  # This is asserted separately from the placeholder test below on purpose: that test
+  # also checks [ "$status" -eq 0 ], so a render abort surfaced there under a name
+  # about placeholders, which sent the first investigation down the wrong path.
+  local out
+  out="$(mktemp -d)"
+  export SMTP_PORT=587 SMTP_HOST=smtp.example.org SMTP_USER=x POCKET_ID_SMTP_TLS=starttls
+  export POCKET_ID_FRONTEND_URL=https://auth.example POCKET_ID_URL=http://pocket-id:1411 POCKET_ID_DOMAIN=id.example
+  run bash "$FLUX_RENDER" --out "$out"
+  rm -rf "$out"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"validation gate passed"* ]]
+  [[ "$output" != *"VALIDATION FAILED"* ]]
+  [[ "$output" != *"could not determine a constructor"* ]]
+}
+
+@test "T002236: the validation gate still rejects a manifest doc without apiVersion" {
+  # The value-key constructor must not soften the rest of the gate. A doc missing
+  # apiVersion has to keep failing, otherwise the fix would trade one silent
+  # deploy freeze for silently pushing a broken artifact.
+  run python3 -c "
+import yaml, sys
+yaml.SafeLoader.add_constructor(
+    'tag:yaml.org,2002:value', lambda loader, node: loader.construct_scalar(node))
+docs = list(yaml.safe_load_all('kind: ConfigMap\nmetadata:\n  name: x\n'))
+for i, doc in enumerate(docs):
+    if doc is None:
+        continue
+    if not doc.get('apiVersion'):
+        print('ERROR: doc %d has no apiVersion' % i, file=sys.stderr)
+        sys.exit(1)
+"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no apiVersion"* ]]
+}
+
+@test "T002236: the value-key constructor parses the upstream matchType enum" {
+  # Pin the exact upstream shape that broke the gate, so a future loader swap that
+  # reintroduces the strictness fails here rather than in the post-merge workflow.
+  run python3 -c "
+import yaml
+yaml.SafeLoader.add_constructor(
+    'tag:yaml.org,2002:value', lambda loader, node: loader.construct_scalar(node))
+doc = yaml.safe_load('''
+apiVersion: v1
+matchType:
+  enum:
+  - '!='
+  - =
+  - =~
+  - '!~'
+''')
+vals = doc['matchType']['enum']
+assert len(vals) == 4, vals
+print('parsed:', vals)
+"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"parsed:"* ]]
+}
+
 @test "T002083: flux-render-artifact.sh renders a placeholder-free tree (no bare \${VAR})" {
   # Non-secret fixture env (same shape as the T001411 offline render test);
   # secret-backed values live in SealedSecrets and are never envsubst-substituted.


### PR DESCRIPTION
## Prod-Deploys sind aktuell eingefroren

`render-fleet-artifact.yml` schlägt seit **2026-07-26 18:19** bei jedem Push auf `main` fehl. Kein OCI-Artefakt erreicht `ghcr.io/paddione/fleet-manifests`, Flux reconciliert weiter das letzte gute Artefakt. Beide Brands betroffen.

```
30215592498  failure  18:51  fix(infra): remove dead health-goals-cronjob manifest [T002185]
30214670479  failure  18:19  fix(infra): decouple one-shot Jobs, healthChecks [T002207]   ← erster Fehlschlag
30212880373  success  17:5x  feat(secrets): centralize dev-tool secrets
```

Das Tückische: die Kustomizations bleiben `Ready`, weil sie ein *gültiges* Alt-Artefakt reconcilieren. Im Cluster ist kein Fehler sichtbar — dieselbe Signatur wie der stille Deploy-Drift aus T002202/T002207. Nur der rote Workflow verrät es, und der läuft erst nach dem Merge.

## Ursache

Das Validation-Gate wurde in T002207 hinzugefügt (`scripts/flux-render-artifact.sh:279`) und nutzt ein blankes `yaml.safe_load_all`. PyYAMLs `SafeLoader` hat keinen Konstruktor für `tag:yaml.org,2002:value` — das unquotierte `=` im mitgelieferten kube-prometheus-stack-CRD, mitten zwischen quotierten Operatoren:

```yaml
matchType:
  enum:
  - '!='
  - =        # <-- tag:yaml.org,2002:value
  - =~
  - '!~'
```

Ein alleinstehendes `=` ist in YAML 1.1 der Spezialtyp *Wertschlüssel*. Da das Gate fail-closed ist, brach es den Artefakt-Push ab.

**Das Manifest ist korrekt.** Go-YAML — womit kubectl, kustomize und Flux tatsächlich parsen — liest es anmerkungslos, und es ist vendorter Upstream-CRD-Inhalt, kein handgeschriebenes YAML. Umformatieren ist also keine Option; der Validator war zu streng.

Der CRD-Inhalt lag immer schon vor. Erst das neue Gate stolpert darüber — daher der Beginn genau beim T002207-Merge.

## Fix

`yaml.SafeLoader` erhält einen Plain-Scalar-Konstruktor für genau diesen Tag. Alle übrigen Prüfungen des Gates bleiben unverändert scharf.

## Verifikation

| Prüfung | Vorher | Nachher |
|---|---|---|
| `flux-render-artifact.sh --out …` | exit 1, `VALIDATION FAILED` für beide Brands | **exit 0** |
| mentolder-Baum | Abbruch | `OK: 337 docs` |
| korczewski-Baum | Abbruch | `OK: 335 docs` |
| `T002083`/`T002236`-Subset von `workspace-deploy.bats` | 1 rot | **13/13 grün** |

Der bislang rote Test `T002083: renders a placeholder-free tree` ist jetzt grün. Er scheiterte an `[ "$status" -eq 0 ]`, nicht an der Platzhalter-Prüfung — die Platzhalter waren immer sauber. Das hat die erste Fehlersuche in die falsche Richtung geschickt, deshalb drei neue Tests, die das trennen:

- `T002236: validation gate accepts YAML 1.1 value-key scalars` — pinnt Render-Exit-Status und Gate-Ausgabe unter eigenem Namen
- `T002236: still rejects a manifest doc without apiVersion` — beweist, dass der Fix das Gate nicht aufweicht (sonst tauschte man einen stillen Deploy-Freeze gegen ein still gepushtes kaputtes Artefakt)
- `T002236: parses the upstream matchType enum` — pinnt die exakte Upstream-Form, damit ein künftiger Loader-Wechsel hier fehlschlägt und nicht erst im Post-Merge-Workflow

## Nach dem Merge

Der nächste `main`-Push rendert und pusht das Artefakt wieder; Flux zieht es innerhalb seines Reconcile-Intervalls. Der Rückstand seit 18:19 umfasst T002207, T002185 und T002224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JA9qyiTbqvcKe3gX83WDe
