### PR TITLE
fix(agent-guide): drop invented tool names that made 3 of 6 domain agents unspawnable [T002221]

### DIFF
--- a/.claude/agents/bachelorprojekt-db.md
+++ b/.claude/agents/bachelorprojekt-db.md
@@ -6,8 +6,13 @@ description: >
   database, PostgreSQL, psql, schema, query, backup, restore, tracking, timeline,
   bachelorprojekt.features, v_timeline.
 model: sonnet
-tools:
-  - mcp_postgres_query
+# [T002221] No `tools:` key on purpose — the agent inherits every tool, as
+# bachelorprojekt-test and -website already do. The previous list named
+# `mcp_postgres_query`, which is not a real tool: MCP tools resolve as
+# `mcp__mcp-postgres__query` (double underscore, server name in the middle).
+# The list resolved to the empty set and every dispatch died with
+# "would be spawned with zero tools - refusing", taking the opus/sonnet tiering
+# down with it. Inheriting all tools also survives future MCP renames.
 ---
 
 ## Library

--- a/.claude/agents/bachelorprojekt-infra.md
+++ b/.claude/agents/bachelorprojekt-infra.md
@@ -7,9 +7,12 @@ description: >
   workspace. Triggers on: k3d/, prod*/, manifest, kustomize, overlay, Taskfile,
   ENV=, environments/, deploy (when referring to k8s resources), workspace:setup.
 model: opus
-tools:
-  - mcp_kubernetes_*
-  - task
+# [T002221] No `tools:` key on purpose — see bachelorprojekt-db.md for the full
+# reasoning. The previous list named `mcp_kubernetes_*` and `task`: wildcards are
+# never expanded, and the real names are `mcp__mcp-kubernetes__pods_list` and
+# friends. Neither entry resolved, so every dispatch to this agent failed and had
+# to fall back to general-purpose — which also lost the `opus` tier this agent
+# carries precisely because its domain is cross-system and irreversible.
 ---
 
 ## Library

--- a/.claude/agents/bachelorprojekt-security.md
+++ b/.claude/agents/bachelorprojekt-security.md
@@ -5,11 +5,12 @@ description: >
   compliance checks, and secret rotation in the Bachelorprojekt platform. Triggers on:
   SealedSecret, Pocket ID, OIDC client, DSGVO, credentials, rotate, certificate, secret.
 model: opus
-tools:
-  - mcp_postgres_query
-  - mcp_kubernetes_pods_*
-  - mcp_kubernetes_resources_*
-  - ticket_mcp_*
+# [T002221] No `tools:` key on purpose — see bachelorprojekt-db.md for the full
+# reasoning. All four previous entries were invented names (`mcp_postgres_query`,
+# `mcp_kubernetes_pods_*`, `mcp_kubernetes_resources_*`, `ticket_mcp_*`): single
+# underscores instead of the `mcp__<server>__<tool>` form, plus wildcards that are
+# never expanded. The list resolved to nothing and every dispatch failed, dropping
+# the `opus` tier this agent needs for secret and OIDC work.
 ---
 
 ## Library

--- a/tests/spec/agent-library.bats
+++ b/tests/spec/agent-library.bats
@@ -49,3 +49,71 @@
     done < "$agent"
   done
 }
+
+# ── [T002221] tools: frontmatter must name tools that actually resolve ──────#
+#
+# bachelorprojekt-db/-infra/-security each declared invented tool names — single
+# underscores (`mcp_postgres_query`) and wildcards (`mcp_kubernetes_*`, `ticket_mcp_*`)
+# instead of the real `mcp__<server>__<tool>` form. Neither shape resolves, so the
+# lists collapsed to the empty set and every dispatch died with
+# "would be spawned with zero tools - refusing". Three of six domain agents were
+# unusable — including the two carrying the `opus` tier for the riskiest domains —
+# and nothing caught it, because a tools list is never validated at author time.
+
+@test "T002221: no agent declares a wildcard tool name (wildcards are never expanded)" {
+  local bad=""
+  for agent in .claude/agents/*.md; do
+    while IFS= read -r entry; do
+      [[ "$entry" == *"*"* ]] && bad="${bad}${agent}: ${entry}"$'\n'
+    done < <(python3 tests/spec/helpers/agent-tools.py "$agent")
+  done
+  [ -z "$bad" ] || { echo "wildcard tool names found:"; echo "$bad"; return 1; }
+}
+
+@test "T002221: every MCP tool name uses the mcp__<server>__<tool> form" {
+  local bad=""
+  for agent in .claude/agents/*.md; do
+    while IFS= read -r entry; do
+      # An entry that mentions mcp or a known MCP server must match the real shape.
+      if [[ "$entry" == mcp_* || "$entry" == *_mcp_* ]]; then
+        [[ "$entry" =~ ^mcp__[a-z0-9-]+__[a-z0-9_]+$ ]] || bad="${bad}${agent}: ${entry}"$'\n'
+      fi
+    done < <(python3 tests/spec/helpers/agent-tools.py "$agent")
+  done
+  [ -z "$bad" ] || { echo "malformed MCP tool names (expected mcp__<server>__<tool>):"; echo "$bad"; return 1; }
+}
+
+@test "T002221: every non-MCP tool name is a known built-in" {
+  local known=" Agent Artifact Bash BashOutput Edit ExitPlanMode Glob Grep KillShell LS NotebookEdit NotebookRead Read Skill Task TodoWrite ToolSearch WebFetch WebSearch Write "
+  local bad=""
+  for agent in .claude/agents/*.md; do
+    while IFS= read -r entry; do
+      [[ "$entry" == mcp__* || "$entry" == mcp_* || "$entry" == *_mcp_* ]] && continue
+      [[ "$known" == *" ${entry} "* ]] || bad="${bad}${agent}: ${entry}"$'\n'
+    done < <(python3 tests/spec/helpers/agent-tools.py "$agent")
+  done
+  [ -z "$bad" ] || { echo "unknown built-in tool names:"; echo "$bad"; return 1; }
+}
+
+@test "T002221: bachelorprojekt-db/-infra/-security declare no tools key (they inherit all)" {
+  # Regression pin for the three agents that were broken. Dropping the key is the
+  # deliberate fix (see the comment in each file) — it also survives MCP renames,
+  # which a hand-maintained list does not.
+  for agent in bachelorprojekt-db bachelorprojekt-infra bachelorprojekt-security; do
+    local n
+    n=$(python3 tests/spec/helpers/agent-tools.py ".claude/agents/${agent}.md" | grep -c . || true)
+    [ "$n" -eq 0 ] || { echo "$agent declares $n tools entries — expected none"; return 1; }
+  done
+}
+
+@test "T002221: an agent that does declare tools resolves to a non-empty list" {
+  # Whatever an agent declares, it must not resolve to zero tools — that is the
+  # exact condition that makes a dispatch refuse to spawn.
+  for agent in .claude/agents/*.md; do
+    if grep -qE '^tools:( *$| *\[)' "$agent"; then
+      local n
+      n=$(python3 tests/spec/helpers/agent-tools.py "$agent" | grep -c . || true)
+      [ "$n" -gt 0 ] || { echo "$agent has a tools key that resolves to zero entries"; return 1; }
+    fi
+  done
+}

--- a/tests/spec/helpers/agent-tools.py
+++ b/tests/spec/helpers/agent-tools.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""[T002221] Print one tools: entry per line from an agent definition's frontmatter.
+
+Prints nothing when the file has no frontmatter or no tools: key — "no tools key"
+and "empty tools list" are deliberately distinguishable by the caller via the
+presence of the key itself, which the caller greps for.
+
+Supports both frontmatter spellings used in .claude/agents/:
+    tools: [Bash, Read, Glob, Grep]        # inline flow sequence
+    tools:                                  # block sequence
+      - Bash
+      - Read
+"""
+import sys
+import pathlib
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml ships with the CI image
+    print("PyYAML missing", file=sys.stderr)
+    sys.exit(2)
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+if not text.startswith("---"):
+    sys.exit(0)
+
+# Frontmatter is everything up to the second '---' line.
+parts = text.split("\n---", 1)
+if len(parts) < 2:
+    sys.exit(0)
+front = parts[0].lstrip("-\n")
+
+try:
+    meta = yaml.safe_load(front) or {}
+except yaml.YAMLError as exc:
+    print(f"{path}: unparseable frontmatter: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+tools = meta.get("tools")
+if tools is None:
+    sys.exit(0)
+if isinstance(tools, str):
+    tools = [t.strip() for t in tools.split(",")]
+for entry in tools:
+    entry = str(entry).strip()
+    if entry:
+        print(entry)


### PR DESCRIPTION
## Problem

Drei der sechs Domain-Agenten waren nicht dispatchbar:

```
Agent 'bachelorprojekt-infra' would be spawned with zero tools - refusing.
Its tools list resolved to nothing: unrecognized [mcp_kubernetes_*, task]
```

Ursache: erfundene Tool-Namen im `tools:`-Frontmatter. MCP-Tools heißen `mcp__<server>__<tool>` — doppelter Unterstrich, Servername in der Mitte. Die drei Dateien nutzten einfache Unterstriche und Wildcards:

| Datei | `tools:` |
|---|---|
| `bachelorprojekt-db.md` | `mcp_postgres_query` |
| `bachelorprojekt-infra.md` | `mcp_kubernetes_*`, `task` |
| `bachelorprojekt-security.md` | `mcp_postgres_query`, `mcp_kubernetes_pods_*`, `mcp_kubernetes_resources_*`, `ticket_mcp_*` |

Weder die Schreibweise noch Wildcards werden aufgelöst — jede Liste kollabierte zur leeren Menge, der Spawn wurde verweigert.

## Tragweite

Die Routing-Tabellen in `CLAUDE.md` und `AGENTS.md` verweisen für Infra-, Security- und DB-Arbeit auf genau diese drei. Für die risikoreichsten Domänen gab es also keinen funktionierenden Weg — jeder Dispatch musste auf `general-purpose` ausweichen, wodurch zusätzlich das **`opus`-Tiering** verlorenging, das `-infra` und `-security` bewusst tragen (cross-system, riskant, irreversibel; siehe „Session model & delegation", T002153).

Funktionierend waren nur `-ops` (echte Namen: `Bash, Read, Glob, Grep`) sowie `-test` und `-website` (ohne `tools:`-Key).

## Fix

`tools:` bei allen drei ersatzlos gestrichen — sie erben damit alle Tools, wie `-test` und `-website` es schon tun. Gegenüber dem Korrigieren der Namen bevorzugt, weil es auch künftige MCP-Umbenennungen übersteht; eine handgepflegte Liste tut das nicht.

An jeder Stelle steht ein Kommentar, der erklärt, dass das Fehlen des Keys Absicht ist — sonst trägt der nächste Durchgang ihn wieder ein.

## Warum das unbemerkt verrottete

Eine `tools:`-Liste wird zum Autorenzeitpunkt nirgends validiert. Ein Tippfehler fällt erst beim Dispatch auf, und dann als Laufzeitfehler in einer fremden Session. Fünf Guardrail-Tests in `tests/spec/agent-library.bats` schließen die Lücke:

- keine Wildcards (werden nie expandiert)
- MCP-Namen müssen der Form `mcp__<server>__<tool>` entsprechen
- Nicht-MCP-Namen müssen bekannte Built-ins sein
- ein vorhandener `tools:`-Key darf nicht zu null Einträgen auflösen — genau die Bedingung, die den Spawn verweigert
- die drei betroffenen Agenten sind als key-frei gepinnt

**Gegenprobe durchgeführt:** mit dem alten `-infra`-Frontmatter wiederhergestellt fallen 4 der 5 Tests. Sie fangen den Defekt also tatsächlich, statt nur den Ist-Zustand zu beschreiben. (Der fünfte bleibt grün, weil die Liste auf YAML-Ebene zwei Einträge hat — die Leerheit entsteht erst bei der Tool-Auflösung.)

Das Frontmatter-Parsing liegt in `tests/spec/helpers/agent-tools.py` und beherrscht beide im Repo verwendeten Schreibweisen (Inline-Flow-Sequenz `tools: [Bash, Read]` und Block-Sequenz).

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `task test:agent-library` | 10/10 grün |
| `task freshness:check` | pass |
| `task test:inventory` | reproduziert die committeten 347 Einträge unverändert |
| Gegenprobe alter Zustand | 4 von 5 neuen Tests rot |

Eine Suche nach den erfundenen Namen in `**/*.md`, `**/*.json`, `**/*.yml` ergab außerhalb der drei Agent-Dateien keine Fundstellen — die Routing-Tabellen nennen MCP-*Server*, keine Tool-Namen, und bleiben unverändert korrekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JA9qyiTbqvcKe3gX83WDe
