### PR TITLE
chore(ci): map changed paths onto path-referencing spec bats [T002245]

### DIFF
--- a/scripts/find-changed-tests.sh
+++ b/scripts/find-changed-tests.sh
@@ -17,6 +17,7 @@ fi
 
 CANDIDATES=()
 RUN_ALL=false
+declare -A PROBE_CACHE=()  # path-prefix → matching spec bats (grep memoisation)
 
 is_excluded() {
   local bats_file="$1"
@@ -95,6 +96,32 @@ while IFS= read -r file; do
   # If workflow, configs, or test helper libraries changed, run all tests for safety
   if [[ "$file" == .github/workflows/* ]] || [[ "$file" == Taskfile* ]] || [[ "$file" == tests/unit/lib/* ]] || [[ "$file" == package.json ]]; then
     RUN_ALL=true
+    continue
+  fi
+
+  # Last resort for spec selection: a spec bats that mentions the changed path
+  # is the one asserting about it. Probes the full path first, then walks up the
+  # ancestor directories, deepest match wins — so website/src/pages/admin/x.astro
+  # picks the admin specs rather than every spec that mentions website/src.
+  # Floors above the top-level segment (never probes a bare "website"). Without
+  # this, whole domains (website/**, k3d/**, flux/**) matched no rule above and
+  # a diff-scoped run selected nothing for them. [T002245]
+  if [ "$TYPE" = "spec" ] && [ "$RUN_ALL" != "true" ]; then
+    probe="$file"
+    matched=""
+    while [[ "$probe" == */* ]]; do
+      if [ -n "${PROBE_CACHE[$probe]+set}" ]; then
+        matched="${PROBE_CACHE[$probe]}"
+      else
+        matched=$(grep -lF -- "$probe" "$BASE_DIR"/*.bats 2>/dev/null || true)
+        PROBE_CACHE["$probe"]="$matched"
+      fi
+      [ -n "$matched" ] && break
+      probe="${probe%/*}"
+    done
+    while IFS= read -r m; do
+      [ -n "$m" ] && CANDIDATES+=("$m")
+    done <<< "$matched"
   fi
 done <<< "$CHANGED"
 

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -1009,6 +1009,41 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
   [ "$(echo "$output" | wc -l)" -eq 2 ]
 }
 
+@test "T002245: find-changed-tests.sh spec picks the deepest path-referencing spec" {
+  local finder="$REPO_ROOT/scripts/find-changed-tests.sh"
+  local tmp="$BATS_TEST_TMPDIR/probe-repo"
+  mkdir -p "$tmp/scripts" "$tmp/tests/spec" "$tmp/website/src/pages/admin"
+  cp "$finder" "$tmp/scripts/find-changed-tests.sh"
+  # deep.bats names the exact directory, shallow.bats only a broader prefix,
+  # toplevel.bats only the bare top-level segment (must never win).
+  echo '# covers website/src/pages/admin' > "$tmp/tests/spec/deep.bats"
+  echo '# covers website/src' > "$tmp/tests/spec/shallow.bats"
+  echo '# covers website' > "$tmp/tests/spec/toplevel.bats"
+  : > "$tmp/website/src/pages/admin/dora.astro"
+  : > "$tmp/website/loose.txt"
+
+  cd "$tmp"
+  git init -q -b main .
+  git add -A && git -c user.email=t@t -c user.name=t commit -q -m tree
+  git update-ref refs/remotes/origin/main HEAD
+
+  # Deepest match wins: the admin spec, not the broader website/src one.
+  git checkout -q -b topic
+  echo change >> website/src/pages/admin/dora.astro
+  git add -A && git -c user.email=t@t -c user.name=t commit -q -m deep
+  run bash scripts/find-changed-tests.sh spec
+  [ "$status" -eq 0 ]
+  [ "$output" = "tests/spec/deep.bats" ]
+
+  # Floor: a top-level-only reference must not drag in the whole domain.
+  git checkout -q main && git checkout -q -b topic2
+  echo change >> website/loose.txt
+  git add -A && git -c user.email=t@t -c user.name=t commit -q -m floor
+  run bash scripts/find-changed-tests.sh spec
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 # ── T002170: Restposten der Renovate-Config-Migration. fileMatch ist deprecated
 #    und wurde durch managerFilePatterns ersetzt (slash-gekapselte Regexes, wie
 #    schon bei matchPackageNames in T002165). Wichtig: der kubernetes-Manager hat


### PR DESCRIPTION
Nachzügler zu #3294. Der dortige Auto-Merge feuerte, bevor dieser zweite Commit gepusht war — der Commit landete auf einem Branch mit bereits geschlossenem PR und fehlt daher auf `main`. Inhalt unverändert, hier auf aktuellem `main` neu aufgesetzt.

## Problem

#3294 hat den Required Check **Factory + OpenSpec + Guards** auf PRs diff-scoped. Die dortige Auswahl-Logik (OpenSpec-Slug + Skriptname) griff aber für ganze Domänen nicht: `website/**`, `k3d/**` und `flux/**` fielen durch alle Regeln und wählten **null** Spec-Tests aus. Die Abdeckung wanderte dort vollständig in den push-to-main-Lauf — Regressionen zeigten sich erst nach dem Merge.

## Lösung

Für `TYPE=spec` probt der Finder den geänderten Pfad und dessen Elternverzeichnisse gegen den *Inhalt* der Spec-Files: wer den Pfad erwähnt, assertet über ihn. **Deepest-Match-Wins**, Boden oberhalb des Top-Level-Segments, Grep-Ergebnisse memoisiert.

Bewusst inhaltsbasiert statt als handgepflegte `website/** → [a,b,c]`-Tabelle — die würde genau wie die 4-Datei-Liste aus T002182 verrotten, sobald ein neues Spec-File dazukommt.

Gemessen an echten Pfaden:

| Geänderte Datei | Gewählter Prefix | Treffer |
|---|---|---|
| `website/src/pages/admin/dora.astro` | `website/src/pages/admin` | 3 |
| `website/src/components/kore/KoreHomepage.svelte` | exakter Pfad | 1 |
| `website/src/lib/website-db.ts` | exakter Pfad | 1 → `website-core.bats` |
| `website/src/pages/404.astro` | `website/src/pages` | 10 |
| `k3d/pocket-id.yaml` | exakter Pfad | 4 → auth-sso, pocket-id-*, workspace-deploy |
| `flux/clusters/fleet/ks-jobs-mentolder.yaml` | `flux/clusters/fleet` | 1 |

Also 1–10 statt 0. Ohne den Boden hätte `website/loose.txt` bis zum bloßen Segment `website` hochgeprobt und alle 41 Files gezogen — dafür gibt es eine eigene Assertion.

Unit-Verhalten ist unverändert: der Block ist auf `TYPE = spec` gated.

## Verify

- `tests/spec/ci-cd.bats`: **87/87 ok**, 0 `not ok` (inkl. 2 neuer Assertions: Deepest-Match, Top-Level-Boden)
- `task freshness:check` → exit 0, keine Artefakt-Drift
- S1-Ratchet `find-changed-tests.sh` (`.sh`, Limit 500): Restbudget +362
- **Selbsttest:** dieser PR berührt weder Workflow noch Taskfile, löst also kein RUN_ALL aus — er ist der erste echte Lauf des scoped Pfads. Der Finder wählt genau `tests/spec/ci-cd.bats`, also exakt die Datei, die diese Änderung testet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JA9qyiTbqvcKe3gX83WDe