### PR TITLE
fix(ci): make freshness:check regenerate before diffing [T002252]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1002,7 +1002,27 @@ tasks:
   freshness:check:
     desc: "Fail if any generated artifact is stale or violates invariants (CI gate + local pre-commit safety)"
     cmds:
-      # --- Phase 1: regenerate everything, then diff-check each file ---
+      # --- Phase 0: regenerate, THEN diff-check (T002252) ---
+      # Without this step the diff below compares the artifacts against
+      # themselves: on a fresh checkout the tree is clean by definition, so the
+      # gate was structurally green even for stale artifacts. Verified against
+      # merge commit c792d6f85 (brett file_count 366, actual 365):
+      #   task freshness:check                       -> exit 0   (green, wrong)
+      #   task quality:index && task freshness:check -> exit 201 (drift caught)
+      # Consequence of the blind gate: nearly every PR left stale artifacts on
+      # main and freshness-regen.yml healed them with a bot commit afterwards
+      # (21 such commits on 2026-07-26 alone), which keeps main moving and is one
+      # of the reasons Renovate's ~150s run aborts with repository-changed
+      # (T002249).
+      #
+      # Yes, this makes a "check" mutate the working tree — it rewrites exactly
+      # the generated files the error message below already tells you to
+      # regenerate and commit, same as `gofmt -l` / `cargo fmt --check` flows.
+      # Safe to do so because regeneration is deterministic: two consecutive runs
+      # from an identical tree produce zero changed files, and none of the 16
+      # artifacts embed a wall-clock timestamp. Costs ~9s.
+      - task: freshness:regenerate
+      # --- Phase 1: diff-check each file ---
       - |
         ERRORS=0
         FILES="

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -1210,3 +1210,27 @@ MOCKEOF
   run grep -nE '\|\| FAILED_TASKS|deploy blocked|deploy failed' "$REPO_ROOT/scripts/devflow-post-merge-deploy.sh"
   [ "$status" -eq 0 ]
 }
+
+# ── T002252: freshness:check muss vor dem Diff regenerieren ─────────
+# Ohne diesen Schritt prueft `git diff --exit-code` den Artefakt-Stand nur gegen
+# sich selbst: auf einem frischen CI-Checkout ist der Baum immer sauber, die Gate
+# also strukturell gruen — auch wenn die Artefakte gegenueber ihren Quellen
+# veraltet sind. Belegt gegen c792d6f85: `task freshness:check` -> 0, aber
+# `task quality:index && task freshness:check` -> 201.
+@test "T002252: freshness:check regeneriert die Artefakte vor dem Diff-Check" {
+  # cmds-Block von freshness:check bis zum naechsten Top-Level-Task extrahieren
+  local block
+  block=$(awk '/^  freshness:check:/{f=1} f&&/^  [a-z][a-z0-9:-]*:$/&&!/^  freshness:check:/{exit} f' \
+    "$REPO_ROOT/Taskfile.yml")
+
+  # Der Regenerate-Schritt muss existieren ...
+  [[ "$block" =~ task:[[:space:]]*freshness:regenerate ]]
+
+  # ... und VOR der Diff-Schleife stehen, sonst diffed er gegen den alten Stand.
+  local regen_line diff_line
+  regen_line=$(grep -n 'task:[[:space:]]*freshness:regenerate' <<<"$block" | head -1 | cut -d: -f1)
+  diff_line=$(grep -n 'git diff --exit-code' <<<"$block" | head -1 | cut -d: -f1)
+  [ -n "$regen_line" ]
+  [ -n "$diff_line" ]
+  [ "$regen_line" -lt "$diff_line" ]
+}


### PR DESCRIPTION
Folgt aus der `repo-index.json`-Drift nach #3298. Die Frage war, warum die Freshness-Gate das nicht gemeldet hat.

## Root Cause

`Taskfile.yml:1002` prüft die 16 generierten Artefakte mit `git diff --exit-code <file>` — gegen den **Arbeitsbaum**, nicht gegen ihre Quellen. Der eigene Kommentar versprach

```
# --- Phase 1: regenerate everything, then diff-check each file ---
```

aber es gab weder ein `deps:` noch einen Regenerate-Befehl. Auf einem frischen Checkout ist der Baum per Definition sauber — die Gate war dort **strukturell immer grün**, egal wie veraltet die Artefakte waren.

Belegt gegen Merge-Commit `c792d6f85`, sauberer Baum, `brett file_count` committet als 366 bei tatsächlich 365:

| Aufruf | Exit |
|---|---|
| `task freshness:check` | **0** — grün, falsch |
| `task quality:index` → `task freshness:check` | **201** — Drift erkannt |

CI ruft es genau so auf (`ci.yml:104`, frischer `actions/checkout`, kein Regenerate davor).

## Warum es niemandem auffiel

`freshness-regen.yml` triggert auf jeden Push nach `main` und heilt die Artefakte per Bot-Commit *nach* dem Merge — **21 solcher Commits allein am 26.07.** Das Ergebnis war korrekt, nur eben zu spät und um den Preis permanenter Bewegung auf `main`. Das ist eine der Ursachen, an denen Renovates ~150-Sekunden-Lauf mit `repository-changed` scheitert (T002249).

## Der Trade-off existiert nicht mehr

Die Annahme, `freshness:regenerate` bette Wall-Clock-Timestamps ein und churne jeden Lauf, hätte Diff-only gerechtfertigt. Gemessen: **zwei Läufe vom selben Stand, je null geänderte Dateien**, kein Artefakt mit Timestamp-Feld. Kosten **9,2 s** — gegen die 9,45 s, die `freshness:check` ohnehin schon braucht.

## Zur Mutation

Ein „check", der den Baum schreibt, ist ungewöhnlich. Er schreibt aber exakt die Dateien, zu deren Regenerierung die bestehende Fehlermeldung auffordert (*„run 'task freshness:regenerate' locally and commit"*) — dieselbe Form wie `gofmt -l` / `cargo fmt --check`. Alternative wäre gewesen, nur `ci.yml` zu ändern; dann bliebe die Lücke lokal und in allen dev-flow-Skills bestehen.

## Test

Strukturelle Assertion in `tests/spec/ci-cd.bats`: der Regenerate-Schritt muss existieren **und** vor der Diff-Schleife stehen — die Reihenfolge ist der Kern, ein nachgelagertes Regenerate würde weiterhin den alten Stand diffen.

- **RED** vor dem Fix (Schritt fehlt) ✓
- **GREEN** danach ✓
- **End-to-End**: mit absichtlich veraltetem, committetem Artefakt und sauberem Baum liefert die reparierte Gate `201` ✓

## Verifikation

- `task test:all` → exit 0, 0 failures
- `task test:inventory` → exit 0, keine Drift
- `task freshness:check` (neue Fassung) → exit 0, keine Drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgGJHzt2RRSbAd4RLp9xv