### PR TITLE
chore(ci): match the real ghcr.io/paddione packageName in renovate disable rule [T002257]

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -165,19 +165,28 @@
     // alternative matchPackagePatterns is deprecated in Renovate v43+ and would
     // trigger "Config needs migrating".
     //
-    // The bare "paddione" entry is NOT a typo (T002246). k3d/website.yaml uses
+    // The second, slash-less entry is NOT a typo. k3d/website.yaml uses
     //   image: ghcr.io/paddione/${WEBSITE_IMAGE}:${WEBSITE_IMAGE_TAG}
     // and the kubernetes manager does not resolve envsubst placeholders — it
-    // drops them and extracts the dep as bare "paddione". That name is invalid
-    // on ghcr.io, so the lookup produced
-    //   WARN: Error obtaining docker token … NAME_INVALID
+    // drops the whole placeholder segment and extracts the dep as
+    //   depName/packageName: "ghcr.io/paddione"   (currentValue: undefined)
+    // A single-segment path is invalid on ghcr.io, so the lookup produced
+    //   WARN: Error obtaining docker token … NAME_INVALID (dockerRepository: "paddione")
     //   WARN: No docker auth found - returning
-    // on every run. The regex above only matches "ghcr.io/paddione/<something>"
-    // and therefore never covered it. An earlier comment here claimed the warning
-    // was unavoidable because the token request precedes rule evaluation — that
-    // was wrong: enabled:false drops the dep before the datasource lookup runs.
+    // on every run. The regex above requires a trailing slash and therefore
+    // never covered it.
+    //
+    // T002246 tried to fix this with a bare "paddione" entry, on the assumption
+    // that the dep is extracted under that name. It is not — matchPackageNames
+    // compares against the full packageName "ghcr.io/paddione", so the exact
+    // match never fired and the warning survived (T002257). Verified with
+    //   docker run --rm -v "$PWD":/repo:ro -w /repo \
+    //     -e RENOVATE_PLATFORM=local -e RENOVATE_DRY_RUN=lookup \
+    //     ghcr.io/renovatebot/renovate:43
+    // which reproduces the warning before and no longer emits it after.
+    // enabled:false does drop the dep before the datasource lookup runs.
     {
-      "matchPackageNames": ["/^ghcr.io/paddione//", "paddione"],
+      "matchPackageNames": ["/^ghcr.io/paddione//", "ghcr.io/paddione"],
       "enabled": false
     },
 


### PR DESCRIPTION
## Problem

Jeder Renovate-Run endet mit:

```
WARN: Error obtaining docker token  registryHost: https://ghcr.io, dockerRepository: "paddione"
      NAME_INVALID: invalid repository name
WARN: No docker auth found - returning
```

## Root Cause

`k3d/website.yaml:222` nutzt `image: ghcr.io/paddione/${WEBSITE_IMAGE}:${WEBSITE_IMAGE_TAG}`.
Renovates Kubernetes-Manager löst envsubst-Platzhalter nicht auf, sondern **verwirft das
Segment** — der Dep landet als `packageName: "ghcr.io/paddione"` in der Extraktion. Ein
einsegmentiger Pfad ist auf ghcr.io ungültig → `NAME_INVALID` beim Token-Request.

T002246 wollte das mit einem `matchPackageNames`-Eintrag `"paddione"` unterdrücken — unter der
falschen Annahme, der Dep heiße bare `paddione`. `matchPackageNames` vergleicht aber gegen den
**vollen packageName**; `dockerRepository` im Log ist bereits das Ergebnis des Registry-Splits.
Der Exact-Match hat daher nie gegriffen, der Regex `/^ghcr.io/paddione//` verlangt einen Slash
danach. Die Warnung erschien auch im Run vom 2026-07-26 22:40 wieder — mit dem T002246-Fix
bereits auf `main` (merged 21:42).

## Fix

Toter Eintrag `"paddione"` → `"ghcr.io/paddione"`. Kommentar korrigiert, Reproduktionsbefehl
dokumentiert.

## Verifikation

```
docker run --rm -v "$PWD":/repo:ro -w /repo \
  -e RENOVATE_PLATFORM=local -e RENOVATE_DRY_RUN=lookup \
  ghcr.io/renovatebot/renovate:43
```

- **vorher:** `dockerRepository: "paddione"` + `NAME_INVALID` + `No docker auth found` (3 Treffer)
- **nachher:** 0 Treffer — `enabled:false` verwirft den Dep vor dem Datasource-Lookup
- Extract-Dry-Run belegt den Dep direkt: `"depName": "ghcr.io/paddione", "packageName": "ghcr.io/paddione"`
- `task test:changed` ✓ (52/52), `task freshness:check` ✓ (exit 0)

## Nicht Teil dieses PRs

Derselbe Run endete mit `Repository has changed during renovation - aborting` — zwischen 22:32
und 22:39 sind drei PRs nach `main` gemergt worden. Race-Condition, kein Config-Bug; separat zu
beobachten, falls es dauerhaft auftritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KxVx3bnbgEG7MnbmGyxWy