### PR TITLE
chore(scripts): set -b/-ub 8192 on embed+rerank servers [T002260]

### DIFF
--- a/scripts/llm/register-scheduled-tasks.ps1
+++ b/scripts/llm/register-scheduled-tasks.ps1
@@ -34,13 +34,20 @@ $Tasks = @(
     Name = "LlamaEmbedServer"
     Description = "bge-m3 Embedding-Server (Port 8095)"
     Exe = "$env:UserProfile\llama-b10090-13.3\llama-server.exe"
-    Args = "-m `"$env:UserProfile\.lmstudio\models\gpustack\bge-m3-GGUF\bge-m3-Q8_0.gguf`" --embedding --pooling cls --embd-normalize 2 -c 8192 -ngl 99 -fa on --host 0.0.0.0 --port 8095"
+    # T002260: -b/-ub 8192 sind PFLICHT. bge-m3 ist nicht-kausal, llama.cpp kann
+    # eine Sequenz nicht ueber mehrere physische Batches splitten -> ohne -ub
+    # gilt der Default 512 und jeder laengere Input scheitert mit
+    # "input (N tokens) is too large to process". -c allein genuegt NICHT.
+    Args = "-m `"$env:UserProfile\.lmstudio\models\gpustack\bge-m3-GGUF\bge-m3-Q8_0.gguf`" --embedding --pooling cls --embd-normalize 2 -c 8192 -b 8192 -ub 8192 -ngl 99 -fa on --host 0.0.0.0 --port 8095"
   }
   @{
     Name = "LlamaRerankServer"
     Description = "bge-reranker-v2-m3 Rerank-Server (Port 8096)"
     Exe = "$env:UserProfile\llama-b10090-13.3\llama-server.exe"
-    Args = "-m `"$env:UserProfile\.lmstudio\models\gpustack\bge-reranker-v2-m3-GGUF\bge-reranker-v2-m3-Q8_0.gguf`" --reranking -c 8192 -ngl 99 -fa on --host 0.0.0.0 --port 8096"
+    # T002260: -b/-ub 8192 sind PFLICHT, gleiche Begruendung wie beim
+    # Embed-Server. Beim Cross-Encoder gilt die Grenze fuer Query+Dokument
+    # zusammen — realistische Dokumente ab ~1500 Zeichen reissen 512 Tokens.
+    Args = "-m `"$env:UserProfile\.lmstudio\models\gpustack\bge-reranker-v2-m3-GGUF\bge-reranker-v2-m3-Q8_0.gguf`" --reranking -c 8192 -b 8192 -ub 8192 -ngl 99 -fa on --host 0.0.0.0 --port 8096"
   }
 )
 
@@ -49,7 +56,12 @@ $SchTasks = "$env:SystemRoot\System32\schtasks.exe"
 foreach ($Task in $Tasks) {
   $Name = $Task.Name
   $Desc = $Task.Description
-  $Exe = $Task.Expr
+  # T002264: stand hier als $Task.Expr — ein Key dieses Namens existiert nicht,
+  # PowerShell liefert dafuer still $null (kein Set-StrictMode). Jede Task wurde
+  # damit als /tr "" <args> registriert, also mit LEEREM Executable-Pfad, und
+  # konnte nichts starten. Das ist der Grund, warum es faktisch keine
+  # Server-Persistenz gab, obwohl das Skript existierte.
+  $Exe = $Task.Exe
   $Args = $Task.Args
 
   # Prüfe ob Task bereits existiert

--- a/scripts/llm/start-embed-server.ps1
+++ b/scripts/llm/start-embed-server.ps1
@@ -5,6 +5,20 @@
   Startet eine persistente llama.cpp-Instanz für Text-Embeddings (bge-m3 Q8_0)
   auf Port 8095. Der Server wird mit Flash Attention und GPU-Offload betrieben.
   VRAM-Notausstieg via Umgebungsvariable LLM_EMBED_NGL (Default 99).
+
+  T002260 — WARUM -b/-ub 8192 gesetzt sein MUSS:
+  bge-m3 ist ein nicht-kausales Modell (XLM-RoBERTa). llama.cpp kann eine solche
+  Sequenz NICHT über mehrere physische Batches aufteilen — jede Sequenz muss
+  komplett in einen n_ubatch passen. Ohne -b/-ub gilt der Default n_ubatch=512,
+  und der Server lehnt jeden längeren Input ab:
+    "input (734 tokens) is too large to process.
+     increase the physical batch size (current batch size: 512)"
+  Das gesetzte -c 8192 hilft nicht: /props meldet n_ctx 8192, nutzbar sind 512.
+  Gemessen 2026-07-27: 2000 Zeichen Code = 774 Tokens -> HTTP 500.
+  Die abgelöste TEI-Instanz konnte 8192 (max_position_embeddings 8194), der
+  Cutover T002110 hatte die nutzbare Eingabelänge also unbemerkt auf 512
+  reduziert. Beim Ändern dieser Werte immer mit einem LANGTEXT nachprüfen —
+  ein "Hallo Welt"-Smoke-Test bleibt in jedem Fall grün.
 .PARAMETER LlamaDir
   Verzeichnis mit llama-server.exe. Default: C:\Users\PatrickKorczewski\llama-b10090-13.3
 .EXAMPLE
@@ -39,6 +53,10 @@ $Params = @(
   "--pooling", "cls"
   "--embd-normalize", "2"
   "-c", "8192"
+  # T002260: logischer UND physischer Batch auf die volle Kontextlaenge.
+  # Ohne -ub scheitert jede Sequenz > 512 Tokens (Default n_ubatch), s. .DESCRIPTION.
+  "-b", "8192"
+  "-ub", "8192"
   "-ngl", $Ngl
   "-fa", "on"
   "--host", "0.0.0.0"
@@ -54,4 +72,11 @@ $Job = Start-Job -ScriptBlock {
 Write-Host "Embedding server started (Job ID: $($Job.Id))"
 Write-Host "Endpoint: http://127.0.0.1:8095/v1/embeddings"
 Write-Host ""
-Write-Host "Test: curl -s http://127.0.0.1:8095/v1/embeddings -H 'Content-Type: application/json' -d '{\"model\":\"bge-m3\",\"input\":[\"Hallo Welt\"]}'"
+Write-Host ""
+Write-Host "Test (T002260 — MIT LANGTEXT pruefen, ein Kurztext bleibt auch bei"
+Write-Host "kaputtem -ub gruen und verdeckt die 512-Token-Kappung):"
+Write-Host '  $long = "kubernetes deployment reconciliation " * 120   # ~600+ Tokens'
+Write-Host '  $body = @{ model = "bge-m3"; input = @($long) } | ConvertTo-Json'
+Write-Host '  Invoke-RestMethod -Uri http://127.0.0.1:8095/v1/embeddings -Method Post `'
+Write-Host '    -ContentType application/json -Body $body | ForEach-Object { $_.data[0].embedding.Count }'
+Write-Host "  -> erwartet: 1024. HTTP 500 'too large to process' = -b/-ub fehlen."

--- a/scripts/llm/start-rerank-server.ps1
+++ b/scripts/llm/start-rerank-server.ps1
@@ -6,6 +6,19 @@
   auf Port 8096. Getrennter Prozess vom Embedding-Server, da llama.cpp Embedding-Pooling
   (CLS) und Rerank-Pooling (RANK) nicht in einem Server bedienen kann.
   VRAM-Notausstieg via Umgebungsvariable LLM_RERANK_NGL (Default 99).
+
+  T002260 — WARUM -b/-ub 8192 gesetzt sein MUSS:
+  bge-reranker-v2-m3 ist ein Cross-Encoder auf XLM-RoBERTa, also nicht-kausal.
+  llama.cpp kann eine solche Sequenz NICHT über mehrere physische Batches
+  aufteilen — jedes Query+Dokument-Paar muss komplett in einen n_ubatch passen.
+  Ohne -b/-ub gilt der Default n_ubatch=512 und der Server antwortet:
+    "input (1253 tokens) is too large to process.
+     increase the physical batch size (current batch size: 512)"
+  Gemessen 2026-07-27: ein Dokument von 4000 Zeichen (1253 Tokens) schlug fehl,
+  1500 Zeichen gingen noch durch. Realistische Dokumente liegen also mitten in
+  der Ausfallzone. Verschärfend: website/src/lib/rerank.ts verschluckt Fehler und
+  liefert dann still score: 0 — der Ausfall ist von aussen unsichtbar.
+  Beim Ändern dieser Werte immer mit einem LANGEN Dokument nachprüfen.
 .PARAMETER LlamaDir
   Verzeichnis mit llama-server.exe. Default: C:\Users\PatrickKorczewski\llama-b10090-13.3
 .EXAMPLE
@@ -38,6 +51,10 @@ $Params = @(
   "-m", $Model
   "--reranking"
   "-c", "8192"
+  # T002260: logischer UND physischer Batch auf die volle Kontextlaenge.
+  # Ohne -ub scheitert jedes Query+Dokument-Paar > 512 Tokens, s. .DESCRIPTION.
+  "-b", "8192"
+  "-ub", "8192"
   "-ngl", $Ngl
   "-fa", "on"
   "--host", "0.0.0.0"
@@ -52,4 +69,11 @@ $Job = Start-Job -ScriptBlock {
 Write-Host "Rerank server started (Job ID: $($Job.Id))"
 Write-Host "Endpoint: http://127.0.0.1:8096/v1/rerank"
 Write-Host ""
-Write-Host "Test: curl -s http://127.0.0.1:8096/v1/rerank -H 'Content-Type: application/json' -d '{\"model\":\"bge-reranker-v2-m3\",\"query\":\"capital of germany\",\"documents\":[\"paris\",\"berlin\",\"hamburg\",\"munich\"]}'"
+Write-Host ""
+Write-Host "Test (T002260 — mit LANGEM Dokument pruefen; Kurzdokumente wie"
+Write-Host "'paris'/'berlin' bleiben auch bei kaputtem -ub gruen):"
+Write-Host '  $long = "flux reconciles the oci artifact every ten minutes " * 100  # ~1200 Tokens'
+Write-Host '  $body = @{ query = "how often does flux reconcile"; documents = @($long, "apple pie recipe") } | ConvertTo-Json'
+Write-Host '  Invoke-RestMethod -Uri http://127.0.0.1:8096/v1/rerank -Method Post `'
+Write-Host '    -ContentType application/json -Body $body | ForEach-Object { $_.results }'
+Write-Host "  -> erwartet: index 0 vor index 1. HTTP 500 'too large to process' = -b/-ub fehlen."

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -161,3 +161,54 @@ assert_var_not_declared() {
 @test "scripts/llm/register-scheduled-tasks.ps1 exists" {
   [ -f "$REPO/scripts/llm/register-scheduled-tasks.ps1" ]
 }
+
+# ── Physischer Batch (T002260) ────────────────────────────────────────
+# bge-m3 und bge-reranker-v2-m3 sind nicht-kausal (XLM-RoBERTa). llama.cpp kann
+# eine solche Sequenz NICHT über mehrere physische Batches aufteilen — ohne
+# -b/-ub gilt der Default n_ubatch=512 und jeder längere Input scheitert mit
+# "input (N tokens) is too large to process". Das gesetzte -c 8192 hilft nicht.
+# Der Ausfall ist unsichtbar: Kurztext-Smoke-Tests bleiben grün, und
+# website/src/lib/rerank.ts verschluckt Rerank-Fehler zu score: 0. Diese Tests
+# sind der Regressionsschutz — die Flags dürfen nicht wieder verschwinden.
+# Schreibweise wie bei --pooling (s. T002181-Kommentar oben): PowerShell
+# übergibt Array-Elemente, nicht zusammenhängende Strings.
+
+@test "start-embed-server.ps1 sets -b and -ub to the full context length (T002260)" {
+  run grep -qE '"-b",[[:space:]]*"8192"' "$REPO/scripts/llm/start-embed-server.ps1"
+  [ "$status" -eq 0 ]
+  run grep -qE '"-ub",[[:space:]]*"8192"' "$REPO/scripts/llm/start-embed-server.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "start-rerank-server.ps1 sets -b and -ub to the full context length (T002260)" {
+  run grep -qE '"-b",[[:space:]]*"8192"' "$REPO/scripts/llm/start-rerank-server.ps1"
+  [ "$status" -eq 0 ]
+  run grep -qE '"-ub",[[:space:]]*"8192"' "$REPO/scripts/llm/start-rerank-server.ps1"
+  [ "$status" -eq 0 ]
+}
+
+# Hier ist die Inline-String-Form korrekt — register-scheduled-tasks.ps1 baut die
+# Argumente als eine zusammenhaengende Kommandozeile fuer schtasks.exe.
+@test "register-scheduled-tasks.ps1 passes -b/-ub 8192 to the embed server (T002260)" {
+  run grep -qE 'bge-m3-Q8_0\.gguf.*-b 8192 -ub 8192' "$REPO/scripts/llm/register-scheduled-tasks.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "register-scheduled-tasks.ps1 passes -b/-ub 8192 to the rerank server (T002260)" {
+  run grep -qE 'bge-reranker-v2-m3-Q8_0\.gguf.*-b 8192 -ub 8192' "$REPO/scripts/llm/register-scheduled-tasks.ps1"
+  [ "$status" -eq 0 ]
+}
+
+# T002264: der Zugriff stand auf $Task.Expr, ein Key dieses Namens existiert nicht.
+# PowerShell liefert dafür still $null, also wurde jede Scheduled Task mit leerem
+# Executable-Pfad registriert (/tr "" <args>) und konnte nichts starten — der
+# Grund, warum es faktisch keine Server-Persistenz gab.
+@test "register-scheduled-tasks.ps1 reads \$Task.Exe, not a nonexistent key (T002264)" {
+  run grep -qE '\$Exe[[:space:]]*=[[:space:]]*\$Task\.Exe' "$REPO/scripts/llm/register-scheduled-tasks.ps1"
+  [ "$status" -eq 0 ]
+  # Kein CODE-Zugriff auf einen Key, den die Hashtable nicht definiert.
+  # PowerShell-Kommentarzeilen (#) vorher wegfiltern — der Fix ist dort mitsamt
+  # des alten, falschen Namens dokumentiert, und das soll so bleiben.
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/scripts/llm/register-scheduled-tasks.ps1' | grep -qE '\\\$Task\\.Expr'"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Symptom

Die llama.cpp-Server für `bge-m3` (`:8095`) und `bge-reranker-v2-m3` (`:8096`) lehnten jeden
Input über **512 Tokens** ab:

```
input (734 tokens) is too large to process.
increase the physical batch size (current batch size: 512)
```

Gemessen 2026-07-27 gegen die laufenden Server:

| Input | `:8095` embed | `:8096` rerank |
|---|---|---|
| ~300 Tokens | OK | OK |
| ~470 Tokens (1500 Zeichen) | — | OK |
| 774 Tokens (2000 Zeichen Code) | **HTTP 500** | — |
| 1253 Tokens (4000 Zeichen Dokument) | — | **HTTP 500** |
| 3093 Tokens (8000 Zeichen) | **HTTP 500** | — |

## Ursache

Keines der Startskripte setzte `-b`/`-ub`, also galt der llama.cpp-Default `n_ubatch = 512`.

Beide Modelle sind **nicht-kausal** (XLM-RoBERTa — Embedding bzw. Cross-Encoder-Rerank).
llama.cpp kann eine solche Sequenz **nicht** über mehrere physische Batches aufteilen: jede
Sequenz muss vollständig in einen `n_ubatch` passen. Das gesetzte `-c 8192` war damit
wirkungslos — `/props` meldete `n_ctx: 8192`, nutzbar waren 512. Ein Konfigurationswert, der
die Wahrheit verdeckt.

**Regression gegen den Vorzustand:** die abgelöste TEI-Instanz meldete
`max_input_length: 8192` und lieferte das auch (beide Modelle haben
`max_position_embeddings: 8194`). Der Cutover **T002110** hatte die nutzbare Eingabelänge also
unbemerkt von 8192 auf 512 reduziert.

## Warum es nicht auffiel

Alle Smoke-Tests arbeiteten mit Kurztexten — die Test-Hinweise am Ende der Startskripte nannten
wörtlich `"Hallo Welt"` bzw. `"paris"`/`"berlin"`. Beides bleibt auch bei kaputtem `-ub` grün.
Diese Hinweise sind jetzt durch **Langtext-Beispiele** ersetzt, inklusive der Aussage, was ein
HTTP 500 an dieser Stelle bedeutet.

Beim Reranker verschluckt zusätzlich `website/src/lib/rerank.ts` den Fehler und liefert still
`score: 0` — der Ausfall ist von außen unsichtbar.

## Betroffene Konsumenten

- **`task scs:index`** — `CHUNK_MAX_TOKENS = 512` ist über `chars/4` geschätzt; Code tokenisiert
  bei ~2,6 Zeichen/Token, ein 2000-Zeichen-Chunk ergibt real 774 Tokens. Betroffene Dateien
  landen im `catch` und werden als `SKIP` verbucht → ein Voll-Index hätte großflächige Löcher,
  ohne hart zu scheitern.
- **`scripts/openspec-embed.mjs`** — OpenSpec-Dokumente sind deutlich länger als 512 Tokens.
- **Rerank** — realistische Dokumente ab ~1500 Zeichen.

## Zusätzlich [T002264]

`register-scheduled-tasks.ps1` las `$Task.Expr`, der Hashtable-Key heißt aber `Exe`. PowerShell
liefert für einen nicht existierenden Key still `$null` (kein `Set-StrictMode`), also wurde
**jede** der drei Scheduled Tasks als `/tr "" <args>` registriert — mit leerem
Executable-Pfad — und konnte nichts starten.

Das erklärt den dokumentierten Zustand „Persistenz existiert nicht — kein Scheduled Task, kein
Windows-Dienst": nicht ungenutzt, sondern strukturell funktionslos. Liegt auf dem kritischen
Pfad dieses Fixes, weil die neuen Flags sonst nur in einer Task landen, die ohnehin nicht
startet.

## Regressionsschutz

5 neue `@test` in `tests/spec/llm-pipeline.bats`. Jeder wurde **beidseitig** geprüft — GREEN im
Sollzustand und nachweislich **RED** nach temporärem Zurückdrehen der Flags bzw. des
Key-Zugriffs. Ein Test, der nicht fehlschlagen kann, ist wertlos.

Der T002264-Test filtert PowerShell-Kommentarzeilen: ohne den Filter traf der negative `grep`
den eigenen Dokumentationskommentar in derselben Datei (erst rot, dann korrigiert).

Schreibweise folgt dem Präzedenzfall im selben File (T002181-Kommentar): PowerShell übergibt
Array-Elemente (`"-ub", "8192"`), `register-scheduled-tasks.ps1` dagegen eine zusammenhängende
Kommandozeile (`-ub 8192`).

## Verifikation

- `bats tests/spec/llm-pipeline.bats` → **27/27**
- `task test:changed` → **52 pass / 0 fail**
- `task freshness:check` → **grün**
- `task freshness:regenerate` erzeugte keine Artefakt-Diffs — `test-inventory.json` indexiert
  Test-IDs (`FA-*`/`NFA-*`), nicht rohe `@test`-Namen. Explizit gegengeprüft statt angenommen.
- S1-Ratchet nicht betroffen: `.ps1`/`.bats` haben keine Baseline-Einträge (`plan-lint
  residual_budget` liefert für unbekannte Extensions `0 − Zeilen`, daher die irritierenden
  Negativwerte).

## Manuell noch offen

Von WSL aus nicht automatisierbar (Interop defekt: `Invalid argument` für jeden Windows-Exec):

```powershell
.\scripts\llm\register-scheduled-tasks.ps1
schtasks /query /tn "Llama\LlamaEmbedServer" /fo LIST /v   # muss einen Executable-Pfad zeigen
```

Danach beide Server neu starten und **mit Langtext** nachprüfen — die Kommandos stehen jetzt in
den Skripten selbst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)