### PR TITLE
chore(scripts): bound YAML and single-line chunks in index-repo [T002266]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2913,7 +2913,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 547,
+      "file_count": 548,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3259,6 +3259,7 @@
         "scripts/hooks/precompact-prune.sh",
         "scripts/import-users.sh",
         "scripts/index-repo-incremental.sh",
+        "scripts/index-repo.test.ts",
         "scripts/index-repo.ts",
         "scripts/install-dev-tools.sh",
         "scripts/knowledge/ingest-bug-tickets.mjs",

--- a/scripts/index-repo.test.ts
+++ b/scripts/index-repo.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// .js-Endung fuer eine .ts-Datei — ESM-Konvention, wie in
+// scripts/openspec-validate.test.ts. Ein '.ts'-Import braucht
+// allowImportingTsExtensions, das hier nicht gesetzt ist.
+import { chunkCode, chunkSource, chunkYaml, estimateTokens } from './index-repo.js';
+
+// T002266 — Regressionsschutz gegen uebergrosse Chunks.
+//
+// Vorgeschichte: chunkYaml() splittete YAML ausschliesslich an Top-Level-Keys
+// und kannte KEINE Obergrenze; chunkSource() brach nur ZWISCHEN Zeilen um, eine
+// einzelne ueberlange Zeile wurde also nie geteilt. Gemessen 2026-07-27 ueber
+// das ganze Repo: 298 von 3385 YAML-Chunks lagen ueber 512 Tokens, 31 sogar
+// ueber 8192 (max_position_embeddings von bge-m3), der groesste bei 318.500
+// Tokens. Der Embedding-Server lehnt solche Chunks mit HTTP 500 ab; sie landen
+// still im catch von main() und werden als SKIP verbucht — ein Voll-Index
+// bekommt dadurch systematische Loecher, ohne hart zu scheitern.
+//
+// Die Grenze hier ist bewusst das MODELL-Maximum (8192) und nicht der
+// Konfigurationswert: sie muss auch dann halten, wenn jemand CHUNK_MAX_TOKENS
+// hochdreht.
+const MODEL_MAX_TOKENS = 8192;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..');
+
+function assertAllBounded(chunks: string[], label: string) {
+  expect(chunks.length).toBeGreaterThan(0);
+  for (const [i, c] of chunks.entries()) {
+    expect(
+      estimateTokens(c),
+      `${label}: Chunk ${i} hat ${estimateTokens(c)} geschaetzte Tokens ` +
+      `(${c.length} Zeichen) und ueberschreitet damit das Modell-Maximum`,
+    ).toBeLessThanOrEqual(MODEL_MAX_TOKENS);
+  }
+}
+
+describe('estimateTokens', () => {
+  it('rechnet dichter als 4 Zeichen/Token (Code tokenisiert bei ~2.6)', () => {
+    // 2000 Zeichen Code ergaben am laufenden Server real 774 Tokens.
+    // Mit der alten chars/4-Annahme waeren es 500 gewesen — zu optimistisch.
+    const est = estimateTokens('x'.repeat(2000));
+    expect(est).toBeGreaterThanOrEqual(700);
+  });
+});
+
+describe('chunkYaml (T002266)', () => {
+  it('begrenzt einen einzelnen riesigen Top-Level-Block', () => {
+    // Genau der Fall aus den Helm-Renders: EIN Top-Level-Key, darunter alles.
+    const yaml = 'data:\n' + '  key: value with some padding text\n'.repeat(20_000);
+    const chunks = chunkYaml(yaml);
+    assertAllBounded(chunks, 'ein Top-Level-Key');
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  it('begrenzt auch eine einzelne ueberlange Zeile', () => {
+    // Base64-Blobs und eingebettete JSON-Strings in Manifests sehen so aus.
+    const yaml = 'secret:\n  data: ' + 'A'.repeat(400_000) + '\n';
+    assertAllBounded(chunkYaml(yaml), 'eine Riesenzeile');
+  });
+
+  it('behaelt die Gruppierung an Top-Level-Keys fuer kleine Manifeste', () => {
+    const yaml = [
+      'apiVersion: v1',
+      'kind: ConfigMap',
+      'metadata:',
+      '  name: demo-configmap-with-enough-text-to-pass-the-filter',
+      'data:',
+      '  answer: forty-two and some more padding so the chunk survives',
+    ].join('\n');
+    const chunks = chunkYaml(yaml);
+    assertAllBounded(chunks, 'kleines Manifest');
+    // Kleine Dateien sollen nicht kuenstlich zerhackt werden.
+    expect(chunks.length).toBeLessThanOrEqual(4);
+  });
+});
+
+describe('chunkSource (T002266)', () => {
+  it('begrenzt eine einzelne ueberlange Zeile (minified / Base64)', () => {
+    const src = 'const x = "' + 'y'.repeat(300_000) + '";\n';
+    assertAllBounded(chunkSource(src), 'minifizierte Zeile');
+  });
+
+  it('bricht normalen Code in mehrere Chunks um', () => {
+    const src = 'export function f() { return 1; }\n'.repeat(5000);
+    const chunks = chunkSource(src);
+    assertAllBounded(chunks, 'normaler Code');
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+});
+
+describe('chunkCode gegen echte Repo-Dateien (T002266)', () => {
+  // Die Dateien, die den Bug in der Praxis ausgeloest haben bzw. am
+  // anfaelligsten sind. Fehlt eine, wird der Fall uebersprungen statt zu
+  // scheitern — der Test soll nicht an Repo-Umbauten zerbrechen.
+  const candidates = [
+    'Taskfile.yml',
+    'k3d/llm-gpu.yaml',
+    '.github/workflows/ci.yml',
+    'scripts/index-repo.ts',
+  ];
+
+  for (const rel of candidates) {
+    it(`haelt die Grenze fuer ${rel}`, () => {
+      const abs = resolve(REPO_ROOT, rel);
+      if (!existsSync(abs)) return;
+      const content = readFileSync(abs, 'utf8');
+      assertAllBounded(chunkCode(content, abs), rel);
+    });
+  }
+});

--- a/scripts/index-repo.ts
+++ b/scripts/index-repo.ts
@@ -13,6 +13,31 @@ const CHUNK_MAX_TOKENS = 512;
 const CHUNK_OVERLAP = 64;
 const BATCH_SIZE = 16;
 
+// T002266: estimateTokens rechnete mit 4 Zeichen/Token. Das gilt fuer Prosa —
+// Code und YAML tokenisieren dichter. Gemessen am laufenden bge-m3-Server:
+// 2000 Zeichen Code = 774 echte Tokens, 4000 Zeichen YAML = 1253. Das sind
+// ~2.6 Zeichen/Token, die Schaetzung war also rund 1.5x zu optimistisch und
+// die nominell "512-Token"-Chunks enthielten real bis zu ~774 Tokens.
+const CHARS_PER_TOKEN = 2.6;
+
+// Harter Backstop in ZEICHEN, unabhaengig von jeder Schaetzung. Er greift genau
+// dort, wo die zeilenweise Token-Logik strukturell nicht greifen kann:
+//   - eine einzelne ueberlange Zeile (minifiziert, Base64, eingebettetes JSON)
+//     wurde nie gesplittet, weil nur ZWISCHEN Zeilen umgebrochen wurde;
+//   - chunkYaml kannte ueberhaupt keine Obergrenze und splittete nur an
+//     Top-Level-Keys. Gemessen 2026-07-27 ueber das ganze Repo: 298 von 3385
+//     YAML-Chunks lagen ueber 512 Tokens, 31 sogar ueber 8192 (dem
+//     max_position_embeddings des Modells), der groesste bei 318.500 Tokens
+//     (k3d/monitoring/kube-prometheus-stack-rendered.yaml). Solche Chunks
+//     werden vom Embedding-Server mit HTTP 500 abgelehnt und landen still im
+//     catch von main() als SKIP.
+const CHUNK_MAX_CHARS = Math.floor(CHUNK_MAX_TOKENS * CHARS_PER_TOKEN);
+
+// Helm-Renders und vergleichbare generierte Mega-Manifeste. Sie gehoeren nicht
+// in einen semantischen CODE-Index: sie sind Ausgabe, nicht Quelle, und
+// kube-prometheus-stack-rendered.yaml allein ist 5 MB.
+const IGNORE_FILE_PATTERNS: RegExp[] = [/-rendered\.ya?ml$/];
+
 const IGNORE_DIRS = new Set([
   'node_modules', 'dist', '.git', 'docs-content-built',
   'k3d/docs-content-built', '.svelte-kit', '.astro', 'build',
@@ -88,63 +113,101 @@ function walkDir(dir: string, out: string[] = []): string[] {
     if (IGNORE_DIRS.has(e.name)) continue;
     const full = join(dir, e.name);
     if (e.isDirectory()) walkDir(full, out);
-    else if (e.isFile() && INDEXABLE_EXTS.has(extname(e.name))) out.push(full);
+    else if (
+      e.isFile()
+      && INDEXABLE_EXTS.has(extname(e.name))
+      && !IGNORE_FILE_PATTERNS.some(re => re.test(e.name))
+    ) out.push(full);
   }
   return out;
 }
 
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
 }
 
-function chunkCode(content: string, filePath: string): string[] {
+export function chunkCode(content: string, filePath: string): string[] {
   const ext = extname(filePath);
   if (ext === '.yaml' || ext === '.yml') return chunkYaml(content);
   return chunkSource(content);
 }
 
-function chunkYaml(content: string): string[] {
+// Zerlegt eine einzelne Zeile, die allein schon zu gross ist. Ohne das bleibt
+// jede Token-Rechnung wirkungslos, denn umgebrochen wurde nur ZWISCHEN Zeilen.
+function splitOversizedLine(line: string): string[] {
+  if (line.length <= CHUNK_MAX_CHARS) return [line];
+  const parts: string[] = [];
+  for (let i = 0; i < line.length; i += CHUNK_MAX_CHARS) {
+    parts.push(line.slice(i, i + CHUNK_MAX_CHARS));
+  }
+  return parts;
+}
+
+// Gemeinsamer Kern beider Chunker: akkumuliert zeilenweise und deckelt sowohl
+// die geschaetzten Tokens ALS AUCH die Zeichen. Der Zeichendeckel ist die
+// Garantie — er haengt an keiner Schaetzung.
+function boundedChunks(text: string): string[] {
   const chunks: string[] = [];
-  const lines = content.split('\n');
   let current: string[] = [];
-  for (const line of lines) {
-    if (/^[^\s#]/.test(line) && current.length > 0) {
-      chunks.push(current.join('\n'));
-      current = [line];
-    } else {
+  let currentTokens = 0;
+  let currentChars = 0;
+
+  for (const rawLine of text.split('\n')) {
+    for (const line of splitOversizedLine(rawLine)) {
+      const lineTokens = estimateTokens(line);
+      const lineChars = line.length + 1; // +1 fuer das \n beim Join
+      const wouldExceed =
+        currentTokens + lineTokens > CHUNK_MAX_TOKENS ||
+        currentChars + lineChars > CHUNK_MAX_CHARS;
+
+      if (wouldExceed && current.length > 0) {
+        chunks.push(current.join('\n'));
+        // Overlap uebernehmen (Kontext ueber die Chunk-Grenze hinweg).
+        // Durch CHUNK_OVERLAP << CHUNK_MAX_TOKENS bleibt der Overlap immer
+        // deutlich unter dem Deckel, ein Endlos-Flush ist damit ausgeschlossen.
+        const overlapLines: string[] = [];
+        let overlapTokens = 0;
+        for (let i = current.length - 1; i >= 0; i--) {
+          const t = estimateTokens(current[i]);
+          if (overlapTokens + t > CHUNK_OVERLAP) break;
+          overlapLines.unshift(current[i]);
+          overlapTokens += t;
+        }
+        current = overlapLines;
+        currentTokens = overlapTokens;
+        currentChars = overlapLines.reduce((acc, l) => acc + l.length + 1, 0);
+      }
+
       current.push(line);
+      currentTokens += lineTokens;
+      currentChars += lineChars;
     }
   }
   if (current.length > 0) chunks.push(current.join('\n'));
   return chunks.filter(c => c.trim().length > 20);
 }
 
-function chunkSource(content: string): string[] {
-  const chunks: string[] = [];
-  const lines = content.split('\n');
+// YAML behaelt die semantische Gruppierung an Top-Level-Keys, jeder Block wird
+// danach aber zwingend auf die Obergrenze gebracht. Vorher fehlte dieser zweite
+// Schritt vollstaendig — ein Manifest mit einem Top-Level-Key wurde zu EINEM
+// Chunk in Dateigroesse.
+export function chunkYaml(content: string): string[] {
+  const blocks: string[] = [];
   let current: string[] = [];
-  let currentTokens = 0;
-
-  for (const line of lines) {
-    const lineTokens = estimateTokens(line);
-    if (currentTokens + lineTokens > CHUNK_MAX_TOKENS && current.length > 0) {
-      chunks.push(current.join('\n'));
-      const overlapLines: string[] = [];
-      let overlapTokens = 0;
-      for (let i = current.length - 1; i >= 0; i--) {
-        const t = estimateTokens(current[i]);
-        if (overlapTokens + t > CHUNK_OVERLAP) break;
-        overlapLines.unshift(current[i]);
-        overlapTokens += t;
-      }
-      current = overlapLines;
-      currentTokens = overlapTokens;
+  for (const line of content.split('\n')) {
+    if (/^[^\s#]/.test(line) && current.length > 0) {
+      blocks.push(current.join('\n'));
+      current = [line];
+    } else {
+      current.push(line);
     }
-    current.push(line);
-    currentTokens += lineTokens;
   }
-  if (current.length > 0) chunks.push(current.join('\n'));
-  return chunks.filter(c => c.trim().length > 20);
+  if (current.length > 0) blocks.push(current.join('\n'));
+  return blocks.flatMap(b => boundedChunks(b));
+}
+
+export function chunkSource(content: string): string[] {
+  return boundedChunks(content);
 }
 
 function extractImports(content: string, filePath: string): string[] {
@@ -330,7 +393,16 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(err => {
-  console.error('[SCS] FATAL:', err);
-  process.exit(1);
-});
+// T002266: main() lief bisher beim Modulladen, wodurch die Datei nicht
+// importierbar war — ein Unit-Test der Chunk-Logik haette eine DB-Verbindung
+// aufgebaut und den ganzen Index angefasst. Der Guard prueft, ob die Datei als
+// Skript aufgerufen wurde. Unter `npx tsx scripts/index-repo.ts` ist argv[1]
+// der Pfad dieser Datei; importiert ein Test-Runner sie, zeigt argv[1] auf
+// dessen Entrypoint und main() bleibt aus. Das CLI-Verhalten ist unveraendert.
+const invokedAsScript = /(^|[\\/])index-repo\.ts$/.test(process.argv[1] ?? '');
+if (invokedAsScript) {
+  main().catch(err => {
+    console.error('[SCS] FATAL:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Symptom

`chunkYaml()` in `scripts/index-repo.ts` splittete YAML **ausschließlich** an Top-Level-Keys und
kannte **keine** Obergrenze — `CHUNK_MAX_TOKENS` wurde dort, anders als in `chunkSource()`, gar
nicht gelesen. `chunkSource()` wiederum brach nur *zwischen* Zeilen um, eine einzelne überlange
Zeile wurde also nie geteilt.

## Messung vor dem Fix (ganzes Repo, 2026-07-27)

| Kennzahl | Wert |
|---|---|
| YAML-Chunks gesamt | 3385 |
| davon > 512 Tokens (damalige Server-Grenze) | 298 |
| davon **> 8192 Tokens** (`max_position_embeddings` von bge-m3) | **31** |
| größter Einzel-Chunk | **318.500 Tokens** |

Die sechs größten stammten alle aus `k3d/monitoring/kube-prometheus-stack-rendered.yaml`
(230k–318k Tokens je Chunk).

Solche Chunks lehnt der Embedding-Server mit HTTP 500 ab; sie landen still im `catch` von
`main()` und werden als `SKIP` verbucht. Ein Voll-Index bekommt dadurch **systematische Löcher,
ohne hart zu scheitern** — plausibel die Erklärung dafür, dass `public.code_embeddings` nur 66
von über 3000 indexierbaren Dateien enthielt.

## Änderungen

- **`boundedChunks()`** als gemeinsamer Kern beider Chunker — deckelt **Tokens und Zeichen**. Der
  Zeichendeckel ist die eigentliche Garantie, weil er an keiner Schätzung hängt.
- **`splitOversizedLine()`** zerlegt eine Zeile, die allein schon zu groß ist (minifiziert,
  Base64, eingebettetes JSON in Manifests).
- **`chunkYaml()`** behält die Gruppierung an Top-Level-Keys, schickt jeden Block danach aber
  zwingend durch `boundedChunks()`.
- **`estimateTokens()`**: `länge/4` → `länge/2.6`. Die 4 gilt für Prosa; am laufenden
  bge-m3-Server gemessen sind 2000 Zeichen Code real **774** Tokens und 4000 Zeichen YAML real
  **1253**. Die Schätzung war ~1,5× zu optimistisch — die nominell „512-Token"-Chunks enthielten
  real bis zu 774.
- **`IGNORE_FILE_PATTERNS`**: `*-rendered.yaml` ausgeschlossen (drei Helm-Renders in
  `k3d/monitoring/`, Prometheus allein 5 MB). Generierte Mega-Manifeste sind Ausgabe, nicht
  Quelle — in einem semantischen *Code*-Index Rauschen.

`CHUNK_MAX_TOKENS` bleibt bewusst bei **512**: Chunk-Größe ist eine Retrieval-Design-Entscheidung,
kein Teil dieses Bugfixes. Mit dem korrigierten Schätzer sind die Chunks jetzt *ehrlich* ≤ 512
statt nominell 512 / real 774.

## Messung nach dem Fix (ganzes Repo)

| Kennzahl | Wert |
|---|---|
| Dateien | 3494 |
| Chunks gesamt | 18.268 |
| > 512 Tokens | 3 |
| **> 8192 Tokens** | **0** |
| größter Chunk | **565** Tokens |

Die 565 sind gewollt: die effektive Obergrenze ist `CHUNK_MAX_TOKENS + CHUNK_OVERLAP` (512+64),
weil der Overlap beim Chunk-Wechsel ohne Deckelprüfung übernommen wird.

## Testbarkeit

`main()` lief beim Modulladen und die Datei hatte keine `export`s — ein Unit-Test hätte eine
DB-Verbindung aufgebaut und den echten Index angefasst. Der neue Guard prüft `process.argv[1]`
auf den eigenen Dateinamen: als Skript aufgerufen läuft `main()`, von einem Test-Runner
importiert nicht. **Live gegengeprüft**, das CLI verhält sich unverändert (`npx tsx
scripts/index-repo.ts --file …` startet weiterhin und meldet
`embed=http://localhost:8095 model=bge-m3`).

## Tests

`scripts/index-repo.test.ts`, 10 Tests, im `vitest.config.ts`-Scope `scripts/**/*.test.ts`
(Präzedenzfälle: `openspec-validate.test.ts`, `factory/run-pipeline.test.ts`). Import mit
`.js`-Endung nach der dortigen ESM-Konvention.

Die Tests prüfen gegen das **Modell-Maximum 8192**, nicht gegen den Konfigurationswert — die
Grenze muss auch halten, wenn jemand `CHUNK_MAX_TOKENS` hochdreht.

**Beidseitig bewiesen:** im RED-Lauf (Deckelung temporär zurückgedreht) fielen **5 von 10**,
darunter die echten Repo-Dateien `Taskfile.yml` und `.github/workflows/ci.yml` — der Bug war für
tatsächliche Dateien real, nicht nur für synthetische Eingaben.

## Verifikation

- `vitest run scripts/index-repo.test.ts` → **10/10**
- `task test:changed` → **52 pass / 0 fail**
- `task freshness:check` → **grün** (`repo-index.json` nachgezogen — zählt getrackte Dateien, die
  Drift entsteht also erst nach dem Commit der neuen Testdatei)

## Einordnung in die Kette

Dritter von drei Blockern des Voll-Index nach dem TEI→llama.cpp-Cutover:

1. **T002258** (#3304) — Konsumenten zeigten auf tote TEI-Ports
2. **T002260** (#3308) — Server kappte bei 512 statt 8192 Tokens (`-b/-ub` fehlten)
3. **T002266** (dieser PR) — Chunks überschritten selbst 8192

Nach diesem Merge fehlt für den Voll-Index nur noch der Neustart der Windows-Server mit den
Flags aus T002260. Zwischenstand: `public.code_embeddings` trägt auf allen 331 Zeilen den
Sentinel `file_hash = 'force-reembed-20260727'` — Vektoren vorhanden, nur veraltet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)