### PR TITLE
chore(scripts): align Bonsai autostart args with the maintained start script [T002274]

### DIFF
--- a/scripts/llm/register-scheduled-tasks.ps1
+++ b/scripts/llm/register-scheduled-tasks.ps1
@@ -9,8 +9,9 @@
   3 Mal im Abstand von 1 Minute neu gestartet.
 .TASK 1
   Name: LlamaBonsaiServer
-  Command: %UserProfile%\llama-b10090-13.3\llama-server.exe
-  Args: -m ...\Ternary-Bonsai-8B-TQ2_0.gguf -c 131072 -np 4 ...
+  Command: %UserProfile%\llama-bonsai-cuda13.3\bin\llama-server.exe  (PrismML-Fork)
+  Args: -m ...\prism-ml\...\Ternary-Bonsai-8B-Q2_0.gguf -c 65536 -np 1 ...
+  Achtung: Fork-Build und Q2_0 sind Pflicht, siehe Kommentar am Eintrag (T002274).
 .TASK 2
   Name: LlamaEmbedServer
   Command: %UserProfile%\llama-b10090-13.3\llama-server.exe
@@ -26,9 +27,38 @@
 $Tasks = @(
   @{
     Name = "LlamaBonsaiServer"
-    Description = "Ternary-Bonsai-8B mit 4 Slots (Factory-Orchestrator)"
-    Exe = "$env:UserProfile\llama-b10090-13.3\llama-server.exe"
-    Args = "-m `"$env:UserProfile\.lmstudio\models\gpustack\Ternary-Bonsai-8B-TQ2_0.gguf`" -c 131072 -np 4 --cache-ram 24576 -ngl 99 -fa on -ctk q4_0 -ctv q4_0 --jinja --temp 0.7 --top-p 0.95 --top-k 20 --min-p 0 --host 0.0.0.0 --port 8093"
+    Description = "Ternary-Bonsai-8B, 1 Slot (Factory-Orchestrator)"
+    # T002274: dieser Eintrag beschrieb eine Konfiguration, die nicht
+    # funktioniert und im interaktiven Startskript bereits verworfen wurde.
+    # Drei unabhaengige Probleme, alle behoben:
+    #
+    # 1. MODELL: stand auf ...\gpustack\Ternary-Bonsai-8B-TQ2_0.gguf - diese
+    #    Datei existiert nicht (geprueft 2026-07-27). Vorhanden ist der
+    #    prism-ml-Q2_0-Build. Der Task waere sofort gescheitert.
+    # 2. FORMAT + BUILD: TQ2_0 hat im PrismML-Fork KEINE CUDA-Kernel
+    #    (T002111: grep -ril TQ2_0 ggml/src/ggml-cuda/ -> 0 Dateien, Q2_0 -> 8),
+    #    im Upstream-Build ebenso nicht. Gemessen mit TQ2_0: Prompt 54 tok/s,
+    #    Generierung 12,8 tok/s, GPU 10-12 %, 7,7 von 8 CPU-Threads am Anschlag.
+    #    Mit Q2_0 auf dem Fork-Build: Prompt 6355 tok/s, Generierung 234 tok/s.
+    #    Deshalb Fork-Build (llama-bonsai-cuda13.3\bin) statt b10090.
+    # 3. SLOTS: -np 4 ist die nach T002102 bewusst verworfene Variante. Unter
+    #    echter 3-4x-Last blieben fertig generierte Slots unfreigegeben, einmal
+    #    stiller Server-Crash. Serialisierung liegt seitdem im scripts/llm-proxy
+    #    (FIFO), der Server faehrt EINEN Slot mit dem vollen Kontext exklusiv.
+    #    Ausserdem passt -c 131072 -np 4 nicht ins VRAM-Budget, wenn bge-m3 und
+    #    der Reranker mitlaufen (die belegen zusammen 1,3 GB).
+    #
+    # KV-Quant q8_0 statt q4_0: 2026-07-23 gegeneinander gemessen, q8_0 war in
+    # BEIDEN Dimensionen besser (+3 % Prompt, +9 % Generierung) und gilt als
+    # nahezu verlustfrei. --metrics ergaenzt, weil ohne den Prometheus-Endpoint
+    # genau die oben genannte CPU-Regression unsichtbar blieb.
+    #
+    # SSOT fuer diese Argumente ist start-bonsai-parallel.ps1 auf dem GPU-Host.
+    # Bei Aenderungen dort MUSS dieser Eintrag mitgezogen werden - zwei
+    # Wahrheiten sind genau das Muster, das bei start-embeddings.ps1 die
+    # -b/-ub-Flags verschluckt hat (T002260).
+    Exe = "$env:UserProfile\llama-bonsai-cuda13.3\bin\llama-server.exe"
+    Args = "-m `"$env:UserProfile\.lmstudio\models\prism-ml\Ternary-Bonsai-8B-gguf\Ternary-Bonsai-8B-Q2_0.gguf`" -c 65536 -np 1 --cache-ram 24576 -ngl 99 -fa on -ctk q8_0 -ctv q8_0 --jinja --temp 0.7 --top-p 0.95 --top-k 20 --min-p 0 --metrics --host 0.0.0.0 --port 8093"
   }
   @{
     Name = "LlamaEmbedServer"

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -203,6 +203,35 @@ assert_var_not_declared() {
 # PowerShell liefert dafür still $null, also wurde jede Scheduled Task mit leerem
 # Executable-Pfad registriert (/tr "" <args>) und konnte nichts starten — der
 # Grund, warum es faktisch keine Server-Persistenz gab.
+# ── Bonsai-Autostart-Argumente (T002274) ──────────────────────────────
+# Der Task-Eintrag war ein Schnappschuss einer verworfenen Konfiguration:
+# nicht existierende TQ2_0-Datei, Upstream-Build ohne CUDA-Kernel fuer dieses
+# Format, und -np 4 statt des nach T002102 bewusst gewaehlten Einzel-Slots.
+# Die Guards greifen bewusst NUR die Args-/Exe-ZEILE (identifiziert ueber
+# --port 8093 bzw. den Fork-Pfad) und nicht die Datei als Ganzes — der
+# Kommentar am Eintrag nennt die alten, falschen Werte absichtlich.
+
+@test "Bonsai task uses the existing prism-ml Q2_0 model, not TQ2_0 (T002274)" {
+  run bash -c "grep -E '^[[:space:]]+Args = .*--port 8093' '$REPO/scripts/llm/register-scheduled-tasks.ps1' | grep -q 'prism-ml.*Ternary-Bonsai-8B-Q2_0\\.gguf'"
+  [ "$status" -eq 0 ]
+  # TQ2_0 hat in keinem der Builds CUDA-Kernel -> waere CPU-Notbetrieb
+  run bash -c "grep -E '^[[:space:]]+Args = .*--port 8093' '$REPO/scripts/llm/register-scheduled-tasks.ps1' | grep -q 'TQ2_0'"
+  [ "$status" -ne 0 ]
+}
+
+@test "Bonsai task runs a single slot, not -np 4 (T002274)" {
+  run bash -c "grep -E '^[[:space:]]+Args = .*--port 8093' '$REPO/scripts/llm/register-scheduled-tasks.ps1' | grep -qE '\\-np 1( |$)'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -E '^[[:space:]]+Args = .*--port 8093' '$REPO/scripts/llm/register-scheduled-tasks.ps1' | grep -qE '\\-np 4( |$)'"
+  [ "$status" -ne 0 ]
+}
+
+@test "Bonsai task uses the PrismML fork build (T002274)" {
+  # Nur der Fork hat CUDA-Kernel fuer Q2_0.
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/scripts/llm/register-scheduled-tasks.ps1' | grep -qE 'Exe = .*llama-bonsai-cuda13\\.3'"
+  [ "$status" -eq 0 ]
+}
+
 # ── gpt-oss-20b als Factory-Kandidat (T002268) ────────────────────────
 # Der Kandidat muss INERT bleiben, bis jemand bewusst umschaltet. Zwei
 # Invarianten sichern das ab: priority 1 (Bonsai steht auf 0, route-provider.sh


### PR DESCRIPTION
## Symptom

Der `LlamaBonsaiServer`-Eintrag in `scripts/llm/register-scheduled-tasks.ps1` war ein
**Schnappschuss einer verworfenen Konfiguration**.

| | vorher | nachher |
|---|---|---|
| Modell | `…\gpustack\Ternary-Bonsai-8B-TQ2_0.gguf` — **existiert nicht** | `…\prism-ml\Ternary-Bonsai-8B-gguf\Ternary-Bonsai-8B-Q2_0.gguf` (2,18 GB) |
| Build | `llama-b10090-13.3` (Upstream) | `llama-bonsai-cuda13.3\bin` (PrismML-Fork) |
| Slots / Kontext | `-c 131072 -np 4` | `-c 65536 -np 1` |
| KV-Quant | `q4_0` | `q8_0` |
| Metrics | fehlte | `--metrics` |

## Drei unabhängige Probleme

**1. Die Modelldatei existiert nicht.** Geprüft am 2026-07-27 — der Task wäre sofort
gescheitert.

**2. Format und Build wären CPU-Notbetrieb.** `TQ2_0` hat im PrismML-Fork **keine**
CUDA-Kernel (T002111: `grep -ril TQ2_0 ggml/src/ggml-cuda/` → 0 Dateien, `Q2_0` → 8), im
Upstream-Build ebenso nicht. Gemessen mit TQ2_0: Prompt 54 tok/s, Generierung 12,8 tok/s, GPU
bei 10–12 %, 7,7 von 8 CPU-Threads am Anschlag. Mit Q2_0 auf dem Fork-Build: Prompt 6355 tok/s,
Generierung 234 tok/s.

**3. `-np 4` ist die nach T002102 bewusst verworfene Variante.** Unter echter 3–4-facher Last
blieben fertig generierte Slots unfreigegeben, einmal mit stillem Server-Crash. Serialisierung
liegt seitdem im `scripts/llm-proxy` (FIFO-Queue), der Server fährt einen Slot mit dem vollen
Kontext exklusiv. Zusätzlich passt `-c 131072 -np 4` nicht ins VRAM-Budget, wenn bge-m3 und der
Reranker mitlaufen.

## Warum es nicht auffiel

Die Registrierung war selbst funktionslos: `$Exe = $Task.Expr` (der Key heißt `Exe`) legte jede
Task mit **leerem Executable-Pfad** an — T002264, gemergt in #3308. Der Inhalt der Args wurde
deshalb nie wirksam. Nach jenem Fix werden diese Args **erstmals scharf**, weshalb dieser PR vor
dem nächsten Reboot kommt.

## Weitere Angleichungen

`q8_0` statt `q4_0`: am 2026-07-23 gegeneinander gemessen, q8_0 war in **beiden** Dimensionen
besser (+3 % Prompt, +9 % Generierung) und gilt als nahezu verlustfrei.

`--metrics` ergänzt: ohne den Prometheus-Endpoint blieb genau die oben genannte CPU-Regression
unsichtbar.

Im Kommentar am Eintrag steht jetzt ausdrücklich, dass `start-bonsai-parallel.ps1` die **SSOT**
dieser Argumente ist und Änderungen dort mitgezogen werden müssen. Zwei Wahrheiten sind genau das
Muster, das bei `start-embeddings.ps1` die `-b/-ub`-Flags verschluckt hat (T002260).

## VRAM nach dem Fix

| Dienst | GB |
|---|---|
| Bonsai `:8093` — 2,2 Gewichte + ~2,8 KV (65536 @ q8_0) | ~5,0 |
| bge-m3 `:8095` | 0,65 |
| bge-reranker `:8096` | 0,65 |
| **Summe der drei Autostart-Dienste** | **~6,3** von 16,3 |

Vorher hätte `-c 131072 -np 4` allein das Budget gesprengt.

## Tests

3 neue `@test` in `tests/spec/llm-pipeline.bats` — Modell, Slot-Zahl, Fork-Build.

Sie greifen bewusst **nur die `Args`-/`Exe`-Zeile** (identifiziert über `--port 8093` bzw. den
Fork-Pfad), nicht die Datei als Ganzes: der Kommentar am Eintrag nennt die alten, falschen Werte
absichtlich. Dieselbe Falle hatte zuvor zwei meiner Guard-Tests zunächst rot werden lassen —
negative Greps müssen auf Syntax zielen, nicht auf Vorkommen.

**Beidseitig geprüft:** alle drei werden rot, wenn die alten Args wiederhergestellt werden.

## Verifikation

- `bats tests/spec/llm-pipeline.bats` → **34/34**
- `task test:changed` → **52 pass / 0 fail**
- `task freshness:check` → **grün**
- Modelldateien auf dem Host gegengeprüft: `prism-ml`-Q2_0 vorhanden, `gpustack`-TQ2_0 fehlt

## Danach

Reihenfolge für den Autostart-Test:

1. Administrator-PowerShell: `& '\\wsl$\k3d-dev\home\patrick\Bachelorprojekt\scripts\llm\register-scheduled-tasks.ps1'`
2. `schtasks /query /tn "Llama\LlamaEmbedServer" /fo LIST /v` — „Task auszuführen" muss einen Pfad zeigen
3. Reboot → testet alle drei Dienste; die TEI-Units müssen **nicht** wiederkommen (`disabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)