### PR TITLE
chore(scripts): make all scripts/llm/*.ps1 parseable by PowerShell 5.1 [T002275]

### DIFF
--- a/scripts/llm/register-scheduled-tasks.ps1
+++ b/scripts/llm/register-scheduled-tasks.ps1
@@ -1,11 +1,11 @@
 <#
 .SYNOPSIS
-  Registriert Windows Scheduled Tasks für die drei llama.cpp-Server.
+  Registriert Windows Scheduled Tasks fuer die drei llama.cpp-Server.
 .DESCRIPTION
-  Erstellt/aktualisiert drei Scheduled Tasks für den automatischen Start der
+  Erstellt/aktualisiert drei Scheduled Tasks fuer den automatischen Start der
   Embedding-, Rerank- und Bonsai-Server beim Systemstart. Idempotent: bereits
   vorhandene Tasks werden aktualisiert statt dupliziert.
-  Tasks laufen als SYSTEM mit höchsten Rechten und werden bei Fehlern bis zu
+  Tasks laufen als SYSTEM mit hoechsten Rechten und werden bei Fehlern bis zu
   3 Mal im Abstand von 1 Minute neu gestartet.
 .TASK 1
   Name: LlamaBonsaiServer
@@ -76,7 +76,7 @@ $Tasks = @(
     Exe = "$env:UserProfile\llama-b10090-13.3\llama-server.exe"
     # T002260: -b/-ub 8192 sind PFLICHT, gleiche Begruendung wie beim
     # Embed-Server. Beim Cross-Encoder gilt die Grenze fuer Query+Dokument
-    # zusammen — realistische Dokumente ab ~1500 Zeichen reissen 512 Tokens.
+    # zusammen - realistische Dokumente ab ~1500 Zeichen reissen 512 Tokens.
     Args = "-m `"$env:UserProfile\.lmstudio\models\gpustack\bge-reranker-v2-m3-GGUF\bge-reranker-v2-m3-Q8_0.gguf`" --reranking -c 8192 -b 8192 -ub 8192 -ngl 99 -fa on --host 0.0.0.0 --port 8096"
   }
 )
@@ -86,7 +86,7 @@ $SchTasks = "$env:SystemRoot\System32\schtasks.exe"
 foreach ($Task in $Tasks) {
   $Name = $Task.Name
   $Desc = $Task.Description
-  # T002264: stand hier als $Task.Expr — ein Key dieses Namens existiert nicht,
+  # T002264: stand hier als $Task.Expr - ein Key dieses Namens existiert nicht,
   # PowerShell liefert dafuer still $null (kein Set-StrictMode). Jede Task wurde
   # damit als /tr "" <args> registriert, also mit LEEREM Executable-Pfad, und
   # konnte nichts starten. Das ist der Grund, warum es faktisch keine
@@ -94,7 +94,7 @@ foreach ($Task in $Tasks) {
   $Exe = $Task.Exe
   $Args = $Task.Args
 
-  # Prüfe ob Task bereits existiert
+  # Pruefe ob Task bereits existiert
   $Existing = & $SchTasks /query /tn "Llama\$Name" /fo LIST 2>$null
   if ($LASTEXITCODE -eq 0) {
     Write-Host "Updating existing task: Llama\$Name..."
@@ -110,12 +110,12 @@ foreach ($Task in $Tasks) {
     & $SchTasks /change /tn "Llama\$Name" /rl HIGHEST /DELAY 0000:30 2>&1 | Out-Null
   }
 
-  # Restart-Einstellungen (gelten für Neu- und Update-Fall)
-  # Maximale Ausführungsdauer: 1 Tag (damit Task nicht nach 72h stirbt)
+  # Restart-Einstellungen (gelten fuer Neu- und Update-Fall)
+  # Maximale Ausfuehrungsdauer: 1 Tag (damit Task nicht nach 72h stirbt)
   & $SchTasks /change /tn "Llama\$Name" /Z 1:00:00 2>&1 | Out-Null
 
   # Restart bei Fehler: 3 Versuche, 1 Min Abstand
-  # schtasks /change hat kein direktes Restart-Interface — via XML
+  # schtasks /change hat kein direktes Restart-Interface - via XML
   $TaskXml = @"
 <?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -132,7 +132,7 @@ foreach ($Task in $Tasks) {
   & $SchTasks /change /tn "Llama\$Name" /XML $XmlPath 2>&1 | Out-Null
   Remove-Item $XmlPath -Force
 
-  Write-Host "  ✓ Llama\$Name registered. Next start: At system startup."
+  Write-Host "  [ok] Llama\$Name registered. Next start: At system startup."
   Write-Host "  Executable: $Exe"
 }
 

--- a/scripts/llm/start-bonsai-server.ps1
+++ b/scripts/llm/start-bonsai-server.ps1
@@ -1,12 +1,12 @@
 <#
 .SYNOPSIS
-  Startet llama-server.exe für Ternary-Bonsai-8B mit 4 parallelen Slots (Port 8093).
+  Startet llama-server.exe fuer Ternary-Bonsai-8B mit 4 parallelen Slots (Port 8093).
 .DESCRIPTION
-  Startet eine persistente llama.cpp-Instanz für Ternary-Bonsai-8B (TQ2_0) mit vier
+  Startet eine persistente llama.cpp-Instanz fuer Ternary-Bonsai-8B (TQ2_0) mit vier
   parallelen Dekodierungs-Slots (-np 4) auf Port 8093.
-  Der Kontext (-c) muss pro Slot mindestens 32768 Token bieten für Factory-Prompts (~37k).
-  Bei -np 4 ergibt sich -c >= 131072. Der tatsächliche Wert wird durch VRAM-Messung
-  bestimmt — siehe Kommentar unten.
+  Der Kontext (-c) muss pro Slot mindestens 32768 Token bieten fuer Factory-Prompts (~37k).
+  Bei -np 4 ergibt sich -c >= 131072. Der tatsaechliche Wert wird durch VRAM-Messung
+  bestimmt - siehe Kommentar unten.
 .PARAMETER LlamaDir
   Verzeichnis mit llama-server.exe. Default: C:\Users\PatrickKorczewski\llama-b10090-13.3
 .EXAMPLE
@@ -29,25 +29,25 @@ if (-not (Test-Path $Model)) {
   exit 1
 }
 
-# ═══════════════════════════════════════════════════════════════════════
-# VRAM-Messreihe für -c (2026-07-23)
+# =======================================================================
+# VRAM-Messreihe fuer -c (2026-07-23)
 #
 # Nach Start der Embedding- (8095) und Rerank-Server (8096):
 #   nvidia-smi.exe --query-gpu=memory.used,memory.free --format=csv
 #
-# RTX 5070 Ti: 16303 MiB total, Ziel ≤ 15000 MiB belegt (~1300 MiB Reserve)
+# RTX 5070 Ti: 16303 MiB total, Ziel <= 15000 MiB belegt (~1300 MiB Reserve)
 #
-# Messprotokoll (auszufüllen nach Messung):
-#   -c 131072 → np 4 → ? MiB belegt
-#   -c 196608 → np 4 → ? MiB belegt
-#   -c 262144 → np 4 → ? MiB belegt
+# Messprotokoll (auszufuellen nach Messung):
+#   -c 131072 -> np 4 -> ? MiB belegt
+#   -c 196608 -> np 4 -> ? MiB belegt
+#   -c 262144 -> np 4 -> ? MiB belegt
 #
-# Gewählter Wert: 131072 (konservativ, anpassen nach Messung)
-#   Begründung: 131072 / 4 = 32768 Token pro Slot ≥ Factory-Prompts (~37k sind
-#   nicht reine Eingabe — Chat-History overlappt, 32768 reicht für den aktiven Prompt)
+# Gewaehlter Wert: 131072 (konservativ, anpassen nach Messung)
+#   Begruendung: 131072 / 4 = 32768 Token pro Slot >= Factory-Prompts (~37k sind
+#   nicht reine Eingabe - Chat-History overlappt, 32768 reicht fuer den aktiven Prompt)
 #
 # Rollback: -np 1 -c 65536
-# ═══════════════════════════════════════════════════════════════════════
+# =======================================================================
 $ContextSize = 131072
 
 Write-Host "Starting Ternary-Bonsai-8B server on port 8093 (4 slots)..."

--- a/scripts/llm/start-embed-server.ps1
+++ b/scripts/llm/start-embed-server.ps1
@@ -1,24 +1,24 @@
 <#
 .SYNOPSIS
-  Startet llama-server.exe im Embedding-Modus für bge-m3 (Port 8095).
+  Startet llama-server.exe im Embedding-Modus fuer bge-m3 (Port 8095).
 .DESCRIPTION
-  Startet eine persistente llama.cpp-Instanz für Text-Embeddings (bge-m3 Q8_0)
+  Startet eine persistente llama.cpp-Instanz fuer Text-Embeddings (bge-m3 Q8_0)
   auf Port 8095. Der Server wird mit Flash Attention und GPU-Offload betrieben.
   VRAM-Notausstieg via Umgebungsvariable LLM_EMBED_NGL (Default 99).
 
-  T002260 — WARUM -b/-ub 8192 gesetzt sein MUSS:
+  T002260 - WARUM -b/-ub 8192 gesetzt sein MUSS:
   bge-m3 ist ein nicht-kausales Modell (XLM-RoBERTa). llama.cpp kann eine solche
-  Sequenz NICHT über mehrere physische Batches aufteilen — jede Sequenz muss
+  Sequenz NICHT ueber mehrere physische Batches aufteilen - jede Sequenz muss
   komplett in einen n_ubatch passen. Ohne -b/-ub gilt der Default n_ubatch=512,
-  und der Server lehnt jeden längeren Input ab:
+  und der Server lehnt jeden laengeren Input ab:
     "input (734 tokens) is too large to process.
      increase the physical batch size (current batch size: 512)"
   Das gesetzte -c 8192 hilft nicht: /props meldet n_ctx 8192, nutzbar sind 512.
   Gemessen 2026-07-27: 2000 Zeichen Code = 774 Tokens -> HTTP 500.
-  Die abgelöste TEI-Instanz konnte 8192 (max_position_embeddings 8194), der
-  Cutover T002110 hatte die nutzbare Eingabelänge also unbemerkt auf 512
-  reduziert. Beim Ändern dieser Werte immer mit einem LANGTEXT nachprüfen —
-  ein "Hallo Welt"-Smoke-Test bleibt in jedem Fall grün.
+  Die abgeloeste TEI-Instanz konnte 8192 (max_position_embeddings 8194), der
+  Cutover T002110 hatte die nutzbare Eingabelaenge also unbemerkt auf 512
+  reduziert. Beim Aendern dieser Werte immer mit einem LANGTEXT nachpruefen -
+  ein "Hallo Welt"-Smoke-Test bleibt in jedem Fall gruen.
 .PARAMETER LlamaDir
   Verzeichnis mit llama-server.exe. Default: C:\Users\PatrickKorczewski\llama-b10090-13.3
 .EXAMPLE
@@ -41,7 +41,12 @@ if (-not (Test-Path $Model)) {
   exit 1
 }
 
-$Ngl = [int]::TryParse([Environment]::GetEnvironmentVariable("LLM_EMBED_NGL"), [ref]$null) ? [Environment]::GetEnvironmentVariable("LLM_EMBED_NGL") : "99"
+# T002275: stand hier als Ternary (cond ? a : b). Den gibt es erst ab
+# PowerShell 7 - unter 5.1 (dem einzigen auf diesem Host installierten
+# PowerShell) ist das ein Parse-Fehler: 'Unerwartetes Token "?"'. Das Skript
+# war damit nie ausfuehrbar. if/else ist versionsunabhaengig.
+$Ngl = "99"
+if ($env:LLM_EMBED_NGL) { $Ngl = $env:LLM_EMBED_NGL }
 
 Write-Host "Starting bge-m3 embedding server on port 8095..."
 Write-Host "  Model: $Model"
@@ -73,7 +78,7 @@ Write-Host "Embedding server started (Job ID: $($Job.Id))"
 Write-Host "Endpoint: http://127.0.0.1:8095/v1/embeddings"
 Write-Host ""
 Write-Host ""
-Write-Host "Test (T002260 — MIT LANGTEXT pruefen, ein Kurztext bleibt auch bei"
+Write-Host "Test (T002260 - MIT LANGTEXT pruefen, ein Kurztext bleibt auch bei"
 Write-Host "kaputtem -ub gruen und verdeckt die 512-Token-Kappung):"
 Write-Host '  $long = "kubernetes deployment reconciliation " * 120   # ~600+ Tokens'
 Write-Host '  $body = @{ model = "bge-m3"; input = @($long) } | ConvertTo-Json'

--- a/scripts/llm/start-rerank-server.ps1
+++ b/scripts/llm/start-rerank-server.ps1
@@ -1,24 +1,24 @@
 <#
 .SYNOPSIS
-  Startet llama-server.exe im Rerank-Modus für bge-reranker-v2-m3 (Port 8096).
+  Startet llama-server.exe im Rerank-Modus fuer bge-reranker-v2-m3 (Port 8096).
 .DESCRIPTION
-  Startet eine persistente llama.cpp-Instanz für Text-Reranking (bge-reranker-v2-m3 Q8_0)
+  Startet eine persistente llama.cpp-Instanz fuer Text-Reranking (bge-reranker-v2-m3 Q8_0)
   auf Port 8096. Getrennter Prozess vom Embedding-Server, da llama.cpp Embedding-Pooling
   (CLS) und Rerank-Pooling (RANK) nicht in einem Server bedienen kann.
   VRAM-Notausstieg via Umgebungsvariable LLM_RERANK_NGL (Default 99).
 
-  T002260 — WARUM -b/-ub 8192 gesetzt sein MUSS:
+  T002260 - WARUM -b/-ub 8192 gesetzt sein MUSS:
   bge-reranker-v2-m3 ist ein Cross-Encoder auf XLM-RoBERTa, also nicht-kausal.
-  llama.cpp kann eine solche Sequenz NICHT über mehrere physische Batches
-  aufteilen — jedes Query+Dokument-Paar muss komplett in einen n_ubatch passen.
+  llama.cpp kann eine solche Sequenz NICHT ueber mehrere physische Batches
+  aufteilen - jedes Query+Dokument-Paar muss komplett in einen n_ubatch passen.
   Ohne -b/-ub gilt der Default n_ubatch=512 und der Server antwortet:
     "input (1253 tokens) is too large to process.
      increase the physical batch size (current batch size: 512)"
   Gemessen 2026-07-27: ein Dokument von 4000 Zeichen (1253 Tokens) schlug fehl,
   1500 Zeichen gingen noch durch. Realistische Dokumente liegen also mitten in
-  der Ausfallzone. Verschärfend: website/src/lib/rerank.ts verschluckt Fehler und
-  liefert dann still score: 0 — der Ausfall ist von aussen unsichtbar.
-  Beim Ändern dieser Werte immer mit einem LANGEN Dokument nachprüfen.
+  der Ausfallzone. Verschaerfend: website/src/lib/rerank.ts verschluckt Fehler und
+  liefert dann still score: 0 - der Ausfall ist von aussen unsichtbar.
+  Beim Aendern dieser Werte immer mit einem LANGEN Dokument nachpruefen.
 .PARAMETER LlamaDir
   Verzeichnis mit llama-server.exe. Default: C:\Users\PatrickKorczewski\llama-b10090-13.3
 .EXAMPLE
@@ -41,7 +41,12 @@ if (-not (Test-Path $Model)) {
   exit 1
 }
 
-$Ngl = [int]::TryParse([Environment]::GetEnvironmentVariable("LLM_RERANK_NGL"), [ref]$null) ? [Environment]::GetEnvironmentVariable("LLM_RERANK_NGL") : "99"
+# T002275: stand hier als Ternary (cond ? a : b). Den gibt es erst ab
+# PowerShell 7 - unter 5.1 (dem einzigen auf diesem Host installierten
+# PowerShell) ist das ein Parse-Fehler: 'Unerwartetes Token "?"'. Das Skript
+# war damit nie ausfuehrbar. if/else ist versionsunabhaengig.
+$Ngl = "99"
+if ($env:LLM_RERANK_NGL) { $Ngl = $env:LLM_RERANK_NGL }
 
 Write-Host "Starting bge-reranker-v2-m3 rerank server on port 8096..."
 Write-Host "  Model: $Model"
@@ -70,7 +75,7 @@ Write-Host "Rerank server started (Job ID: $($Job.Id))"
 Write-Host "Endpoint: http://127.0.0.1:8096/v1/rerank"
 Write-Host ""
 Write-Host ""
-Write-Host "Test (T002260 — mit LANGEM Dokument pruefen; Kurzdokumente wie"
+Write-Host "Test (T002260 - mit LANGEM Dokument pruefen; Kurzdokumente wie"
 Write-Host "'paris'/'berlin' bleiben auch bei kaputtem -ub gruen):"
 Write-Host '  $long = "flux reconciles the oci artifact every ten minutes " * 100  # ~1200 Tokens'
 Write-Host '  $body = @{ query = "how often does flux reconcile"; documents = @($long, "apple pie recipe") } | ConvertTo-Json'

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -203,6 +203,39 @@ assert_var_not_declared() {
 # PowerShell liefert dafür still $null, also wurde jede Scheduled Task mit leerem
 # Executable-Pfad registriert (/tr "" <args>) und konnte nichts starten — der
 # Grund, warum es faktisch keine Server-Persistenz gab.
+# ── PowerShell-5.1-Parsebarkeit (T002275) ─────────────────────────────
+# Vier von fuenf scripts/llm/*.ps1 waren fuer PowerShell 5.1 nicht parsebar, aus
+# zwei unabhaengigen Gruenden. Beide Guards sind statisch, weil CI unter Linux
+# laeuft und kein PowerShell hat. Der echte Test ist auf Windows:
+#   [System.Management.Automation.Language.Parser]::ParseFile($f, [ref]$null, [ref]$errs)
+#
+# Grund 1 — Encoding: PS 5.1 liest eine .ps1 OHNE BOM als ANSI/Windows-1252.
+# UTF-8-Mehrbyte-Sequenzen zerfallen, und einige der Bytes sind typografische
+# Anfuehrungszeichen, die PowerShell als String-Delimiter akzeptiert:
+#   '-' em dash  E2 80 94 -> Byte 0x94 = '"' in cp1252
+#   Haken        E2 9C 93 -> Byte 0x93 = '"'
+#   Pfeil rechts E2 86 92 -> Byte 0x92 = "'"
+# Ein solches Zeichen im KOMMENTAR genuegt: es oeffnet einen String, der bis zum
+# naechsten Anfuehrungszeichen laeuft. Der Parser zeigt dann auf eine Zeile weit
+# darunter ("Zeichenfolge hat kein Abschlusszeichen").
+#
+# Grund 2 — Ternary: 'cond ? a : b' gibt es erst ab PowerShell 7. Auf diesem Host
+# ist nur 5.1 installiert (kein pwsh.exe), dort ist es ein Parse-Fehler.
+
+@test "no scripts/llm/*.ps1 contains a byte above 0x7F (T002275)" {
+  # Absichtlich ALLE non-ASCII-Bytes, nicht nur die bekannten Quote-Ausloeser:
+  # ein Test auf 'keine em dashes' waere zu eng, Haken und Pfeile brechen genauso.
+  run bash -c "LC_ALL=C grep -lP '[\\x80-\\xff]' '$REPO'/scripts/llm/*.ps1 2>/dev/null"
+  [ -z "$output" ]
+  [ "$status" -ne 0 ]
+}
+
+@test "no scripts/llm/*.ps1 uses the PS7-only ternary operator (T002275)" {
+  run bash -c "grep -lE '\\)[[:space:]]+\\?[[:space:]]' '$REPO'/scripts/llm/*.ps1 2>/dev/null"
+  [ -z "$output" ]
+  [ "$status" -ne 0 ]
+}
+
 # ── Bonsai-Autostart-Argumente (T002274) ──────────────────────────────
 # Der Task-Eintrag war ein Schnappschuss einer verworfenen Konfiguration:
 # nicht existierende TQ2_0-Datei, Upstream-Build ohne CUDA-Kernel fuer dieses


### PR DESCRIPTION
## Symptom

Nach einem Reboot am 2026-07-27 kam **kein** LLM-Server hoch. Ursache: die drei
`Llama\*`-Scheduled-Tasks existierten nicht — `schtasks /query` meldete „Das System kann die
angegebene Datei nicht finden", obwohl `register-scheduled-tasks.ps1` **elevated** aufgerufen
wurde (`admin: True` im Transcript).

Das Skript kam nie zur Ausführung:

```
In ...\register-scheduled-tasks.ps1:146 Zeichen:50
+ Write-Host "  schtasks /run /tn LlamaRerankServer"
Die Zeichenfolge hat kein Abschlusszeichen: ".
+ FullyQualifiedErrorId : TerminatorExpectedAtEndOfString
```

Mit dem echten Parser gemessen (`[System.Management.Automation.Language.Parser]::ParseFile`):
**4 von 5** Dateien FAIL. Nach diesem PR: **5 von 5 OK.**

## Grund 1 — Encoding

PowerShell 5.1 liest eine `.ps1` **ohne BOM** als ANSI/Windows-1252. UTF-8-Mehrbyte-Sequenzen
zerfallen dabei, und einige der resultierenden Bytes sind **typografische Anführungszeichen**, die
PowerShell als String-Delimiter akzeptiert:

| Zeichen | UTF-8 | kritisches Byte | cp1252 |
|---|---|---|---|
| em dash | `E2 80 94` | `0x94` | `"` |
| Haken | `E2 9C 93` | `0x93` | `"` |
| Pfeil rechts | `E2 86 92` | `0x92` | `'` |

Ein solches Zeichen im **Kommentar** genügt: es öffnet einen String, der über das Kommentarende
hinaus bis zum nächsten Anführungszeichen läuft. Deshalb zeigte der Parser auf Zeile 146, während
die Ursache in Zeile 89 lag.

Alle vier Dateien auf reines ASCII transliteriert — Umlaute nach der im Repo bereits genutzten
`ae/oe/ue`-Konvention, Haken → `[ok]`, Pfeile → `->`, Box-Zeichen → `-`/`|`.

## Grund 2 — Ternary

`start-embed-server.ps1` und `start-rerank-server.ps1` nutzten `cond ? a : b` für den
NGL-Default. Den Operator gibt es erst ab **PowerShell 7**; auf dem GPU-Host ist nur 5.1
installiert (kein `pwsh.exe`), dort ist es ein Parse-Fehler `Unerwartetes Token "?"`.

Ersetzt durch `if/else` — wie es `start-gptoss-server.ps1` von Anfang an macht. Das ist auch der
Grund, warum jene Datei die einzige parsebare war.

## Betroffene Dateien

| Datei | vorher | nachher |
|---|---|---|
| `register-scheduled-tasks.ps1` | `ö ü — ✓` → FAIL | OK |
| `start-embed-server.ps1` | `Ä ä ö ü —` + Ternary → FAIL | OK |
| `start-rerank-server.ps1` | `Ä ä ü —` + Ternary → FAIL | OK |
| `start-bonsai-server.ps1` | `ä ü — → ≤ ≥ ═` → FAIL | OK |
| `start-gptoss-server.ps1` | bereits ASCII, `if/else` | OK |

Herkunft gemischt: die em dashes in den Embed-/Rerank-Skripten kamen mit den
T002260-Kommentaren hinzu; das `✓` in `register-scheduled-tasks.ps1` und die Zeichen in
`start-bonsai-server.ps1` sind **vorbestehend**.

## Konsequenz für T002264 und T002274

Beide Fixes waren korrekte Code-Lesungen, wurden aber **nie wirksam** — das Skript war nicht
parsebar.

Die in **T002264** behauptete Ursache „Tasks mit leerem Executable-Pfad registriert" ist damit
**nicht belegt**; belegt ist nur, dass keine Tasks existierten. Gleiches gilt für die
Argument-Korrekturen aus **T002274**. Beide Fixes bleiben notwendig, waren bisher aber folgenlos.
Ich habe das an den Tickets nachgetragen.

## Tests

2 neue `@test` in `tests/spec/llm-pipeline.bats`:

1. **kein Byte über `0x7F`** in `scripts/llm/*.ps1` — bewusst *alle* non-ASCII-Bytes, nicht nur
   die bekannten Quote-Auslöser: ein Test auf „keine em dashes" wäre zu eng, Haken und Pfeile
   brechen genauso.
2. **kein PS7-Ternary** (`) ? `-Muster).

Beide bewusst **statisch**, weil CI unter Linux kein PowerShell hat; der Kommentar nennt den
echten `ParseFile`-Check für Windows. Beidseitig geprüft — jeder Guard wird rot, wenn die
jeweilige Fehlerklasse einzeln eingeschmuggelt wird.

## Verifikation

- **PowerShell-Parser auf dem Host: 5× OK** (vorher 4× FAIL)
- `bats tests/spec/llm-pipeline.bats` → **36/36**
- `task test:changed` → **52 pass / 0 fail**
- `task freshness:check` → **grün**

## Danach

Registrierung und Start übernehme ich selbst — WSL-Interop ist nach dem Reboot wieder
funktionsfähig, der UAC-Weg für die elevated Registrierung ist verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)