### PR TITLE
chore(scripts): version gemma start script, systemd proxy autostart, opus routing from DB [T002277]

### DIFF
--- a/Taskfile.llm.yml
+++ b/Taskfile.llm.yml
@@ -95,8 +95,18 @@ tasks:
           set -e
           DIR="$HOME/.local/state/llm-proxy"; mkdir -p "$DIR"
           PIDF="$DIR/proxy.pid"; LOGF="$DIR/proxy.log"
+          PORT="${LLM_PROXY_PORT:-18235}"
           if [ -f "$PIDF" ] && kill -0 "$(cat "$PIDF")" 2>/dev/null; then
             echo "llm-proxy already running (pid $(cat "$PIDF"))"; exit 0
+          fi
+          # T002277: das PID-File kennt nur die nohup-Instanz. Laeuft der Proxy als
+          # systemd-Unit (task llm:proxy:install-service), ist der Port belegt, aber
+          # kein PID-File da - der Start unten wuerde mit EADDRINUSE sterben und ein
+          # PID-File hinterlassen, das auf einen toten Prozess zeigt. Der Port ist
+          # die verlaessliche Auskunft, nicht das PID-File.
+          if curl -fsS --max-time 2 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+            echo "llm-proxy already answering on :$PORT (systemd unit? -> systemctl --user status llm-proxy)"
+            exit 0
           fi
           nohup node scripts/llm-proxy/server.mjs >> "$LOGF" 2>&1 &
           echo $! > "$PIDF"
@@ -123,6 +133,57 @@ tasks:
     desc: "Tail the local LLM proxy log"
     cmds:
       - tail -n 100 -f "$HOME/.local/state/llm-proxy/proxy.log"
+
+  # ── llm-proxy als systemd USER service (T002277) ────────────────────────
+  # Gleiche Form wie agents:factory-mcp:install. Der Windows-Startup-Ordner
+  # (scripts/llm/install-startup-autostart.ps1) startet nur die llama.cpp-Server
+  # auf der Windows-Seite; der Proxy ist ein WSL-Node-Prozess und gehoert hierher.
+  proxy:install-service:
+    desc: "Install the LLM proxy as a persistent systemd USER service (autostart + Restart=always)"
+    silent: true
+    cmds:
+      - |
+        set -euo pipefail
+        if ! systemctl --user show-environment >/dev/null 2>&1; then
+          echo "No systemd --user manager on this host (WSL without lingering?)."
+          echo "Enable it: 'loginctl enable-linger $USER' then re-run. Falling back: task llm:proxy:start."
+          exit 1
+        fi
+        # Manuell gestartete nohup-Instanz beenden, damit der Port fuer systemd frei ist.
+        PIDF="$HOME/.local/state/llm-proxy/proxy.pid"
+        if [[ -f "$PIDF" ]] && kill -0 "$(cat "$PIDF")" 2>/dev/null; then
+          kill "$(cat "$PIDF")" && rm -f "$PIDF"
+          echo "stopped manually started instance"
+        fi
+        UNIT_DIR="${HOME}/.config/systemd/user"
+        mkdir -p "${UNIT_DIR}"
+        ln -sf "$(pwd)/scripts/llm-proxy/llm-proxy.service" "${UNIT_DIR}/llm-proxy.service"
+        systemctl --user daemon-reload
+        systemctl --user enable --now llm-proxy.service
+        echo "llm-proxy installed as systemd --user service (autostart + Restart=always)."
+
+  proxy:uninstall-service:
+    desc: "Stop + disable the llm-proxy systemd service and remove the symlinked unit."
+    silent: true
+    cmds:
+      - |
+        set -euo pipefail
+        systemctl --user disable --now llm-proxy.service 2>/dev/null || true
+        rm -f "${HOME}/.config/systemd/user/llm-proxy.service"
+        systemctl --user daemon-reload 2>/dev/null || true
+        echo "llm-proxy systemd service uninstalled."
+
+  proxy:service-status:
+    desc: "Show the llm-proxy systemd service state + recent journal tail."
+    silent: true
+    cmds:
+      - |
+        set -euo pipefail
+        if ! systemctl --user show-environment >/dev/null 2>&1; then
+          echo "No systemd --user manager on this host."
+          exit 0
+        fi
+        systemctl --user status llm-proxy.service --no-pager -n 20 || true
 
   measure-equivalence:
     desc: "Measure embedding equivalence between TEI and new llama.cpp endpoint"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -634,7 +634,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 47,
+      "file_count": 48,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -682,7 +682,8 @@
         "scripts/migrations/2026-07-21-provider-config-bonsai-only.sql",
         "scripts/migrations/2026-07-22-llm-proxy-backends.sql",
         "scripts/migrations/2026-07-22-slot-count-gang.sql",
-        "scripts/migrations/2026-07-23-llm-proxy-max-inflight.sql"
+        "scripts/migrations/2026-07-23-llm-proxy-max-inflight.sql",
+        "scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql"
       ]
     },
     {
@@ -2914,7 +2915,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 551,
+      "file_count": 553,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3293,6 +3294,7 @@
         "scripts/llm-proxy/backends.mjs",
         "scripts/llm-proxy/discovery.mjs",
         "scripts/llm-proxy/fixups.mjs",
+        "scripts/llm-proxy/llm-proxy.service",
         "scripts/llm-proxy/server.mjs",
         "scripts/llm-proxy/server.test.mjs",
         "scripts/llm-pull-models.sh",
@@ -3301,6 +3303,7 @@
         "scripts/llm/ollama.service",
         "scripts/llm/register-scheduled-tasks.ps1",
         "scripts/llm/start-embed-server.ps1",
+        "scripts/llm/start-gemma-server.ps1",
         "scripts/llm/start-gptoss-server.ps1",
         "scripts/llm/start-rerank-server.ps1",
         "scripts/lmstudio-preload.sh",

--- a/scripts/factory/route-provider.sh
+++ b/scripts/factory/route-provider.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/factory/route-provider.sh <source> <tier>
 # Emits JSON: {"provider":..,"modelId":..,"baseUrl":..|null,"slotId":..|null,"emergency":bool}
-# opus → hardcoded Anthropic, no DB. Used by dev-flow AND inlined into pipeline.js.
+# opus → provider_config lookup without slot claim (T002277). Used by dev-flow AND inlined into pipeline.js.
 # slotId == provider name (slots are per-provider counters, not per-claim UUIDs).
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -19,10 +19,47 @@ if [[ -z "$PHASE" ]]; then
   esac
 fi
 
-OPUS_MODEL="ternary-bonsai-27b"
-OPUS_BASE_URL="http://127.0.0.1:18235"
+# Tier "opus": Modell aus der Registry, aber OHNE Slot-Claim.
+#
+# T002277: hier stand ein hardcodiertes ternary-bonsai-27b, das die DB komplett
+# umging. Nach dem Gemma-Cutover (2026-07-27) existiert dieses Modell auf keinem
+# Backend mehr - der Aufruf lief nur deshalb noch, weil resolveModel() im
+# llm-proxy unbekannte Modelle still auf das erste gesunde Backend umbiegt. Ein
+# Routing, das von einem Fallback lebt, ist keins.
+#
+# WARUM KEIN SLOT-CLAIM: opus lieferte immer slotId:null, es gibt fuer diesen Tier
+# also keinen Release-Pfad beim Aufrufer. Ginge er jetzt durch die normale
+# Claim-Kette weiter unten, wuerde jeder Aufruf provider_health.active_agents
+# erhoehen, ohne ihn je zu senken - der Provider waere nach max_concurrent
+# Aufrufen dauerhaft blockiert. Daher eigener Zweig mit reinem Lookup.
+#
+# WARUM DER FALLBACK BLEIBT: der alte Hardcode hatte eine Eigenschaft, die nicht
+# verloren gehen darf - opus routete OHNE Cluster. factory_psql geht ueber
+# `kubectl exec` in den shared-db-Pod; ohne erreichbaren Cluster (CI, offline
+# arbeitendes dev-flow) waere ein reiner DB-Lookup ein harter Abbruch. Die DB
+# gewinnt, wenn sie antwortet; sonst greift der Default unten. Er ist bewusst
+# derselbe Wert, den die Migration in die Registry schreibt - weicht er ab, ist
+# das ein Bug, kein Feature.
+OPUS_FALLBACK=$'llamacpp\tgemma-4-12b\thttp://127.0.0.1:18235'
 if [[ "$TIER" == "opus" ]]; then
-  printf '{"provider":"ternary-bonsai-27b","modelId":"%s","baseUrl":"%s","slotId":null,"ctx":0,"emergency":false}\n' "$OPUS_MODEL" "$OPUS_BASE_URL"
+  OPUS_ROW=$(factory_psql -v src="$SOURCE" 2>/dev/null <<'SQL' || true
+SELECT provider||E'\t'||model_id||E'\t'||COALESCE(base_url,'')
+FROM tickets.provider_config
+WHERE (source=:'src' OR source='*') AND tier='opus' AND enabled=true
+ORDER BY (source=:'src') DESC, priority ASC
+LIMIT 1;
+SQL
+)
+  if [[ -z "$OPUS_ROW" ]]; then
+    echo "route-provider: provider_config fuer tier=opus nicht lesbar oder leer (source=$SOURCE)." >&2
+    echo "  Fallback auf den eingebauten Default. Bei erreichbarem Cluster:" >&2
+    echo "  scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql anwenden." >&2
+    OPUS_ROW="$OPUS_FALLBACK"
+  fi
+  IFS=$'\t' read -r opus_prov opus_model opus_burl <<< "$OPUS_ROW"
+  OPUS_BJSON=$([[ -n "$opus_burl" ]] && printf '"%s"' "$opus_burl" || printf 'null')
+  printf '{"provider":"%s","modelId":"%s","baseUrl":%s,"slotId":null,"ctx":0,"emergency":false}\n' \
+    "$opus_prov" "$opus_model" "$OPUS_BJSON"
   exit 0
 fi
 

--- a/scripts/llm-proxy/llm-proxy.service
+++ b/scripts/llm-proxy/llm-proxy.service
@@ -1,0 +1,43 @@
+# scripts/llm-proxy/llm-proxy.service
+# LLM-Proxy - systemd USER service. Long-running HTTP proxy auf 127.0.0.1:18235,
+# der Factory- und dev-flow-Anfragen auf die lokalen llama.cpp-Server bzw. LM
+# Studio verteilt (Backend-Registry: tickets.llm_proxy_backends).
+# Installation/Deinstallation: `task llm:proxy:install-service` / `:uninstall-service`
+# (symlinkt diese Datei nach ~/.config/systemd/user/).
+#
+# WARUM SYSTEMD UND NICHT DER WINDOWS-STARTUP-ORDNER (T002277):
+# Der Proxy ist ein Node-Prozess in WSL, kein Windows-Programm. Der
+# Startup-Ordner (install-startup-autostart.ps1) startet die llama.cpp-Server
+# auf der Windows-Seite und ist fuer WSL-Dienste der falsche Ort - er liefe nur
+# bei der Windows-Anmeldung und muesste den Umweg ueber wsl.exe nehmen.
+# systemd --user laeuft in dieser WSL-Distribution bereits (weitere Units:
+# factory.service, factory-mcp.service) und startet den Proxy beim Hochfahren
+# der Distribution mit.
+#
+# ABHAENGIGKEIT ZUM CLUSTER: die Backend-Registry wird per `kubectl exec ... psql`
+# gelesen (scripts/factory/lib.sh). Ist der Cluster beim Start nicht erreichbar,
+# loggt der Poll eine Warnung und behaelt den letzten Stand - beim Kaltstart ist
+# der LEER, der Proxy antwortet dann auf jedes Modell mit 404. Er faengt sich
+# selbst, sobald der naechste Poll (30 s) durchkommt; ein Neustart der Unit ist
+# nicht noetig.
+
+[Unit]
+Description=Local LLM proxy (OpenAI-compatible, 127.0.0.1:18235)
+Documentation=file:///home/patrick/Bachelorprojekt/openspec/specs/local-llm-proxy.md
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/patrick/Bachelorprojekt
+# kubectl liegt unter /usr/local/bin und wird von factory_psql gebraucht; die
+# systemd-Default-PATH enthaelt es nicht.
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/node /home/patrick/Bachelorprojekt/scripts/llm-proxy/server.mjs
+Restart=always
+RestartSec=5
+# Optionale Overrides (LLM_PROXY_PORT, DEEPSEEK_API_KEY, ...) - fehlt die Datei,
+# startet die Unit trotzdem (fuehrendes Minus).
+EnvironmentFile=-%h/.config/llm-proxy/proxy.env
+
+[Install]
+WantedBy=default.target

--- a/scripts/llm/start-gemma-server.ps1
+++ b/scripts/llm/start-gemma-server.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+  Startet llama-server.exe fuer Gemma 4 12B QAT mit MTP-Draft-Head (Port 8091).
+.DESCRIPTION
+  Chat-Modell fuer die Factory-Phasen plan/implement/verify. Die
+  Routing-Entscheidung faellt NICHT hier, sondern in tickets.factory_model_slots
+  bzw. tickets.provider_config (siehe
+  scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql). Dieses Skript
+  startet nur den Server.
+
+  HERKUNFT (T002277): das Skript lag bis 2026-07-27 unversioniert als
+  %UserProfile%\.lmstudio\start-gemma4-12b-mtp.ps1 auf dem Host und war damit
+  weder reviewbar noch reproduzierbar. Uebernommen wurden die Parameter
+  unveraendert; ergaenzt wurden Existenzpruefungen, der Health-Poll und der
+  VRAM-Hinweis, analog zu start-gptoss-server.ps1.
+
+  WARUM KEIN AUTOSTART: install-startup-autostart.ps1 startet bewusst nur
+  Embedding und Rerank. Gemma laeuft mit "-fit on" und nimmt sich ALLES freie
+  VRAM (siehe unten) - wuerde es beim Anmelden vor dem Embedding-Stack starten,
+  bliebe fuer bge-m3 und den Reranker nichts uebrig. Dieses Skript wird deshalb
+  von Hand aufgerufen, nachdem :8095 und :8096 stehen.
+
+  WARUM KEIN EXPLIZITES -c: ohne -c bleibt n_ctx "unset", und --fit (Default on)
+  laedt n_ctx_train (262144) und verkleinert ihn so weit, bis er mit -fitt MiB
+  Reserve ins VRAM passt. Ein gesetztes -c wuerde das Fitting abschalten.
+  -fitc 32768 ist die Untergrenze: passt nicht mindestens so viel Kontext,
+  scheitert der Start hart, statt still auf 4096 zu fallen. Die Factory fuellt
+  31-37k Tokens pro Prompt - unter 32768 waere der Server fuer sie nutzlos.
+
+  WARUM DER FORK-BUILD: --spec-type draft-mtp gibt es nur im
+  llama-bonsai-cuda13.3-Build, nicht im Upstream-Release b10090, das Embedding
+  und Rerank verwenden. Gemma bringt einen Multi-Token-Prediction-Head mit; ihn
+  als Draft-Modell zu nutzen ist billiger als ein separates kleines Draft-Modell,
+  weil der Head ohnehin Teil der Gewichte ist. Gemessen 2026-07-27:
+  ~157 Tokens/s bei 69 Prozent Draft-Akzeptanz (draft_n_accepted 36 / draft_n 52).
+
+  ACHTUNG REASONING-CONTENT: mit --jinja antwortet Gemma 4 als Reasoning-Modell.
+  llama.cpp legt den Denkteil in reasoning_content, waehrend content LEER bleibt,
+  bis das Denken abgeschlossen ist. Bei zu knappem max_tokens kommt deshalb eine
+  Antwort mit leerem content und finish_reason=length zurueck - kein Fehler, aber
+  auch kein Ergebnis. Gemessen: max_tokens 64 liefert leeren content, 512 liefert
+  "Berlin". Wer Clients gegen diesen Server baut, muss das Budget entsprechend
+  bemessen.
+.PARAMETER LlamaDir
+  Verzeichnis mit dem Fork-Build. Default: C:\Users\PatrickKorczewski\llama-bonsai-cuda13.3
+.PARAMETER Port
+  Listen-Port. Default 8091 (so in tickets.llm_proxy_backends registriert).
+.EXAMPLE
+  .\scripts\llm\start-gemma-server.ps1
+#>
+
+param(
+  [string]$LlamaDir = "C:\Users\PatrickKorczewski\llama-bonsai-cuda13.3",
+  [int]$Port = 8091
+)
+
+# Bei diesem Build liegt llama-server.exe in \bin, nicht flach im Root.
+$Exe = Join-Path $LlamaDir "bin\llama-server.exe"
+if (-not (Test-Path $Exe)) { $Exe = Join-Path $LlamaDir "llama-server.exe" }
+if (-not (Test-Path $Exe)) {
+  Write-Error "llama-server.exe not found under: $LlamaDir"
+  exit 1
+}
+
+$ModelDir = "$env:UserProfile\.lmstudio\models\unsloth\gemma-4-12B-it-qat-UD-Q4_K_XL"
+$Model   = Join-Path $ModelDir "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"
+$MtpHead = Join-Path $ModelDir "mtp-gemma-4-12b-it-Q8_0.gguf"
+
+if (-not (Test-Path $Model)) {
+  Write-Error "Model not found at: $Model"
+  Write-Output "  hf download unsloth/gemma-4-12B-it-qat-UD-Q4_K_XL --local-dir $ModelDir"
+  exit 1
+}
+if (-not (Test-Path $MtpHead)) {
+  Write-Error "MTP draft head not found at: $MtpHead"
+  Write-Output "  Ohne den Head kann --spec-type draft-mtp nicht starten."
+  exit 1
+}
+
+# Port raeumen - ein noch laufender Server auf diesem Port laesst den neuen
+# still am Bind scheitern.
+$conns = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+foreach ($c in $conns) {
+  if ($c.OwningProcess -and $c.OwningProcess -ne 0) {
+    Write-Output "Stopping existing process on port $Port (PID $($c.OwningProcess)) ..."
+    & taskkill.exe /F /T /PID $c.OwningProcess 2>&1 | Out-Null
+  }
+}
+
+$freeMiB = [int](& nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits).Trim()
+Write-Output "Starting Gemma 4 12B QAT + MTP head on port $Port (auto-fit context, Q8_0 KV, 1 slot) ..."
+Write-Output "  Model:     $Model"
+Write-Output "  MTP head:  $MtpHead"
+Write-Output "  Free VRAM: $freeMiB MiB"
+if ($freeMiB -lt 9000) {
+  Write-Output "  WARNUNG: unter 9000 MiB frei. Die Gewichte allein brauchen ~7.4 GB,"
+  Write-Output "           dazu der MTP-Head (~0.5 GB) und mindestens 32768 Tokens KV."
+  Write-Output "           Laeuft parallel ein anderes Chat-Modell (gpt-oss :8097)? Dann beenden."
+}
+if ($freeMiB -gt 15000) {
+  Write-Output "  HINWEIS: sehr viel VRAM frei - laufen bge-m3 (:8095) und der Reranker"
+  Write-Output "           (:8096) ueberhaupt? '-fit on' nimmt sich sonst deren Speicher mit."
+}
+
+$Params = @(
+  "-m", $Model
+  # Speculative Decoding ueber den mitgelieferten MTP-Head. -n-max 2 heisst:
+  # hoechstens 2 Tokens vorausraten, bevor das Hauptmodell verifiziert.
+  "--spec-type", "draft-mtp"
+  "--spec-draft-model", $MtpHead
+  "--spec-draft-n-max", "2"
+  "-ngl", "999"
+  # Ein einziger Slot - sonst gilt n_parallel=auto=4 und der Kontext wird
+  # geviertelt. Der llm-proxy serialisiert ohnehin per Semaphor
+  # (tickets.llm_proxy_backends.max_inflight, Default 1).
+  "-np", "1"
+  # KV q8_0: praktisch verlustfrei, halbiert den Cache gegenueber f16 und
+  # verdoppelt damit den Kontext, den "-fit" unterbringt.
+  "--cache-type-k", "q8_0"
+  "--cache-type-v", "q8_0"
+  "-fit", "on"
+  "-fitt", "1024"
+  "-fitc", "32768"
+  # --jinja: strukturierte tool_calls aus der im GGUF hinterlegten Vorlage.
+  # Ohne sie liefert der Server keine tool_calls - fuer die Factory unbrauchbar.
+  "--jinja"
+  "--host", "0.0.0.0"
+  "--port", "$Port"
+)
+
+$logDir = Split-Path $Exe -Parent
+$logOut = Join-Path $logDir "gemma4-12b-mtp-out.log"
+$logErr = Join-Path $logDir "gemma4-12b-mtp-err.log"
+Remove-Item $logOut -ErrorAction SilentlyContinue
+Remove-Item $logErr -ErrorAction SilentlyContinue
+
+# T002276: Start-Process statt Start-Job. Ein Job haengt an der PowerShell-
+# SITZUNG - endet sie, stirbt der Server mit.
+$p = Start-Process -FilePath $Exe -ArgumentList $Params -WindowStyle Hidden -PassThru `
+       -RedirectStandardOutput $logOut -RedirectStandardError $logErr
+"PID: $($p.Id)" | Out-File -FilePath (Join-Path $logDir "gemma4-12b-mtp.pid") -Encoding ascii
+
+$deadline = (Get-Date).AddSeconds(240)
+$healthy = $false
+while ((Get-Date) -lt $deadline) {
+  Start-Sleep -Seconds 3
+  if ($p.HasExited) { break }
+  try {
+    $r = Invoke-RestMethod -Uri "http://127.0.0.1:$Port/health" -TimeoutSec 2
+    if ($r.status -eq 'ok') { $healthy = $true; break }
+  } catch {}
+}
+
+if ($healthy) {
+  Write-Output "Gemma 4 12B: PID $($p.Id) healthy on :$Port"
+  Write-Output "  VRAM danach: $((& nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits).Trim()) MiB frei"
+  Write-Output ""
+  Write-Output "Der llm-proxy (:18235) findet den Server ueber die Registry und den Alias"
+  Write-Output "'gemma-4-12b'. Laeuft er nicht, aus WSL heraus starten:"
+  Write-Output "  task llm:proxy:start        # oder: systemctl --user start llm-proxy"
+  Write-Output ""
+  Write-Output "Smoke-Test MIT ausreichendem Budget (max_tokens 64 liefert wegen"
+  Write-Output "reasoning_content einen LEEREN content, siehe .DESCRIPTION):"
+  Write-Output '  $b = @{ model = "gemma-4-12b"; max_tokens = 512;'
+  Write-Output '          messages = @(@{ role = "user"; content = "Hauptstadt von Deutschland?" }) } | ConvertTo-Json -Depth 5'
+  Write-Output '  Invoke-RestMethod -Uri http://127.0.0.1:18235/v1/chat/completions -Method Post `'
+  Write-Output '    -ContentType application/json -Body $b | ForEach-Object { $_.choices[0].message.content }'
+} elseif ($p.HasExited) {
+  Write-Output "Gemma 4 12B FAILED: exited (code $($p.ExitCode)) - see $logErr"
+  Get-Content $logErr -Tail 20
+} else {
+  Write-Output "Gemma 4 12B WARNING: PID $($p.Id) laeuft, aber nach 240s nicht healthy - see $logErr"
+}

--- a/scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql
+++ b/scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql
@@ -1,0 +1,79 @@
+-- 2026-07-27-llm-proxy-gemma-backend.sql
+-- Schreibt den Gemma-4-12B-Cutover vom 2026-07-27 fest, der bis hierhin nur live in
+-- der DB stand und einen Reset nicht ueberlebt haette.
+--
+-- WAS SICH GEAENDERT HAT: die Factory lief auf ternary-bonsai-27b (:8093). Dieser
+-- Server laeuft nicht mehr; an seiner Stelle steht Gemma 4 12B QAT mit MTP-Draft-Head
+-- auf :8091 (Startskript: scripts/llm/start-gemma-server.ps1).
+--
+-- REIHENFOLGE: setzt 2026-07-22-llm-proxy-backends.sql (Tabelle llm_proxy_backends)
+-- und 2026-07-23-llm-proxy-max-inflight.sql (Spalte max_inflight) voraus. Letztere war
+-- auf mentolder nie angewandt worden - ohne sie wirft der Registry-Poll in
+-- scripts/llm-proxy/backends.mjs bei jedem Tick, der Proxy laeuft mit LEERER
+-- Backend-Liste und beantwortet jedes Modell mit 404, ohne dass /health das zeigt.
+--
+-- Idempotent (ON CONFLICT DO UPDATE, WHERE NOT EXISTS, gezielte UPDATE-Praedikate).
+-- Reversibel: llamacpp-gemma auf enabled=false, llamacpp-bonsai zurueck auf true.
+--
+-- Apply to BOTH brands (separate per-brand DBs):
+--   BRAND=mentolder  bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql'
+--   BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql'
+BEGIN;
+
+-- 1) Backend-Registry: Gemma auf :8091 aufnehmen, Bonsai auf :8093 stilllegen.
+--
+-- Der Alias entkoppelt den Namen, den Clients anfragen ('gemma-4-12b'), vom
+-- GGUF-Dateinamen, den llama.cpp unter /v1/models meldet. Ohne ihn muesste jede
+-- provider_config-Zeile den vollen Dateinamen fuehren und beim naechsten
+-- Quant-Wechsel nachgezogen werden.
+--
+-- WARUM DER ALIAS NICHT OPTIONAL IST: resolveModel() in scripts/llm-proxy/discovery.mjs
+-- hat einen Last-Resort-Fallback auf das erste gesunde Backend mit irgendeinem Modell.
+-- Ein unbekannter Modellname landet also NICHT im 404, sondern still bei einem
+-- beliebigen Server. Explizite Aliase machen aus diesem Zufall eine Zusage.
+INSERT INTO tickets.llm_proxy_backends
+  (name, kind, base_url, api_key_env, enabled, priority, fixups, model_aliases, max_inflight)
+VALUES
+  ('llamacpp-gemma', 'llamacpp', 'http://127.0.0.1:8091/v1', NULL, true, 1, '[]'::jsonb,
+   '{"gemma-4-12b":"gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"}'::jsonb, 1)
+ON CONFLICT (name) DO UPDATE
+  SET kind          = EXCLUDED.kind,
+      base_url      = EXCLUDED.base_url,
+      enabled       = true,
+      priority      = EXCLUDED.priority,
+      fixups        = EXCLUDED.fixups,
+      model_aliases = EXCLUDED.model_aliases,
+      max_inflight  = EXCLUDED.max_inflight,
+      updated_at    = now();
+
+UPDATE tickets.llm_proxy_backends
+   SET enabled = false, updated_at = now()
+ WHERE name = 'llamacpp-bonsai' AND enabled;
+
+-- 2) Routing: alles, was noch auf Bonsai zeigt, auf Gemma biegen.
+-- Das Praedikat auf model_id macht den zweiten Lauf zum No-op und ueberschreibt
+-- keine spaetere, bewusste Umstellung auf ein drittes Modell.
+UPDATE tickets.factory_model_slots
+   SET model_id = 'gemma-4-12b', provider = 'llamacpp',
+       base_url = 'http://127.0.0.1:18235', set_by = 'migration-2026-07-27', updated_at = now()
+ WHERE model_id = 'ternary-bonsai-27b';
+
+UPDATE tickets.provider_config
+   SET model_id = 'gemma-4-12b', provider = 'llamacpp',
+       base_url = 'http://127.0.0.1:18235', updated_at = now()
+ WHERE enabled AND model_id = 'ternary-bonsai-27b';
+
+-- 3) Tier 'opus' aus der Registry statt aus dem Skript.
+-- scripts/factory/route-provider.sh hatte fuer tier=opus ein hardcodiertes
+-- ternary-bonsai-27b, das die DB komplett umging. Das Skript liest jetzt hier;
+-- fehlt die Zeile, bricht es mit einer Fehlermeldung ab, statt still ein Modell
+-- zu behaupten, das es nicht mehr gibt. Diese Zeile ist also PFLICHT, nicht Kosmetik.
+INSERT INTO tickets.provider_config
+  (source, tier, priority, provider, model_id, base_url, max_concurrent, enabled, brand)
+SELECT '*', 'opus', 0, 'llamacpp', 'gemma-4-12b', 'http://127.0.0.1:18235', 3, true, '*'
+ WHERE NOT EXISTS (
+   SELECT 1 FROM tickets.provider_config
+    WHERE source = '*' AND tier = 'opus' AND provider = 'llamacpp'
+ );
+
+COMMIT;

--- a/tests/local/FA-SF-70-provider-router.bats
+++ b/tests/local/FA-SF-70-provider-router.bats
@@ -28,8 +28,15 @@ setup() { load 'test_helper.bash'; }
 @test "FA-SF-70: route-provider.sh emits valid JSON keys for opus without DB" {
   run bash scripts/factory/route-provider.sh factory-plan opus
   [ "$status" -eq 0 ]
-  # Post ternary-bonsai-27b migration: opus routes to local proxy ternary-bonsai-27b, not Anthropic cloud or lmstudio.
-  echo "$output" | jq -e '.modelId and (.provider=="ternary-bonsai-27b")'
+  # T002277: opus liest jetzt provider_config statt eines hardcodierten Modells.
+  # Ohne Cluster faellt es auf den eingebauten Default zurueck - beide Wege muessen
+  # dieselbe Invariante erfuellen: gueltiges JSON, das auf den LOKALEN Proxy zeigt
+  # und keinen Slot claimt (opus hat beim Aufrufer keinen Release-Pfad).
+  # Auf modelId wird bewusst nicht hart geprueft: welches Modell hinter dem Proxy
+  # steht, entscheidet die Registry und darf sich ohne Testaenderung verschieben.
+  # Die letzte Zeile isolieren - ohne DB schreibt das Skript eine Warnung auf stderr,
+  # und `run` fuehrt stdout und stderr in $output zusammen.
+  echo "${lines[${#lines[@]}-1]}" | jq -e '.modelId and (.baseUrl | test("127.0.0.1:18235")) and (.slotId == null)'
 }
 
 @test "FA-SF-70: route-provider.sh requires source and tier args" {

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -316,3 +316,44 @@ assert_var_not_declared() {
     [ "$status" -eq 0 ]
   done
 }
+
+# ── Gemma-Chat-Server (T002277) ───────────────────────────────────────
+# Das Skript lag bis 2026-07-27 unversioniert unter %UserProfile%\.lmstudio\.
+# Die Guards sichern die drei Parameter, ohne die der Server fuer die Factory
+# unbrauchbar waere - alle drei waren im Original bereits richtig gesetzt und
+# sollen es beim Uebertragen ins Repo geblieben sein.
+
+@test "start-gemma-server.ps1 exists and enables MTP speculative decoding (T002277)" {
+  [ -f "$REPO/scripts/llm/start-gemma-server.ps1" ]
+  run grep -qE '"--spec-type",[[:space:]]*"draft-mtp"' "$REPO/scripts/llm/start-gemma-server.ps1"
+  [ "$status" -eq 0 ]
+  run grep -q '\--spec-draft-model' "$REPO/scripts/llm/start-gemma-server.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "start-gemma-server.ps1 keeps the 32768 context floor (T002277)" {
+  # -fitc ist die Untergrenze des Auto-Fittings. Die Factory fuellt 31-37k Tokens
+  # pro Prompt; faellt der Server still auf 4096, ist er fuer sie wertlos, ohne
+  # dass ein Smoke-Test das zeigt.
+  run grep -qE '"-fitc",[[:space:]]*"32768"' "$REPO/scripts/llm/start-gemma-server.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "start-gemma-server.ps1 sets no explicit -c (T002277)" {
+  # Ein gesetztes -c schaltet --fit ab und friert den Kontext auf einen festen
+  # Wert ein. Genau das soll hier NICHT passieren.
+  run bash -c "grep -E '^[[:space:]]+\"-c\",' '$REPO/scripts/llm/start-gemma-server.ps1'"
+  [ "$status" -ne 0 ]
+}
+
+# Kein eigener Start-Job-Guard fuer start-gemma-server.ps1: der Test
+# "no scripts/llm/*.ps1 starts a server via Start-Job (T002276)" oben deckt
+# jedes Skript im Verzeichnis ab, auch neu hinzugekommene.
+
+@test "install-startup-autostart.ps1 does NOT autostart a chat model (T002276/T002277)" {
+  # Bewusste Entscheidung aus T002276: Gemma laeuft mit '-fit on' und nimmt sich
+  # alles freie VRAM. Im Autostart vor dem Embedding-Stack wuerde es bge-m3 und
+  # dem Reranker den Speicher wegnehmen. Der Guard haelt diese Entscheidung fest.
+  run bash -c "grep -E 'start-(gemma|gptoss|bonsai)' '$REPO/scripts/llm/install-startup-autostart.ps1'"
+  [ "$status" -ne 0 ]
+}

--- a/tests/spec/local-llm-proxy.bats
+++ b/tests/spec/local-llm-proxy.bats
@@ -195,3 +195,58 @@ _sanitize() {  # $1 = pattern -> sanitisiertes Pattern auf stdout
   # muss, ist genau dann aus, wenn er gebraucht wird.
   grep -q 'sanitizeToolSchemaPatterns' "${BATS_TEST_DIRNAME}/../../scripts/llm-proxy/server.mjs"
 }
+
+# ── systemd-Unit + Registry-Migration (T002277) ───────────────────────
+# Der Proxy lief bis 2026-07-27 ausschliesslich als manuell gestarteter
+# Node-Prozess; nach jedem Reboot war die Factory ohne Zutun tot.
+
+@test "llm-proxy.service existiert und startet server.mjs (T002277)" {
+  local unit="${BATS_TEST_DIRNAME}/../../scripts/llm-proxy/llm-proxy.service"
+  [ -f "$unit" ]
+  grep -qE '^ExecStart=.*/node .*/scripts/llm-proxy/server\.mjs$' "$unit"
+  grep -qE '^WantedBy=default\.target$' "$unit"
+}
+
+@test "llm-proxy.service hat kubectl im PATH (T002277)" {
+  # Die Backend-Registry wird per `kubectl exec ... psql` gelesen
+  # (scripts/factory/lib.sh). kubectl liegt unter /usr/local/bin, das die
+  # systemd-Default-PATH NICHT enthaelt - ohne diese Zeile laeuft der Proxy
+  # dauerhaft mit leerer Backend-Liste und meldet trotzdem /health ok.
+  grep -qE '^Environment=PATH=.*(/usr/local/bin)' \
+    "${BATS_TEST_DIRNAME}/../../scripts/llm-proxy/llm-proxy.service"
+}
+
+@test "proxy:start erkennt eine bereits laufende systemd-Instanz (T002277)" {
+  # Das PID-File kennt nur die nohup-Instanz. Ohne Port-Pruefung wuerde ein
+  # zweiter Start mit EADDRINUSE sterben und ein PID-File hinterlassen, das auf
+  # einen toten Prozess zeigt.
+  grep -qE 'curl .*127\.0\.0\.1:\$PORT/health' \
+    "${BATS_TEST_DIRNAME}/../../Taskfile.llm.yml"
+}
+
+@test "Gemma-Migration registriert das Backend mit Alias (T002277)" {
+  local mig="${BATS_TEST_DIRNAME}/../../scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql"
+  [ -f "$mig" ]
+  # Der Alias ist die einzige Zusage, dass 'gemma-4-12b' auf diesem Backend
+  # landet - resolveModel() biegt unbekannte Modelle sonst still auf das erste
+  # gesunde Backend um.
+  grep -q '"gemma-4-12b"' "$mig"
+  grep -qE "llamacpp-gemma" "$mig"
+}
+
+@test "route-provider.sh liest tier=opus aus der Registry (T002277)" {
+  # Vorher stand hier ein hardcodiertes Modell, das die DB komplett umging.
+  local rp="${BATS_TEST_DIRNAME}/../../scripts/factory/route-provider.sh"
+  run bash -c "grep -E \"OPUS_MODEL=.ternary-bonsai-27b\" '$rp'"
+  [ "$status" -ne 0 ]
+  grep -qE "tier='opus'" "$rp"
+}
+
+@test "route-provider.sh claimt fuer tier=opus keinen Slot (T002277)" {
+  # opus liefert slotId:null - es gibt beim Aufrufer keinen Release-Pfad. Ginge
+  # es durch die normale Claim-Kette, waere der Provider nach max_concurrent
+  # Aufrufen dauerhaft blockiert.
+  run bash scripts/factory/route-provider.sh factory-plan opus
+  [ "$status" -eq 0 ]
+  echo "${lines[${#lines[@]}-1]}" | jq -e '.slotId == null'
+}

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3107,8 +3107,15 @@ REG="scripts/factory/service-registry.sh"
 @test "FA-SF-70: route-provider.sh emits valid JSON keys for opus without DB" {
   run bash scripts/factory/route-provider.sh factory-plan opus
   [ "$status" -eq 0 ]
-  # Post local-llm-proxy migration: opus routes to ternary-bonsai-27b on :18235 [T002081]
-  echo "$output" | jq -e '.modelId and (.provider=="ternary-bonsai-27b")'
+  # T002277: opus liest jetzt provider_config statt eines hardcodierten Modells.
+  # Ohne Cluster faellt es auf den eingebauten Default zurueck - beide Wege muessen
+  # dieselbe Invariante erfuellen: gueltiges JSON, das auf den LOKALEN Proxy zeigt
+  # und keinen Slot claimt (opus hat beim Aufrufer keinen Release-Pfad).
+  # Auf modelId wird bewusst nicht hart geprueft: welches Modell hinter dem Proxy
+  # steht, entscheidet die Registry und darf sich ohne Testaenderung verschieben.
+  # Die letzte Zeile isolieren - ohne DB schreibt das Skript eine Warnung auf stderr,
+  # und `run` fuehrt stdout und stderr in $output zusammen.
+  echo "${lines[${#lines[@]}-1]}" | jq -e '.modelId and (.baseUrl | test("127.0.0.1:18235")) and (.slotId == null)'
 }
 
 @test "FA-SF-70: route-provider.sh requires source and tier args" {


### PR DESCRIPTION
Folgearbeit zum **Gemma-4-12B-Cutover vom 2026-07-27**. Der Cutover selbst stand bis hierhin nur live in der DB und hätte einen Reset nicht überlebt; das Startskript lag unversioniert auf dem Host.

## Was drin ist

| Teil | Datei |
|---|---|
| Gemma-Startskript versioniert | `scripts/llm/start-gemma-server.ps1` (neu) |
| Proxy-Autostart via systemd | `scripts/llm-proxy/llm-proxy.service` (neu) + 3 Taskfile-Targets |
| Registry als Migration | `scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql` (neu) |
| Tier `opus` aus der DB statt hardcodiert | `scripts/factory/route-provider.sh` |

## Entscheidungen, die Erklärung brauchen

**Der Autostart bekommt weiterhin KEIN Chat-Modell.** T002276 (#3317) hat das bewusst so entschieden: Gemma läuft mit `-fit on` und nimmt sich alles freie VRAM — im Startup-Ordner vor dem Embedding-Stack würde es bge-m3 und dem Reranker den Speicher wegnehmen. Ein Test hält die Entscheidung jetzt fest, statt sie nur im Docstring stehen zu lassen.

**Der opus-Hardcode ist nicht ersatzlos weg.** `FA-SF-70` dokumentiert im Testnamen („emits valid JSON keys for opus **without DB**") eine Eigenschaft, die der Hardcode nebenbei hatte: `opus` routete ohne Cluster. `factory_psql` geht über `kubectl exec` — ein reiner DB-Lookup hätte dev-flow offline lahmgelegt. Jetzt gilt: DB gewinnt, wenn sie antwortet; sonst greift ein explizit markierter Default mit Warnung auf stderr. Verifiziert mit einem `kubectl`-Stub, der `exit 1` liefert.

**`opus` claimt weiterhin keinen Slot.** Es liefert `slotId:null` und hat beim Aufrufer keinen Release-Pfad. Durch die normale Claim-Kette geführt, würde jeder Aufruf `provider_health.active_agents` erhöhen, ohne ihn je zu senken — genau der Leak, der dort aktuell bei `deepseek`=3 (am Cap, dauerhaft blockiert) und `lmstudio`=8 sichtbar ist.

**`Environment=PATH` in der Unit ist nicht Kosmetik.** Die Backend-Registry wird per `kubectl exec … psql` gelesen; kubectl liegt unter `/usr/local/bin`, das die systemd-Default-PATH nicht enthält. Ohne die Zeile läuft der Proxy dauerhaft mit **leerer Backend-Liste** und meldet trotzdem `/health ok` — `startRegistryPoll` fängt den Fehler ab und behält den letzten Stand, der beim Kaltstart leer ist.

**`task llm:proxy:start` war gegen die systemd-Variante blind.** Es prüfte nur das PID-File; mit laufender Unit wäre der zweite Start an `EADDRINUSE` gestorben und hätte ein PID-File auf einen toten Prozess hinterlassen. Prüft jetzt zusätzlich den Port.

## Verifikation

- Migration zweimal angewandt — idempotent, exit 0
- `route-provider.sh factory-plan opus` mit Cluster → DB-Wert; mit `kubectl`-Stub (`exit 1`) → Fallback + stderr-Warnung, exit 0
- `systemd-analyze verify llm-proxy.service` → exit 0
- `tests/spec/local-llm-proxy.bats` 20/20, `tests/spec/llm-pipeline.bats` 39/39, `tests/local/FA-SF-70-provider-router.bats` 7/7
- `task freshness:check` → exit 0, „no new or worsened violations", 0 blocking

**Einschränkung:** Der volle `task test:changed`-Lauf lief 1406 von 1878 Tests mit **0 Fehlschlägen** durch und hing dann an einem fremden, DB-berührenden Test (`software-factory.bats → T001444-3a stage-plan auto-emits scout/design/plan done`). Ich habe ihn abgebrochen; der Rest liegt bei CI.

Die Migration ist bisher **nur auf mentolder** angewandt — korczewski steht aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
