### PR TITLE
fix(factory): release provider slots, add TTL reaper, isolate test writes [T002281]

### DIFF
--- a/Taskfile.llm.yml
+++ b/Taskfile.llm.yml
@@ -149,18 +149,45 @@ tasks:
           echo "Enable it: 'loginctl enable-linger $USER' then re-run. Falling back: task llm:proxy:start."
           exit 1
         fi
+        PORT="${LLM_PROXY_PORT:-18235}"
         # Manuell gestartete nohup-Instanz beenden, damit der Port fuer systemd frei ist.
         PIDF="$HOME/.local/state/llm-proxy/proxy.pid"
         if [[ -f "$PIDF" ]] && kill -0 "$(cat "$PIDF")" 2>/dev/null; then
           kill "$(cat "$PIDF")" && rm -f "$PIDF"
-          echo "stopped manually started instance"
+          echo "stopped manually started instance (pid file)"
         fi
+        # T002281: das PID-File allein reicht NICHT. Am 2026-07-27 lief die Altinstanz
+        # mit PID 280029 weiter, obwohl PID-File und 'kill -0' gueltig waren - der Block
+        # oben griff nicht, und die frisch installierte Unit fiel in eine
+        # EADDRINUSE-Restart-Schleife. Der Port ist die verlaessliche Auskunft.
+        for _ in 1 2 3; do
+          curl -fsS --max-time 2 "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 || break
+          OWNER="$(ss -lptnH "sport = :$PORT" 2>/dev/null | grep -oE 'pid=[0-9]+' | head -1 | cut -d= -f2)"
+          [[ -z "$OWNER" ]] && { echo "Port $PORT belegt, Besitzer nicht ermittelbar — abbrechen." >&2; exit 1; }
+          echo "Port $PORT noch belegt von PID $OWNER — beende ihn."
+          kill "$OWNER" 2>/dev/null || true
+          sleep 2
+        done
         UNIT_DIR="${HOME}/.config/systemd/user"
         mkdir -p "${UNIT_DIR}"
         ln -sf "$(pwd)/scripts/llm-proxy/llm-proxy.service" "${UNIT_DIR}/llm-proxy.service"
         systemctl --user daemon-reload
         systemctl --user enable --now llm-proxy.service
-        echo "llm-proxy installed as systemd --user service (autostart + Restart=always)."
+        # T002281: 'enable --now' kehrt erfolgreich zurueck, waehrend die Unit in
+        # auto-restart haengt - 'is-active' meldet dann 'activating', was wie ein langsamer
+        # Start aussieht. Erfolgsmeldung ohne Pruefung ist dieselbe Klasse, die T002276 bei
+        # schtasks gefunden hat. Also den Endzustand abwarten und belegen.
+        for _ in $(seq 1 15); do
+          STATE="$(systemctl --user show llm-proxy.service -p SubState --value 2>/dev/null || echo unknown)"
+          [[ "$STATE" == "running" ]] && break
+          sleep 2
+        done
+        if [[ "$(systemctl --user is-active llm-proxy.service 2>/dev/null)" != "active" ]]; then
+          echo "llm-proxy: Unit erreicht 'active' nicht (SubState=$STATE). Journal:" >&2
+          journalctl --user -u llm-proxy.service -n 15 --no-pager >&2 || true
+          exit 1
+        fi
+        echo "llm-proxy installed as systemd --user service (active/running, autostart + Restart=always)."
 
   proxy:uninstall-service:
     desc: "Stop + disable the llm-proxy systemd service and remove the symlinked unit."

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -639,7 +639,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 48,
+      "file_count": 49,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -688,7 +688,8 @@
         "scripts/migrations/2026-07-22-llm-proxy-backends.sql",
         "scripts/migrations/2026-07-22-slot-count-gang.sql",
         "scripts/migrations/2026-07-23-llm-proxy-max-inflight.sql",
-        "scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql"
+        "scripts/migrations/2026-07-27-llm-proxy-gemma-backend.sql",
+        "scripts/migrations/2026-07-27-provider-health-integrity.sql"
       ]
     },
     {
@@ -2920,7 +2921,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 553,
+      "file_count": 554,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3196,6 +3197,7 @@
         "scripts/factory/qa-notify.sh",
         "scripts/factory/queue.sh",
         "scripts/factory/readiness-check.sh",
+        "scripts/factory/reap-provider-slots.sh",
         "scripts/factory/reconcile-ticket-status.sh",
         "scripts/factory/release-slot.sh",
         "scripts/factory/review-agents-md-staleness.prompt.md",

--- a/openspec/changes/provider-slot-leak/design.md
+++ b/openspec/changes/provider-slot-leak/design.md
@@ -1,0 +1,111 @@
+# Design: Provider-Slot-Leak und Test-Nebenwirkungen [T002281]
+
+## Purpose
+
+Vier Befunde aus dem Gemma-Cutover (T002277, 2026-07-27). Drei davon teilen dieselbe
+Fehlerklasse: **eine Bedingung prüft einen Stellvertreter statt den tatsächlichen Zustand** —
+ein Zähler statt des lebenden Prozesses, ein PID-File statt des Ports, ein `cd` ohne
+Erfolgsprüfung. Der vierte ist Datenmüll aus einer abgelösten Codeversion.
+
+## Root Causes
+
+### B1 — `provider_health.active_agents` wird nie freigegeben
+
+`route-provider.sh` claimt in der `provider_config`-Kette atomar einen Slot
+(`active_agents + 1`) und liefert `slotId`. Freigegeben wird über
+`scripts/factory/release-slot.sh`.
+
+**Dieses Skript wird von keinem Produktionscode aufgerufen — nur von Tests.**
+
+Die Treffer, die nach Freigabe aussehen (`ticket.sh release-slot --id …` in
+`factory-prep-bridge.sh`, `factory-prep-runner.sh`, `ticket-reclaim.sh`), sind ein
+**gleichnamiges, anderes Kommando**: es gibt den Ticket-Pipeline-Slot frei, nicht den
+`provider_health`-Zähler. Zwei Dinge mit identischem Namen und verschiedener Semantik.
+
+Von den zwei echten Aufrufern des Routers macht es nur einer richtig:
+
+| Aufrufer | Claim | Release |
+|---|---|---|
+| `scout-llm-fallback.sh` | ja | ja — `trap release_slot EXIT` (Zeile 68) |
+| `auto-triage.sh` | ja (Zeile 153, `triage flash`) | **nein** — liest `slotId` nicht einmal aus |
+
+`auto-triage.sh` befragt laut Header „pro Ticket DeepSeek via route-provider". Das erklärt
+exakt, warum `deepseek` auf `active_agents=3` steht — genau `max_concurrent`. Der Provider
+wird seitdem von `route-provider.sh` still übersprungen; es gibt keine Fehlermeldung, die
+Kette fällt einfach auf den nächsten Kandidaten durch.
+
+Gemessen 2026-07-27: `deepseek=3`, `lmstudio=8`, `ternary-bonsai-27b=3`. `llamacpp` wuchs
+innerhalb einer Stunde nach manuellem Reset wieder auf 1 — der Leak ist aktiv.
+
+Nebenbefund: der Kommentar in `route-provider.sh:4` behauptet „inlined into pipeline.js".
+`pipeline.js` enthält weder `slotId` noch `route-provider` noch `provider_health`.
+
+### B2 — Korrupte `provider`-Werte
+
+Zwei Zeilen in `provider_health` tragen als Provider-Namen eine ganze Ergebniszeile:
+
+```
+anthropic\tclaude-sonnet-4-6\t\t3
+deepseek\tdeepseek-v4-pro\thttps://api.deepseek.com/anthropic\t3
+```
+
+Zwei Beobachtungen datieren das: die Werte enthalten **literale** `\t`-Sequenzen (keine
+echten Tabs, sonst zeigte psql sie als Leerraum), und sie haben **vier** Felder. Die heutige
+Kandidaten-Query liefert **sechs** (mit `ctx` und `budget`, seit T001590). Die Zeilen stammen
+also aus einer abgelösten Codeversion, in der `E'\t'` nicht als Escape interpretiert wurde.
+Sie sind mit `active_agents=0` folgenlos.
+
+### B3 — Tests schreiben ins echte Repo und in die echte DB
+
+`tests/unit/check-commit-vs-diff.bats` (Zeilen 141, 151, 169):
+
+```bash
+mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && …
+printf 'fix(infra): …\n' > "$TMP/msg-subject"
+mkdir -p openspec/changes/x && printf 'plan' > openspec/changes/x/tasks.md
+```
+
+Die dritte Zeile hängt **nicht** an der `&&`-Kette der ersten. Schlägt `cd` fehl, entsteht
+`openspec/changes/x/` im Repo-Root. Bats setzt in `@test`-Blöcken kein `set -e`, der Test
+bricht deshalb nicht ab — er verschmutzt still das Arbeitsverzeichnis. Genau das wurde am
+2026-07-27 beobachtet (0-Byte-`tasks.md`, Zeitstempel im Testfenster).
+
+Verwandt: `FA-SF-70` ruft `provider-config.sh set --source x --tier opus …` gegen die
+**echte** `provider_config` auf und hinterlässt dort dauerhaft `x|opus|1|anthropic|m`.
+Folgenlos, weil `source='x'` nie matcht — aber ein Test, der in eine produktive
+Routing-Tabelle schreibt, ist eine Zeitbombe.
+
+### B4 — `install-service` prüft den Port nicht
+
+`task llm:proxy:install-service` (aus PR #3320) beendet eine laufende `nohup`-Instanz nur
+über das PID-File. Am 2026-07-27 05:02 lief die Altinstanz mit PID 280029, das PID-File
+enthielt `280029`, `kill -0 280029` war erfolgreich — der Block griff trotzdem nicht, und die
+frisch installierte Unit lief in eine `EADDRINUSE`-Restart-Schleife. Sichtbar nur im Journal;
+`systemctl is-active` meldet währenddessen `activating`, was wie ein langsamer Start aussieht.
+
+## Entscheidungen
+
+**B1 → Aufrufer fixen UND die Klasse absichern.** `auto-triage.sh` bekommt denselben
+`trap release_slot EXIT` wie `scout-llm-fallback.sh`. Zusätzlich ein TTL-Reaper: `provider_health`
+bekommt `claimed_at`, und ein Aufräumlauf gibt Claims frei, die älter als die TTL sind.
+Begründung: zwei Aufrufer, einer hat den Release bereits vergessen — der nächste wird es
+wieder. Ein reiner Aufrufer-Fix macht den Leak unsichtbar, nicht unmöglich.
+
+**B2 → Bereinigen und Wiederkehr ausschließen.** Migration löscht die Müllzeilen und ergänzt
+einen CHECK auf `provider`: kein Backslash, kein Tab, kein Whitespace. Der Constraint ist
+unabhängig davon, welcher Schreibpfad die Zeilen erzeugt hat — genau deshalb ist er den
+Ballast wert.
+
+**B3 → `cd` absichern, Testschreibzugriff auf die echte DB entfernen.**
+
+**B4 → Port-Check vor `enable --now`, Zustandsprüfung danach.** Derselbe Check, den
+`proxy:start` bereits hat. Zusätzlich verifizieren, dass die Unit `active (running)` erreicht,
+statt nur die Erfolgsmeldung zu drucken — die Klasse „Erfolgsmeldung ohne Prüfung", die
+T002276 bei `schtasks` schon einmal gefunden hat.
+
+## Nicht in diesem Fix
+
+- Die TTL-Länge ist konservativ zu wählen (Vorschlag: 30 min). Ein zu kurzer Wert gäbe Slots
+  laufender Anfragen frei und höbe die Concurrency-Begrenzung faktisch auf.
+- `route-provider.sh:4` (falscher `pipeline.js`-Kommentar) wird mitkorrigiert, weil er beim
+  Debuggen dieses Befunds aktiv in die Irre geführt hat.

--- a/openspec/changes/provider-slot-leak/specs/local-llm-proxy.md
+++ b/openspec/changes/provider-slot-leak/specs/local-llm-proxy.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Service installation verifies port ownership and the resulting unit state
+
+`task llm:proxy:install-service` SHALL determine whether the proxy port is still served before
+enabling the systemd unit, and SHALL NOT rely on the PID file alone — the PID file only knows the
+`nohup` instance and stays silent when the port is held by anything else. After
+`systemctl enable --now`, the task SHALL confirm the unit actually reaches `active (running)`
+rather than printing a success message: `enable --now` returns successfully while a unit is stuck
+in `auto-restart`, and `is-active` reports `activating` during that state, which is
+indistinguishable from a slow start.
+
+#### Scenario: A manually started instance still holding the port is stopped
+
+- **GIVEN** a proxy instance answers on the port but is not described by the PID file
+- **WHEN** the install task runs
+- **THEN** the task identifies the owning process via the port and stops it before enabling the unit
+
+#### Scenario: A unit stuck in a restart loop fails the install
+
+- **GIVEN** the unit cannot bind its port and systemd keeps restarting it
+- **WHEN** the install task waits for the unit state
+- **THEN** the task exits non-zero and prints the journal tail instead of reporting success

--- a/openspec/changes/provider-slot-leak/specs/software-factory.md
+++ b/openspec/changes/provider-slot-leak/specs/software-factory.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: Every claimed provider slot is released on all return paths
+
+Any script that obtains a slot from `scripts/factory/route-provider.sh` SHALL release it again on
+**every** return path, including error paths. A claim increments
+`tickets.provider_health.active_agents`; a provider whose counter reaches `max_concurrent` is
+silently skipped by the candidate chain, without any error being surfaced to the caller.
+
+Scripts that claim more than once per run SHALL NOT rely on an `EXIT` trap alone, because such a
+trap releases only the final claim.
+
+#### Scenario: The triage helper releases its slot after a successful call
+
+- **GIVEN** `auto-triage.sh` has routed a ticket and holds a slot for provider `deepseek`
+- **WHEN** the LLM call completes successfully
+- **THEN** `active_agents` for `deepseek` is back at its pre-call value
+
+#### Scenario: The triage helper releases its slot after a failed call
+
+- **GIVEN** `auto-triage.sh` holds a slot and the downstream `curl` fails
+- **WHEN** the helper returns a non-zero status
+- **THEN** the slot is released just as on the success path
+
+#### Scenario: A provider at its concurrency cap is skipped, not reported
+
+- **GIVEN** `tickets.provider_health.active_agents` for a provider equals its `max_concurrent`
+- **WHEN** `route-provider.sh` walks the candidate chain
+- **THEN** that provider is passed over and the next candidate is claimed instead
+
+### Requirement: Orphaned provider slots are reclaimed after a TTL
+
+`tickets.provider_health` SHALL record `claimed_at` for every active claim, and
+`scripts/factory/reap-provider-slots.sh` SHALL release claims older than
+`PROVIDER_SLOT_TTL_MIN` (default 30). The TTL SHALL stay well above the runtime of a single LLM
+request — a shorter value would release slots of requests still in flight and thereby defeat the
+concurrency limit it is meant to protect.
+
+#### Scenario: A stale claim is reclaimed
+
+- **GIVEN** a provider row with `active_agents` above zero and `claimed_at` older than the TTL
+- **WHEN** the reaper runs
+- **THEN** `active_agents` is decremented and `claimed_at` is reset to `NULL`
+
+#### Scenario: A fresh claim is left alone
+
+- **GIVEN** a provider row whose `claimed_at` lies within the TTL
+- **WHEN** the reaper runs
+- **THEN** the row is left untouched
+
+#### Scenario: Releasing one of several concurrent claims keeps the timestamp
+
+- **GIVEN** a provider holds more than one concurrent claim
+- **WHEN** `release-slot.sh` releases one of them
+- **THEN** `claimed_at` is retained, so the reaper can still see the remaining claim
+
+### Requirement: Provider names are free of structural characters
+
+`tickets.provider_health.provider` SHALL reject values containing a backslash, tab or any other
+whitespace. Such values indicate a failed field split, where an entire result row was written as a
+single provider name.
+
+#### Scenario: A malformed provider name is rejected
+
+- **GIVEN** an insert whose provider value contains an escaped tab sequence
+- **WHEN** the row is written to `tickets.provider_health`
+- **THEN** the database rejects it via a CHECK constraint
+
+### Requirement: Tests never write to production routing tables or the working tree
+
+Test suites SHALL NOT write to `tickets.provider_config`, `tickets.provider_health` or the repository
+working tree. Argument-validation tests SHALL use a dry-run mode that stops before any database
+access, and shell tests that change directory SHALL fail loudly if the change fails — bats does not
+set `set -e` inside `@test` blocks, so an unguarded `cd` lets subsequent commands run against the
+real repository root.
+
+#### Scenario: Validation is tested without touching the database
+
+- **GIVEN** a test asserting that `provider-config.sh set` accepts `tier=opus` with a warning
+- **WHEN** the test invokes the script with `--dry-run`
+- **THEN** the warning is emitted and no row is written to `tickets.provider_config`
+
+#### Scenario: A failed directory change aborts the test
+
+- **GIVEN** a test that changes into a temporary repository before creating files
+- **WHEN** the directory change fails
+- **THEN** the test returns non-zero instead of creating those files in the repository root

--- a/openspec/changes/provider-slot-leak/tasks.md
+++ b/openspec/changes/provider-slot-leak/tasks.md
@@ -1,0 +1,119 @@
+---
+title: Provider-Slot-Leak und Test-Nebenwirkungen beheben
+ticket_id: T002281
+domains: [factory, infra, test]
+status: plan_staged
+---
+
+# provider-slot-leak — Implementation Plan
+
+Vier Befunde aus dem Gemma-Cutover (T002277). Drei teilen dieselbe Fehlerklasse: eine
+Bedingung prüft einen Stellvertreter statt den tatsächlichen Zustand. Root-Cause-Analyse
+und Entscheidungen: `openspec/changes/provider-slot-leak/design.md`.
+
+## File Structure
+
+| Datei | Ist | Budget |
+| --- | --- | --- |
+| `scripts/factory/auto-triage.sh` | 351 | 149 |
+| `scripts/factory/route-provider.sh` | 114 | 386 |
+
+Ohne S1-Gate (Dateityp nicht gegated, seit T002265 als leeres Budget gemeldet):
+`tests/unit/check-commit-vs-diff.bats`, `tests/spec/software-factory.bats`,
+`tests/spec/local-llm-proxy.bats`, `Taskfile.llm.yml`.
+
+Neu: `scripts/factory/reap-provider-slots.sh`,
+`scripts/migrations/2026-07-27-provider-health-integrity.sql`.
+
+## Task 1 — RED-Nachweis (bereits erbracht, hier zur Reproduktion)
+
+Die acht Guards sind geschrieben und schlagen fehl. Vor jeder Codeänderung reproduzieren:
+
+```bash
+bats --filter "T002281" tests/spec/software-factory.bats tests/spec/local-llm-proxy.bats
+# expected: FAIL — alle 8 rot (auto-triage-Release, Reaper, Migration,
+# pipeline.js-Kommentar, cd-Absicherung, provider-config-Schreibzugriff,
+# install-service Port-Check, install-service Zustandsprüfung)
+```
+
+## Task 2 — Migration: `claimed_at`, Müllbereinigung, CHECK
+
+Neue Datei `scripts/migrations/2026-07-27-provider-health-integrity.sql`, idempotent,
+Header mit beiden Brand-Kommandos wie in `2026-07-27-llm-proxy-gemma-backend.sql`.
+
+Inhalt:
+1. `ALTER TABLE tickets.provider_health ADD COLUMN IF NOT EXISTS claimed_at timestamptz` —
+   Grundlage des TTL-Reapers. Kommentar: NULL bedeutet „kein aktiver Claim".
+2. `DELETE` der Zeilen, deren `provider` einen Backslash, Tab oder Whitespace enthält.
+   Vorher deren `active_agents` prüfen; die bekannten zwei stehen auf 0 und sind folgenlos.
+3. `ADD CONSTRAINT provider_health_provider_clean CHECK (provider !~ '[\\\\[:space:]]')` —
+   die Klasse zuhalten, unabhängig vom Schreibpfad. `IF NOT EXISTS`-Äquivalent über
+   `DO $$ … pg_constraint …`, damit der zweite Lauf durchgeht.
+4. Reset der geleakten Zähler auf 0 (`deepseek`, `lmstudio`, `ternary-bonsai-27b`), damit
+   `deepseek` als Fallback wieder erreichbar ist — mit Kommentar, dass dies die Altlast
+   räumt und der Reaper aus Task 3 die Wiederkehr verhindert.
+
+Anwenden auf **beide** Brands, Idempotenz durch zweiten Lauf belegen.
+
+## Task 3 — Slot-Freigabe: Aufrufer und Reaper
+
+**3a — `scripts/factory/auto-triage.sh`** (Budget 149): `slotId` und `ctx` aus der
+`route-provider`-Antwort auslesen und wie in `scout-llm-fallback.sh:55-68` per
+`trap release_slot EXIT` freigeben. `release-slot.sh` nimmt `<provider> [success] [ctx]`;
+`ctx` mitgeben, sonst bleibt `reserved_tokens` stehen.
+
+**3b — `scripts/factory/reap-provider-slots.sh`** (neu): gibt Claims frei, deren
+`claimed_at` älter als die TTL ist. TTL über `PROVIDER_SLOT_TTL_MIN` (Default **30**)
+konfigurierbar. Der Wert ist bewusst konservativ: zu kurz gewählt würde er Slots laufender
+Anfragen freigeben und die Concurrency-Begrenzung faktisch aufheben. Skript setzt
+`active_agents = GREATEST(0, active_agents - 1)` und `claimed_at = NULL` für abgelaufene
+Zeilen und meldet, wie viele es waren.
+
+**3c — `scripts/factory/route-provider.sh`** (Budget 386): der Claim setzt zusätzlich
+`claimed_at = now()`; `release-slot.sh` setzt es auf NULL zurück. Außerdem den falschen
+Kommentar in Zeile 4 korrigieren — `pipeline.js` enthält weder `slotId` noch
+`provider_health`, die Behauptung hat beim Debuggen aktiv in die Irre geführt.
+
+## Task 4 — Test-Isolation
+
+**4a — `tests/unit/check-commit-vs-diff.bats`:** jedes `cd "$TMP/repo"` bekommt einen
+Fehlerpfad (`|| return 1`). Ohne ihn läuft ein fehlgeschlagenes `cd` weiter und legt
+`openspec/changes/x/` im Repo-Root an; bats setzt in `@test`-Blöcken kein `set -e`.
+
+**4b — `tests/spec/software-factory.bats`:** der `FA-SF-70`-Test darf
+`provider-config.sh set` nicht mehr gegen die produktive Tabelle fahren. Er prüft die
+Argument-Validierung, nicht den Schreibpfad — also auf einen Modus umstellen, der vor dem
+DB-Zugriff endet. Bereits vorhandene Müllzeile `x|opus|1|anthropic|m` in derselben Migration
+aus Task 2 entfernen.
+
+## Task 5 — `install-service` prüft den echten Zustand
+
+`Taskfile.llm.yml`, Target `proxy:install-service`:
+
+1. **Vor** `systemctl enable --now`: `curl -fsS --max-time 2 http://127.0.0.1:$PORT/health`.
+   Antwortet der Port, obwohl das PID-File nichts hergibt, den Belegenden über den Port
+   ermitteln (`ss -lptn "sport = :$PORT"`) und beenden — nicht dem PID-File vertrauen.
+2. **Nach** `enable --now`: verifizieren, dass die Unit `active (running)` erreicht, statt
+   nur die Erfolgsmeldung zu drucken. Bleibt sie in `activating`/`auto-restart`, den
+   Journal-Auszug ausgeben und mit Exit-Code enden.
+
+## Task 6 — Verifikation
+
+```bash
+bats --filter "T002281" tests/spec/software-factory.bats tests/spec/local-llm-proxy.bats
+bats tests/unit/check-commit-vs-diff.bats
+bash scripts/factory/route-provider.sh factory-plan opus
+task test:inventory
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+
+Zusätzlich manuell, weil es keinen Offline-Test dafür gibt:
+
+- Migration zweimal auf beide Brands anwenden (Idempotenz).
+- `provider_health` prüfen: keine Zeile mit Backslash/Whitespace im `provider`, `deepseek`
+  wieder unter `max_concurrent`.
+- `task llm:proxy:uninstall-service && task llm:proxy:start && task llm:proxy:install-service`
+  — der Port-Check muss die `nohup`-Instanz erkennen und beenden, die Unit danach
+  `active (running)` erreichen.

--- a/scripts/factory/auto-triage.sh
+++ b/scripts/factory/auto-triage.sh
@@ -113,8 +113,44 @@ validate_triage() {
   return 0
 }
 
-# ── call_llm: build prompt → route-provider → curl → response ──────────
+# ── Slot-Freigabe [T002281] ────────────────────────────────────────────
+# route-provider.sh claimt atomar (active_agents + 1) und liefert slotId. Dieses
+# Skript las slotId frueher nicht einmal aus - und da es pro Ticket einmal claimt,
+# stand deepseek nach drei Laeufen auf active_agents=3 = max_concurrent und wurde
+# von der Kandidaten-Kette still uebersprungen, ohne jede Fehlermeldung.
+#
+# WARUM EIN WRAPPER UND KEIN 'trap RETURN': _call_llm_inner hat fuenf Ruecksprung-
+# pfade (route-provider failed, leere Felder, leere baseUrl, curl failed, kein
+# content, Erfolg). Ein Release an jedem einzelnen waere genau die Stelle, an der
+# der naechste Patch einen vergisst. Der Wrapper faengt alle ab.
+#
+# WARUM KEIN 'trap EXIT' WIE IN scout-llm-fallback.sh: jenes Skript claimt EINMAL
+# pro Lauf, hier wird pro Ticket geclaimt. Ein EXIT-Trap gaebe nur den letzten Slot
+# frei und liesse alle vorherigen stehen.
+CURRENT_ROUTE_JSON=""
+
+release_current_slot() {
+  [[ -z "$CURRENT_ROUTE_JSON" ]] && return 0
+  local slot ctx
+  slot="$(printf '%s' "$CURRENT_ROUTE_JSON" | jq -r '.slotId // empty' 2>/dev/null)"
+  ctx="$(printf '%s' "$CURRENT_ROUTE_JSON" | jq -r '.ctx // 0' 2>/dev/null)"
+  CURRENT_ROUTE_JSON=""   # vor dem Aufruf leeren: macht die Funktion idempotent
+  [[ -z "$slot" || "$slot" == "null" ]] && return 0
+  # ctx mitgeben, sonst bleibt reserved_tokens stehen (release-slot.sh Zeile 5).
+  bash "$HERE/release-slot.sh" "$slot" true "${ctx:-0}" >/dev/null 2>&1 || true
+}
+# Netz fuer Abbrueche mitten im Lauf (Ctrl-C, Timeout, set -e).
+trap release_current_slot EXIT
+
 call_llm() {
+  local rc=0
+  _call_llm_inner "$@" || rc=$?
+  release_current_slot
+  return $rc
+}
+
+# ── _call_llm_inner: build prompt → route-provider → curl → response ────
+_call_llm_inner() {
   local title="$1" description="$2" enums="$3"
   local system_prompt
   system_prompt=$(cat <<'PROMPT'
@@ -154,6 +190,9 @@ PROMPT
     echo "auto-triage: route-provider failed" >&2
     return 1
   }
+  # Ab hier haelt dieser Aufruf einen Slot — der Wrapper call_llm gibt ihn auf
+  # jedem Ruecksprungpfad wieder frei [T002281].
+  CURRENT_ROUTE_JSON="$route"
   local provider; provider=$(echo "$route" | jq -r '.provider // ""')
   local model; model=$(echo "$route" | jq -r '.modelId // ""')
   local base_url; base_url=$(echo "$route" | jq -r '.baseUrl // ""')

--- a/scripts/factory/provider-config.sh
+++ b/scripts/factory/provider-config.sh
@@ -18,14 +18,24 @@ exit 2; }
 cmd="${1:-}"; shift || true
 case "$cmd" in
   set)
-    src= tier= prio= prov= model= burl= maxc=3
+    src= tier= prio= prov= model= burl= maxc=3 dry=false
     while [[ $# -gt 0 ]]; do case "$1" in
       --source) src="$2"; shift 2;; --tier) tier="$2"; shift 2;;
       --priority) prio="$2"; shift 2;; --provider) prov="$2"; shift 2;;
       --model) model="$2"; shift 2;; --base-url) burl="$2"; shift 2;;
-      --max-concurrent) maxc="$2"; shift 2;; *) usage;; esac; done
+      --max-concurrent) maxc="$2"; shift 2;;
+      --dry-run) dry=true; shift;; *) usage;; esac; done
     [[ -n "$src" && -n "$tier" && -n "$prio" && -n "$prov" && -n "$model" ]] || usage
     if [[ "$tier" == "opus" ]]; then echo "WARNING: opus tier — ensure a provider_config row exists for this source/tier." >&2; fi
+    # --dry-run [T002281]: validiert Argumente und gibt Warnungen aus, beruehrt die
+    # DB aber nicht. FA-SF-70 prueft genau diese Validierung und fuhr dafuer bis 2026-07-27
+    # gegen die PRODUKTIVE provider_config — die Zeile x|opus|1|anthropic|m blieb dort
+    # dauerhaft stehen. Folgenlos, weil source='x' nie matcht, aber ein Test, der in die
+    # produktive Routing-Tabelle schreibt, ist eine Zeitbombe.
+    if $dry; then
+      echo "DRY-RUN: would upsert ${src}/${tier}/${prio} → ${prov}/${model}"
+      exit 0
+    fi
     factory_psql \
       -v src="$src" -v tier="$tier" -v prio="$prio" -v prov="$prov" \
       -v model="$model" -v burl="${burl:-}" -v maxc="$maxc" <<'SQL'

--- a/scripts/factory/reap-provider-slots.sh
+++ b/scripts/factory/reap-provider-slots.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# scripts/factory/reap-provider-slots.sh [--dry-run]
+# Gibt Provider-Slots frei, deren Claim aelter als die TTL ist [T002281].
+#
+# WARUM ES DAS GIBT: route-provider.sh claimt atomar (active_agents + 1); freigegeben
+# wird ueber release-slot.sh. Von den zwei Aufrufern des Routers hatte einer den Release
+# schlicht vergessen - deepseek stand dadurch auf active_agents=3 = max_concurrent und
+# wurde von der Kandidaten-Kette still uebersprungen, ohne jede Fehlermeldung. Ein reiner
+# Aufrufer-Fix macht den Leak unsichtbar, nicht unmoeglich: der naechste Aufrufer wird es
+# wieder vergessen. Dieser Reaper ist das Netz darunter.
+#
+# TTL-WAHL: Default 30 Minuten, bewusst konservativ. Zu kurz gewaehlt gibt der Reaper
+# Slots noch LAUFENDER Anfragen frei und hebt die Concurrency-Begrenzung faktisch auf -
+# der Zaehler faellt dann unter die Zahl der echten In-Flight-Requests. Eine
+# LLM-Anfrage der Factory laeuft im Minutenbereich; 30 Minuten liegen sicher darueber.
+#
+# IDEMPOTENZ: Zeilen ohne Claim (claimed_at IS NULL) bleiben unberuehrt, ebenso
+# active_agents=0. Mehrfache Laeufe sind folgenlos.
+#
+# Usage:
+#   bash scripts/factory/reap-provider-slots.sh              # raeumt ab
+#   bash scripts/factory/reap-provider-slots.sh --dry-run    # zeigt nur, was faellig waere
+# Env:
+#   PROVIDER_SLOT_TTL_MIN   TTL in Minuten (Default 30)
+#   BRAND                   Ziel-Brand (Default mentolder, via lib.sh)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$HERE/lib.sh"; factory_resolve
+
+TTL_MIN="${PROVIDER_SLOT_TTL_MIN:-30}"
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+if $DRY_RUN; then
+  factory_psql -v ttl="$TTL_MIN" <<'SQL'
+SELECT provider||' | active='||active_agents||' | claimed_at='||COALESCE(claimed_at::text,'NULL')
+FROM tickets.provider_health
+WHERE active_agents > 0
+  AND claimed_at IS NOT NULL
+  AND claimed_at < now() - (:'ttl' || ' minutes')::interval;
+SQL
+  exit 0
+fi
+
+# Ein einzelnes UPDATE statt Read-then-Write: der Zaehler wird sonst zwischen SELECT und
+# UPDATE von einem parallelen Claim veraendert.
+REAPED=$(factory_psql -v ttl="$TTL_MIN" <<'SQL'
+WITH stale AS (
+  UPDATE tickets.provider_health
+     SET active_agents   = GREATEST(0, active_agents - 1),
+         reserved_tokens = 0,
+         claimed_at      = NULL,
+         updated_at      = now()
+   WHERE active_agents > 0
+     AND claimed_at IS NOT NULL
+     AND claimed_at < now() - (:'ttl' || ' minutes')::interval
+  RETURNING provider
+)
+SELECT count(*) FROM stale;
+SQL
+)
+
+if [[ "${REAPED:-0}" -gt 0 ]]; then
+  echo "reap-provider-slots: $REAPED verwaiste(n) Slot(s) freigegeben (TTL ${TTL_MIN}min)."
+else
+  echo "reap-provider-slots: nichts faellig (TTL ${TTL_MIN}min)."
+fi

--- a/scripts/factory/release-slot.sh
+++ b/scripts/factory/release-slot.sh
@@ -16,6 +16,9 @@ factory_psql -v prov="$PROV" -v ctx="$CTX" <<'SQL'
 UPDATE tickets.provider_health
 SET active_agents = GREATEST(0, active_agents - 1),
     reserved_tokens = GREATEST(0, reserved_tokens - :'ctx'::int),
+    -- claimed_at nur loeschen, wenn danach kein Claim mehr offen ist: sonst haelt
+    -- der TTL-Reaper den verbleibenden Claim faelschlich fuer frisch [T002281].
+    claimed_at = CASE WHEN active_agents - 1 <= 0 THEN NULL ELSE claimed_at END,
     updated_at = now()
 WHERE provider = :'prov';
 SQL

--- a/scripts/factory/route-provider.sh
+++ b/scripts/factory/route-provider.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 # scripts/factory/route-provider.sh <source> <tier>
 # Emits JSON: {"provider":..,"modelId":..,"baseUrl":..|null,"slotId":..|null,"emergency":bool}
-# opus → provider_config lookup without slot claim (T002277). Used by dev-flow AND inlined into pipeline.js.
+# opus → provider_config lookup without slot claim (T002277). Used by dev-flow, auto-triage.sh
+# and scout-llm-fallback.sh. (Hier stand bis T002281 der Hinweis, die Logik sei zusätzlich in
+# pipeline.js dupliziert — das stimmt nicht: pipeline.js enthält weder slotId noch
+# provider_health, und die Behauptung hat beim Debuggen des Slot-Leaks in die Irre geführt.)
 # slotId == provider name (slots are per-provider counters, not per-claim UUIDs).
+# WER CLAIMT, MUSS FREIGEBEN: scripts/factory/release-slot.sh — sonst bleibt active_agents
+# stehen, bis der Provider auf max_concurrent steht und still übersprungen wird. Netz
+# darunter: scripts/factory/reap-provider-slots.sh (TTL über claimed_at).
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
@@ -95,7 +101,8 @@ while IFS=$'\t' read -r prov model burl maxc ctx budget; do
   CLAIM=$(factory_psql -v prov="$prov" -v maxc="$maxc" -v ctx="${ctx:-0}" -v budget="$budget" <<'SQL'
 INSERT INTO tickets.provider_health (provider) VALUES (:'prov') ON CONFLICT (provider) DO NOTHING;
 UPDATE tickets.provider_health
-SET active_agents = active_agents + 1, reserved_tokens = reserved_tokens + :'ctx'::int, updated_at = now()
+SET active_agents = active_agents + 1, reserved_tokens = reserved_tokens + :'ctx'::int,
+    claimed_at = now(), updated_at = now()
 WHERE provider = :'prov'
   AND active_agents < :'maxc'::int
   AND (cooldown_until IS NULL OR cooldown_until <= now())

--- a/scripts/migrations/2026-07-27-provider-health-integrity.sql
+++ b/scripts/migrations/2026-07-27-provider-health-integrity.sql
@@ -1,0 +1,75 @@
+-- 2026-07-27-provider-health-integrity.sql
+-- Datenintegritaet fuer tickets.provider_health [T002281].
+--
+-- DREI DINGE:
+--  1. claimed_at als Grundlage des TTL-Reapers (scripts/factory/reap-provider-slots.sh).
+--  2. Bereinigung geleakter Zaehler und korrupter provider-Werte.
+--  3. CHECK, der die korrupte Klasse zuhaelt.
+--
+-- WARUM DIE ZAEHLER LEAKEN: route-provider.sh claimt atomar (active_agents + 1) und
+-- liefert slotId; freigegeben wird ueber scripts/factory/release-slot.sh. Dieses Skript
+-- wird von KEINEM Produktionscode gerufen, nur von Tests. Was nach Freigabe aussieht
+-- (ticket.sh release-slot --id …) ist ein gleichnamiges, anderes Kommando fuer den
+-- Ticket-Pipeline-Slot. Von den zwei echten Router-Aufrufern gibt nur
+-- scout-llm-fallback.sh frei; auto-triage.sh las slotId nicht einmal aus. Gemessen
+-- 2026-07-27: deepseek=3 (= max_concurrent, damit als Fallback dauerhaft tot),
+-- lmstudio=8, ternary-bonsai-27b=3.
+--
+-- WARUM DIE PROVIDER-WERTE KORRUPT SIND: zwei Zeilen tragen eine ganze Ergebniszeile als
+-- Namen, z. B. 'anthropic\tclaude-sonnet-4-6\t\t3'. Sie enthalten LITERALE \t-Sequenzen
+-- (keine echten Tabs - sonst zeigte psql Leerraum) und haben VIER Felder, waehrend die
+-- heutige Kandidaten-Query SECHS liefert (seit T001590). Also Altlast einer abgeloesten
+-- Codeversion. Mit active_agents=0 folgenlos, aber der CHECK haelt die Klasse zu -
+-- unabhaengig davon, welcher Schreibpfad sie erzeugt hat.
+--
+-- Idempotent (IF NOT EXISTS, pg_constraint-Guard, praedikatgebundene UPDATEs).
+-- Reversibel: DROP CONSTRAINT provider_health_provider_clean, DROP COLUMN claimed_at.
+--
+-- Apply to BOTH brands (separate per-brand DBs):
+--   BRAND=mentolder  bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-07-27-provider-health-integrity.sql'
+--   BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-07-27-provider-health-integrity.sql'
+BEGIN;
+
+-- 1) claimed_at: Zeitstempel des aktiven Claims. NULL = kein aktiver Claim.
+ALTER TABLE tickets.provider_health
+  ADD COLUMN IF NOT EXISTS claimed_at timestamptz;
+
+COMMENT ON COLUMN tickets.provider_health.claimed_at IS
+  'Zeitpunkt des juengsten Slot-Claims durch route-provider.sh. NULL = kein aktiver Claim. Grundlage des TTL-Reapers (scripts/factory/reap-provider-slots.sh); ohne ihn bleibt ein vergessener Release unbemerkt, bis der Provider auf max_concurrent steht.';
+
+-- 2a) Korrupte Zeilen entfernen. Das Praedikat trifft Backslash, Tab und jeden
+-- Whitespace - ein legitimer Provider-Name enthaelt nichts davon.
+DELETE FROM tickets.provider_health
+ WHERE provider ~ '[\\[:space:]]';
+
+-- 2b) Geleakte Zaehler zuruecksetzen. Das ist die Altlast; die Wiederkehr verhindern
+-- der trap in auto-triage.sh und der TTL-Reaper, nicht dieses UPDATE.
+UPDATE tickets.provider_health
+   SET active_agents = 0, reserved_tokens = 0, claimed_at = NULL, updated_at = now()
+ WHERE active_agents > 0 OR reserved_tokens > 0;
+
+-- 2c) Test-Muell aus der produktiven Routing-Tabelle. FA-SF-70 rief
+-- 'provider-config.sh set --source x --tier opus --provider anthropic --model m'
+-- gegen die echte DB auf. Folgenlos, weil source='x' nie matcht - aber ein Test,
+-- der in die produktive Routing-Tabelle schreibt, ist eine Zeitbombe. Der Test
+-- wird im selben Ticket auf einen Modus ohne DB-Zugriff umgestellt.
+DELETE FROM tickets.provider_config
+ WHERE source = 'x' AND tier = 'opus' AND provider = 'anthropic' AND model_id = 'm';
+
+-- 3) CHECK gegen die korrupte Klasse. pg_constraint-Guard statt IF NOT EXISTS,
+-- das ADD CONSTRAINT nicht kennt.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'provider_health_provider_clean'
+       AND conrelid = 'tickets.provider_health'::regclass
+  ) THEN
+    ALTER TABLE tickets.provider_health
+      ADD CONSTRAINT provider_health_provider_clean
+      CHECK (provider !~ '[\\[:space:]]');
+  END IF;
+END
+$$;
+
+COMMIT;

--- a/tests/local/FA-SF-70-provider-router.bats
+++ b/tests/local/FA-SF-70-provider-router.bats
@@ -13,7 +13,7 @@ setup() { load 'test_helper.bash'; }
   # still fail downstream (factory_psql needs a live shared-db pod) — only
   # assert the pre-DB validation behavior: opus passes argument validation
   # and emits a warning, instead of being hard-rejected like before.
-  run bash scripts/factory/provider-config.sh set --source x --tier opus --priority 1 --provider anthropic --model m
+  run bash scripts/factory/provider-config.sh set --source x --tier opus --priority 1 --provider anthropic --model m --dry-run
   [[ "$output" == *"WARNING"* ]]
   [[ "$output" == *"opus"* ]]
   [[ "$output" != *"Usage:"* ]]

--- a/tests/spec/local-llm-proxy.bats
+++ b/tests/spec/local-llm-proxy.bats
@@ -250,3 +250,26 @@ _sanitize() {  # $1 = pattern -> sanitisiertes Pattern auf stdout
   [ "$status" -eq 0 ]
   echo "${lines[${#lines[@]}-1]}" | jq -e '.slotId == null'
 }
+
+# ── T002281: install-service prueft den tatsaechlichen Zustand ────────
+# Bei der Live-Installation am 2026-07-27 lief die Altinstanz weiter (PID-File
+# gueltig, kill -0 erfolgreich, Block griff trotzdem nicht) und die frische Unit
+# fiel in eine EADDRINUSE-Restart-Schleife. Nur im Journal sichtbar -
+# 'systemctl is-active' meldete 'activating', was wie ein langsamer Start aussieht.
+
+@test "proxy:install-service prueft den Port, nicht nur das PID-File (T002281)" {
+  # Derselbe Check, den proxy:start seit T002277 hat. Das PID-File kennt nur die
+  # nohup-Instanz und luegt, sobald der Port anderweitig belegt ist.
+  run bash -c "sed -n '/proxy:install-service:/,/^  [a-z]/p' \
+    '${BATS_TEST_DIRNAME}/../../Taskfile.llm.yml' | grep -cE 'curl .*health'"
+  [ "$output" != "0" ]
+}
+
+@test "proxy:install-service verifiziert den Unit-Zustand nach enable (T002281)" {
+  # 'Erfolgsmeldung ohne Pruefung' - dieselbe Klasse, die T002276 bei schtasks
+  # gefunden hat. enable --now kann erfolgreich zurueckkehren, waehrend die Unit
+  # in auto-restart haengt.
+  run bash -c "sed -n '/proxy:install-service:/,/^  [a-z]/p' \
+    '${BATS_TEST_DIRNAME}/../../Taskfile.llm.yml' | grep -cE 'is-active|ActiveState'"
+  [ "$output" != "0" ]
+}

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -4228,3 +4228,64 @@ EOF
   run grep -c "inflightOf" scripts/llm-proxy/server.mjs
   [ "$output" -ge 2 ]
 }
+
+# ── T002281: Provider-Slot-Leak + Datenintegritaet ────────────────────
+# Vier Befunde aus dem Gemma-Cutover (T002277). Die Guards sind strukturell,
+# weil die Verhaltenspfade eine Live-DB brauchen und diese Suite offline laeuft.
+
+@test "T002281: auto-triage.sh gibt den geclaimten Provider-Slot frei" {
+  # route-provider.sh claimt atomar (active_agents+1) und liefert slotId.
+  # auto-triage.sh las slotId bisher nicht einmal aus - deshalb stand deepseek
+  # auf active_agents=3 = max_concurrent und war als Fallback dauerhaft tot,
+  # ohne jede Fehlermeldung. scout-llm-fallback.sh macht es korrekt vor.
+  run bash -c "grep -Eq 'trap .*release.* EXIT' '$REPO/scripts/factory/auto-triage.sh'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -q 'slotId' '$REPO/scripts/factory/auto-triage.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002281: es gibt einen TTL-Reaper fuer verwaiste Provider-Slots" {
+  # Ein reiner Aufrufer-Fix macht den Leak unsichtbar, nicht unmoeglich:
+  # zwei Aufrufer, einer hatte den Release bereits vergessen.
+  [ -f "$REPO/scripts/factory/reap-provider-slots.sh" ]
+  run bash -c "grep -q 'claimed_at' '$REPO/scripts/factory/reap-provider-slots.sh'"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002281: Migration bereinigt Muell-Provider und sperrt die Klasse" {
+  # Die Altlast traegt ganze TSV-Zeilen als Provider-Namen (literale \t,
+  # 4-Feld-Format einer abgeloesten Query-Version). Der CHECK haelt die Klasse
+  # zu, unabhaengig davon welcher Schreibpfad sie erzeugt hat.
+  local mig="$REPO/scripts/migrations/2026-07-27-provider-health-integrity.sql"
+  [ -f "$mig" ]
+  run bash -c "grep -Eq 'ADD COLUMN IF NOT EXISTS claimed_at' '$mig'"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -Eiq 'CHECK' '$mig'"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002281: route-provider.sh behauptet kein Inlining in pipeline.js" {
+  # pipeline.js enthaelt weder slotId noch route-provider noch provider_health -
+  # der Kommentar hat beim Debuggen dieses Befunds aktiv in die Irre gefuehrt.
+  run bash -c "grep -q 'inlined into pipeline.js' '$REPO/scripts/factory/route-provider.sh'"
+  [ "$status" -ne 0 ]
+}
+
+@test "T002281: check-commit-vs-diff.bats schreibt nie ins Repo-Root" {
+  # 'mkdir -p \$TMP/repo && cd \$TMP/repo && git init' - die folgenden Zeilen
+  # hingen NICHT an dieser Kette. Schlaegt cd fehl, entsteht openspec/changes/x
+  # im echten Repo; bats setzt in @test-Bloecken kein set -e, der Test laeuft
+  # stillschweigend weiter.
+  run bash -c "grep -cE 'cd \"\\\$TMP/repo\"( |\$)' '$REPO/tests/unit/check-commit-vs-diff.bats'"
+  [ "$status" -eq 0 ]
+  # Jedes cd in diese Datei muss einen Fehlerpfad haben (|| return / || fail).
+  run bash -c "grep -E 'cd \"\\\$TMP/repo\"' '$REPO/tests/unit/check-commit-vs-diff.bats' | grep -vcE '\\|\\|'"
+  [ "$output" = "0" ]
+}
+
+@test "T002281: FA-SF-70 schreibt nicht in die echte provider_config" {
+  # Der Test rief 'provider-config.sh set --source x --tier opus' gegen die
+  # produktive Tabelle auf und hinterliess dort dauerhaft x|opus|1|anthropic|m.
+  run bash -c "grep -E 'provider-config\.sh set' '$REPO/tests/spec/software-factory.bats' | grep -vcE '(--dry-run|DRY_RUN|--help)'"
+  [ "$output" = "0" ]
+}

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -3093,7 +3093,7 @@ REG="scripts/factory/service-registry.sh"
 @test "FA-SF-70: provider-config.sh set accepts tier=opus with warning" {
   kubectl() { if [ "$1" = "get" ]; then echo "mock-pod"; else echo "ok"; fi; }
   export -f kubectl
-  run bash scripts/factory/provider-config.sh set --source x --tier opus --priority 1 --provider anthropic --model m
+  run bash scripts/factory/provider-config.sh set --source x --tier opus --priority 1 --provider anthropic --model m --dry-run
   [ "$status" -eq 0 ]
   [[ "$output" == *"opus"* ]]
 }
@@ -4286,6 +4286,8 @@ EOF
 @test "T002281: FA-SF-70 schreibt nicht in die echte provider_config" {
   # Der Test rief 'provider-config.sh set --source x --tier opus' gegen die
   # produktive Tabelle auf und hinterliess dort dauerhaft x|opus|1|anthropic|m.
-  run bash -c "grep -E 'provider-config\.sh set' '$REPO/tests/spec/software-factory.bats' | grep -vcE '(--dry-run|DRY_RUN|--help)'"
+  # Nur vollstaendige Aufrufe pruefen (erkennbar an --provider): unvollstaendige enden
+  # in usage() vor jedem DB-Zugriff und sind unbedenklich.
+  run bash -c "grep -E 'provider-config\.sh set .*--provider' '$REPO/tests/spec/software-factory.bats' | grep -vcE '\-\-dry-run'"
   [ "$output" = "0" ]
 }

--- a/tests/unit/check-commit-vs-diff.bats
+++ b/tests/unit/check-commit-vs-diff.bats
@@ -41,7 +41,7 @@ teardown() {
 # ── 2. Subject-line classification (allow cases) ─────────────────────────────
 
 @test "allows: fix(real-code) — production-code change" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'src/middleware.ts' > "$TMP/msg-subject"
   mkdir -p src && printf 'real code' > src/middleware.ts
   git add src/middleware.ts
@@ -50,7 +50,7 @@ teardown() {
 }
 
 @test "allows: fix(real-code+test) — production + test in same commit" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): chain middleware sequence\n' > "$TMP/msg-subject"
   mkdir -p src && printf 'real' > src/middleware.ts && printf 'test' > src/middleware.test.ts
   git add src/
@@ -59,7 +59,7 @@ teardown() {
 }
 
 @test "allows: test(red-only) — RED-test commit uses test: prefix" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'test(red): verify locals.requestLogger is set\n' > "$TMP/msg-subject"
   mkdir -p src && printf 'test' > src/middleware.test.ts
   git add src/
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "allows: chore(plan-only) — plan-only commit uses chore(plans):" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'chore(plans): stage t001434 for execution [T001434]\n' > "$TMP/msg-subject"
   mkdir -p openspec/changes/t001434 && printf 'plan' > openspec/changes/t001434/tasks.md
   git add openspec/
@@ -77,7 +77,7 @@ teardown() {
 }
 
 @test "allows: docs: readme update is not an implementation claim" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'docs: update README\n' > "$TMP/msg-subject"
   printf 'hello' > README.md
   git add README.md
@@ -86,7 +86,7 @@ teardown() {
 }
 
 @test "allows: ci: workflow bump is not an implementation claim" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'ci: bump action versions\n' > "$TMP/msg-subject"
   mkdir -p .github/workflows && printf 'on: push' > .github/workflows/ci.yml
   git add .github/
@@ -95,7 +95,7 @@ teardown() {
 }
 
 @test "allows: fix(kustomize) — yaml/manifest counts as production code" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): tweak configmap\n' > "$TMP/msg-subject"
   mkdir -p k3d && printf 'data:' > k3d/configmap-domains.yaml
   git add k3d/
@@ -104,7 +104,7 @@ teardown() {
 }
 
 @test "allows: fix(scope-less) — no-scope implementation title is still fine if real code is staged" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix: typo in error message\n' > "$TMP/msg-subject"
   mkdir -p src && printf 'export const E = 1;' > src/typo.ts
   git add src/
@@ -113,7 +113,7 @@ teardown() {
 }
 
 @test "allows: feat!: breaking-change marker still allowed" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'feat(api)!: drop legacy /v1 endpoints\n' > "$TMP/msg-subject"
   mkdir -p src/api && printf 'export {}' > src/api/v2.ts
   git add src/
@@ -124,7 +124,7 @@ teardown() {
 # ── 3. Block cases — the T001434 pattern ────────────────────────────────────
 
 @test "blocks: fix(red-only-test) — the T001434 pattern (T001434-mishap)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): chain loggingMiddleware in middleware.ts via sequence() [T001434]\n' > "$TMP/msg-subject"
   mkdir -p src && printf 'test' > src/middleware.test.ts
   git add src/
@@ -136,7 +136,7 @@ teardown() {
 }
 
 @test "blocks: fix(plan-only)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
   mkdir -p openspec/changes/x && printf 'plan' > openspec/changes/x/tasks.md
   git add openspec/
@@ -145,7 +145,7 @@ teardown() {
 }
 
 @test "blocks: fix(plan-and-test combined)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
   mkdir -p src && printf 'test' > src/middleware.test.ts
   mkdir -p openspec/changes/x && printf 'plan' > openspec/changes/x/tasks.md
@@ -155,7 +155,7 @@ teardown() {
 }
 
 @test "blocks: fix(spec-only — openspec/specs)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
   mkdir -p openspec/specs && printf 'spec' > openspec/specs/centralized-logging.md
   git add openspec/specs/
@@ -164,7 +164,7 @@ teardown() {
 }
 
 @test "blocks: feat(plan-only)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'feat(infra): add logging chain\n' > "$TMP/msg-subject"
   mkdir -p openspec/changes/x && printf 'p' > openspec/changes/x/tasks.md && printf 'p' > openspec/changes/x/proposal.md
   git add openspec/changes/x/
@@ -173,7 +173,7 @@ teardown() {
 }
 
 @test "blocks: refactor(plan-only)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'refactor(scripts): consolidate guards\n' > "$TMP/msg-subject"
   mkdir -p openspec/changes/cleanup && printf 'p' > openspec/changes/cleanup/tasks.md
   git add openspec/changes/cleanup/
@@ -182,7 +182,7 @@ teardown() {
 }
 
 @test "blocks: perf(plan-only)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'perf(db): index tickets table\n' > "$TMP/msg-subject"
   mkdir -p openspec/changes/perf && printf 'p' > openspec/changes/perf/tasks.md
   git add openspec/changes/perf/
@@ -191,7 +191,7 @@ teardown() {
 }
 
 @test "blocks: doc-only files (superpowers specs) with implementation title" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): chain middleware\n' > "$TMP/msg-subject"
   mkdir -p docs/superpowers/specs && printf 'spec' > docs/superpowers/specs/2026-07-02-design.md
   git add docs/superpowers/specs/
@@ -202,7 +202,7 @@ teardown() {
 # ── 4. Bypass semantics ──────────────────────────────────────────────────────
 
 @test "SKIP_COMMIT_VS_DIFF=1 bypasses the check (commit-msg hook)" {
-  mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init -q && git config user.email t@t && git config user.name t
+  mkdir -p "$TMP/repo" && cd "$TMP/repo" || return 1 && git init -q && git config user.email t@t && git config user.name t
   printf 'fix(infra): should be allowed with SKIP_COMMIT_VS_DIFF=1\n' > "$TMP/msg-subject"
   mkdir -p src && printf 'test' > src/middleware.test.ts
   git add src/


### PR DESCRIPTION
Vier Befunde aus dem Gemma-Cutover (T002277). Drei teilen dieselbe Fehlerklasse: **eine Bedingung prüft einen Stellvertreter statt den tatsächlichen Zustand.** Root-Cause-Analyse: `openspec/changes/provider-slot-leak/design.md`.

## 1. Der Slot-Leak war eine Namenskollision

`route-provider.sh` claimt atomar (`active_agents + 1`) und liefert `slotId`. Freigegeben wird über `scripts/factory/release-slot.sh` — **das von keinem Produktionscode gerufen wurde, nur von Tests.** Was nach Freigabe aussah (`ticket.sh release-slot --id` an vier Stellen), ist ein **gleichnamiges, anderes Kommando** für den Ticket-Pipeline-Slot.

Von den zwei echten Router-Aufrufern gab nur `scout-llm-fallback.sh` frei. `auto-triage.sh` las `slotId` nicht einmal aus — und claimt **pro Ticket**. Das erklärt exakt, warum `deepseek` auf `3 = max_concurrent` stand und von der Kandidaten-Kette still übersprungen wurde.

**Warum ein Wrapper statt eines `trap`:** `_call_llm_inner` hat **fünf** Rücksprungpfade. Ein Release an jedem einzelnen wäre genau die Stelle, an der der nächste Patch einen vergisst. Und ein `trap EXIT` wie in `scout-llm-fallback.sh` reicht hier nicht — jenes Skript claimt einmal pro Lauf, dieses pro Ticket; ein EXIT-Trap gäbe nur den letzten Slot frei.

**Netz darunter:** neue Spalte `provider_health.claimed_at` + `reap-provider-slots.sh` mit TTL (Default 30 min, bewusst konservativ — zu kurz gewählt gäbe der Reaper Slots *laufender* Anfragen frei und höbe die Concurrency-Begrenzung faktisch auf).

## 2. Die korrupten Werte sind datierbar

Zwei Zeilen trugen ganze Ergebniszeilen als Provider-Namen. Sie enthalten **literale** `\t`-Sequenzen (keine echten Tabs — sonst zeigte psql Leerraum) und haben **vier** Felder, während die heutige Query **sechs** liefert (seit T001590). Also Altlast einer abgelösten Codeversion. Migration löscht sie und ergänzt einen CHECK gegen Backslash/Whitespace — unabhängig davon, welcher Schreibpfad sie erzeugt hat.

## 3. Tests schrieben ins echte Repo und in die echte DB

`check-commit-vs-diff.bats`: `mkdir -p "$TMP/repo" && cd "$TMP/repo" && git init` — die folgenden Zeilen hingen **nicht** an dieser Kette, und bats setzt in `@test`-Blöcken kein `set -e`. Ein fehlgeschlagenes `cd` legte `openspec/changes/x/` im Repo-Root an, ohne dass der Test abbrach.

`FA-SF-70` fuhr `provider-config.sh set` gegen die **produktive** `provider_config` und hinterließ dort dauerhaft `x|opus|1|anthropic|m`. `provider-config.sh` bekommt `--dry-run` (validiert und warnt, berührt die DB nicht).

## 4. install-service prüfte den falschen Zustand

Das PID-File allein reichte nicht: am 2026-07-27 lief die Altinstanz weiter, obwohl PID-File und `kill -0` gültig waren, und die frische Unit fiel in eine `EADDRINUSE`-Restart-Schleife. Jetzt Port-Check (`ss`) vor dem `enable` und ein Wartelauf auf `SubState=running` danach — `enable --now` kehrt erfolgreich zurück, während die Unit in `auto-restart` hängt.

Außerdem: der Kommentar in `route-provider.sh`, die Logik sei in `pipeline.js` dupliziert, war **falsch** und hat beim Debuggen aktiv in die Irre geführt.

## Verifikation

- **8/8** T002281-Guards von rot auf grün
- `FA-SF-70` 15/15 (beide Kopien), `check-commit-vs-diff` 21/21, `local-llm-proxy` und `software-factory` ohne Fehlschlag
- Migration auf **beiden** Brands angewandt, zweiter Lauf idempotent
- CHECK greift: `INSERT` mit `boese\tzeile\t3` wird abgewiesen
- Claim setzt `claimed_at` → Reaper (TTL=0) gibt frei → `release-slot.sh` setzt zurück
- `provider_health` jetzt durchgängig `active=0`; **`deepseek` wieder als Fallback nutzbar**
- `task freshness:check` exit 0, 0 blocking

**Nicht verifiziert:** der LLM-Pfad in `auto-triage.sh`. Ein Dry-Run fand keine untriagierten Tickets, `call_llm` wurde also nicht durchlaufen. Die Struktur deckt der Guard ab, das Laufzeitverhalten bleibt offen.

Closes T002281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
