### PR TITLE
chore(llm): gemma-server auf festen Kontext-Deckel 65536 + Autostart [T002286]

### DIFF
--- a/scripts/llm/install-startup-autostart.ps1
+++ b/scripts/llm/install-startup-autostart.ps1
@@ -6,6 +6,7 @@
   Anmelden die Startskripte aufruft:
     start-embed-server.ps1   (bge-m3,             Port 8095)
     start-rerank-server.ps1  (bge-reranker-v2-m3, Port 8096)
+    start-gemma-server.ps1   (Gemma 4 12B QAT,    Port 8091)
 
   WARUM NICHT SCHEDULED TASKS (T002276):
   Auf diesem Host schlaegt der Task-Weg aus drei Gruenden fehl, alle gemessen am
@@ -31,12 +32,18 @@
   Einzelplatz-Workstation ist das ausreichend - die Modelle liegen ohnehin im
   Benutzerprofil, und die GPU wird interaktiv genutzt.
 
-  UMFANG: nur Embedding und Rerank. Ein Chat-Modell wird bewusst NICHT
-  mitgestartet - welches die Factory nutzt, entscheidet
-  tickets.factory_model_slots, und die Chat-Server unterscheiden sich stark im
-  VRAM-Bedarf (gpt-oss-20b 12,1 GB; Gemma-4-12B laeuft mit "-fit on" und nimmt
-  alles freie VRAM). Ein pauschaler Autostart wuerde dem Embedding-Stack den
-  Speicher wegnehmen.
+  UMFANG: Embedding, Rerank und Gemma - in dieser Reihenfolge. Gemma kam mit
+  T002286 dazu, nachdem sein Startskript von "-fit on" auf den festen Deckel
+  "-c 65536 -fit off" umgestellt wurde. Vorher nahm sich der Server ALLES freie
+  VRAM und haette dem Embedding-Stack den Speicher weggenommen; jetzt ist sein
+  Bedarf deterministisch (rund 13,0 GB von 16,3 GB, gemessen 2026-07-27), sodass
+  bge-m3 und der Reranker mit zusammen ~1,7 GB daneben passen. Die Reihenfolge
+  bleibt trotzdem embed -> rerank -> gemma: scheitert der groesste Brocken,
+  steht der Embedding-Stack wenigstens.
+
+  WEITERHIN NICHT IM AUTOSTART: gpt-oss-20b (:8097, 12,1 GB). Welches Chat-Modell
+  die Factory nutzt, entscheidet tickets.factory_model_slots - zwei Chat-Server
+  gleichzeitig passen nicht auf die Karte.
 .PARAMETER Uninstall
   Entfernt den Startup-Eintrag wieder.
 .PARAMETER RepoRoot
@@ -77,7 +84,7 @@ if (-not (Test-Path $llmDir)) {
 # damit kein Umweg ueber eine .lnk mit Zielpfad-Escaping noetig ist.
 # -WindowStyle Hidden, damit beim Anmelden kein Fenster aufpoppt; die
 # Startskripte protokollieren selbst in <build>\*-out.log / *-err.log.
-$scripts = @('start-embed-server.ps1', 'start-rerank-server.ps1')
+$scripts = @('start-embed-server.ps1', 'start-rerank-server.ps1', 'start-gemma-server.ps1')
 $lines = @(
   '@echo off',
   'rem Erzeugt von scripts/llm/install-startup-autostart.ps1 [T002276].',

--- a/scripts/llm/start-gemma-server.ps1
+++ b/scripts/llm/start-gemma-server.ps1
@@ -14,18 +14,22 @@
   unveraendert; ergaenzt wurden Existenzpruefungen, der Health-Poll und der
   VRAM-Hinweis, analog zu start-gptoss-server.ps1.
 
-  WARUM KEIN AUTOSTART: install-startup-autostart.ps1 startet bewusst nur
-  Embedding und Rerank. Gemma laeuft mit "-fit on" und nimmt sich ALLES freie
-  VRAM (siehe unten) - wuerde es beim Anmelden vor dem Embedding-Stack starten,
-  bliebe fuer bge-m3 und den Reranker nichts uebrig. Dieses Skript wird deshalb
-  von Hand aufgerufen, nachdem :8095 und :8096 stehen.
+  AUTOSTART: seit T002286 startet install-startup-autostart.ps1 auch Gemma.
+  Der fruehere Ausschlussgrund war "-fit on" - damit nahm sich der Server ALLES
+  freie VRAM und haette dem Embedding-Stack den Speicher weggenommen, wenn er
+  vor ihm gestartet waere. Mit dem festen -c unten ist der Bedarf deterministisch
+  und die Startreihenfolge damit unkritisch.
 
-  WARUM KEIN EXPLIZITES -c: ohne -c bleibt n_ctx "unset", und --fit (Default on)
-  laedt n_ctx_train (262144) und verkleinert ihn so weit, bis er mit -fitt MiB
-  Reserve ins VRAM passt. Ein gesetztes -c wuerde das Fitting abschalten.
-  -fitc 32768 ist die Untergrenze: passt nicht mindestens so viel Kontext,
-  scheitert der Start hart, statt still auf 4096 zu fallen. Die Factory fuellt
-  31-37k Tokens pro Prompt - unter 32768 waere der Server fuer sie nutzlos.
+  WARUM FESTES -c 65536 (T002286): "-fit on" ohne -c laedt n_ctx_train (262144)
+  und verkleinert ihn nur so weit, bis er ins VRAM passt - auf diesem Host also
+  gar nicht, weil 262144 hineinpassen. Die Factory fuellt aber nur 31-37k Tokens
+  pro Prompt, nutzte also ~14 Prozent des Kontexts und band den Rest als KV-Cache.
+  Gemessen 2026-07-27: -c 65536 senkt die VRAM-Belegung von 15670 auf 13054 MiB
+  (2560 MiB frei), der Frei-Speicher steigt von 328 auf 2944 MiB. 65536 laesst
+  gegenueber 37k weiterhin Reserve. "-fit off" ist dabei sicher, weil 65536
+  deutlich UNTER dem vorher passenden Wert liegt - das OOM-Risiko von "-fit off"
+  besteht nur nach oben. Nebeneffekt: die Konfiguration ist reproduzierbar,
+  waehrend Auto-Fit je nach Belegung durch :8095/:8096 andere Groessen ergab.
 
   WARUM DER FORK-BUILD: --spec-type draft-mtp gibt es nur im
   llama-bonsai-cuda13.3-Build, nicht im Upstream-Release b10090, das Embedding
@@ -88,18 +92,20 @@ foreach ($c in $conns) {
 }
 
 $freeMiB = [int](& nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits).Trim()
-Write-Output "Starting Gemma 4 12B QAT + MTP head on port $Port (auto-fit context, Q8_0 KV, 1 slot) ..."
+Write-Output "Starting Gemma 4 12B QAT + MTP head on port $Port (65536 ctx, Q8_0 KV, 1 slot) ..."
 Write-Output "  Model:     $Model"
 Write-Output "  MTP head:  $MtpHead"
 Write-Output "  Free VRAM: $freeMiB MiB"
 if ($freeMiB -lt 9000) {
   Write-Output "  WARNUNG: unter 9000 MiB frei. Die Gewichte allein brauchen ~7.4 GB,"
-  Write-Output "           dazu der MTP-Head (~0.5 GB) und mindestens 32768 Tokens KV."
+  Write-Output "           dazu der MTP-Head (~0.5 GB) und 65536 Tokens KV."
+  Write-Output "           Mit '-fit off' faellt der Start bei zu wenig VRAM hart aus,"
+  Write-Output "           statt still auf weniger Kontext auszuweichen - das ist Absicht."
   Write-Output "           Laeuft parallel ein anderes Chat-Modell (gpt-oss :8097)? Dann beenden."
 }
 if ($freeMiB -gt 15000) {
   Write-Output "  HINWEIS: sehr viel VRAM frei - laufen bge-m3 (:8095) und der Reranker"
-  Write-Output "           (:8096) ueberhaupt? '-fit on' nimmt sich sonst deren Speicher mit."
+  Write-Output "           (:8096) ueberhaupt? Sie belegen zusammen rund 1,7 GB."
 }
 
 $Params = @(
@@ -110,17 +116,29 @@ $Params = @(
   "--spec-draft-model", $MtpHead
   "--spec-draft-n-max", "2"
   "-ngl", "999"
-  # Ein einziger Slot - sonst gilt n_parallel=auto=4 und der Kontext wird
-  # geviertelt. Der llm-proxy serialisiert ohnehin per Semaphor
-  # (tickets.llm_proxy_backends.max_inflight, Default 1).
+  # Ein einziger Slot. Zwei Gruende, beide 2026-07-27 gemessen (T002286):
+  #   1. tickets.llm_proxy_backends.max_inflight = 1 fuer llamacpp-gemma - der
+  #      llm-proxy serialisiert. Weitere Slots blieben schlicht ungenutzt.
+  #   2. Ein Slot haelt EINEN KV-Zustand, den aufeinanderfolgende Aufrufer per
+  #      Praefix-Reuse teilen: bei gleichem System-Prompt wurden nur 12 von 3034
+  #      Prompt-Token neu berechnet (99,6 Prozent Treffer). Mit 4 Slots prefillt
+  #      jeder Slot den gemeinsamen Praefix voll (3240 Token je Slot) - bei einem
+  #      37k-Factory-Prompt also ~148k statt ~37k Token. Parallelitaet und
+  #      Praefix-Reuse sind hier Gegenspieler; seriell gewinnt der Cache.
+  # Falls doch einmal echte Parallelitaet noetig ist: -np N NUR zusammen mit
+  # -kvu (--kv-unified) setzen, sonst teilt llama.cpp -c stur durch -np.
+  # Gemessen: "-c 8192 -np 4 -kvu" => n_ctx 8192 je Slot, mit "-no-kvu" => 2048.
+  # Zusaetzlich max_inflight in der DB hochsetzen, sonst wirkt es nicht.
   "-np", "1"
-  # KV q8_0: praktisch verlustfrei, halbiert den Cache gegenueber f16 und
-  # verdoppelt damit den Kontext, den "-fit" unterbringt.
+  # KV q8_0: praktisch verlustfrei und halbiert den Cache gegenueber f16.
+  # Bewusst NICHT q4_0: das spart nur Kontext, von dem hier ohnehin Ueberschuss
+  # herrscht, und degradiert genau das woertliche Zurueckholen von Pfaden,
+  # Symbolnamen und Tool-Call-Argumenten aus dem Kontext.
   "--cache-type-k", "q8_0"
   "--cache-type-v", "q8_0"
-  "-fit", "on"
-  "-fitt", "1024"
-  "-fitc", "32768"
+  # Fester Deckel statt Auto-Fit - Begruendung und Messwerte in .DESCRIPTION.
+  "-c", "65536"
+  "-fit", "off"
   # --jinja: strukturierte tool_calls aus der im GGUF hinterlegten Vorlage.
   # Ohne sie liefert der Server keine tool_calls - fuer die Factory unbrauchbar.
   "--jinja"

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -258,13 +258,15 @@ assert_var_not_declared() {
   [ -z "$output" ]
 }
 
-@test "install-startup-autostart.ps1 covers embed and rerank only (T002276)" {
+@test "install-startup-autostart.ps1 covers embed, rerank and gemma in that order (T002286)" {
   [ -f "$REPO/scripts/llm/install-startup-autostart.ps1" ]
-  run grep -q "start-embed-server.ps1', 'start-rerank-server.ps1')" \
+  # Reihenfolge ist Absicht: scheitert Gemma (der groesste Brocken), steht der
+  # Embedding-Stack trotzdem. Gemma kam erst dazu, nachdem sein Startskript von
+  # "-fit on" auf den festen Deckel "-c 65536" umgestellt wurde - vorher haette
+  # es sich alles freie VRAM genommen.
+  run grep -q "start-embed-server.ps1', 'start-rerank-server.ps1', 'start-gemma-server.ps1')" \
       "$REPO/scripts/llm/install-startup-autostart.ps1"
   [ "$status" -eq 0 ]
-  # Chat-Server bewusst nicht im Autostart: stark unterschiedlicher VRAM-Bedarf,
-  # ein pauschaler Start wuerde dem Embedding-Stack den Speicher wegnehmen.
   run bash -c "grep -nE '^[^#]*start-bonsai-server' '$REPO'/scripts/llm/*.ps1 2>/dev/null"
   [ -z "$output" ]
 }
@@ -331,29 +333,50 @@ assert_var_not_declared() {
   [ "$status" -eq 0 ]
 }
 
-@test "start-gemma-server.ps1 keeps the 32768 context floor (T002277)" {
-  # -fitc ist die Untergrenze des Auto-Fittings. Die Factory fuellt 31-37k Tokens
-  # pro Prompt; faellt der Server still auf 4096, ist er fuer sie wertlos, ohne
-  # dass ein Smoke-Test das zeigt.
-  run grep -qE '"-fitc",[[:space:]]*"32768"' "$REPO/scripts/llm/start-gemma-server.ps1"
+@test "start-gemma-server.ps1 pins the context at 65536 (T002286)" {
+  # Loest den -fitc-Floor aus T002277 ab. Die Schutzabsicht ist dieselbe - die
+  # Factory fuellt 31-37k Tokens pro Prompt und braucht mehr als den llama.cpp-
+  # Default -, nur strenger umgesetzt: ein fester -c kann gar nicht erst still
+  # nach unten ausweichen, waehrend Auto-Fit je nach VRAM-Belegung variierte.
+  run grep -qE '"-c",[[:space:]]*"65536"' "$REPO/scripts/llm/start-gemma-server.ps1"
   [ "$status" -eq 0 ]
 }
 
-@test "start-gemma-server.ps1 sets no explicit -c (T002277)" {
-  # Ein gesetztes -c schaltet --fit ab und friert den Kontext auf einen festen
-  # Wert ein. Genau das soll hier NICHT passieren.
-  run bash -c "grep -E '^[[:space:]]+\"-c\",' '$REPO/scripts/llm/start-gemma-server.ps1'"
+@test "start-gemma-server.ps1 disables auto-fit (T002286)" {
+  # "-fit on" zog den Kontext auf n_ctx_train (262144) hoch und band ~86 Prozent
+  # davon ungenutzt als KV-Cache. Gemessen 2026-07-27: der feste Deckel gibt
+  # 3094 MiB VRAM frei (15670 -> 12576 MiB belegt). Ohne "-fit off" wuerde das
+  # gesetzte -c zwar gelten, aber die Absicht waere im Skript nicht mehr lesbar.
+  run grep -qE '"-fit",[[:space:]]*"off"' "$REPO/scripts/llm/start-gemma-server.ps1"
+  [ "$status" -eq 0 ]
+  run bash -c "grep -E '\"-fit\",[[:space:]]*\"on\"' '$REPO/scripts/llm/start-gemma-server.ps1'"
   [ "$status" -ne 0 ]
+}
+
+@test "start-gemma-server.ps1 pairs -np > 1 with -kvu if it ever parallelises (T002286)" {
+  # llama.cpp teilt -c stur durch -np, SOFERN nicht --kv-unified gesetzt ist.
+  # Gemessen: "-c 8192 -np 4 -kvu" => n_ctx 8192 je Slot, mit "-no-kvu" => 2048.
+  # Wer hier auf mehrere Slots umstellt, ohne -kvu zu setzen, viertelt den
+  # Kontext lautlos unter den Factory-Bedarf. Aktuell steht -np auf 1.
+  # Der Wert steht in Anfuehrungszeichen ("-np", "1"), daher tr statt Anker-Regex.
+  np="$(grep -oE '"-np",[[:space:]]*"[0-9]+"' "$REPO/scripts/llm/start-gemma-server.ps1" | tr -dc '0-9')"
+  [ -n "$np" ]
+  if [ "$np" -gt 1 ]; then
+    run grep -q '"-kvu"' "$REPO/scripts/llm/start-gemma-server.ps1"
+    [ "$status" -eq 0 ]
+  fi
 }
 
 # Kein eigener Start-Job-Guard fuer start-gemma-server.ps1: der Test
 # "no scripts/llm/*.ps1 starts a server via Start-Job (T002276)" oben deckt
 # jedes Skript im Verzeichnis ab, auch neu hinzugekommene.
 
-@test "install-startup-autostart.ps1 does NOT autostart a chat model (T002276/T002277)" {
-  # Bewusste Entscheidung aus T002276: Gemma laeuft mit '-fit on' und nimmt sich
-  # alles freie VRAM. Im Autostart vor dem Embedding-Stack wuerde es bge-m3 und
-  # dem Reranker den Speicher wegnehmen. Der Guard haelt diese Entscheidung fest.
-  run bash -c "grep -E 'start-(gemma|gptoss|bonsai)' '$REPO/scripts/llm/install-startup-autostart.ps1'"
+@test "install-startup-autostart.ps1 autostarts no SECOND chat model (T002286)" {
+  # Die urspruengliche Absicht (T002276) - der Embedding-Stack darf nicht
+  # verhungern - gilt weiter, nur nicht mehr pauschal gegen jedes Chat-Modell.
+  # Gemma ist mit festem -c 65536 planbar (12576 von 16303 MiB) und laesst
+  # bge-m3 + Reranker mit zusammen ~1,7 GB Platz. Ein ZWEITES Chat-Modell passt
+  # daneben nicht: gpt-oss-20b allein braucht 12,1 GB.
+  run bash -c "grep -E 'start-(gptoss|bonsai)' '$REPO/scripts/llm/install-startup-autostart.ps1'"
   [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Was

`scripts/llm/start-gemma-server.ps1` von Auto-Fit auf einen festen Kontext-Deckel umgestellt und Gemma damit in den Autostart aufgenommen.

| | vorher | nachher |
|---|---|---|
| Kontext | 262 144 (Auto-Fit auf `n_ctx_train`) | **65 536** (fest) |
| VRAM belegt | 15 670 MiB | **12 576 MiB** |
| VRAM frei | 328 MiB | **3 422 MiB** |
| Autostart | nein | **ja** |

## Warum

`-fit on` ohne `-c` zieht den Kontext auf `n_ctx_train` hoch. Die Factory füllt ~31–37k Token pro Prompt, band also rund 86 % des Kontexts ungenutzt als KV-Cache. Auf einer 16-GB-Karte, die sich drei Modelle teilen, blieben zuletzt 328 MiB frei — jeder Neustart eines Embedders konnte das kippen.

Weil der Bedarf mit festem `-c` deterministisch ist, entfällt der bisherige Grund, Gemma aus `install-startup-autostart.ps1` auszuschließen (der Kommentar dort nannte explizit `-fit on` als Blocker). Reihenfolge bleibt embed → rerank → gemma.

## Warum `-np 1` bleibt

- `tickets.llm_proxy_backends.max_inflight = 1` für `llamacpp-gemma` — der llm-proxy serialisiert, weitere Slots blieben ungenutzt.
- Ein Slot hält **einen** KV-Zustand, den aufeinanderfolgende Aufrufer per Präfix-Reuse teilen. Gemessen: 12 von 3 234 Token neu berechnet (99,6 % Treffer). Mit 4 Slots prefillt jeder Slot den gemeinsamen Präfix voll (3 240 Token je Slot) — bei einem 37k-Prompt also ~148k statt ~37k Token.

Für den Fall, dass später doch Parallelität gebraucht wird, ist im Skript dokumentiert, dass `-np N` zwingend mit `-kvu` kombiniert werden muss (gemessen: `-c 8192 -np 4 -kvu` → 8192/Slot, mit `-no-kvu` → 2048/Slot) und `max_inflight` mitziehen muss.

## Verifikation

Mit dem geänderten Skript gestartet:
- `/slots`: 1 Slot, `n_ctx = 65536`
- VRAM: 12 576 MiB belegt / 3 422 MiB frei
- Generation: 3/3 Requests `finish_reason: stop`, Präfix-Reuse 12/3 234
- PowerShell-Parse beider Skripte fehlerfrei
- `task test:changed` → 52/52 pass
- `task freshness:check` → Exit 0

## Verworfen: Embedder auf CPU auslagern

Am Reranker gemessen (16 Docs): `-ngl 99` = 101 ms / 860 MiB · `-ngl 0` = 339 ms (3,4×) / 609 MiB · `-dev none` = 12 817 ms (127×) / 218 MiB. Ertrag zu schlecht — Embedder bleiben auf GPU. (Nebenbefund: `-ngl 0` ist nicht CPU-only, solange ein CUDA-Backend initialisiert ist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)