### PR TITLE
fix(ci): make Renovate cache dir writable for the container user [T002289]

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -124,6 +124,16 @@ jobs:
           IMAGE='ghcr.io/renovatebot/renovate:43@sha256:2a4e6df0330b0aa42b21f40589666b678bbd19bcd9a14c3c24ce0492c237c2ff'
           MAX_ATTEMPTS=3
           mkdir -p /tmp/renovate-cache
+          # The runner owns this directory (it creates it, and actions/cache
+          # restores into it as `runner`), but the Renovate container runs under a
+          # different UID and needs to write here — without this it dies with
+          # `EACCES: mkdir '/tmp/renovate-cache/containerbase'` before it ever
+          # reaches a repository (T002289, run 30240257345). Mode instead of
+          # chown-to-a-fixed-UID on purpose: it survives an image that changes its
+          # user. Wide permissions are acceptable on an ephemeral single-tenant
+          # runner under /tmp; the post-run chown below hands ownership back so
+          # the actions/cache post step can pack the directory.
+          chmod -R a+rwX /tmp/renovate-cache
 
           success=0
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -1410,3 +1410,62 @@ setup_renovate_mock() {
   [ "$status" -eq 42 ]
   [ "$calls" -eq 1 ]
 }
+
+# ── T002289: Der Cache-Mount aus T002249 machte den Renovate-Lauf unbrauchbar.
+#    /tmp/renovate-cache wird vom GitHub-Runner-User angelegt; der Renovate-
+#    Container laeuft als 'ubuntu' (UID 1000) und scheitert beim ersten Schreiben:
+#      EACCES: permission denied, mkdir '/tmp/renovate-cache/containerbase'
+#    (run 30240257345, Exit 1 nach ~0.5s, noch vor der Repository-Phase).
+#    T002249 antizipierte die UMGEKEHRTE Richtung — "Container schreibt als root,
+#    der actions/cache-Post-Step als runner kann nicht packen" — und baute das
+#    chown nur NACH dem Lauf. Beide Richtungen werden gebraucht: vor dem Lauf fuer
+#    den Container, nach dem Lauf fuer actions/cache.
+#    Erwartet: FAIL — der Fix ist noch nicht implementiert.
+
+@test "T002289: Cache-Verzeichnis wird VOR dem docker run fuer den Container beschreibbar" {
+  local wf="$REPO_ROOT/.github/workflows/renovate.yml"
+  local body
+  body=$(python3 - "$wf" <<'PY'
+import sys, yaml
+steps = yaml.safe_load(open(sys.argv[1]))['jobs']['renovate']['steps']
+print(next(s['run'] for s in steps if s.get('name', '').startswith('Self-hosted Renovate')))
+PY
+)
+
+  # Eine Rechteanpassung muss ueberhaupt existieren ...
+  local perm_line
+  perm_line=$(grep -nE 'chown|chmod' <<<"$body" | head -1 | cut -d: -f1)
+  [ -n "$perm_line" ] || {
+    echo "FAIL: der Renovate-Step passt die Rechte auf dem Cache-Verzeichnis nicht an."
+    echo "      Der Runner legt /tmp/renovate-cache an, der Container laeuft unter"
+    echo "      einer anderen UID und kann nicht hineinschreiben — Renovate bricht"
+    echo "      mit EACCES ab, bevor es ein Repository sieht."
+    return 1
+  }
+
+  # ... und VOR dem docker run stehen, sonst kommt sie zu spaet.
+  local docker_line
+  docker_line=$(grep -n 'docker run' <<<"$body" | head -1 | cut -d: -f1)
+  [ -n "$docker_line" ]
+  [ "$perm_line" -lt "$docker_line" ] || {
+    echo "FAIL: die Rechteanpassung steht NACH dem docker run (Zeile ${perm_line} vs ${docker_line})."
+    echo "      Genau das war der Defekt: T002249 hatte nur den Post-Lauf-chown fuer"
+    echo "      actions/cache, nicht den Pre-Lauf-chown fuer den Container."
+    return 1
+  }
+}
+
+@test "T002289: der Post-Lauf-chown fuer actions/cache bleibt erhalten" {
+  local wf="$REPO_ROOT/.github/workflows/renovate.yml"
+  # Regression-Guard: beim Fix der einen Richtung darf die andere nicht wegfallen.
+  # Ohne den Post-Lauf-chown scheitert der actions/cache-Post-Step am Packen —
+  # lautlos, der Cache bliebe dauerhaft kalt.
+  python3 - "$wf" <<'PY'
+import sys, yaml
+steps = yaml.safe_load(open(sys.argv[1]))['jobs']['renovate']['steps']
+names = [s.get('name', '') for s in steps]
+idx = next(i for i, n in enumerate(names) if n.startswith('Self-hosted Renovate'))
+after = [s for s in steps[idx + 1:] if 'chown' in s.get('run', '')]
+assert after, "kein chown-Step NACH dem Renovate-Step (actions/cache kann nicht packen)"
+PY
+}


### PR DESCRIPTION
Folgefehler aus #3341 (T002249), entdeckt im ersten Live-Lauf [30240257345](https://github.com/Paddione/Bachelorprojekt/actions/runs/30240257345).

## Problem

Der neue Cache-Mount macht den Renovate-Lauf unbrauchbar. `/tmp/renovate-cache` wird vom Runner angelegt, der Renovate-Container läuft unter einer anderen UID und stirbt beim ersten Schreibversuch:

```
FATAL: Unknown error
  errno -13, code EACCES, syscall mkdir
  path /tmp/renovate-cache/containerbase
```

Exit 1 nach ~0,5 s — noch bevor Renovate ein Repository sieht.

## Ursache

T002249 hat die Rechte-Richtung falsch antizipiert. Geplant war *„Container schreibt als root, der `actions/cache`-Post-Step als `runner` kann nicht packen"* — also ein `chown` **nach** dem Lauf. Real werden **beide** Richtungen gebraucht: vor dem Lauf für den Container, nach dem Lauf für `actions/cache`.

## Fix

`chmod -R a+rwX` auf das Cache-Verzeichnis vor dem `docker run`. Bewusst `chmod` statt `chown` auf eine feste UID: das überlebt ein Image, das seinen User wechselt. Weite Rechte sind auf einem ephemeren Single-Tenant-Runner unter `/tmp` vertretbar; der Post-Lauf-`chown` gibt den Besitz an `runner` zurück.

## Tests

- **Reihenfolge-Gate** — der Rechte-Schritt muss *vor* dem `docker run` stehen; er prüft beide Positionen im extrahierten Step-Body, nicht bloß die Anwesenheit
- **Regression-Guard** — hält den Post-Lauf-`chown` fest, damit beim Reparieren der einen Richtung die andere nicht stillschweigend wegfällt

Alle 9 Renovate-Tests grün (7 aus T002249 + 2 neue).

## Einordnung

Der T002249-Mechanismus hat funktioniert wie spezifiziert: der Job war **rot statt still grün**, und der Hartfehler-Pfad griff korrekt — kein sinnloser Retry bei einem Nicht-Drift-Fehler, Exit-Code durchgereicht (Verhalten aus Test `T002249-E`, Fall 3). Vor #3341 wäre das ein weiterer grüner Lauf ohne Wirkung gewesen.

Closes T002289

🤖 Generated with [Claude Code](https://claude.com/claude-code)