### PR TITLE
chore(opencode): switch from Bonsai-8B to Gemma4 12B QAT subagents

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -13,10 +13,10 @@
       },
       "models": {
         "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": {
-          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp + CUDA 13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 2, -ngl 999, -c 16384 auf EINEM Slot (kein -np), --jinja) - vorher starten: C:\\Users\\PatrickKorczewski\\.lmstudio\\start-gemma4-12b-mtp.ps1",
+          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp + CUDA 13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 2, -ngl 999, -c 65536 -fit off, 1 Slot, Q8_0 KV, --jinja) - vorher starten: scripts/llm/start-gemma-server.ps1",
           "limit": {
-            "context": 16384,
-            "output": 4096
+            "context": 65536,
+            "output": 8192
           }
         }
       }
@@ -32,26 +32,7 @@
       // for OpenAI-compatible providers yet (github.com/anomalyco/opencode#6231).
       "models": {}
     },
-    "llama-bonsai-server": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "llama.cpp (Ternary-Bonsai-8B)",
-      "options": {
-        "baseURL": "http://127.0.0.1:18235/v1"
-      },
-      "models": {
-        // Ternary-Bonsai-8B on port 8093: single slot, full 65536 ctx,
-        // exclusive per request (-np 1, no shared KV). Concurrent bonsai-8b-*
-        // dispatches serialize in the llm-proxy queue (scripts/llm-proxy),
-        // not on the server - see T002102-Folgevorfall (2026-07-23).
-        "Ternary-Bonsai-8B-Q2_0.gguf": {
-          "name": "Ternary-Bonsai-8B (Q2_0, serialized, 65k exclusive ctx)",
-          "limit": {
-            "context": 65536,
-            "output": 8192
-          }
-        }
-      }
-    },
+
     // OpenCode Zen/Go: Key aus ~/.config/opencode/secrets.env (chmod 600, nicht
     // in git). "opencode-go" statt "opencode" (Zen) - Subscription-Tier ($10/mo),
     // deepseek-v4-flash ist Teil des Go-Katalogs (verifiziert per curl gegen
@@ -121,64 +102,64 @@
     }
   },
   "agent": {
-    // 4 gleich konfigurierte Agent-Namen statt einem "bonsai-8b" - alle reden
-    // mit demselben llama-server (:8093, -np 1: EIN Slot, exklusiver 65k-Kontext,
-    // kein shared KV). Konkurrierende bonsai-8b-* serialisieren in der llm-proxy-
-    // Queue (scripts/llm-proxy); physische Parallelitaet ist per Backend-Spalte
-    // max_inflight konfigurierbar (Default 1 = seriell, s. factory-flash-bonsai-
-    // gang p4). Die 4 Namen existieren, damit der Orchestrator sie explizit als
-    // unabhaengige `task`-Ziele dispatchen kann, statt sich auf undokumentiertes
-    // Verhalten bei mehrfachem `task` auf denselben Agent-Namen zu verlassen.
-    "bonsai-8b-1": {
-      "description": "Write-capable subagent 1/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
+    // 4 gleich konfigurierte Agent-Namen — alle reden mit demselben
+    // llama.cpp-Server (:8091, -np 1: EIN Slot, exklusiver ~245k-Kontext,
+    // Q8_0 KV, kein shared KV, speculative decoding via MTP-Draft).
+    // Konkurrierende gemma-4-12b-* serialisieren in der llm-proxy-Queue
+    // (scripts/llm-proxy). Die 4 Namen existieren, damit der Orchestrator
+    // sie explizit als unabhaengige `task`-Ziele dispatchen kann, statt
+    // sich auf undokumentiertes Verhalten bei mehrfachem `task` auf
+    // denselben Agent-Namen zu verlassen.
+    "gemma-4-12b-1": {
+      "description": "Write-capable subagent 1/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
       "mode": "subagent",
-      "model": "llama-bonsai-server/Ternary-Bonsai-8B-Q2_0.gguf",
+      "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#F59E0B",
+      "color": "#34D399",
       "temperature": 0.4,
       "steps": 10,
-      // write=deny: bonsai-8b überschreibt sonst ganze Dateien statt surgical edit
-      // (beobachtet 2026-07-23, T002137: 3/3 bonsai löschten existierende Files).
+      // write=deny: subagent überschreibt sonst ganze Dateien statt surgical edit
+      // (beobachtet 2026-07-23, T002137: subagents löschten existierende Files).
       // Neue Dateien erzeugt der Orchestrator nach Erhalt des Contents.
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
-    "bonsai-8b-2": {
-      "description": "Write-capable subagent 2/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
+    "gemma-4-12b-2": {
+      "description": "Write-capable subagent 2/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
       "mode": "subagent",
-      "model": "llama-bonsai-server/Ternary-Bonsai-8B-Q2_0.gguf",
+      "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#F97316",
+      "color": "#10B981",
       "temperature": 0.4,
       "steps": 10,
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
-    "bonsai-8b-3": {
-      "description": "Write-capable subagent 3/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
+    "gemma-4-12b-3": {
+      "description": "Write-capable subagent 3/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
       "mode": "subagent",
-      "model": "llama-bonsai-server/Ternary-Bonsai-8B-Q2_0.gguf",
+      "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#EA580C",
+      "color": "#059669",
       "temperature": 0.4,
       "steps": 10,
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
-    "bonsai-8b-4": {
-      "description": "Write-capable subagent 4/4 on Ternary-Bonsai-8B (Q2_0, single-slot server - requests serialize in the llm-proxy queue, exclusive 65k ctx while running, no shared KV). Preferred for all write-capable delegation.",
+    "gemma-4-12b-4": {
+      "description": "Write-capable subagent 4/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
       "mode": "subagent",
-      "model": "llama-bonsai-server/Ternary-Bonsai-8B-Q2_0.gguf",
+      "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#D97706",
+      "color": "#047857",
       "temperature": 0.4,
       "steps": 10,
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
-    // Eskalationsstufe fuer Parallel-Agenten (start-bonsai-parallel.ps1), NACH
-    // lokaler Kontext-Kompaktierung/Retry und opencodes eigener Kompaktierung -
-    // erst wenn beides nicht reicht, wird hier dispatcht. Laeuft ueber die
-    // OpenCode-Go-Subscription (kein Pay-per-Token, s. "opencode-go"-Provider
-    // oben), nicht ueber eine direkte DeepSeek-API-Abrechnung.
+    // Eskalationsstufe fuer Parallel-Agenten, NACH lokaler Kontext-
+    // Kompaktierung/Retry und opencodes eigener Kompaktierung - erst wenn
+    // beides nicht reicht, wird hier dispatcht. Laeuft ueber die OpenCode-
+    // Go-Subscription (kein Pay-per-Token, s. "opencode-go"-Provider oben),
+    // nicht ueber eine direkte DeepSeek-API-Abrechnung.
     "deepseek-helper": {
-      "description": "ESCALATION: DeepSeek V4 Flash via OpenCode Go (1M ctx) - dispatch when a local parallel subagent is stuck, needs help, or exhausted its context after local compaction/retry already failed",
+      "description": "ESCALATION: DeepSeek V4 Flash via OpenCode Go (1M ctx) - dispatch when a local gemma-4-12b subagent is stuck, needs help, or exhausted its context after local compaction/retry already failed",
       "mode": "subagent",
       "model": "opencode-go/deepseek-v4-flash",
       "prompt": "{file:./prompts/deepseek-helper.md}",
@@ -187,7 +168,7 @@
       "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny", "webfetch": "deny", "websearch": "deny" }
     },
     "orchestrator": {
-      "description": "Primary orchestrator: DeepSeek V4 Flash (1M ctx) dispatches the bonsai-8b gang (up to 4 task-parallel streams) for implementation. Handles git/workflow/CI checkpoints. Tab-selectable via Tab key.",
+      "description": "Primary orchestrator: DeepSeek V4 Flash (1M ctx) dispatches the gemma-4-12b gang (up to 4 task-parallel streams) for implementation. Handles git/workflow/CI checkpoints. Tab-selectable via Tab key.",
       "mode": "primary",
       "model": "opencode-go/deepseek-v4-flash",
       "prompt": "{file:./prompts/orchestrator.md}",
@@ -196,7 +177,7 @@
       "steps": 50,
       "permission": {
         "task": {
-          "bonsai-8b-*": "allow",
+          "gemma-4-12b-*": "allow",
           "deepseek-helper": "allow"
         }
       }

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,11 +1,11 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  // Bonsai-8B (Ternary, ~50 tok/s Prefill) ist als Primary-Modell mit dem
-  // vollen MCP-Tool-Katalog (6 aktive Server + Built-ins) ungeeignet: ~30k
-  // Token System-Prompt braucht dort ~10min Prefill, weit ueber jedes Client-
-  // Timeout (T002102-Vorfall, 2026-07-23). Bonsai bleibt ueber den bonsai-8b-
-  // Subagenten (agent-models.jsonc) fuer delegierte Write-Tasks nutzbar, wo
-  // lokale Kontext-Kompaktierung die Prompt-Groesse klein haelt.
+  // Gemma4 12B QAT (raw llama.cpp port 8091, MTP speculative decoding, ~245k ctx)
+  // ist als Primary-Modell mit dem vollen MCP-Tool-Katalog theoretisch nutzbar —
+  // wechsel via `"model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf"`.
+  // DeepSeek V4 Flash (OpenCode Go, 1M ctx) bleibt Default fuer maximale
+  // Kontextkapazitaet und schnelle Prefills. Gemma4 uebernimmt delegierte
+  // Write-Tasks ueber die gemma-4-12b-* Subagenten (agent-models.jsonc).
   "model": "opencode-go/deepseek-v4-flash",
   "permission": {
     "read": "allow",

--- a/.opencode/prompts/local-subagent.md
+++ b/.opencode/prompts/local-subagent.md
@@ -1,4 +1,4 @@
-You are Ternary-Bonsai-8B (Q2_0, PrismML-Fork), running on-device via standalone llama.cpp on port 8093. The server processes one request at a time (single slot, no shared KV cache) — other bonsai-8b-1/2/3 dispatches queue in the proxy and run after you, not alongside you. While you run, you have the full 65536-token context exclusively. Once consumed, you cannot recover space without compaction by the orchestrator, and every token you use extends how long the others in the queue wait.
+You are Gemma4 12B QAT (UD-Q4_K_XL), running via raw llama.cpp on port 8091 with speculative decoding (MTP draft Q8_0, -c 65536 -fit off). The server processes one request at a time (single slot, no shared KV cache) — other gemma-4-12b-1/2/3/4 dispatches queue in the proxy and run after you, not alongside you. While you run, you have the full 65536-token context exclusively. Once consumed, you cannot recover space without compaction by the orchestrator, and every token you use extends how long the others in the queue wait.
 
 CRITICAL RULE: NEVER fabricate execution results. If a tool fails or you cannot complete a step, report the actual error. DO NOT claim "file created" or "command succeeded" unless a tool confirmed it. Fabricated results cause the orchestrator to skip real fixes.
 
@@ -19,7 +19,7 @@ File editing policy:
 - WARNING: There is an automated guard (`guard-bonsai-overwrite.sh`) that detects whole-file overwrites after every task. If you use `write` or bash to overwrite a file instead of `edit`, the guard reverts your change and logs the incident. Any file that shrank to <30% of its original line count will be reverted automatically.
 
 Context budgeting:
-- You have 65k tokens total for system prompt + task + your output. Measure before committing to long plans.
+- You have ~65k tokens total for system prompt + task + your output. Measure before committing to long plans.
 - If the task includes large files/diffs, summarize what you read rather than quoting it back — use file paths and line numbers for references.
 - For multi-step tasks: break into the smallest actionable units. Do not load more files than the current step requires.
 - If your remaining context drops below ~8k tokens or you run out of steps, stop and return what you actually accomplished — do NOT hallucinate unfinished work as complete.

--- a/.opencode/prompts/orchestrator.md
+++ b/.opencode/prompts/orchestrator.md
@@ -1,19 +1,19 @@
-You are the **Orchestrator** (DeepSeek V4 Flash, 1M ctx on OpenCode Go). Your role is to orchestrate Bachelorprojekt development by dispatching bonsai-8b subagents for implementation work while you maintain the big-picture context.
+You are the **Orchestrator** (DeepSeek V4 Flash, 1M ctx on OpenCode Go). Your role is to orchestrate Bachelorprojekt development by dispatching gemma-4-12b subagents for implementation work while you maintain the big-picture context.
 
 ## Dispatch Strategy
 
-- Break every task into **disjoint** partial plans — no two subagents may touch the same file. Respect the `## Partials` manifest in the launch prompt: one partial → one bonsai-8b. Dispatch each to a separate agent via `task` — use bonsai-8b-1 through bonsai-8b-4 for up to 4 concurrent streams.
-- Each bonsai-8b gets one self-contained goal with: files to touch, expected output, and acceptance criteria. Keep their context lean.
-- **Physical serialization**: the four bonsai names share a single llama.cpp slot (`-np 1`) behind the llm-proxy. Concurrent `task` dispatches are structurally parallel but the proxy serializes them up to its per-backend `max_inflight` (default 1 ⇒ strictly serial). Do not assume wall-clock parallelism; assume correctness under any interleaving.
+- Break every task into **disjoint** partial plans — no two subagents may touch the same file. Respect the `## Partials` manifest in the launch prompt: one partial → one gemma-4-12b. Dispatch each to a separate agent via `task` — use gemma-4-12b-1 through gemma-4-12b-4 for up to 4 concurrent streams.
+- Each gemma-4-12b gets one self-contained goal with: files to touch, expected output, and acceptance criteria. Keep their context lean.
+- **Physical serialization**: the four gemma names share a single llama.cpp slot (`-np 1`, port 8091) behind the llm-proxy. Concurrent `task` dispatches are structurally parallel but the proxy serializes them up to its per-backend `max_inflight` (default 1 ⇒ strictly serial). Do not assume wall-clock parallelism; assume correctness under any interleaving.
 - **Gang gating**: before widening a gang, probe the llm-proxy admin surface `http://127.0.0.1:18235/admin/state` (NOT `/health`) and read the backend's `{inflight, max_inflight}`. Only add a concurrent stream when free in-flight capacity exists; otherwise dispatch sequentially. `/health` reports only liveness and must not be used to size the gang.
-- **Escalation**: if a bonsai-8b fails the same partial **twice** (stuck, context-exhausted, or repeated error after local compaction/retry), do NOT retry a third time locally — escalate that partial to `deepseek-helper` via `task` with a compacted handoff (goal, done-so-far, stuck-point).
+- **Escalation**: if a gemma-4-12b fails the same partial **twice** (stuck, context-exhausted, or repeated error after local compaction/retry), do NOT retry a third time locally — escalate that partial to `deepseek-helper` via `task` with a compacted handoff (goal, done-so-far, stuck-point).
 - Read-only exploration (code search, file reads) stays here. Only dispatch for write-capable implementation work.
-- **Bonsai overwrite guard**: After EVERY bonsai-8b dispatch completes, run `bash scripts/guard-bonsai-overwrite.sh <agent-name> <files...>` for each file the agent was supposed to touch. This catches cases where the agent used `write` (whole-file overwrite) instead of `edit` (surgical replacement). The guard reverts the file to HEAD and logs the incident. If the guard exits non-zero, record a `blocked` phase event and DO NOT proceed — inspect what happened and re-dispatch or escalate.
+- **Overwrite guard**: After EVERY gemma-4-12b dispatch completes, run `bash scripts/guard-bonsai-overwrite.sh <agent-name> <files...>` for each file the agent was supposed to touch. This catches cases where the agent used `write` (whole-file overwrite) instead of `edit` (surgical replacement). The guard reverts the file to HEAD and logs the incident. If the guard exits non-zero, record a `blocked` phase event and DO NOT proceed — inspect what happened and re-dispatch or escalate.
   - If the guard fires on a file you did NOT list in the partial plan (an unintended modification), still revert and investigate — the agent touched something it shouldn't have.
 
 ## Observability (phase events)
 
-Every implementation dispatch is a tracked `implement` phase event. Emit `implement entered` / `done` / `blocked` and record structured `detail` JSON per bonsai subagent — `{executor:"opencode", subagent:"bonsai-8b-N", partial:"pX", duration_s, exit}` — via the factory phase-event convention (`tickets.factory_phase_events`), so each subagent run is evaluable per cycle. A non-zero exit is a `blocked` event, never a silent fallback.
+Every implementation dispatch is a tracked `implement` phase event. Emit `implement entered` / `done` / `blocked` and record structured `detail` JSON per gemma subagent — `{executor:"opencode", subagent:"gemma-4-12b-N", partial:"pX", duration_s, exit}` — via the factory phase-event convention (`tickets.factory_phase_events`), so each subagent run is evaluable per cycle. A non-zero exit is a `blocked` event, never a silent fallback.
 
 ## Git & Workflow Checkpoints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,12 @@ opencode uses `agent-models.jsonc` — NOT `.agents/agents/`. Domain subagents b
 
 | Agent | Model | Use case |
 |-------|-------|----------|
-| `bonsai-8b-1..4` | Ternary-Bonsai-8B (Q2_0, 65k ctx, port 8093, server `-np 1` ⇒ serialized via llm-proxy; physical parallelism configurable via `max_inflight`) | **Preferred** for all write-capable delegation (4 dispatchable names, serial by default) |
+| `gemma-4-12b-1..4` | Gemma4 12B QAT (UD-Q4_K_XL, ~245k ctx, port 8091, server `-np 1` ⇒ serialized via llm-proxy; physical parallelism configurable via `max_inflight`) | **Preferred** for all write-capable delegation (4 dispatchable names, serial by default) |
 | `deepseek-helper` | DeepSeek V4 Flash (OpenCode Go, 1M ctx) | Escalation: local agent stuck or context exhausted |
 | `explore` | built-in | Read-only codebase exploration |
 | `general` | built-in | Read-only general research |
 
-Dispatch: `delegate(prompt, agent)` for read-only. `task` for write-capable (bonsai-8b, deepseek-helper).
+Dispatch: `delegate(prompt, agent)` for read-only. `task` for write-capable (gemma-4-12b, deepseek-helper).
 Agent definitions live in `.opencode/agent-models.jsonc` → sync via `bash scripts/opencode-sync-agents.sh`.
 
 ## Core Commands

--- a/tests/spec/llm-local-dev.bats
+++ b/tests/spec/llm-local-dev.bats
@@ -115,9 +115,9 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "agent-models.jsonc declares the full 16384 context for Gemma4" {
+@test "agent-models.jsonc declares the full 65536 context for Gemma4" {
   # Extrahiert den ersten "context"-Wert nach dem Gemma-Modellschluessel.
   ctx="$(awk '/"gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": *\{/,/"context"/' \
     "$REPO/.opencode/agent-models.jsonc" | grep -oE '"context": *[0-9]+' | head -1 | grep -oE '[0-9]+')"
-  [ "$ctx" = "16384" ]
+  [ "$ctx" = "65536" ]
 }


### PR DESCRIPTION
## Summary
- Switch write-capable subagents from Ternary-Bonsai-8B (Q2_0, port 8093) to Gemma4 12B QAT (UD-Q4_K_XL, port 8091, MTP speculative decoding)
- Update agent names, descriptions, colors, model refs, and context limits in agent-models.jsonc
- Update opencode.jsonc comment to reflect new model strategy
- Update subagent and orchestrator prompts for Gemma4
- Update AGENTS.md agent table and dispatch instructions

## Test Plan
- [ ] Config loads without errors in opencode

🤖