### PR TITLE
chore(llm): Autostart startet Gemma mit Max-Kontext-Profil [T002297]

### DIFF
--- a/scripts/llm/install-startup-autostart.ps1
+++ b/scripts/llm/install-startup-autostart.ps1
@@ -84,16 +84,45 @@ if (-not (Test-Path $llmDir)) {
 # damit kein Umweg ueber eine .lnk mit Zielpfad-Escaping noetig ist.
 # -WindowStyle Hidden, damit beim Anmelden kein Fenster aufpoppt; die
 # Startskripte protokollieren selbst in <build>\*-out.log / *-err.log.
-$scripts = @('start-embed-server.ps1', 'start-rerank-server.ps1', 'start-gemma-server.ps1')
+# Reihenfolge ist Absicht (T002286): scheitert Gemma - der groesste Brocken -,
+# steht der Embedding-Stack trotzdem. Args je Eintrag seit T002297, weil Gemma
+# sonst die Skript-Defaults bekaeme (-Ctx 65536, -KvType q4_0) statt des
+# gemessenen Max-Kontext-Profils. Embed und Rerank brauchen keine Argumente,
+# ihre Flags (-b/-ub 8192, --pooling cls) stehen in den Startskripten selbst.
+#
+# WARUM 262144/q8_0/1 Slot (T002297), alles am 2026-07-27 gemessen:
+#   - 262144 ist n_ctx_train, das harte Modell-Maximum. Darueber warnt
+#     llama.cpp und nutzt es nicht.
+#   - q8_0 statt q4_0: schneller (146,9 vs 138,0 t/s) und praktisch verlustfrei.
+#     Der 4-Bit-Umweg (T002296) diente nur dazu, VRAM fuer den mmproj-Tower
+#     freizuraeumen - bei einem Slot ist der Platz auch mit 8 Bit da.
+#   - 1 Slot: maximaler Praefix-Reuse (T002286), und mehrere Slots teilen sich
+#     mit -kvu ohnehin denselben Pool.
+#   Ergebnis: 15437 von 16303 MiB belegt, 561 MiB frei, :8095/:8096 laufen
+#   daneben weiter. Verifiziert mit einem 155009-Token-Prompt.
+$startups = @(
+  @{ Script = 'start-embed-server.ps1';  Arguments = '' },
+  @{ Script = 'start-rerank-server.ps1'; Arguments = '' },
+  @{ Script = 'start-gemma-server.ps1';  Arguments = '-Ctx 262144 -Slots 1 -KvType q8_0' }
+)
 $lines = @(
   '@echo off',
   'rem Erzeugt von scripts/llm/install-startup-autostart.ps1 [T002276].',
   'rem Nicht von Hand editieren - Aenderungen gehen beim naechsten Lauf verloren.',
   'rem Entfernen: install-startup-autostart.ps1 -Uninstall'
 )
-foreach ($s in $scripts) {
-  $full = Join-Path $llmDir $s
-  $lines += ('powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}"' -f $full)
+foreach ($s in $startups) {
+  # T002264 als Mahnung: dort wurde $Task.Expr statt $Task.Exe gelesen, ein Key
+  # dieses Namens existierte nicht, und PowerShell lieferte still $null - alle
+  # Tasks bekamen ein leeres Executable. Deshalb hier fail-loud statt Vertrauen.
+  if (-not $s.ContainsKey('Script') -or -not $s.ContainsKey('Arguments')) {
+    Write-Error "Startup-Eintrag ohne Script/Arguments-Key: $($s | Out-String)"
+    exit 1
+  }
+  $full = Join-Path $llmDir $s.Script
+  $line = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}"' -f $full
+  if ($s.Arguments -ne '') { $line += ' ' + $s.Arguments }
+  $lines += $line
 }
 
 Set-Content -Path $shim -Value $lines -Encoding ascii

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -278,11 +278,32 @@ assert_var_not_declared() {
   # Embedding-Stack trotzdem. Gemma kam erst dazu, nachdem sein Startskript von
   # "-fit on" auf den festen Deckel "-c 65536" umgestellt wurde - vorher haette
   # es sich alles freie VRAM genommen.
-  run grep -q "start-embed-server.ps1', 'start-rerank-server.ps1', 'start-gemma-server.ps1')" \
-      "$REPO/scripts/llm/install-startup-autostart.ps1"
-  [ "$status" -eq 0 ]
+  # Seit T002297 ist die flache Namensliste eine Liste von Hashtables mit
+  # Script/Arguments, weil Gemma Parameter braucht. Die Reihenfolge wird
+  # deshalb ueber die Zeilennummern der Script-Eintraege geprueft statt ueber
+  # einen Literal-Vergleich der Array-Zeile.
+  auto="$REPO/scripts/llm/install-startup-autostart.ps1"
+  emb="$(grep -n "Script *= *'start-embed-server.ps1'" "$auto" | cut -d: -f1)"
+  rer="$(grep -n "Script *= *'start-rerank-server.ps1'" "$auto" | cut -d: -f1)"
+  gem="$(grep -n "Script *= *'start-gemma-server.ps1'" "$auto" | cut -d: -f1)"
+  [ -n "$emb" ] && [ -n "$rer" ] && [ -n "$gem" ]
+  [ "$emb" -lt "$rer" ]
+  [ "$rer" -lt "$gem" ]
   run bash -c "grep -nE '^[^#]*start-bonsai-server' '$REPO'/scripts/llm/*.ps1 2>/dev/null"
   [ -z "$output" ]
+}
+
+@test "autostart passes the measured max-context profile to gemma (T002297)" {
+  # Ohne Argumente bekaeme Gemma die Skript-Defaults (-Ctx 65536, q4_0) - das
+  # waere nach einem Reboot ein anderer Server als der, den wir vermessen
+  # haben, ohne dass irgendwo etwas rot wird. Deshalb ein eigener Guard.
+  # 262144 ist n_ctx_train; ein hoeherer Wert waere nicht nutzbar.
+  auto="$REPO/scripts/llm/install-startup-autostart.ps1"
+  gemline="$(grep "Script *= *'start-gemma-server.ps1'" "$auto")"
+  [ -n "$gemline" ]
+  echo "$gemline" | grep -q -- '-Ctx 262144'
+  echo "$gemline" | grep -q -- '-Slots 1'
+  echo "$gemline" | grep -q -- '-KvType q8_0'
 }
 
 # ── gpt-oss-20b als Factory-Kandidat (T002268) ────────────────────────


### PR DESCRIPTION
Der Startup-Shim rief `start-gemma-server.ps1` **ohne Argumente** auf und bekam damit die Skript-Defaults (`-Ctx 65536`, `-KvType q4_0`). Nach einem Reboot lief also ein anderer Server als der vermessene — ohne dass irgendwo etwas rot wurde.

## Änderung

Die flache Namensliste wird zu einer Liste von Hashtables mit `Script`/`Arguments`:

```powershell
$startups = @(
  @{ Script = 'start-embed-server.ps1';  Arguments = '' },
  @{ Script = 'start-rerank-server.ps1'; Arguments = '' },
  @{ Script = 'start-gemma-server.ps1';  Arguments = '-Ctx 262144 -Slots 1 -KvType q8_0' }
)
```

Embed und Rerank bleiben argumentlos — ihre Flags (`-b/-ub 8192`, `--pooling cls`) stehen in den eigenen Startskripten.

## Warum genau dieses Profil

| | Wert | Begründung (2026-07-27 gemessen) |
|---|---|---|
| `-Ctx` | **262144** | `n_ctx_train`, das harte Modell-Maximum. Darüber warnt llama.cpp und nutzt es nicht. |
| `-KvType` | **q8_0** | schneller als `q4_0` (146,9 vs. 138,0 t/s) und praktisch verlustfrei. Der 4-Bit-Umweg aus T002296 diente nur der VRAM-Beschaffung für den mmproj-Tower — bei **einem** Slot ist der Platz auch mit 8 Bit da. |
| `-Slots` | **1** | maximaler Präfix-Reuse (T002286); mehrere Slots teilen sich mit `-kvu` ohnehin denselben Pool. |

Ergebnis: **15437 / 16303 MiB belegt, 561 MiB frei**, `:8095` und `:8096` laufen daneben weiter (ihre ~1,3 GB stecken in der Basis). Verifiziert mit einem **155 009-Token-Prompt** bei 1750 t/s Prompt-Processing; VRAM unter Last nur +21 MiB.

## Guards

- Der Reihenfolge-Guard aus T002286 prüfte die **Literal-Arrayzeile** und wäre durch den Umbau gebrochen. Er prüft jetzt die **Zeilennummern** der drei Einträge — gleiche Schutzabsicht (scheitert Gemma, steht der Embedding-Stack trotzdem), robuster gegen Formatänderungen.
- **Neuer Guard** auf die drei Gemma-Argumente, sonst fällt ein versehentliches Zurückfallen auf die Defaults wieder niemandem auf.

Beide per Negativtest geprüft **und gegeneinander isoliert**: falsche Reihenfolge macht nur den Reihenfolge-Guard rot, fehlende Argumente nur den Argument-Guard.

## Fail-loud auf die Hashtable-Keys

Als Lehre aus **T002264**, wo `$Task.Expr` statt `.Exe` gelesen wurde, PowerShell still `$null` lieferte und alle Scheduled Tasks ein **leeres Executable** bekamen: fehlt `Script` oder `Arguments`, bricht der Installer ab statt eine kaputte `.cmd` zu schreiben.

## Verifikation

- Installer real ausgeführt, erzeugter Shim geprüft — die Gemma-Zeile trägt `-Ctx 262144 -Slots 1 -KvType q8_0`, Embed/Rerank unverändert
- PowerShell-Parser `SYNTAX OK`, ASCII-Guard (T002275) 0 Treffer, kein PS7-Ternary
- `tests/spec/llm-pipeline.bats` **44/44**, `task test:changed` grün, `task freshness:check` exit 0