### PR TITLE
chore(opencode): genau ein Gemma-Subagent plus primaerer Gemma-Agent [T002298]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -13,9 +13,12 @@
       },
       "models": {
         "gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": {
-          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q8_0 (raw llama.cpp + CUDA 13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 2, -ngl 999, -c 65536 -fit off, 1 Slot, Q8_0 KV, --jinja) - vorher starten: scripts/llm/start-gemma-server.ps1",
+          "name": "Gemma4 12B QAT (UD-Q4_K_XL) + MTP-draft Q4_0 (raw llama.cpp + CUDA 13.3, speculative decoding via --spec-type draft-mtp --spec-draft-n-max 4, -ngl 999, -c 262144 -fit off, 1 Slot, Q8_0 KV, mmproj F16, --jinja) - vorher starten: scripts/llm/start-gemma-server.ps1 (Autostart-Profil seit T002297)",
+          // 262144 = n_ctx_train, der Wert den der Server seit T002297 faehrt
+          // (-Ctx 262144 -Slots 1 -KvType q8_0). Vorher stand hier 65536 - das
+          // war der alte Server-Deckel; opencode haette den Rest nie genutzt.
           "limit": {
-            "context": 65536,
+            "context": 262144,
             "output": 8192
           }
         }
@@ -102,16 +105,21 @@
     }
   },
   "agent": {
-    // 4 gleich konfigurierte Agent-Namen — alle reden mit demselben
-    // llama.cpp-Server (:8091, -np 1: EIN Slot, exklusiver ~245k-Kontext,
-    // Q8_0 KV, kein shared KV, speculative decoding via MTP-Draft).
-    // Konkurrierende gemma-4-12b-* serialisieren in der llm-proxy-Queue
-    // (scripts/llm-proxy). Die 4 Namen existieren, damit der Orchestrator
-    // sie explizit als unabhaengige `task`-Ziele dispatchen kann, statt
-    // sich auf undokumentiertes Verhalten bei mehrfachem `task` auf
-    // denselben Agent-Namen zu verlassen.
-    "gemma-4-12b-1": {
-      "description": "Write-capable subagent 1/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
+    // GENAU EIN summonbarer Gemma-Subagent (T002298). Vorher gab es vier
+    // gleich konfigurierte Namen (gemma-4-12b-1..4), damit der Orchestrator
+    // sie als unabhaengige `task`-Ziele parallel dispatchen konnte. Das war
+    // strukturelle Parallelitaet ohne physische: alle vier treffen denselben
+    // llama.cpp-Server auf :8091, der mit "-np 1" genau EINEN Slot hat, und
+    // serialisieren in der llm-proxy-Queue (max_inflight=1). Die vier Namen
+    // erzeugten also nur den Anschein von Nebenlaeufigkeit - und vier
+    // konkurrierende Streams zerstoeren zusaetzlich den Praefix-Reuse des
+    // einen Slots (T002286: bei mehreren Streams prefillt jeder den
+    // gemeinsamen System-Prompt erneut).
+    //
+    // Ein einziger Name ist die einzige im Config-Schema durchsetzbare
+    // Obergrenze: was nicht existiert, kann nicht dispatcht werden.
+    "gemma-4-12b": {
+      "description": "The ONLY write-capable Gemma subagent (Gemma4 12B QAT, raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server with 262144 ctx). There is exactly one - do not attempt to dispatch parallel Gemma streams, the server has one slot and the llm-proxy serializes anyway. Preferred for all write-capable delegation.",
       "mode": "subagent",
       "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
@@ -123,35 +131,36 @@
       // Neue Dateien erzeugt der Orchestrator nach Erhalt des Contents.
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
-    "gemma-4-12b-2": {
-      "description": "Write-capable subagent 2/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
-      "mode": "subagent",
+    // Primaerer (Tab-waehlbarer) Gemma-Agent mit vollem Kontext (T002298).
+    // "mode": "primary" heisst: vom Benutzer direkt gewaehlt, NICHT per `task`
+    // summonbar - er zaehlt deshalb nicht gegen die Ein-Subagent-Grenze oben
+    // und kann sie auch nicht umgehen.
+    //
+    // Gedacht fuer Arbeit, die komplett lokal laufen soll, ohne DeepSeek-
+    // Orchestrator davor. Bekommt die vollen 262144 Token des Servers.
+    // `task` bewusst nur auf deepseek-helper: wuerde er gemma-4-12b
+    // dispatchen, laegen zwei Gemma-Kontexte auf demselben einen Slot und
+    // wuerden sich gegenseitig in der Proxy-Queue blockieren.
+    "gemma-4-12b-primary": {
+      "description": "Primary (Tab-selectable) Gemma4 12B QAT agent with the full 262144-token context. Use for fully local work without the DeepSeek orchestrator in front. Can escalate to deepseek-helper but must not dispatch gemma-4-12b - both would contend for the same single server slot.",
+      "mode": "primary",
       "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#10B981",
-      "temperature": 0.4,
-      "steps": 10,
-      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
-    },
-    "gemma-4-12b-3": {
-      "description": "Write-capable subagent 3/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
-      "mode": "subagent",
-      "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#059669",
-      "temperature": 0.4,
-      "steps": 10,
-      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
-    },
-    "gemma-4-12b-4": {
-      "description": "Write-capable subagent 4/4 on Gemma4 12B QAT (raw llama.cpp on port 8091, speculative decoding via MTP draft, single-slot server - requests serialize in the llm-proxy queue, exclusive ~245k ctx while running, no shared KV). Preferred for all write-capable delegation.",
-      "mode": "subagent",
-      "model": "llamacpp-mtp/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#047857",
-      "temperature": 0.4,
-      "steps": 10,
-      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
+      "color": "#6EE7B7",
+      // Zwischen Orchestrator (0.2) und Subagent (0.4): der primaere Agent
+      // plant UND implementiert. Deutlich hoehere Werte riskieren den
+      // Tool-Call-im-<think>-Block-Fehler aus der fablevibes-Diagnose.
+      "temperature": 0.3,
+      "steps": 50,
+      // write=deny aus demselben Grund wie beim Subagenten - das ist eine
+      // Modell-Eigenschaft (Ganzdatei-Overwrite statt Edit), keine Frage des
+      // Agent-Modus. Neue Dateien legt der Benutzer bzw. ein Folgeschritt an.
+      "permission": {
+        "edit": "allow",
+        "write": "deny",
+        "bash": "allow",
+        "task": { "deepseek-helper": "allow", "gemma-4-12b": "deny" }
+      }
     },
     // Eskalationsstufe fuer Parallel-Agenten, NACH lokaler Kontext-
     // Kompaktierung/Retry und opencodes eigener Kompaktierung - erst wenn
@@ -168,16 +177,21 @@
       "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny", "webfetch": "deny", "websearch": "deny" }
     },
     "orchestrator": {
-      "description": "Primary orchestrator: DeepSeek V4 Flash (1M ctx) dispatches the gemma-4-12b gang (up to 4 task-parallel streams) for implementation. Handles git/workflow/CI checkpoints. Tab-selectable via Tab key.",
+      "description": "Primary orchestrator: DeepSeek V4 Flash (1M ctx) dispatches the single gemma-4-12b subagent sequentially for implementation. Handles git/workflow/CI checkpoints. Tab-selectable via Tab key.",
       "mode": "primary",
       "model": "opencode-go/deepseek-v4-flash",
       "prompt": "{file:./prompts/orchestrator.md}",
       "color": "#8B5CF6",
       "temperature": 0.2,
       "steps": 50,
+      // Exakter Name statt "gemma-4-12b-*" (T002298): das Wildcard wuerde
+      // jeden neu hinzugefuegten gemma-4-12b-<n> automatisch mitfreigeben und
+      // die Ein-Subagent-Grenze lautlos aufheben. Ein weiterer Gemma-Subagent
+      // muss hier bewusst eingetragen werden - und dann faellt auf, dass er
+      // sich denselben einen Server-Slot teilt.
       "permission": {
         "task": {
-          "gemma-4-12b-*": "allow",
+          "gemma-4-12b": "allow",
           "deepseek-helper": "allow"
         }
       }

--- a/.opencode/prompts/orchestrator.md
+++ b/.opencode/prompts/orchestrator.md
@@ -1,11 +1,12 @@
-You are the **Orchestrator** (DeepSeek V4 Flash, 1M ctx on OpenCode Go). Your role is to orchestrate Bachelorprojekt development by dispatching gemma-4-12b subagents for implementation work while you maintain the big-picture context.
+You are the **Orchestrator** (DeepSeek V4 Flash, 1M ctx on OpenCode Go). Your role is to orchestrate Bachelorprojekt development by dispatching the gemma-4-12b subagent for implementation work while you maintain the big-picture context.
 
 ## Dispatch Strategy
 
-- Break every task into **disjoint** partial plans — no two subagents may touch the same file. Respect the `## Partials` manifest in the launch prompt: one partial → one gemma-4-12b. Dispatch each to a separate agent via `task` — use gemma-4-12b-1 through gemma-4-12b-4 for up to 4 concurrent streams.
-- Each gemma-4-12b gets one self-contained goal with: files to touch, expected output, and acceptance criteria. Keep their context lean.
-- **Physical serialization**: the four gemma names share a single llama.cpp slot (`-np 1`, port 8091) behind the llm-proxy. Concurrent `task` dispatches are structurally parallel but the proxy serializes them up to its per-backend `max_inflight` (default 1 ⇒ strictly serial). Do not assume wall-clock parallelism; assume correctness under any interleaving.
-- **Gang gating**: before widening a gang, probe the llm-proxy admin surface `http://127.0.0.1:18235/admin/state` (NOT `/health`) and read the backend's `{inflight, max_inflight}`. Only add a concurrent stream when free in-flight capacity exists; otherwise dispatch sequentially. `/health` reports only liveness and must not be used to size the gang.
+- There is **exactly one** write-capable Gemma subagent: `gemma-4-12b`. Dispatch partials to it **one at a time, sequentially** — wait for each to finish before sending the next.
+- Break every task into **disjoint** partial plans — no two partials may touch the same file. Respect the `## Partials` manifest in the launch prompt: one partial → one dispatch.
+- Each dispatch gets one self-contained goal with: files to touch, expected output, and acceptance criteria. Keep its context lean.
+- **Why sequential, not a gang** (T002298): the server on port 8091 runs with `-np 1` — a single slot — and the llm-proxy serializes at `max_inflight=1`. Extra parallel names would produce structural parallelism with zero wall-clock gain, and they actively *hurt*: each concurrent stream re-prefills the shared system prompt instead of reusing the slot's prefix cache (T002286). Do not ask for more Gemma agents; the ceiling is a property of the server, not of this prompt.
+- If a partial is too large for one dispatch, **split it further** — do not try to widen concurrency.
 - **Escalation**: if a gemma-4-12b fails the same partial **twice** (stuck, context-exhausted, or repeated error after local compaction/retry), do NOT retry a third time locally — escalate that partial to `deepseek-helper` via `task` with a compacted handoff (goal, done-so-far, stuck-point).
 - Read-only exploration (code search, file reads) stays here. Only dispatch for write-capable implementation work.
 - **Overwrite guard**: After EVERY gemma-4-12b dispatch completes, run `bash scripts/guard-bonsai-overwrite.sh <agent-name> <files...>` for each file the agent was supposed to touch. This catches cases where the agent used `write` (whole-file overwrite) instead of `edit` (surgical replacement). The guard reverts the file to HEAD and logs the incident. If the guard exits non-zero, record a `blocked` phase event and DO NOT proceed — inspect what happened and re-dispatch or escalate.
@@ -13,7 +14,7 @@ You are the **Orchestrator** (DeepSeek V4 Flash, 1M ctx on OpenCode Go). Your ro
 
 ## Observability (phase events)
 
-Every implementation dispatch is a tracked `implement` phase event. Emit `implement entered` / `done` / `blocked` and record structured `detail` JSON per gemma subagent — `{executor:"opencode", subagent:"gemma-4-12b-N", partial:"pX", duration_s, exit}` — via the factory phase-event convention (`tickets.factory_phase_events`), so each subagent run is evaluable per cycle. A non-zero exit is a `blocked` event, never a silent fallback.
+Every implementation dispatch is a tracked `implement` phase event. Emit `implement entered` / `done` / `blocked` and record structured `detail` JSON per dispatch — `{executor:"opencode", subagent:"gemma-4-12b", partial:"pX", duration_s, exit}` — via the factory phase-event convention (`tickets.factory_phase_events`), so each run is evaluable per cycle. A non-zero exit is a `blocked` event, never a silent fallback.
 
 ## Git & Workflow Checkpoints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ opencode uses `agent-models.jsonc` — NOT `.agents/agents/`. Domain subagents b
 
 | Agent | Model | Use case |
 |-------|-------|----------|
-| `gemma-4-12b-1..4` | Gemma4 12B QAT (UD-Q4_K_XL, ~245k ctx, port 8091, server `-np 1` ⇒ serialized via llm-proxy; physical parallelism configurable via `max_inflight`) | **Preferred** for all write-capable delegation (4 dispatchable names, serial by default) |
+| `gemma-4-12b` | Gemma4 12B QAT (UD-Q4_K_XL, 262144 ctx, port 8091, server `-np 1` ⇒ one slot, serialized via llm-proxy) | **Preferred** for all write-capable delegation — **exactly one** such subagent exists (T002298); dispatch sequentially |
+| `gemma-4-12b-primary` | same model, `mode: primary` (Tab-selectable, not summonable via `task`) | Fully local work without the DeepSeek orchestrator in front; full 262144 ctx |
 | `deepseek-helper` | DeepSeek V4 Flash (OpenCode Go, 1M ctx) | Escalation: local agent stuck or context exhausted |
 | `explore` | built-in | Read-only codebase exploration |
 | `general` | built-in | Read-only general research |

--- a/tests/spec/llm-local-dev.bats
+++ b/tests/spec/llm-local-dev.bats
@@ -115,9 +115,66 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "agent-models.jsonc declares the full 65536 context for Gemma4" {
+@test "agent-models.jsonc declares the full 262144 context for Gemma4 (T002298)" {
+  # Muss dem -Ctx des Servers entsprechen. Steht hier weniger, laesst opencode
+  # Kontext ungenutzt liegen; steht hier mehr, laeuft der Server im Betrieb in
+  # einen Ueberlauf, den opencode nicht kommen sieht. Server-Profil seit
+  # T002297: start-gemma-server.ps1 -Ctx 262144 -Slots 1 -KvType q8_0.
   # Extrahiert den ersten "context"-Wert nach dem Gemma-Modellschluessel.
   ctx="$(awk '/"gemma-4-12B-it-qat-UD-Q4_K_XL.gguf": *\{/,/"context"/' \
     "$REPO/.opencode/agent-models.jsonc" | grep -oE '"context": *[0-9]+' | head -1 | grep -oE '[0-9]+')"
-  [ "$ctx" = "65536" ]
+  [ "$ctx" = "262144" ]
+}
+
+@test "agent-models.jsonc defines exactly ONE summonable gemma subagent (T002298)" {
+  # Der Server auf :8091 hat einen einzigen Slot (-np 1) und die llm-proxy
+  # serialisiert bei max_inflight=1. Mehrere gemma-Subagent-Namen erzeugen
+  # deshalb nur den Anschein von Nebenlaeufigkeit und zerstoeren zusaetzlich
+  # den Praefix-Reuse des Slots (T002286). Ein einziger Name ist die einzige
+  # im Config-Schema durchsetzbare Obergrenze.
+  run node -e "
+    const s = require('fs').readFileSync('$REPO/.opencode/agent-models.jsonc','utf8');
+    const j = s.replace(/^\s*\/\/.*\$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
+    const a = JSON.parse(j).agent || {};
+    const sub = Object.entries(a)
+      .filter(([n,v]) => n.startsWith('gemma') && v.mode === 'subagent')
+      .map(([n]) => n);
+    if (sub.length !== 1) { console.error('gemma subagents: ' + JSON.stringify(sub)); process.exit(1); }
+    process.exit(0);
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "agent-models.jsonc provides a primary gemma agent with full context (T002298)" {
+  # mode:primary heisst Tab-waehlbar und NICHT per task summonbar - er zaehlt
+  # deshalb nicht gegen die Ein-Subagent-Grenze und kann sie nicht umgehen.
+  run node -e "
+    const s = require('fs').readFileSync('$REPO/.opencode/agent-models.jsonc','utf8');
+    const j = s.replace(/^\s*\/\/.*\$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
+    const o = JSON.parse(j);
+    const prim = Object.entries(o.agent || {})
+      .filter(([n,v]) => n.startsWith('gemma') && v.mode === 'primary');
+    if (prim.length !== 1) { console.error('primary gemma agents: ' + prim.length); process.exit(1); }
+    const model = prim[0][1].model;
+    const [prov, mid] = model.split('/');
+    const ctx = o.provider[prov].models[mid].limit.context;
+    if (ctx !== 262144) { console.error('primary gemma ctx: ' + ctx); process.exit(1); }
+    process.exit(0);
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "orchestrator may not dispatch gemma via a wildcard (T002298)" {
+  # "gemma-4-12b-*": "allow" wuerde jeden neu hinzugefuegten gemma-4-12b-<n>
+  # automatisch mitfreigeben und die Ein-Subagent-Grenze lautlos aufheben.
+  run node -e "
+    const s = require('fs').readFileSync('$REPO/.opencode/agent-models.jsonc','utf8');
+    const j = s.replace(/^\s*\/\/.*\$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
+    const t = ((JSON.parse(j).agent || {}).orchestrator || {}).permission || {};
+    const keys = Object.keys(t.task || {});
+    const wild = keys.filter(k => k.startsWith('gemma') && k.includes('*'));
+    if (wild.length) { console.error('wildcard gemma grants: ' + JSON.stringify(wild)); process.exit(1); }
+    process.exit(0);
+  "
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Vorher

Vier gleich konfigurierte Subagenten `gemma-4-12b-1..4` — **strukturelle Parallelität ohne physische**. Alle vier treffen denselben llama.cpp-Server auf `:8091`, der mit `-np 1` genau **einen** Slot hat, und serialisieren in der llm-proxy-Queue (`max_inflight=1`).

Vier Streams bringen also keinen Wall-clock-Gewinn — und kosten zusätzlich: jeder konkurrierende Stream prefillt den gemeinsamen System-Prompt neu, statt den Präfix-Cache des einen Slots wiederzuverwenden (T002286).

## Nachher

| Agent | Modus | Rolle |
|---|---|---|
| `gemma-4-12b` | `subagent` | **der einzige** summonbare Gemma-Subagent |
| `gemma-4-12b-primary` | `primary` | Tab-wählbar, **nicht** per `task` summonbar, voller 262144-Kontext |

**Ein einziger Name ist die einzige im Config-Schema durchsetzbare Obergrenze** — was nicht existiert, kann nicht dispatcht werden. opencode hat keinen `maxConcurrent`-Knopf pro Agent.

Der primäre Agent umgeht die Grenze nicht: `mode: primary` heißt vom Benutzer gewählt, nicht summonbar. Sein `task` erlaubt nur `deepseek-helper` — dispatchte er `gemma-4-12b`, lägen zwei Gemma-Kontexte auf demselben Slot und blockierten sich gegenseitig in der Proxy-Queue.

## Weitere Korrekturen

- `orchestrator.permission.task`: `"gemma-4-12b-*": "allow"` → **exakter Name**. Das Wildcard hätte jeden neu hinzugefügten `gemma-4-12b-<n>` automatisch mitfreigegeben und die Grenze lautlos aufgehoben.
- `limit.context` **65536 → 262144** — der Server läuft seit T002297 auf `n_ctx_train`; opencode hätte den Rest nie genutzt.
- Modellbeschreibung war veraltet: Draft-Head `Q8_0` → `Q4_0`, `n-max 2` → `4`, `-c 65536` → `262144`, mmproj ergänzt.
- `prompts/orchestrator.md` wies noch auf „gemma-4-12b-1 through gemma-4-12b-4 for up to 4 concurrent streams" und Gang-Gating über `/admin/state` an. Jetzt: **sequentiell**, und ein zu großer Partial wird **weiter aufgeteilt**, nicht durch mehr Nebenläufigkeit gelöst.
- `AGENTS.md`-Routingtabelle entsprechend.

## Drei neue Guards

Bisher prüfte nichts die Agent-Topologie. Alle drei per **Negativtest** verifiziert:

| Guard | wird rot bei |
|---|---|
| genau **ein** gemma-Subagent | zweitem `mode: subagent`-Gemma |
| **ein** primärer Gemma mit 262144 ctx | Degradierung zu `subagent` oder falschem Kontext |
| kein Wildcard-Grant im Orchestrator | Rückkehr zu `"gemma-4-12b-*": "allow"` |

Bemerkenswert: das Degradieren des primären Agenten zum Subagenten macht **beide** ersten Guards rot — dieses Schlupfloch ist damit zu.

## Verifikation

- `.opencode/agent-models.jsonc` parst; Agenten-Topologie geprüft: `gemma-4-12b:subagent  gemma-4-12b-primary:primary  deepseek-helper:subagent  orchestrator:primary`
- `tests/spec/llm-local-dev.bats` **21/21**, `task test:changed` grün, `task freshness:check` exit 0

⚠ Nach dem Merge muss `bash scripts/opencode-sync-agents.sh` laufen, damit die Änderung in `~/.config/opencode/opencode.jsonc` ankommt.