### PR TITLE
fix(infra): restore $$ escaping for runtime vars in shared-db postStart [T002306]

### DIFF
--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -44,18 +44,18 @@ data:
 
     # Sync passwords to match current secrets (works on first run and re-runs)
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
-      -c "ALTER USER nextcloud WITH PASSWORD '${NEXTCLOUD_DB_PASSWORD}';" \
-      -c "ALTER USER vaultwarden WITH PASSWORD '${VAULTWARDEN_DB_PASSWORD}';" \
-      -c "ALTER USER website WITH PASSWORD '${WEBSITE_DB_PASSWORD}';" \
+      -c "ALTER USER nextcloud WITH PASSWORD '$${NEXTCLOUD_DB_PASSWORD}';" \
+      -c "ALTER USER vaultwarden WITH PASSWORD '$${VAULTWARDEN_DB_PASSWORD}';" \
+      -c "ALTER USER website WITH PASSWORD '$${WEBSITE_DB_PASSWORD}';" \
       -c "ALTER USER pentest WITH PASSWORD 'pentest_access_2026';" \
-      -c "ALTER USER videovault WITH PASSWORD '${VIDEOVAULT_DB_PASSWORD}';"
+      -c "ALTER USER videovault WITH PASSWORD '$${VIDEOVAULT_DB_PASSWORD}';"
 
     # Create databases if not exists
     for db_user in nextcloud vaultwarden website pentest videovault; do
       psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-        SELECT 'CREATE DATABASE ${db_user} OWNER ${db_user}'
-        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${db_user}')\gexec
-        GRANT ALL PRIVILEGES ON DATABASE ${db_user} TO ${db_user};
+        SELECT 'CREATE DATABASE $${db_user} OWNER $${db_user}'
+        WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$${db_user}')\gexec
+        GRANT ALL PRIVILEGES ON DATABASE $${db_user} TO $${db_user};
     EOSQL
     done
 
@@ -198,6 +198,19 @@ spec:
                   - -c
                   - |
                     until pg_isready -U postgres; do sleep 2; done
+                    # ACHTUNG (T002306): Die doppelten Dollarzeichen in $${VAR} und $$db
+                    # unten sind KEIN Tippfehler — nicht "korrigieren".
+                    # scripts/flux-render-artifact.sh schickt jedes Manifest durch
+                    # envsubst und macht danach gezielt $${VAR} -> ${VAR} rueckgaengig.
+                    # Das $$ ist also der Mechanismus, mit dem eine Variable die
+                    # BUILD-Zeit uebersteht, um erst zur LAUFZEIT von der Container-Shell
+                    # expandiert zu werden (gleiche Trennung wie bei WEBSITE_CONFIG_SHA).
+                    # Ohne $$ rendert envsubst die Passwoerter zu Leerstrings — der Pod
+                    # fuehrt dann `ALTER USER ... WITH PASSWORD ''` aus und sperrt
+                    # nextcloud, vaultwarden, videovault und pocket_id aus ihrer eigenen
+                    # Datenbank aus (Prod-Ausfall am 2026-07-27, SSO down).
+                    # Der fail-closed-Check im Renderer faengt das NICHT: eine leer
+                    # substituierte Variable sieht fuer ihn korrekt aus.
                     # Self-heal: ensure every service role + database exists on each start.
                     # The one-shot /docker-entrypoint-initdb.d/01-init-databases.sh runs only
                     # on first PGDATA init and has left databases uncreated on fresh clusters
@@ -214,15 +227,15 @@ spec:
                       IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='pocket_id')  THEN CREATE USER pocket_id;  END IF;
                     END \$\$;"
                     for db in nextcloud vaultwarden website pentest videovault pocket_id; do
-                      psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$db'" | grep -q 1 \
-                        || psql -U postgres -c "CREATE DATABASE \"$db\" OWNER \"$db\";"
+                      psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$$db'" | grep -q 1 \
+                        || psql -U postgres -c "CREATE DATABASE \"$$db\" OWNER \"$$db\";"
                     done
                     psql -U postgres \
-                      -c "ALTER USER nextcloud WITH PASSWORD '${NEXTCLOUD_DB_PASSWORD}';" \
-                      -c "ALTER USER vaultwarden WITH PASSWORD '${VAULTWARDEN_DB_PASSWORD}';" \
-                      -c "ALTER USER website WITH PASSWORD '${WEBSITE_DB_PASSWORD}';" \
-                      -c "ALTER USER videovault WITH PASSWORD '${VIDEOVAULT_DB_PASSWORD}';" \
-                      -c "ALTER USER pocket_id WITH PASSWORD '${POCKET_ID_DB_PASSWORD}';"
+                      -c "ALTER USER nextcloud WITH PASSWORD '$${NEXTCLOUD_DB_PASSWORD}';" \
+                      -c "ALTER USER vaultwarden WITH PASSWORD '$${VAULTWARDEN_DB_PASSWORD}';" \
+                      -c "ALTER USER website WITH PASSWORD '$${WEBSITE_DB_PASSWORD}';" \
+                      -c "ALTER USER videovault WITH PASSWORD '$${VIDEOVAULT_DB_PASSWORD}';" \
+                      -c "ALTER USER pocket_id WITH PASSWORD '$${POCKET_ID_DB_PASSWORD}';"
 
                     bash /scripts/ensure-knowledge-schema.sh || true
                     bash /scripts/ensure-meetings-schema.sh || true


### PR DESCRIPTION
## Produktionsausfall — Ursache und Behebung

Revertiert #3360 (`18d9ed02c`) und dokumentiert, warum die Schreibweise so aussieht.

### Was passiert ist

`18d9ed02c` ersetzte `'$${NEXTCLOUD_DB_PASSWORD}'` durch `'${NEXTCLOUD_DB_PASSWORD}'` (und `$$db` durch `$db`). Die doppelten Dollarzeichen waren aber **kein Tippfehler**.

`scripts/flux-render-artifact.sh` schickt jedes Manifest durch `envsubst` und macht danach gezielt `$${VAR}` → `${VAR}` rückgängig (Zeile 106, „unwrap any `$$` escaping"). Das `$$` ist damit der Mechanismus, mit dem eine Variable die **Build-Zeit** übersteht, um erst zur **Laufzeit** von der Container-Shell expandiert zu werden — dieselbe Trennung, die das Skript für `WEBSITE_CONFIG_SHA` schon explizit begründet (T002156).

Ohne `$$` substituiert `envsubst` die Passwort-Variablen zu **Leerstrings** — sie stehen weder in der Render-Allowlist noch werden sie im Workflow gesetzt. Der Pod führt dann bei jedem Start aus:

```sql
ALTER USER nextcloud   WITH PASSWORD '';
ALTER USER vaultwarden WITH PASSWORD '';
ALTER USER videovault  WITH PASSWORD '';
ALTER USER pocket_id   WITH PASSWORD '';
```

### Live-Auswirkung (2026-07-27)

| Dienst | Zustand |
|---|---|
| pocket-id | 0/1 — OIDC-Provider, SSO plattformweit down |
| nextcloud | 0/1 |
| vaultwarden | 0/1 CrashLoopBackOff |
| website | nicht betroffen (eigenes Secret im `website`-Namespace) |

Postgres protokollierte fortlaufend `FATAL: password authentication failed`.

### Warum CI das nicht gefangen hat

Der fail-closed-Check im Renderer (Zeile 139) sucht **übrig gebliebene** `${VAR}`-Platzhalter. Eine leer *substituierte* Variable sieht für ihn korrekt aus. Exakt dieselbe Falle wie T001993.

### Änderung

- Revert der vier `$$`-Stellen (`ALTER USER` × 4 sowie die `$$db`-Schleife)
- Warnkommentar am Block, der die Build-/Laufzeit-Trennung erklärt und auf die Live-Folge verweist — damit das `$$` nicht erneut als Tippfehler gelesen wird

`task workspace:validate` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbCw4MNjiPQ8fkjZjCYoi