### PR TITLE
fix(infra): keep $${VAR} runtime placeholders out of envsubst [T002306]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -433,6 +433,11 @@ tasks:
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/render-cloud-init.bats
 
+  test:unit:flux-render-runtime-vars:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/flux-render-runtime-vars.bats
+
   test:unit:fleet-phase2b:
     internal: true
     cmds:

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 625,
+      "file_count": 626,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -543,6 +543,7 @@
         "tests/unit/fixtures/software-history/mock-anthropic.mjs",
         "tests/unit/fleet-dns-cutover.bats",
         "tests/unit/fleet-phase2b.bats",
+        "tests/unit/flux-render-runtime-vars.bats",
         "tests/unit/freshness-graph.bats",
         "tests/unit/git-crypt-guard.bats",
         "tests/unit/helper-collab-headless.bats",

--- a/scripts/flux-render-artifact.sh
+++ b/scripts/flux-render-artifact.sh
@@ -87,9 +87,30 @@ render_component() {
     vars="$(tr ' ' '\n' <<<"$vars" | sed '/^WEBSITE_CONFIG_SHA$/d;/^$/d' | tr '\n' ' ')"
   fi
 
+  # T002306: Variablen, die im Manifest bewusst als $${VAR} geschrieben sind,
+  # sind LAUFZEIT-Variablen — die Shell IM Container soll sie expandieren, nicht
+  # der Renderer. Der Extraktions-Regex oben sieht durch das $$ hindurch und
+  # nimmt sie sonst in ihre EIGENE Ersetzungsliste auf; envsubst macht aus einer
+  # nicht gesetzten Variable dann "" und uebrig bleibt das erste Dollarzeichen.
+  # Der fail-closed-Check unten faengt das nicht, weil substituiert ja WURDE.
+  #
+  # Genau so gingen am 2026-07-27 die shared-db-Passwoerter verloren: aus
+  #   ALTER USER nextcloud WITH PASSWORD '$${NEXTCLOUD_DB_PASSWORD}';
+  # wurde  ... PASSWORD '$';  — nextcloud, vaultwarden, videovault und pocket_id
+  # waren aus ihrer eigenen Datenbank ausgesperrt, SSO plattformweit down.
+  # Die klammerlose Form $$VAR war nie betroffen, weil der Regex sie nicht sieht.
+  local runtime_vars
+  runtime_vars="$(grep -oE '\$\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$rendered" \
+    | sed -E 's/^\$\$\{//; s/\}$//' | sort -u | tr '\n' ' ')" || true
+  local rv
+  for rv in $runtime_vars; do
+    vars="$(tr ' ' '\n' <<<"$vars" | sed "/^${rv}\$/d;/^\$/d" | tr '\n' ' ')"
+  done
+
   if [[ -z "$vars" ]]; then
-    # No vars to substitute — write as-is
-    echo "$rendered" > "$out"
+    # Nichts zu substituieren — aber das $$-Unwrapping muss trotzdem laufen,
+    # sonst blieben $${VAR}/$$VAR als Doppel-Dollar im Manifest stehen.
+    sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' <<<"$rendered" > "$out"
     return
   fi
   
@@ -136,11 +157,20 @@ render_component() {
   # FAIL-CLOSED: after substitution, check for any remaining unsubstituted ${VAR}
   # references. If any exist, the build fails instead of silently shipping a broken
   # manifest with literal placeholders (secret-exposure risk / fail-open).
-  if grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$out"; then
+  # T002306: Die als $${VAR} markierten Laufzeit-Variablen stehen nach dem
+  # Unwrapping als ${VAR} im Manifest — genau so sollen sie dort stehen. Sie
+  # sind hier deshalb ausgenommen; alles andere bleibt ein harter Fehler.
+  local leftover
+  leftover="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$out" | sort -u)" || true
+  for rv in $runtime_vars; do
+    leftover="$(grep -vxF "\${${rv}}" <<<"$leftover" || true)"
+  done
+  if [[ -n "$leftover" ]]; then
     echo "ERROR: Unsubstituted variable references remain in $out after envsubst." >&2
     echo "       The following vars were not defined in the environment:" >&2
-    grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' "$out" | sort -u >&2
-    echo "       Ensure all referenced env vars are set or add them to the allowlist." >&2
+    echo "$leftover" >&2
+    echo "       Set them, add them to the allowlist, or — if the container shell" >&2
+    echo "       is meant to expand them at runtime — write them as \$\${VAR}." >&2
     exit 1
   fi
 }

--- a/tests/unit/flux-render-runtime-vars.bats
+++ b/tests/unit/flux-render-runtime-vars.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# flux-render-runtime-vars.bats — T002306
+#
+# scripts/flux-render-artifact.sh baut seine envsubst-Allowlist dynamisch aus
+# dem gerenderten Manifest: jede ${VAR}-Referenz landet automatisch darin.
+# Der Regex sah dabei durch ein vorangestelltes $$ hindurch — eine bewusst als
+# $${VAR} geschriebene LAUFZEIT-Variable nahm sich also selbst in ihre eigene
+# Ersetzungsliste auf. envsubst machte aus der nicht gesetzten Variable "" und
+# uebrig blieb das erste Dollarzeichen.
+#
+# Live-Folge am 2026-07-27: aus
+#   ALTER USER nextcloud WITH PASSWORD '$${NEXTCLOUD_DB_PASSWORD}';
+# wurde  ... PASSWORD '$';  — nextcloud, vaultwarden, videovault und pocket_id
+# waren aus ihrer eigenen Datenbank ausgesperrt, SSO plattformweit down.
+
+load test_helper
+
+PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+RENDERER="$PROJECT_DIR/scripts/flux-render-artifact.sh"
+
+@test "T002306: renderer filters \$\${VAR} out of the envsubst allowlist" {
+  run grep -c 'runtime_vars' "$RENDERER"
+  [[ "$output" -ge 3 ]]
+}
+
+@test "T002306: fail-closed check exempts declared runtime vars" {
+  # Der Check darf ${VAR} nicht mehr pauschal als Fehler werten — sonst
+  # scheitert jeder Build, der eine Laufzeit-Variable enthaelt.
+  run grep -c 'leftover' "$RENDERER"
+  [[ "$output" -ge 4 ]]
+}
+
+@test "T002306: \$\${VAR} survives rendering, \${VAR} is still substituted" {
+  # Bildet die Render-Pipeline exakt nach: Allowlist-Extraktion, Filter,
+  # envsubst, Unwrapping.
+  local rendered='a: "$${ARCH}"
+b: "${SUBSTITUTE_ME}"
+c: "$$BIN"'
+  export SUBSTITUTE_ME="ersetzt"
+
+  local vars runtime_vars rv ev out
+  vars="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$rendered" | tr -d '${}' | sort -u | tr '\n' ' ')"
+  runtime_vars="$(grep -oE '\$\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$rendered" | sed -E 's/^\$\$\{//; s/\}$//' | sort -u | tr '\n' ' ')"
+  for rv in $runtime_vars; do
+    vars="$(tr ' ' '\n' <<<"$vars" | sed "/^${rv}\$/d;/^\$/d" | tr '\n' ' ')"
+  done
+  ev=""; for rv in $vars; do ev="${ev}\$${rv} "; done
+  out="$(envsubst "$ev" <<<"$rendered" | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g')"
+
+  # Laufzeit-Variable ueberlebt als ${ARCH} — NICHT als "$" oder leer.
+  [[ "$out" == *'a: "${ARCH}"'* ]]
+  # Build-Zeit-Substitution funktioniert weiterhin.
+  [[ "$out" == *'b: "ersetzt"'* ]]
+  # Klammerlose Form war nie betroffen und bleibt korrekt.
+  [[ "$out" == *'c: "$BIN"'* ]]
+}
+
+@test "T002306: shared-db keeps its runtime password placeholders" {
+  # Regressionsschutz fuer die Stelle, die den Ausfall ausgeloest hat.
+  run grep -c 'PASSWORD .\$\${[A-Z_]*_DB_PASSWORD}' "$PROJECT_DIR/k3d/shared-db.yaml"
+  [[ "$output" -ge 4 ]]
+}


### PR DESCRIPTION
## Ursachen-Fix zum Prod-Ausfall vom 2026-07-27

Behebt die Wurzel des Ausfalls, den #3360 ausgelöst und #3362 nur an einer Stelle zurückgenommen hat.

### Der Mechanismus

`scripts/flux-render-artifact.sh` baut seine `envsubst`-Allowlist **dynamisch aus dem gerenderten Manifest**:

```bash
vars="$(grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$rendered" | tr -d '${}' | sort -u ...)"
```

Der Regex sieht durch ein vorangestelltes `$$` hindurch. Eine bewusst als `$${VAR}` geschriebene **Laufzeit**-Variable nimmt sich damit selbst in ihre eigene Ersetzungsliste auf. Ist sie in der Build-Umgebung nicht gesetzt, ersetzt `envsubst` sie durch Leerstring — übrig bleibt das erste Dollarzeichen.

Empirisch nachgestellt:

| Eingabe | Vorher | Nachher |
|---|---|---|
| `$${ARCH}` | `$` ❌ | `${ARCH}` ✅ |
| `${SUBSTITUTE_ME}` | `ersetzt` ✅ | `ersetzt` ✅ |
| `$$BIN` | `$BIN` ✅ | `$BIN` ✅ |
| `$${NEXTCLOUD_DB_PASSWORD}` | `$` ❌ | `${NEXTCLOUD_DB_PASSWORD}` ✅ |

Die klammerlose Form `$$VAR` war nie betroffen — der Regex verlangt Klammern.

### Reichweite

**39 Vorkommen über sechs Manifeste** schreiben `$${VAR}` in der Annahme, das schütze die Variable. Der Renderer hat sich nie daran gehalten:

- `k3d/shared-db.yaml` — die fünf `*_DB_PASSWORD` → `PASSWORD '$'` → **SSO plattformweit down**
- `k3d/nextcloud.yaml` — `$${ARCH}` → `bin/$/notify_push` → notify-push nie ready
- `k3d/backup-cronjob.yaml`, `k3d/pvc-backup-cronjob.yaml` — `$${db}`, `$${STAMP}`, `$${BACKUP_DIR}` → beide CronJobs auf `Error`
- `k3d/talk-hpb.yaml`, `k3d/knowledge-ingest-cronjob.yaml`

### Warum CI es nicht gefangen hat

Der fail-closed-Check sucht **übrig gebliebene** `${VAR}`-Platzhalter. Eine leer *substituierte* Variable sieht für ihn korrekt aus — dieselbe Falle wie T001993. Der Check nimmt jetzt die deklarierten Laufzeit-Variablen aus und nennt `$${VAR}` explizit als Lösungsweg in der Fehlermeldung.

### Änderung

- `render_component()` filtert alle als `$${VAR}` markierten Namen aus der Allowlist
- der `-z "$vars"`-Zweig wendet das `$$`-Unwrapping jetzt ebenfalls an (sonst blieben Doppel-Dollars stehen)
- fail-closed-Check nimmt die Laufzeit-Variablen aus
- `tests/unit/flux-render-runtime-vars.bats` — 4 Tests, inkl. Regressionsschutz für die shared-db-Passwörter

Behebt alle 39 Stellen an der Wurzel, ohne ein einziges Manifest anzufassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbCw4MNjiPQ8fkjZjCYoi