### PR TITLE
fix(scripts): recognise Postgres shutdown messages, repair scs:index retry [T002292]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4651,9 +4651,14 @@ tasks:
             kill $pf 2>/dev/null || true
             continue
           fi
+          # `|| rc=$?` ist Pflicht: go-task fuehrt jeden cmds-Block mit
+          # set -e-Semantik aus. Ohne das `||` bricht die Shell beim ersten
+          # fehlschlagenden Lauf ab — noch BEVOR `rc=$?` gelesen wird — und die
+          # Retry-Schleife kommt nie zum Zug (beobachtet 2026-07-27: Pass 1
+          # endete mit Exit 1, es folgte kein zweiter Pass).
+          rc=0
           PGHOST=localhost PGPORT=$port PGDATABASE=website PGUSER=website \
-            npx tsx scripts/index-repo.ts
-          rc=$?
+            npx tsx scripts/index-repo.ts || rc=$?
           kill $pf 2>/dev/null || true
           [ $rc -eq 0 ] && break
           echo "→ Pass $pass endete mit Exit $rc, setze fort" >&2

--- a/k3d/shared-db.yaml
+++ b/k3d/shared-db.yaml
@@ -198,18 +198,19 @@ spec:
                   - -c
                   - |
                     until pg_isready -U postgres; do sleep 2; done
-                    # ACHTUNG (T002306): Die doppelten Dollarzeichen in $${VAR} und $$db
-                    # unten sind KEIN Tippfehler — nicht "korrigieren".
-                    # scripts/flux-render-artifact.sh schickt jedes Manifest durch
-                    # envsubst und macht danach gezielt $${VAR} -> ${VAR} rueckgaengig.
-                    # Das $$ ist also der Mechanismus, mit dem eine Variable die
-                    # BUILD-Zeit uebersteht, um erst zur LAUFZEIT von der Container-Shell
-                    # expandiert zu werden (gleiche Trennung wie bei WEBSITE_CONFIG_SHA).
-                    # Ohne $$ rendert envsubst die Passwoerter zu Leerstrings — der Pod
-                    # fuehrt dann `ALTER USER ... WITH PASSWORD ''` aus und sperrt
-                    # nextcloud, vaultwarden, videovault und pocket_id aus ihrer eigenen
-                    # Datenbank aus (Prod-Ausfall am 2026-07-27, SSO down).
-                    # Der fail-closed-Check im Renderer faengt das NICHT: eine leer
+                    # ACHTUNG (T002306): Die doppelten Dollarzeichen in $${VAR} und
+                    # $$db unten sind KEIN Tippfehler — nicht "korrigieren".
+                    # Sie markieren LAUFZEIT-Variablen: die Shell IM Container soll
+                    # sie expandieren, nicht der Renderer.
+                    # scripts/flux-render-artifact.sh baut seine envsubst-Allowlist
+                    # dynamisch aus dem Manifest und filtert die so markierten Namen
+                    # heraus; danach macht es $${VAR} -> ${VAR} rueckgaengig.
+                    # Ohne das $$ landet die Variable in ihrer eigenen Ersetzungsliste,
+                    # envsubst setzt sie (nicht gesetzt) auf "" und der Pod fuehrt
+                    # `ALTER USER ... WITH PASSWORD ''` aus — nextcloud, vaultwarden,
+                    # videovault und pocket_id sind dann aus ihrer eigenen Datenbank
+                    # ausgesperrt (Prod-Ausfall am 2026-07-27, SSO plattformweit down).
+                    # Der fail-closed-Check des Renderers faengt das nicht: eine leer
                     # substituierte Variable sieht fuer ihn korrekt aus.
                     # Self-heal: ensure every service role + database exists on each start.
                     # The one-shot /docker-entrypoint-initdb.d/01-init-databases.sh runs only

--- a/scripts/index-repo.test.ts
+++ b/scripts/index-repo.test.ts
@@ -152,6 +152,23 @@ describe('isInfrastructureError (T002292)', () => {
       .toBe(false);
   });
 
+  it('erkennt einen Postgres-Shutdown (T002292 Nachtrag)', () => {
+    // Gemessen am 2026-07-27: beim Pod-Replace meldet Postgres zuerst
+    // "terminating connection due to administrator command", dann mehrfach
+    // "the database system is shutting down" — erst danach kommt ECONNREFUSED.
+    // Die ersten beiden Stufen trugen keinen .code und passten auf kein Muster,
+    // liefen also als per-Datei-SKIP durch. Sie sind die FRUEHERE und damit
+    // nuetzlichere Warnung als der spaetere Socket-Fehler.
+    expect(isInfrastructureError(new Error('terminating connection due to administrator command')))
+      .toBe(true);
+    expect(isInfrastructureError(new Error('the database system is shutting down'))).toBe(true);
+  });
+
+  it('erkennt eine noch startende Datenbank (T002292 Nachtrag)', () => {
+    // Gegenstueck beim Hochfahren des Ersatz-Pods.
+    expect(isInfrastructureError(new Error('the database system is starting up'))).toBe(true);
+  });
+
   it('ist robust gegen Nicht-Error-Werte', () => {
     expect(isInfrastructureError(null)).toBe(false);
     expect(isInfrastructureError('ECONNREFUSED')).toBe(false);

--- a/scripts/index-repo.ts
+++ b/scripts/index-repo.ts
@@ -148,6 +148,15 @@ const INFRA_ERROR_MESSAGES = [
   'fetch failed',
   'Connection terminated',
   'timeout exceeded when trying to connect',
+  // Nachtrag T002292: Beim Pod-Replace meldet Postgres eine Abfolge, die VOR
+  // dem Socket-Fehler kommt und keinen .code traegt. Gemessen 2026-07-27:
+  // erst 1x "terminating connection due to administrator command" (SIGTERM),
+  // dann 9x "the database system is shutting down", erst danach ECONNREFUSED.
+  // Ohne diese Muster liefen die ersten Dateien nach jedem Replace als
+  // per-Datei-SKIP durch — also genau die Maskierung, die dieser Fix abstellt.
+  'terminating connection due to administrator command',
+  'the database system is shutting down',
+  'the database system is starting up',
 ];
 
 export function isInfrastructureError(err: unknown, depth = 0): boolean {

--- a/tests/unit/scs-index.bats
+++ b/tests/unit/scs-index.bats
@@ -112,3 +112,11 @@ PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
     | grep -v '^[[:space:]]*#' | grep -c 'fuser -k'"
   [[ "$output" -eq 0 ]]
 }
+
+@test "SCS-1: scs:index retry loop captures exit code with || (T002292)" {
+  # go-task fuehrt jeden cmds-Block mit set -e-Semantik aus. Ohne `|| rc=$?`
+  # bricht die Shell beim ersten fehlschlagenden Indexer-Lauf ab, bevor der
+  # Exit-Code gelesen wird — die Retry-Schleife kaeme nie zum Zug.
+  run bash -c "sed -n '/^  scs:index:/,/^  scs:search:/p' '$PROJECT_DIR/Taskfile.yml' | grep -c 'npx tsx scripts/index-repo.ts || rc='"
+  [[ "$output" -eq 1 ]]
+}


### PR DESCRIPTION
Zwei Lücken im ursprünglichen T002292-Fix (#3348), beide am 2026-07-27 live aufgetreten.

## 1. `isInfrastructureError()` kannte den Postgres-Shutdown nicht

Beim Pod-Replace meldet Postgres eine Abfolge, die **vor** dem Socket-Fehler kommt und keinen `.code` trägt. Gemessen:

```
 1 × terminating connection due to administrator command   (SIGTERM)
 9 × the database system is shutting down
 …danach erst ECONNREFUSED
```

Die ersten beiden Stufen passten auf kein Muster und liefen als per-Datei-SKIP durch — also genau die Maskierung, die #3348 abstellen sollte. Dabei sind sie die **frühere** und damit nützlichere Warnung als der spätere Socket-Fehler. `the database system is starting up` deckt das Gegenstück beim Hochfahren des Ersatz-Pods ab.

## 2. Die Retry-Schleife in `scs:index` sprang nie an

go-task führt jeden `cmds:`-Block mit `set -e`-Semantik aus. Die Shell brach beim ersten fehlschlagenden Indexer-Lauf ab, **bevor** `rc=$?` gelesen wurde — die Schleife kam nie zum zweiten Pass (beobachtet: Pass 1 endete mit Exit 1, kein weiterer folgte). Jetzt `|| rc=$?`, abgesichert durch einen BATS-Guard.

## 3. Kommentar präzisiert

Der Warnkommentar aus #3362 in `k3d/shared-db.yaml` beschrieb den Mechanismus ungenau (`$$` als Escaping). Tatsächlich schützt `$$` nicht durch Escaping, sondern weil der Renderer die so markierten Namen aus seiner Allowlist filtert — siehe #3363.

## Tests

- `scripts/index-repo.test.ts`: **19/19** (2 neue, RED-zuerst verifiziert)
- `tests/unit/scs-index.bats`: **18/18** (1 neuer Guard)
- `task workspace:validate` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbCw4MNjiPQ8fkjZjCYoi