### PR TITLE
fix(infra): drop bogus traefik healthCheck from brand Kustomizations [T002313]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -438,6 +438,11 @@ tasks:
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/flux-render-runtime-vars.bats
 
+  test:unit:flux-healthchecks:
+    internal: true
+    cmds:
+      - ./tests/unit/lib/bats-core/bin/bats tests/unit/flux-healthchecks.bats
+
   test:unit:fleet-phase2b:
     internal: true
     cmds:

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 626,
+      "file_count": 627,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -543,6 +543,7 @@
         "tests/unit/fixtures/software-history/mock-anthropic.mjs",
         "tests/unit/fleet-dns-cutover.bats",
         "tests/unit/fleet-phase2b.bats",
+        "tests/unit/flux-healthchecks.bats",
         "tests/unit/flux-render-runtime-vars.bats",
         "tests/unit/freshness-graph.bats",
         "tests/unit/git-crypt-guard.bats",

--- a/flux/clusters/fleet/ks-korczewski.yaml
+++ b/flux/clusters/fleet/ks-korczewski.yaml
@@ -14,6 +14,10 @@ spec:
     name: fleet-manifests
   path: ./korczewski
   prune: true
+  # T002313: Hier stehen NUR Workloads, die diese Kustomization selbst ausrollt.
+  # Begruendung und Vorfall siehe ks-mentolder.yaml — Deployment/traefik existiert
+  # im Brand-Namespace nicht; das echte traefik laeuft Helm-verwaltet in
+  # kube-system und gehoert nicht in dieses Gate.
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment
@@ -22,8 +26,4 @@ spec:
     - apiVersion: apps/v1
       kind: Deployment
       name: pocket-id
-      namespace: workspace-korczewski
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: traefik
       namespace: workspace-korczewski

--- a/flux/clusters/fleet/ks-mentolder.yaml
+++ b/flux/clusters/fleet/ks-mentolder.yaml
@@ -14,6 +14,19 @@ spec:
     name: fleet-manifests
   path: ./mentolder
   prune: true
+  # T002313: Hier stehen NUR Workloads, die diese Kustomization selbst ausrollt.
+  # Ein healthCheck ist ein Gate VOR dem Applizieren — Flux wartet, bis alle
+  # genannten Ziele gesund sind. Ein Eintrag auf fremde Infrastruktur macht
+  # deren Ausfall zum Blocker fuer den gesamten Brand-Stack.
+  #
+  # Entfernt: Deployment/traefik in namespace workspace. Das existiert dort
+  # nicht (nur oauth2-proxy-traefik, ein anderer Dienst); das echte traefik
+  # laeuft Helm-verwaltet in kube-system als k3s-Systemkomponente und wird von
+  # dieser Kustomization gar nicht deployed. Als Gate war der Eintrag wertlos,
+  # und auf kube-system umgebogen haette jeder traefik-Neustart den Brand-Stack
+  # blockiert. Am 2026-07-27 hat genau diese Bauart einen Deadlock erzeugt:
+  # pocket-id war wegen zerstoerter DB-Passwoerter unhealthy -> Health-Gate hing
+  # -> der Fix (T002306), der die Passwoerter repariert haette, kam nie an.
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment
@@ -22,8 +35,4 @@ spec:
     - apiVersion: apps/v1
       kind: Deployment
       name: pocket-id
-      namespace: workspace
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: traefik
       namespace: workspace

--- a/tests/unit/flux-healthchecks.bats
+++ b/tests/unit/flux-healthchecks.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# flux-healthchecks.bats — T002313
+#
+# Ein healthCheck in einer Flux-Kustomization ist ein Gate VOR dem Applizieren:
+# Flux wartet, bis alle genannten Ziele gesund sind. Steht dort ein Workload,
+# den die Kustomization gar nicht ausrollt, ist der Eintrag als Gate wertlos —
+# und macht im schlimmsten Fall fremde Infrastruktur zum Blocker fuer den
+# gesamten Brand-Stack.
+#
+# Vorfall 2026-07-27: ks-mentolder.yaml gatete auf Deployment/traefik in
+# namespace workspace. Dort existiert nur oauth2-proxy-traefik; das echte
+# traefik laeuft Helm-verwaltet in kube-system. Zusammen mit einem unhealthy
+# pocket-id (zerstoerte DB-Passwoerter, T002306) entstand ein Deadlock: das
+# Health-Gate hing, dadurch konnte der Fix nicht ausgerollt werden, der die
+# Passwoerter repariert haette. lastAppliedRevision war leer.
+
+load test_helper
+
+PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+FLUX_DIR="$PROJECT_DIR/flux/clusters/fleet"
+
+# Jedes healthCheck-Ziel muss ein Workload sein, den das Repo unter k3d/ auch
+# wirklich definiert. Das ist die eigentliche Regel — nicht "traefik ist boese".
+@test "T002313: every Kustomization healthCheck targets a Deployment the repo defines" {
+  # Sammelt alle metadata.name-Werte, die unter "kind: Deployment" stehen —
+  # ein blosses grep nach dem Namen wuerde auch Middleware-, Service- oder
+  # Ingress-Eintraege treffen und den Test zahnlos machen.
+  local deployed
+  deployed=$(awk '
+    /^kind: Deployment$/ { in_dep=1; next }
+    /^kind: / { in_dep=0 }
+    in_dep && /^  name: / { print $2; in_dep=0 }
+  ' "$PROJECT_DIR"/k3d/*.yaml | sort -u)
+
+  local missing=""
+  for ks in "$FLUX_DIR"/ks-mentolder.yaml "$FLUX_DIR"/ks-korczewski.yaml; do
+    [[ -f "$ks" ]] || continue
+    local names n
+    names=$(sed -n '/^  healthChecks:/,/^  [a-z]/p' "$ks" | grep -E '^\s+name: ' | awk '{print $2}')
+    for n in $names; do
+      grep -qxF "$n" <<<"$deployed" || missing="${missing} ${ks##*/}:${n}"
+    done
+  done
+  [[ -z "$missing" ]] || {
+    echo "healthCheck-Ziele ohne Deployment-Definition unter k3d/:$missing" >&2
+    echo "--- im Repo definierte Deployments ---" >&2
+    echo "$deployed" >&2
+    false
+  }
+}
+
+@test "T002313: no Kustomization gates on traefik (Helm-managed in kube-system)" {
+  run bash -c "grep -l 'name: traefik' '$FLUX_DIR'/ks-*.yaml 2>/dev/null | wc -l"
+  [[ "$output" -eq 0 ]]
+}


### PR DESCRIPTION
## Problem

`ks-mentolder.yaml` und `ks-korczewski.yaml` gateten auf ein `Deployment/traefik` im Brand-Namespace. Das existiert dort nicht:

| | |
|---|---|
| `kubectl -n workspace get deploy traefik` | **NotFound** |
| In `workspace` vorhanden | nur `oauth2-proxy-traefik` — ein anderer Dienst |
| Echtes traefik | `kube-system`, Helm-verwaltet (`traefik-39.0.701_up39.0.7`), k3s-Systemkomponente |
| In `k3d/` definiert | **nein** — die Kustomization rollt traefik gar nicht aus |

Ein `healthCheck` ist ein Gate **vor** dem Applizieren: Flux wartet, bis alle genannten Ziele gesund sind. Auf fremde Infrastruktur gerichtet ist er als Gate wertlos — und auf `kube-system` umgebogen wäre er schädlich, weil dann jeder traefik-Neustart (k3s-Upgrade, Helm-Reconcile) den gesamten Brand-Stack blockiert.

## Der Vorfall

Am 2026-07-27 hat genau diese Bauart einen **Deadlock** erzeugt:

1. `pocket-id` war unhealthy — zerstörte DB-Passwörter (T002306)
2. → das Health-Gate der Kustomization hing
3. → der Fix, der die Passwörter repariert hätte, konnte nicht ausgerollt werden
4. `lastAppliedRevision` war **leer** — die Kustomization hatte nie durchappliziert

## Änderung

Der `traefik`-Eintrag entfällt in beiden Brand-Kustomizations. `shared-db` und `pocket-id` bleiben — beide werden von der Kustomization ausgerollt und sind echte Voraussetzungen für die übrigen Workloads.

## Test

`tests/unit/flux-healthchecks.bats` sichert die eigentliche Regel ab: **jedes healthCheck-Ziel muss ein Deployment sein, das unter `k3d/` definiert ist.** Der Test parst `metadata.name` unterhalb von `kind: Deployment` — ein bloßes `grep` nach dem Namen hätte auch Middleware- und Service-Einträge getroffen und wäre zahnlos gewesen.

Gegengeprüft: der Test schlägt fehl, wenn man `traefik` wieder einträgt **und** wenn man ein frei erfundenes Ziel einträgt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbCw4MNjiPQ8fkjZjCYoi