### PR TITLE
fix(website): point code search at llm-gateway-embed and rerank results [T002317]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2923,7 +2923,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 555,
+      "file_count": 556,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",

--- a/website/src/lib/codesearch-db.test.ts
+++ b/website/src/lib/codesearch-db.test.ts
@@ -41,7 +41,11 @@ describe('codesearch-db', () => {
     expect(sql).toMatch(/ORDER BY embedding <=> \$1/);
     expect((params[0] as string).startsWith('[')).toBe(true);
     expect(params[0]).toContain('0.1,0.2,0.3');
-    expect(params[1]).toBe(5); // default limit
+    // T002317: Die Vektorsuche holt bewusst MEHR als das angefragte Limit
+    // (5 x RERANK_CANDIDATE_FACTOR = 40). Der Reranker kann nur umsortieren,
+    // was die erste Stufe geliefert hat — ein zu enges SQL-LIMIT wuerde ihm
+    // genau die Treffer vorenthalten, die er nach oben holen soll.
+    expect(params[1]).toBe(40);
   });
 
   it('searchCode: throws with .status when the embedding service is unavailable', async () => {
@@ -84,5 +88,101 @@ describe('codesearch-db', () => {
     const paths = out.map(o => o.path);
     expect(new Set(paths).size).toBe(paths.length); // all unique
     expect(paths).toContain('src/a.ts');
+  });
+});
+
+// T002317 — Reranking.
+//
+// Reine Vektor-Naehe rankt Dateien hoch, die fast nur aus sprechenden
+// Bezeichnern bestehen. Gemessen am 2026-07-27 gewann fuer "svelte component
+// for the admin ticket board" die reine ID-Konstantenliste
+// website/src/lib/tickets/cockpit-ids.ts gegen die tatsaechlichen
+// Admin-Komponenten. bge-reranker-v2-m3 sieht Query und Dokument gemeinsam
+// und korrigiert solche Faelle.
+describe('codesearch-db: reranking (T002317)', () => {
+  it('sortiert die Vektor-Treffer nach dem Reranker-Score um', async () => {
+    fetchMock.mockResolvedValueOnce({            // /v1/embeddings
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.1, 0.2] }] }),
+    });
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        { file_path: 'src/ids.ts', chunk_index: 0, content: 'const IDS = [...]', score: 0.90 },
+        { file_path: 'src/Board.svelte', chunk_index: 0, content: '<script>board</script>', score: 0.80 },
+      ],
+    });
+    fetchMock.mockResolvedValueOnce({            // /v1/rerank
+      ok: true,
+      json: async () => ({ results: [
+        { index: 1, relevance_score: -2.1 },     // Board.svelte ist relevanter
+        { index: 0, relevance_score: -9.7 },
+      ] }),
+    });
+
+    const out = await searchCode('svelte board component', 2);
+    // Der Reranker dreht die Reihenfolge gegenueber der Cosine-Sortierung um.
+    expect(out.map(r => r.path)).toEqual(['src/Board.svelte', 'src/ids.ts']);
+    expect(out[0].rerank_score).toBe(-2.1);
+    // Der Cosine-Score bleibt unveraendert erhalten — nur die Reihenfolge aendert sich.
+    expect(out[0].score).toBe(0.80);
+
+    const [, init] = fetchMock.mock.calls[1];
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.query).toBe('svelte board component');
+    expect(body.documents).toHaveLength(2);
+  });
+
+  it('liefert das Vektor-Ranking, wenn der Reranker ausfaellt (fail-soft)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.1] }] }),
+    });
+    queryMock.mockResolvedValueOnce({
+      rows: [
+        { file_path: 'src/a.ts', chunk_index: 0, content: 'a', score: 0.9 },
+        { file_path: 'src/b.ts', chunk_index: 0, content: 'b', score: 0.5 },
+      ],
+    });
+    fetchMock.mockRejectedValueOnce(new Error('connect ECONNREFUSED'));
+
+    const out = await searchCode('x', 2);
+    // Reihenfolge der Vektorsuche bleibt, kein rerank_score.
+    expect(out.map(r => r.path)).toEqual(['src/a.ts', 'src/b.ts']);
+    expect(out[0].rerank_score).toBeUndefined();
+  });
+
+  it('respektiert das angefragte Limit nach dem Reranking', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: [{ embedding: [0.1] }] }),
+    });
+    queryMock.mockResolvedValueOnce({
+      rows: Array.from({ length: 10 }, (_, i) => ({
+        file_path: `src/f${i}.ts`, chunk_index: 0, content: `c${i}`, score: 1 - i / 100,
+      })),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ results: Array.from({ length: 10 }, (_, i) => ({
+        index: 9 - i, relevance_score: -i,   // umgekehrte Reihenfolge
+      })) }),
+    });
+
+    const out = await searchCode('x', 3);
+    expect(out).toHaveLength(3);
+    expect(out[0].path).toBe('src/f9.ts');
+  });
+
+  it('nutzt llm-gateway-embed und das Modell bge-m3 (T002317)', async () => {
+    process.env.LLM_EMBED_URL = 'http://embed.test:8095';
+    fetchMock.mockResolvedValueOnce({
+      ok: true, json: async () => ({ data: [{ embedding: [0.1] }] }),
+    });
+    queryMock.mockResolvedValueOnce({ rows: [] });
+
+    await searchCode('x', 1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://embed.test:8095/v1/embeddings');
+    expect(JSON.parse((init as { body: string }).body).model).toBe('bge-m3');
+    delete process.env.LLM_EMBED_URL;
   });
 });

--- a/website/src/lib/codesearch-db.ts
+++ b/website/src/lib/codesearch-db.ts
@@ -12,21 +12,38 @@ let _pool: pg.Pool | undefined;
 export function __setPoolForTests(testPool: pg.Pool): void { _pool = testPool; }
 function p(): pg.Pool { return _pool ?? defaultPool; }
 
-const EMBED_MODEL = process.env.LLM_EMBED_MODEL ?? 'text-embedding-bge-m3';
+// T002317: war 'text-embedding-bge-m3'. Der Indexer schreibt mit 'bge-m3'
+// (scripts/index-repo.ts) — Query- und Index-Vektoren muessen aus demselben
+// Modell stammen, sonst vergleicht die Suche zwei verschiedene Vektorraeume.
+const EMBED_MODEL = process.env.LLM_EMBED_MODEL ?? 'bge-m3';
+const RERANK_MODEL = process.env.LLM_RERANK_MODEL ?? 'bge-reranker-v2-m3';
 
-// `task scs:search` and local dev shells run outside the cluster, where
-// llm-gateway-lmstudio's DNS never resolves. Resolve once and cache — falls
-// back to the local dev stack (LM Studio direct on :1234) instead of hanging.
+// T002317: zeigte auf llm-gateway-lmstudio:1234. Diesen Service gibt es nicht
+// mehr — bge-m3 zog mit T002258/T002110 auf einen eigenen llama-server um.
+// In Produktion lief die Suche damit ins Leere: DNS liefert NXDOMAIN und der
+// Fallback localhost:1234 existiert im Website-Pod nicht.
 let _embedUrlPromise: Promise<string> | undefined;
 async function resolveEmbedUrl(): Promise<string> {
   if (process.env.LLM_EMBED_URL) return process.env.LLM_EMBED_URL;
   if (!_embedUrlPromise) {
-    const clusterHost = 'llm-gateway-lmstudio.workspace.svc.cluster.local';
+    const clusterHost = 'llm-gateway-embed.workspace.svc.cluster.local';
     _embedUrlPromise = dnsLookup(clusterHost)
-      .then(() => `http://${clusterHost}:1234`)
-      .catch(() => 'http://localhost:1234');
+      .then(() => `http://${clusterHost}:8095`)
+      .catch(() => 'http://localhost:8095');
   }
   return _embedUrlPromise;
+}
+
+let _rerankUrlPromise: Promise<string> | undefined;
+async function resolveRerankUrl(): Promise<string> {
+  if (process.env.LLM_RERANK_URL) return process.env.LLM_RERANK_URL;
+  if (!_rerankUrlPromise) {
+    const clusterHost = 'llm-gateway-rerank.workspace.svc.cluster.local';
+    _rerankUrlPromise = dnsLookup(clusterHost)
+      .then(() => `http://${clusterHost}:8096`)
+      .catch(() => 'http://localhost:8096');
+  }
+  return _rerankUrlPromise;
 }
 
 function vecLiteral(v: number[]): string {
@@ -54,24 +71,73 @@ export interface CodeSearchResult {
   score: number;
   snippet: string;
   chunk_index: number;
+  /** Logit des Rerankers; fehlt, wenn der Reranker nicht erreichbar war. */
+  rerank_score?: number;
+}
+
+// T002317: Wie viele Kandidaten die Vektorsuche holt, bevor der Reranker
+// sortiert. Der Reranker sieht Query und Dokument gemeinsam und erkennt damit
+// Bezuege, die reine Vektor-Naehe verfehlt — er kann aber nur umsortieren, was
+// die erste Stufe geliefert hat. Ein grosszuegiger Faktor ist praktisch
+// gratis: gemessen 2026-07-27 braucht bge-reranker-v2-m3 fuer 40 Kandidaten
+// rund 0.1s.
+const RERANK_CANDIDATE_FACTOR = 8;
+const RERANK_MAX_CANDIDATES = 50;
+
+async function rerank(query: string, docs: string[]): Promise<number[] | null> {
+  try {
+    const url = await resolveRerankUrl();
+    const r = await fetch(`${url}/v1/rerank`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-LLM-Purpose': 'query' },
+      body: JSON.stringify({ model: RERANK_MODEL, query, documents: docs }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!r.ok) return null;
+    const j = await r.json() as { results?: Array<{ index: number; relevance_score: number }> };
+    if (!Array.isArray(j.results)) return null;
+    // Auf die Eingabereihenfolge zurueckmappen: der Server liefert die Treffer
+    // bereits sortiert, mit `index` als Verweis auf das Eingabedokument.
+    const scores = new Array<number>(docs.length).fill(Number.NEGATIVE_INFINITY);
+    for (const res of j.results) {
+      if (res.index >= 0 && res.index < docs.length) scores[res.index] = res.relevance_score;
+    }
+    return scores;
+  } catch {
+    // Fail-soft (T002317): ein nicht erreichbarer Reranker darf die Suche nicht
+    // abschalten. Ohne ihn bleibt das Vektor-Ranking — schlechter sortiert,
+    // aber brauchbar.
+    return null;
+  }
 }
 
 export async function searchCode(query: string, limit = 5): Promise<CodeSearchResult[]> {
   const embedding = await embedQueryText(query);
+  const candidates = Math.min(RERANK_MAX_CANDIDATES, limit * RERANK_CANDIDATE_FACTOR);
   const r = await p().query(
     `SELECT file_path, chunk_index, content,
             1 - (embedding <=> $1) AS score
        FROM code_embeddings
       ORDER BY embedding <=> $1
       LIMIT $2`,
-    [vecLiteral(embedding), limit],
+    [vecLiteral(embedding), candidates],
   );
-  return r.rows.map((row: { file_path: string; chunk_index: number; content: string; score: number }) => ({
+  const rows = r.rows.map((row: { file_path: string; chunk_index: number; content: string; score: number }) => ({
     path: row.file_path,
     score: Number(row.score),
     snippet: row.content.slice(0, 300),
     chunk_index: row.chunk_index,
+    content: row.content,
   }));
+  if (rows.length === 0) return [];
+
+  const scores = await rerank(query, rows.map(x => x.content));
+  const ranked = scores
+    ? rows.map((x, i) => ({ ...x, rerank_score: scores[i] }))
+          .sort((a, b) => b.rerank_score - a.rerank_score)
+    : rows;
+
+  return ranked.slice(0, limit).map(({ content: _content, ...rest }) => rest);
 }
 
 export async function searchCodeAugmented(query: string, limit = 5): Promise<CodeSearchResult[]> {


### PR DESCRIPTION
## Zwei Befunde

### 1. Die Suche zeigte auf einen abgeschalteten Endpunkt

| | |
|---|---|
| `resolveEmbedUrl()` suchte | `llm-gateway-lmstudio…:1234` → **NXDOMAIN**, Service existiert nicht mehr |
| Fallback | `localhost:1234` — im Website-Pod läuft dort nichts |
| `EMBED_MODEL` | `'text-embedding-bge-m3'` statt `'bge-m3'` |

bge-m3 zog mit T002258/T002110 auf einen eigenen llama-server um; der Indexer wurde umgestellt, die Suchseite blieb zurück. **In Produktion konnte die Code-Suche keine Anfrage einbetten.** Der abweichende Modellname hätte zudem Query- und Index-Vektoren aus verschiedenen Räumen kommen lassen.

Jetzt: `llm-gateway-embed:8095` mit `'bge-m3'` — identisch zum Indexer.

### 2. Reranker lief ungenutzt

`llm-gateway-rerank:8096` (bge-reranker-v2-m3) existiert seit drei Tagen und wurde nicht angesprochen. Gemessen für **"svelte component for the admin ticket board"**:

| # | nur Vektorsuche | mit Reranker |
|---|---|---|
| 1 | `lib/tickets/cockpit-ids.ts` ← reine ID-Liste | **`admin/TicketActionBar.svelte`** (+2,47) |
| 2 | `AssetTicketDrawer.svelte` | `TicketWidgetBar.astro` (+1,66) |
| 3 | `AssetTicketDrawer.svelte` (Dublette) | `admin/TicketDetailSections.astro` (+1,21) |

`cockpit-ids.ts` besteht fast nur aus Bezeichnern wie `adminTicketBoard`, enthält aber keine Zeile Board-Logik — und stand auf Platz 1. Mit Reranker fällt sie aus den Top 5.

Der Unterschied liegt im Mechanismus: das Embedding komprimiert Anfrage und Dokument **getrennt** in je einen Vektor und vergleicht danach; der Cross-Encoder sieht **beide gemeinsam**. Sichtbar auch an den Werten — die Top-Treffer bekommen positive Logits, während die Cosine-Scores alle in einem engen Band um 0,6 lagen, in dem die Rangfolge kaum belastbar war.

## Änderung

- Die Vektorsuche holt `limit × 8` (max 50) Kandidaten, der Reranker sortiert sie und die besten `limit` werden zurückgegeben. Ein zu enges SQL-`LIMIT` würde dem Reranker genau die Treffer vorenthalten, die er nach oben holen soll.
- **Fail-soft**: fällt der Reranker aus, bleibt das Vektor-Ranking. Ein nicht erreichbarer Reranker darf die Suche nicht abschalten.
- `score` behält die Cosine-Ähnlichkeit, der Logit kommt als optionales `rerank_score` dazu — rückwärtskompatibel.
- Latenz: **~0,1 s für 40 Kandidaten**.

## Tests

`website/src/lib/codesearch-db.test.ts`: **8/8**, vier neue Fälle — Umsortierung, Fail-soft bei Reranker-Ausfall, Limit-Einhaltung nach dem Reranking, korrekter Endpunkt und Modellname.

Der bestehende Test prüfte `params[1] === 5` (SQL-Limit = angefragtes Limit). Diese Semantik ändert sich bewusst; der Test hält jetzt `40` fest, mit der Begründung im Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbCw4MNjiPQ8fkjZjCYoi