### PR TITLE
feat(scripts): add generic guard-overwrite to factory pipeline [T002286]

### DIFF
--- a/scripts/factory/pipeline-runner.js
+++ b/scripts/factory/pipeline-runner.js
@@ -317,6 +317,65 @@ async function main() {
     ], { stdio: 'ignore', env: { ...process.env, BRAND: brand } });
     console.log("conflict escalated");
 
+  } else if (command === 'guard-overwrite') {
+    // Generic agent overwrite guard (not bonsai-specific).
+    // Detects when an agent used `write` (whole-file overwrite) instead of `edit`
+    // by checking if committed files shrank to <30% of their line count.
+    // Runs on the worktree branch (HEAD~1 vs HEAD).
+    // On detection: reverts the file to HEAD~1 and re-commits with a revert message.
+    // Duplicate of guard-bonsai-overwrite.sh logic, but worktree-aware and generic.
+    const { agent: agentName, files, worktree } = payload;
+    const WT = worktree || REPO;
+    const LOGFILE = path.join(REPO, '.bonsai-write-guard.log');
+    const THRESHOLD_PCT = 30;
+    let reverted = 0;
+    let revertDetails = [];
+
+    // Check if HEAD has a parent commit to compare against
+    let hasParent = false;
+    try {
+      execFileSync('git', ['-C', WT, 'rev-parse', 'HEAD~1'], { stdio: 'ignore', timeout: 5000 });
+      hasParent = true;
+    } catch { /* first commit on branch — nothing to compare */ }
+
+    if (hasParent) {
+      const targetFiles = Array.isArray(files) && files.length > 0
+        ? files
+        : (() => {
+            try {
+              return execFileSync('git', ['-C', WT, 'diff', '--name-only', '--diff-filter=M', 'HEAD~1..HEAD'], { encoding: 'utf8', timeout: 10000 }).trim().split('\n').filter(Boolean);
+            } catch { return []; }
+          })();
+
+      for (const file of targetFiles) {
+        if (!file) continue;
+        try {
+          const headLines = execFileSync('git', ['-C', WT, 'show', `HEAD~1:${file}`], { encoding: 'utf8', timeout: 10000 }).trim().split('\n').length;
+          const currentLines = execFileSync('git', ['-C', WT, 'show', `HEAD:${file}`], { encoding: 'utf8', timeout: 10000 }).trim().split('\n').length;
+
+          // Only flag if HEAD~1 had significant content (>5 lines)
+          if (headLines > 5 && currentLines > 0 && currentLines < (headLines * THRESHOLD_PCT / 100)) {
+            // Overwrite detected — revert to previous version
+            execFileSync('git', ['-C', WT, 'checkout', 'HEAD~1', '--', file], { stdio: 'ignore', timeout: 10000 });
+            const now = new Date().toISOString();
+            const logLine = `[${now}] GUARD:factory-${agentName} REVERTED ${file} (overwrite: ${headLines}→${currentLines} lines, <${THRESHOLD_PCT}%)`;
+            fs.appendFileSync(LOGFILE, logLine + '\n');
+            reverted++;
+            revertDetails.push({ file, before: headLines, after: currentLines });
+          }
+        } catch {
+          // File doesn't exist in HEAD~1 (new file) — skip
+        }
+      }
+
+      if (reverted > 0) {
+        execFileSync('git', ['-C', WT, 'add', '-A'], { stdio: 'ignore', timeout: 10000 });
+        execFileSync('git', ['-C', WT, 'commit', '-m', `fix(${agentName}): revert overwrite — agent used write instead of edit [guard]`], { stdio: 'ignore', timeout: 10000 });
+      }
+    }
+
+    console.log(JSON.stringify({ status: reverted > 0 ? 'blocked' : 'pass', agent: agentName, reverted, details: revertDetails }));
+
   } else if (command === 'resolve-task-source') {
     const { slug } = payload;
     try {

--- a/scripts/factory/pipeline.js
+++ b/scripts/factory/pipeline.js
@@ -170,6 +170,11 @@ if (A.batch_mode === true && Array.isArray(A.sub_features)) {
        After: bash ${REPO}/scripts/factory/sandbox-run.sh ${WORK_WT} 'task workspace:validate && task test:all && task freshness:regenerate'
        Then: cd ${WORK_WT} && git add -A && git commit -m ${JSON.stringify(`feat(${slug}): ${sf.id} [batch-factory]`)}. Return diff + test result.`
     const r = await agent(p + injections, { label: `batch:${sf.id}`, phase: 'Implement', model: FACTORY_MODEL })
+    // Guard: detect agent overwriting files with write instead of edit (T002286)
+    if (r != null) {
+      const guardRes = await runRunner(agent, 'guard-overwrite', { agent: `batch-${sf.id}`, files: sf.assignedFiles || [], worktree: WORK_WT });
+      try { const g = JSON.parse(guardRes || '{}'); if (g.status === 'blocked') log(`Guard blocked batch:${sf.id} — ${g.reverted} file(s) overwritten → reverted.`); } catch {}
+    }
     if (r != null) await phaseEvent('implement', 'partial-done', JSON.stringify({ partial: sf.id, files: sf.assignedFiles || [], tests: /\bfail/i.test(String(r)) ? 'fail' : 'pass' }))
     return r
   }))
@@ -366,6 +371,10 @@ if (tasks.length && !A.batch_mode) {
       { label: `impl:${t.id}`, phase: 'Implement', model: FACTORY_MODEL },
     )
     if (impl == null) continue
+
+    // Guard: detect agent overwriting files with write instead of edit (T002286)
+    const guardRes = await runRunner(agent, 'guard-overwrite', { agent: `impl-${t.id}`, files: t.target_files, worktree: WORK_WT });
+    try { const g = JSON.parse(guardRes || '{}'); if (g.status === 'blocked') log(`Guard blocked ${t.id} — ${g.reverted} file(s) overwritten → reverted.`); } catch {}
 
     const vr = await runTaskVerifyLoop(agent, t, parseInt(process.env.FACTORY_BUILD_LOOP_MAX || '3'), WORK_WT, WORK_BRANCH, slug)
     if (vr) implemented.push(vr)


### PR DESCRIPTION
## Summary
- Add a generic `guard-overwrite` command to `pipeline-runner.js` that detects when a factory write agent used `write` (whole-file overwrite) instead of `edit` (surgical replacement)
- Works on any agent (ternary-bonsai-27b, future write agents) — **not locked to bonsai**
- Worktree-aware: compares `HEAD~1` vs `HEAD` on the worktree branch, reverts files that shrank to <30% of their original line count
- Hook the guard into `pipeline.js` after each implement task (single-task and batch sub-feature paths)

## Why
The orchestrator already runs `guard-bonsai-overwrite.sh` after gemma-4-12b dispatches, but the factory pipeline had no equivalent protection for its write agents. Same problem, same detection heuristic, now generic and worktree-aware.

## Test Plan
- [x] 8/8 unit tests pass (simulated overwrite → blocked + revert, proper edit → pass)
- [x] pipeline-runner.js: `node --check` passes
- [x] pipeline.js: `node --check` passes
- [x] Smoke: guard correctly catches 50→1 line shrink and reverts to previous commit

🤖 [T002286]