### PR TITLE
chore(scripts): add regression test for atomicWriteFile cleanup path [T002308]

### DIFF
--- a/scripts/agent-guide/emit-maps.mjs
+++ b/scripts/agent-guide/emit-maps.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
  * write finished saw an empty file. Now: tmp lives next to dest, rename(2) is
  * atomic on POSIX so dest jumps from old content to new content in one step.
  */
-async function atomicWriteFile(dest, body) {
+export async function atomicWriteFile(dest, body) {
   const tmp = `${dest}.${randomBytes(6).toString('hex')}.tmp`;
   try {
     await writeFile(tmp, body, 'utf8');

--- a/scripts/agent-guide/emit-maps.test.mjs
+++ b/scripts/agent-guide/emit-maps.test.mjs
@@ -1,11 +1,15 @@
 // scripts/agent-guide/emit-maps.test.mjs
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   escapeCell,
   renderGoalsMap,
   renderToolsMap,
   renderDangerMap,
+  atomicWriteFile,
 } from './emit-maps.mjs';
 
 test('escapeCell: pipe is backslash-escaped', () => {
@@ -33,6 +37,30 @@ test('escapeCell: empty/undefined renders as the em-dash placeholder', () => {
   assert.equal(escapeCell(''), '—');
   assert.equal(escapeCell(undefined), '—');
   assert.equal(escapeCell(null), '—');
+});
+
+// ---- regression T002308: atomicWriteFile must unlink (not re-rename) the tmp file on failure ----
+test('atomicWriteFile: on write failure, removes the tmp file instead of re-attempting rename (T002308)', async () => {
+  // T002308: the original catch block was a copy-paste of the try block — it called
+  // `rename(tmp, dest)` again instead of `unlink(tmp)`. That second rename fails for the
+  // exact same reason the first one did, so the tmp sibling is silently left behind on
+  // every failed emitter run. This regression guard forces `dest` to be a pre-existing,
+  // non-empty directory: `rename(tmp, dest)` then fails with EISDIR/ENOTEMPTY, exercising
+  // the catch path realistically. It also proves the tmp path is cleaned up either way,
+  // not just that a specific fs call is invoked.
+  const dir = await mkdtemp(join(tmpdir(), 'emit-maps-atomic-'));
+  try {
+    const dest = join(dir, 'dest');
+    await mkdir(dest); // dest exists as a directory -> rename(tmp, dest) must fail
+    await mkdir(join(dest, 'keep-me-non-empty')); // non-empty, so it's never silently replaced
+
+    await assert.rejects(() => atomicWriteFile(dest, 'body'));
+
+    const leftover = (await readdir(dir)).filter((name) => name.includes('.tmp'));
+    assert.deepEqual(leftover, [], 'no *.tmp sibling must remain after a failed write');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 // ---- shared fixture builder (in-memory registry, mirrors loadRegistry's return shape) ----


### PR DESCRIPTION
## Summary
- T002308 reported that `atomicWriteFile()`'s catch block in `scripts/agent-guide/emit-maps.mjs` re-ran `rename(tmp, dest)` on write failure instead of `unlink(tmp)`, leaving stray `*.tmp` files in `docs/agent-guide/maps/`.
- Verified the underlying bug is **already fixed on `main`** — an unintentional side-effect of `f8a4e9446` (T002304, PR #3365). Current code already calls `unlink(tmp)` in the catch block; no production behavior change is needed.
- Verified no other copy of the buggy pattern exists elsewhere in the repo (checked `website/src/lib/sessions/archive.ts` and other `atomicWrite`-style helpers — none share the rename-in-catch bug).
- Adds a regression test (`emit-maps.test.mjs`) that forces the rename to fail and asserts the tmp sibling is cleaned up. Confirmed it fails against the old rename-based catch and passes against the current unlink-based one.
- Removes the three stray 0-byte `*.tmp` debris files that were left in `docs/agent-guide/maps/` from before the fix (gitignored/untracked, no git object involved).

## Test plan
- [x] `node --test scripts/agent-guide/emit-maps.test.mjs` — 17/17 pass
- [x] `node --test scripts/agent-guide/*.test.mjs` — 62/62 pass
- [x] Manually reintroduced the old buggy catch block and confirmed the new regression test fails, then restored the fix and confirmed it passes
- [x] `task quality:check` — 0 new/worsened violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWbCw4MNjiPQ8fkjZjCYoi