### PR TITLE
chore(llm): default rerank server to CPU RAM [T002337]

### DIFF
--- a/scripts/llm/start-rerank-server.ps1
+++ b/scripts/llm/start-rerank-server.ps1
@@ -5,7 +5,8 @@
   Startet eine persistente llama.cpp-Instanz fuer Text-Reranking (bge-reranker-v2-m3 Q8_0)
   auf Port 8096. Getrennter Prozess vom Embedding-Server, da llama.cpp Embedding-Pooling
   (CLS) und Rerank-Pooling (RANK) nicht in einem Server bedienen kann.
-  VRAM-Notausstieg via Umgebungsvariable LLM_RERANK_NGL (Default 99).
+  Laeuft seit T002337 im CPU-RAM (Default LLM_RERANK_NGL=0). GPU-Rueckweg fuer
+  Massen-Reranking: LLM_RERANK_NGL=99.
 
   T002260 - WARUM -b/-ub 8192 gesetzt sein MUSS:
   bge-reranker-v2-m3 ist ein Cross-Encoder auf XLM-RoBERTa, also nicht-kausal.
@@ -46,7 +47,15 @@ if (-not (Test-Path $Model)) {
 # PowerShell 7 - unter 5.1 (dem einzigen auf diesem Host installierten
 # PowerShell) ist das ein Parse-Fehler: 'Unerwartetes Token "?"'. Das Skript
 # war damit nie ausfuehrbar. if/else ist versionsunabhaengig.
-$Ngl = "99"
+# T002337: Default ist jetzt 0 - das Modell liegt im CPU-RAM statt im VRAM,
+# genau wie bge-m3 seit T002319. Der Reranker blieb dabei versehentlich auf 99
+# stehen; da install-startup-autostart.ps1 dieses Skript ARGUMENTLOS aufruft,
+# holte sich jeder Autostart die GPU-Variante zurueck. Das kollidiert mit dem
+# Gemma-Profil aus T002297 (-Ctx 262144), das mit rund 15,1 von 16,3 GiB fast
+# das gesamte VRAM belegt und nur ~850 MiB Reserve laesst - zu wenig fuer
+# bge-reranker-v2-m3 Q8_0 (~0,6 GB) daneben. Fuer Massen-Reranking, wo der
+# Durchsatz zaehlt und Gemma nicht laeuft, ist LLM_RERANK_NGL=99 der Rueckweg.
+$Ngl = "0"
 if ($env:LLM_RERANK_NGL) { $Ngl = $env:LLM_RERANK_NGL }
 
 Write-Host "Starting bge-reranker-v2-m3 rerank server on port 8096..."
@@ -62,10 +71,16 @@ $Params = @(
   "-b", "8192"
   "-ub", "8192"
   "-ngl", $Ngl
-  "-fa", "on"
   "--host", "0.0.0.0"
   "--port", "$Port"
 )
+
+# T002337: Flash Attention nur mit GPU-Offload, analog start-embed-server.ps1.
+# -fa ist eine GPU-Optimierung; auf dem CPU-Pfad bringt sie nichts und macht
+# den Aufruf nur schwerer mit dem GPU-Profil vergleichbar. Anders als beim
+# Embedder geht es hier NICHT um bitgenaue Reproduzierbarkeit - Rerank-Scores
+# werden pro Anfrage berechnet und nirgends persistiert.
+if ($Ngl -ne "0") { $Params += @("-fa", "on") }
 
 # Port raeumen - ein noch laufender Server auf diesem Port laesst den neuen
 # still am Bind scheitern.

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -187,6 +187,28 @@ assert_var_not_declared() {
   [ "$status" -eq 0 ]
 }
 
+# ── CPU-Default fuer Embed und Rerank (T002337) ───────────────────────
+# Beide Hilfsmodelle liegen im CPU-RAM, damit das VRAM dem Chat-Modell gehoert:
+# Gemma laeuft seit T002297 mit -Ctx 262144 und belegt rund 15,1 von 16,3 GiB.
+# Der Reranker war der Beweis, dass ein einzelner Guard hier nicht reicht —
+# T002319 stellte den Embedder auf 0 um und liess start-rerank-server.ps1 auf
+# 99 stehen; weil install-startup-autostart.ps1 beide Skripte ARGUMENTLOS
+# aufruft, holte jeder Autostart die GPU-Variante zurueck, ohne dass etwas rot
+# wurde. Deshalb pruefen die Guards BEIDE Skripte gemeinsam. Der GPU-Rueckweg
+# bleibt ueber LLM_EMBED_NGL/LLM_RERANK_NGL offen — hier steht nur der Default.
+# Das [[:space:]]*$ am Ende ist kein Schoenheitsfehler: die .ps1-Dateien sind
+# durchgehend CRLF, ein blosses "$ scheitert am \r vor dem Zeilenende.
+
+@test "start-embed-server.ps1 defaults -ngl to 0 (CPU RAM, T002337)" {
+  run grep -qE '^\$Ngl = "0"[[:space:]]*$' "$REPO/scripts/llm/start-embed-server.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "start-rerank-server.ps1 defaults -ngl to 0 (CPU RAM, T002337)" {
+  run grep -qE '^\$Ngl = "0"[[:space:]]*$' "$REPO/scripts/llm/start-rerank-server.ps1"
+  [ "$status" -eq 0 ]
+}
+
 # T002276: die beiden Guards, die dieselben Flags in den Args-Zeilen von
 # register-scheduled-tasks.ps1 prueften, sind entfallen. Dort gibt es keine Args
 # mehr (der Task verweist auf das Startskript), und die beiden Guards oben


### PR DESCRIPTION
## Was

`start-rerank-server.ps1` stand auf `$Ngl = "99"` (voller GPU-Offload), während `start-embed-server.ps1` in T002319 bereits auf `0` umgestellt wurde. `install-startup-autostart.ps1` ruft **beide** Skripte argumentlos auf — jeder Autostart holte den Reranker also wieder ins VRAM.

Das kollidiert mit dem Gemma-Profil aus T002297 (`-Ctx 262144`), das rund 15,1 von 16,3 GiB belegt und nur ~850 MiB Reserve lässt. bge-reranker-v2-m3 Q8_0 braucht ~0,6 GB und passt daneben nicht zuverlässig.

## Warum das aufgefallen ist

Gemma (:8091) und der Reranker (:8096) fielen am 2026-07-27 aus und blieben über drei Stunden tot, ohne dass etwas rot wurde. Beim Wiederhochfahren im Zielprofil fiel der GPU-Default des Rerankers auf.

Die zwei strukturellen Ursachen dahinter sind separat erfasst:
- **T002335** — keine Scheduled Tasks unter `\Llama\` registriert, kein Watchdog
- **T002336** — `llm-proxy` `/health` meldet 200 bei totem Upstream

## Änderungen

- `$Ngl`-Default `99` → `0`; GPU-Rückweg bleibt über `LLM_RERANK_NGL=99`
- `-fa` nur noch bei GPU-Offload, analog `start-embed-server.ps1:89`. Begründung hier aber anders als in T002319: es geht **nicht** um bitgenaue Reproduzierbarkeit (Rerank-Scores werden pro Anfrage berechnet und nirgends persistiert), sondern darum, dass `-fa` eine GPU-Optimierung ist
- Zwei Guards in `tests/spec/llm-pipeline.bats`, die **beide** CPU-Defaults gemeinsam festhalten — T002319 hinterließ keinen, genau deshalb blieb der Reranker unbemerkt auf 99

## Verifikation

- `task test:all` grün (exit 0), `task freshness:check` OK
- `tests/spec/llm-pipeline.bats`: 46/46
- Negativtest beider Guards, gegeneinander isoliert (`ngl 99` im Rerank-Skript macht nur den Rerank-Guard rot)
- PowerShell-5.1-Parse-Check OK (dieses Skript war unter T002275 schon einmal wegen eines PS-7-Ternary nicht ausführbar)
- Live auf dem GPU-Host: :8091 (`n_ctx 262144`), :8095 und :8096 laufen gleichzeitig bei 823 MiB freiem VRAM; Smoke-Test über den Proxy (:18235) liefert korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ltpez1bRJ2aP96ZytH7Yuw