### PR TITLE
docs(agents): warn probe-commit --hard reset drops unstaged work [T002253]

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -44,6 +44,16 @@ fi
 > `git checkout -b` → `git stash pop`: jeder Schritt muss den Abschluss des
 > vorherigen abwarten.
 
+> **Probe-Commit + `--hard` verwirft auch unstaged Dateien (T001454, wiederholt bei
+> T002252/T002253).** Das Muster "Probe committen → prüfen → `git reset -q --hard HEAD~1`
+> zurückrollen" wirkt lokal begrenzt, weil scheinbar nur der eigene Probe-Commit adressiert
+> wird — `--hard` unterscheidet aber nicht zwischen Commit-Rollback und Working-Tree-Verwurf
+> und reißt unstaged Arbeitsdateien mit. Sicher:
+> ```bash
+> git stash -u && git reset --hard HEAD~1 && git stash pop
+> ```
+> Oder den Probe erst gar nicht committen, sondern in einem separaten Wegwerf-Worktree testen.
+
 ---
 
 ## Schritt 1 — Verifikation & Freshness Guard (vor dem Commit)


### PR DESCRIPTION
## Summary
- Ergänzt `.claude/skills/git-workflow/SKILL.md` um eine Doku-Notiz: ein Probe-Commit gefolgt von `git reset -q --hard HEAD~1` verwirft auch unstaged Arbeitsdateien — Wiederholung von T001454 bei T002252 (Taskfile.yml, tests/spec/ci-cd.bats gingen verloren und mussten neu geschrieben werden).
- Sichere Form dokumentiert: `git stash -u && git reset --hard HEAD~1 && git stash pop`, oder Probe im Wegwerf-Worktree statt als Commit.
- Reine Doku-Änderung, kein Verhaltensänderung, kein Skript/Hook.

## Test plan
- [x] `task freshness:check` grün
- [x] `bash scripts/preflight-pr-scope.sh` grün (scope `agents`)