### PR TITLE
docs(agents): note worktree file-tool-path requirement in dev-flow-plan/dev-flow-chore [T002357]

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -82,6 +82,11 @@ cd .worktrees/<slug>
 bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label dev-flow-chore
 ```
 
+> **`cd` wirkt nur auf Bash (T002357):** Ab hier MÜSSEN alle Datei-Tool-Pfade (Read/Write/Edit)
+> explizit den Worktree-Präfix (`.worktrees/<slug>/...`) tragen. `cd` ändert nur das Bash-cwd,
+> nicht den Bezugspunkt der Datei-Tools — ein zu Session-Beginn im Hauptcheckout korrekter Pfad
+> bleibt syntaktisch gültig und trifft danach still die falsche Arbeitskopie (Mishap T002350).
+
 > Enthält `<slug>` eine wiederverwendete `TICKET_EXT_ID` (z.B. `T001869`), sollte deren Ticketnummer
 > im Slug vorkommen (z.B. `doc-cleanup-T001869`) — `preflight-pr-scope.sh` prüft das PR-Titel↔Branch-
 > Matching case-insensitiv (T001873), Groß-/Kleinschreibung im Slug spielt also keine Rolle.

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -87,6 +87,13 @@ und committed Proposals, nicht nur das eigene Branch-Delta. Erst danach entsteht
 | **B — Branch live** | Worktree | `scripts/worktree-create.sh`, agent-lock claimen, Artefakte verschieben, Scaffold-Commit + Push |
 | **C — Partial-Pipeline** | Worktree | Decompose in Partials, pro Partial: Plan schreiben → committen → stagen → enqueuen; danach plan-lint, Embedding, finaler Push |
 
+> **`cd` wirkt nur auf Bash (T002357):** Ab Phase B (Worktree betreten) MÜSSEN alle Datei-Tool-Pfade
+> (Read/Write/Edit) explizit den Worktree-Präfix tragen. `cd` ändert nur das Bash-cwd, nicht den
+> Bezugspunkt der Datei-Tools — ein zu Phase-A-Zeit im Hauptcheckout korrekter Pfad bleibt
+> syntaktisch gültig und trifft danach still die falsche Arbeitskopie (Mishap T002350). Die
+> konkrete `worktree-create.sh`/`cd`-Sequenz steht in `dev-flow-plan-phases.md`, dort gilt derselbe
+> Hinweis.
+
 Vollständige Schrittfolge aller drei Phasen samt Befehlen, Decompose-/Fan-out-Mechanik
 (Schritt 3.7) und Kontext-Injektion für Plan-Subagenten:
 [dev-flow-plan-phases](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-plan-phases.md).

--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -87,12 +87,9 @@ und committed Proposals, nicht nur das eigene Branch-Delta. Erst danach entsteht
 | **B — Branch live** | Worktree | `scripts/worktree-create.sh`, agent-lock claimen, Artefakte verschieben, Scaffold-Commit + Push |
 | **C — Partial-Pipeline** | Worktree | Decompose in Partials, pro Partial: Plan schreiben → committen → stagen → enqueuen; danach plan-lint, Embedding, finaler Push |
 
-> **`cd` wirkt nur auf Bash (T002357):** Ab Phase B (Worktree betreten) MÜSSEN alle Datei-Tool-Pfade
-> (Read/Write/Edit) explizit den Worktree-Präfix tragen. `cd` ändert nur das Bash-cwd, nicht den
-> Bezugspunkt der Datei-Tools — ein zu Phase-A-Zeit im Hauptcheckout korrekter Pfad bleibt
-> syntaktisch gültig und trifft danach still die falsche Arbeitskopie (Mishap T002350). Die
-> konkrete `worktree-create.sh`/`cd`-Sequenz steht in `dev-flow-plan-phases.md`, dort gilt derselbe
-> Hinweis.
+> **`cd` wirkt nur auf Bash (T002357):** Ab Phase B tragen alle Datei-Tool-Pfade (Read/Write/Edit)
+> zwingend den Worktree-Präfix — `cd` ändert nur das Bash-cwd, nicht den Bezugspunkt der
+> Datei-Tools. Begründung und Prüfbefehl stehen bei der `cd`-Sequenz in `dev-flow-plan-phases.md`.
 
 Vollständige Schrittfolge aller drei Phasen samt Befehlen, Decompose-/Fan-out-Mechanik
 (Schritt 3.7) und Kontext-Injektion für Plan-Subagenten:

--- a/.claude/skills/references/dev-flow-plan-phases.md
+++ b/.claude/skills/references/dev-flow-plan-phases.md
@@ -84,6 +84,14 @@ enqueued ist — parallel zum Schreiben des nächsten Partials.
 
 #### Schritt B.1: Worktree anlegen (git-crypt-safe)
 
+> **Ab hier trägt jeder Datei-Tool-Pfad den Worktree-Präfix [T002357].** `cd` und
+> `worktree-create.sh` wirken nur auf Bash; Read/Write/Edit nehmen absolute Pfade und haben
+> keinerlei Bezug zum Bash-cwd. Ein Pfad, der vor der Worktree-Anlage korrekt war
+> (`<repo>/tests/spec/x.bats`), bleibt danach syntaktisch gültig und trifft still den
+> Hauptcheckout — der Verstoß gegen "Mutierende Tasks nie im Hauptcheckout" fällt erst beim
+> `git status` auf (Mishap T002350, Ursprung T001880). Prüfbefehl bei Verdacht, im
+> Hauptcheckout auszuführen: `git -C <repo-root> status --porcelain` muss leer bleiben.
+
 ```bash
 bash scripts/worktree-create.sh feature/<slug>-T<id> .worktrees/<slug>
 
@@ -266,6 +274,10 @@ TICKET_UUID=$(echo "$TICKET_RESULT"   | cut -d'|' -f2)
 bash scripts/worktree-create.sh fix/<slug> .worktrees/<slug>
 cd .worktrees/<slug>
 ```
+
+> **Das `cd` wirkt nur auf Bash [T002357].** Read/Write/Edit nehmen absolute Pfade ohne Bezug
+> zum Bash-cwd — ab hier muss jeder Datei-Tool-Pfad explizit unter `.worktrees/<slug>/` liegen,
+> sonst trifft er still den Hauptcheckout (Mishap T002350).
 ### Schritt 2.5: Ticket & Branch claimen (Session-Koordination [T000510])
 ```bash
 bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" \


### PR DESCRIPTION
## Summary
- Doku-only: notes at the worktree-entry point in `dev-flow-plan/SKILL.md` (Phase B table) and `dev-flow-chore/SKILL.md` (regulärer Pfad) that `cd` only changes the Bash cwd, not Read/Write/Edit tool paths — those must carry the explicit worktree prefix after entering.
- Fixes mishap origin T002350 (RED test for reaper-child-selection was written under the main checkout instead of its worktree) at the docs level. The PreToolUse-hook alternative from the ticket is explicitly out of scope here.

## Test plan
- [x] Doc-only change, no behavior affected
- [x] `git diff` confined to the two named SKILL.md files