### PR TITLE
fix(scripts): agent-lock.sh claim lehnt unbekannte Argumente statt sie stumm zu verwerfen [T002363]

### DIFF
--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -238,13 +238,28 @@ _self_claim_main_checkout() {
   cmd_claim main-checkout "" --branch "$br" --label "$_SELF_CLAIM_LABEL" >/dev/null 2>&1
 }
 
+# Reject an unrecognised argument instead of dropping it silently. The claim parsers
+# used to end in `*) shift;;`, so `claim ticket T123 dev-flow-plan` (label passed
+# positionally instead of via --label) returned 0 while writing a lock with empty
+# `branch` and `label`. That lock then fails the dev-flow-plan pre-commit guard, which
+# compares `.branch` against HEAD — and an empty `branch` also disables the
+# worktree+branch liveness fallback in _reapable (see the [T002267] note below), so the
+# lock goes stale earlier than the caller expects. Failing loudly is the only way the
+# caller finds out. [T002363]
+_reject_arg() {
+  echo "AGENT-LOCK: $1: unbekanntes Argument '$2'" >&2
+  echo "  Erwartet werden benannte Flags: --label <l> --worktree <p> --branch <b> --ticket <id>" >&2
+  [ "$1" = "check-and-claim" ] && echo "  sowie --status-check <pfad>" >&2
+  return 0
+}
+
 cmd_claim() {
   SCOPE="$1"; ID="${2:-}"; shift 2 2>/dev/null || shift $#
   LABEL=""; WT=""; BRANCH=""; TICKET=""
   while [ $# -gt 0 ]; do case "$1" in
     --label) LABEL="$2"; shift 2;; --worktree) WT="$2"; shift 2;;
     --branch) BRANCH="$2"; shift 2;; --ticket) TICKET="$2"; shift 2;;
-    *) shift;; esac; done
+    *) _reject_arg claim "$1"; return 2;; esac; done
   # For a branch-scoped claim the branch name IS the id; callers therefore never
   # pass --branch. Leaving `branch` empty disabled the worktree+branch liveness
   # fallback in _reapable (T002204), which requires a non-empty branch field — so
@@ -302,7 +317,7 @@ cmd_check_and_claim() {
     --status-check) status_check_script="$2"; shift 2;;
     --label) LABEL="$2"; shift 2;; --worktree) WT="$2"; shift 2;;
     --branch) BRANCH="$2"; shift 2;; --ticket) TICKET="$2"; shift 2;;
-    *) shift;; esac; done
+    *) _reject_arg check-and-claim "$1"; return 2;; esac; done
 
   # 1) Optional external status-check (e.g. ticket.sh get --id + jq).
   #    If the ticket is already done/merged/archived, refuse the claim.

--- a/tests/spec/active-sessions-hub.bats
+++ b/tests/spec/active-sessions-hub.bats
@@ -2,9 +2,75 @@
 # tests/spec/active-sessions-hub.bats
 # SSOT: openspec/specs/active-sessions-hub.md
 #
-# Initial placeholder coverage for the Active Sessions Hub spec. [T002010]
+# Deckt den Argument-Vertrag von `agent-lock.sh claim` / `check-and-claim` ab. [T002363]
+# Der frühere Platzhalter-Test (`run true`) ist durch echte Abdeckung ersetzt.
+#
+# ACHTUNG — $output-Falle: der Worktree dieses Changes heißt
+# `agent-lock-claim-strict-args` und enthält damit die Begriffe "claim", "args" und
+# "lock". Jede unqualifizierte Assertion gegen `$output` kann allein über den in der
+# Ausgabe auftauchenden Pfad grün werden. Alle Assertions unten prüfen deshalb
+# entweder den Exit-Code, die Existenz einer Lock-Datei oder eine auf `AGENT-LOCK:`
+# eingeschränkte Zeile.
 
-@test "active-sessions-hub spec covered" {
-  run true
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  LOCK="$REPO/scripts/agent-lock.sh"
+  export AGENT_LOCK_DIR
+  AGENT_LOCK_DIR="$(mktemp -d)"
+  export CLAUDE_SESSION_ID="claude-t002363-suite"
+  unset AGENT_LOCK_SID
+}
+
+teardown() {
+  rm -rf "$AGENT_LOCK_DIR" 2>/dev/null || true
+}
+
+# ── claim weist unbekannte Argumente ab ─────────────────────────────────── #
+
+@test "T002363: claim lehnt ein positionales Argument mit Exit != 0 ab" {
+  run bash "$LOCK" claim ticket T002363 dev-flow-plan
+  [ "$status" -ne 0 ]
+}
+
+@test "T002363: claim legt bei abgelehntem Argument KEINE Lock-Datei an" {
+  run bash "$LOCK" claim ticket T002363 dev-flow-plan
+  [ ! -f "$AGENT_LOCK_DIR/ticket__T002363.json" ]
+}
+
+@test "T002363: die Fehlermeldung nennt das abgelehnte Argument" {
+  # Auf die AGENT-LOCK-Zeile einschränken — der Worktree-Pfad enthält sonst selbst
+  # Begriffe, die eine unqualifizierte Suche befriedigen würden.
+  run bash -c "bash '$LOCK' claim ticket T002363 dev-flow-plan 2>&1 | grep '^AGENT-LOCK:' | grep -c \"dev-flow-plan\""
+  [ "$output" != "0" ]
+}
+
+@test "T002363: check-and-claim lehnt ein positionales Argument ebenfalls ab" {
+  run bash "$LOCK" check-and-claim ticket T002363 dev-flow-execute
+  [ "$status" -ne 0 ]
+  [ ! -f "$AGENT_LOCK_DIR/ticket__T002363.json" ]
+}
+
+# ── der gültige Aufruf bleibt unverändert ───────────────────────────────── #
+
+@test "T002363: claim mit benannten Flags schreibt branch und label in den Lock" {
+  run bash "$LOCK" claim ticket T002363 --label dev-flow-plan --branch chore/probe-T002363
   [ "$status" -eq 0 ]
+  [ -f "$AGENT_LOCK_DIR/ticket__T002363.json" ]
+
+  run bash -c "jq -r '.branch' '$AGENT_LOCK_DIR/ticket__T002363.json'"
+  [ "$output" = "chore/probe-T002363" ]
+
+  run bash -c "jq -r '.label' '$AGENT_LOCK_DIR/ticket__T002363.json'"
+  [ "$output" = "dev-flow-plan" ]
+}
+
+@test "T002363: branch-scoped claim leitet branch weiterhin aus der id ab (T002267)" {
+  # Regressionsschutz: bei --scope branch übergeben Aufrufer kein --branch; das Feld
+  # muss trotzdem gefüllt sein, sonst greift der worktree+branch-Liveness-Fallback
+  # in _reapable nicht.
+  run bash "$LOCK" claim branch chore/probe-T002363 --label dev-flow-chore
+  [ "$status" -eq 0 ]
+
+  run bash -c "jq -r '.branch' '$AGENT_LOCK_DIR/branch__chore-probe-T002363.json'"
+  [ "$output" = "chore/probe-T002363" ]
 }


### PR DESCRIPTION
## Summary
- `cmd_claim`/`cmd_check_and_claim` in `scripts/agent-lock.sh` endeten in `*) shift;;` — ein positional übergebenes Argument (z.B. Label statt `--label`) wurde still verworfen, Exit 0, aber der Lock landete mit leerem `branch`/`label` und bricht den dev-flow-plan-Pre-Commit-Guard.
- Neue `_reject_arg`-Helper-Funktion: unbekanntes Argument → Fehlermeldung auf stderr + `return 2` statt Silent-Drop.
- Aufrufer-Audit (grep über *.sh/*.md/*.yml): alle bekannten Aufrufer nutzen ausschließlich benannte Flags — keine Regression durch die verschärfte Validierung.

## Test plan
- [x] `tests/unit/lib/bats-core/bin/bats tests/spec/active-sessions-hub.bats` — 6/6 grün (neue T002363-Tests)
- [x] `task test:all` — grün

Claude-Session: https://claude.ai/code/session_01Qp4eSdrHrfPN23zF167wLG