### PR TITLE
fix(scripts): Watchdog startet tote LLM-Server neu [T002335]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2924,7 +2924,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 557,
+      "file_count": 558,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3318,6 +3318,7 @@
         "scripts/llm/start-gemma-server.ps1",
         "scripts/llm/start-gptoss-server.ps1",
         "scripts/llm/start-rerank-server.ps1",
+        "scripts/llm/watchdog-llm-servers.ps1",
         "scripts/lmstudio-preload.sh",
         "scripts/mcp-gateway/mcp-gateway.service",
         "scripts/mcp-sync.sh",

--- a/openspec/changes/fix-llm-server-watchdog/design.md
+++ b/openspec/changes/fix-llm-server-watchdog/design.md
@@ -1,0 +1,132 @@
+# Design: LLM-Server Watchdog
+
+## 1. Watchdog-Skript: `scripts/llm/watchdog-llm-servers.ps1`
+
+### Parameter
+
+| Parameter | Default | Beschreibung |
+|-----------|---------|--------------|
+| `-PollSeconds` | 60 | Abfrageintervall in Sekunden |
+| `-NoLoop` | - | Nur einmal prüfen, nicht in Endlosschleife |
+| `-Uninstall` | - | Beende laufende Watchdog-Instanz und entferne Startup-Eintrag |
+
+### Struktur
+
+```
+watchdog-llm-servers.ps1
+├── Parameter / Konfiguration
+├── Funktion: Get-HealthStatus(port) → $true/$false
+├── Funktion: Test-ServerAlive(port, name) → $true/$false
+│   ├── GET /health auf localhost:$port
+│   ├── Timeout 5 Sekunden
+│   └── Antwort: status == "ok" + Prozess existiert (PID-Check)
+├── Funktion: Invoke-ServerRestart(port, name)
+│   ├── Port räumen (Get-NetTCPConnection → taskkill)
+│   ├── Startskript per Start-Process aufrufen
+│   ├── Warten auf Health (max 240s, analog zu start-*-ps1)
+│   └── Log-Eintrag
+├── Funktion: Write-WatchdogLog(message, level)
+│   └── Schreibt ins Log-Verzeichnis des Hosts
+├── Hauptschleife (wenn nicht -NoLoop):
+│   ├── Servers = @(
+│   │   @{ Name="Gemma";    Port=8091; Script="start-gemma-server.ps1";     Args="-Ctx 262144 -Slots 1 -KvType q8_0 -NoWait" },
+│   │   @{ Name="bge-m3";   Port=8095; Script="start-embed-server.ps1";    Args="-NoWait" },
+│   │   @{ Name="Reranker"; Port=8096; Script="start-rerank-server.ps1";   Args="-NoWait" }
+│   │ )
+│   ├── foreach: health check → restart if dead → log
+│   ├── summary (wie viele laufen / tot)
+│   ├── if ALLE tot: exit 1 (damit schtasks-exit auffällt)
+│   └── Start-Sleep -Seconds $PollSeconds
+└── Watchdog-PID-Datei für -Uninstall
+```
+
+### Server-Definitionen
+
+Die Servers-Liste ist das SSOT für "welche Server gehören zum Stack".
+Das Watchdog-Skript definiert sie als Hashtable-Array, sodass sie in
+Zukunft um weitere Server (z.B. gpt-oss :8097) erweitert werden kann.
+
+**Gemma-Start mit Profil:** Der Watchdog startet Gemma mit denselben
+Parametern wie `install-startup-autostart.ps1`: `-Ctx 262144 -Slots 1
+-KvType q8_0 -NoWait`. Die Parameter sind an EINER Stelle (der
+Watchdog-Server-Definition) hinterlegt, nicht doppelt — im Gegensatz zur
+früheren Duplikation zwischen `register-scheduled-tasks.ps1` und den
+Startskripten (T002276).
+
+**Embed- und Rerank-Start ohne Parameter:** `start-embed-server.ps1`
+und `start-rerank-server.ps1` haben sinnvolle Defaults (`-b/-ub 8192`,
+`-ngl 0`), die über Umgebungsvariablen überschreibbar sind. Der Watchdog
+startet sie ohne zusätzliche Argumente.
+
+### Health-Prüfung
+
+Der Watchdog prüft zwei Bedingungen, bevor er einen Server als "tot" wertet:
+
+1. **HTTP-Health:** `GET /health` auf `localhost:$port` mit 5s Timeout
+   — Antwort muss `status == "ok"` enthalten
+2. **Prozess-Existenz:** Der zum Server gehörende Prozess (llama-server.exe)
+   muss noch laufen, und zwar mit dem korrekten Port in der
+   `Get-NetTCPConnection`-Ausgabe
+
+Falls Health ok ist aber kein Prozess gefunden wird → Warnung loggen,
+kein Restart (der Server könnte in einer Race-Condition gerade neu starten).
+Falls Health fehlschlägt → sofort Restart.
+
+### Logging
+
+Der Watchdog schreibt in `$LlamaDir` (Verzeichnis von llama-server.exe) 
+bzw. in einen konfigurierbaren Pfad:
+
+```
+watchdog-llm-servers.log
+```
+
+Format: `[2026-07-27 14:00:00] LEVEL ServerName: Meldung`
+- LEVEL: INFO, WARN, ERROR, RESTART
+- Bei Neustart: vorherige PID, Grund, neue PID
+- Bei erstmaligem Start: "initial health check passed"
+
+### Pid-Datei
+
+```
+$logDir/watchdog.pid
+```
+
+Damit `-Uninstall` die laufende Watchdog-Instanz finden und beenden kann.
+
+## 2. Integration in `install-startup-autostart.ps1`
+
+Die `llm-stack-autostart.cmd` startet nach den Servern den Watchdog im
+Hintergrund:
+
+```cmd
+rem Nach den Servern: Watchdog starten
+start /B powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "\\wsl$\k3d-dev\home\patrick\Bachelorprojekt\scripts\llm\watchdog-llm-servers.ps1" -PollSeconds 60
+```
+
+Ein Modul `-Watchdog` wird dem Skript hinzugefügt:
+
+| Switch | Effekt |
+|--------|--------|
+| `-Watchdog` | Nach Server-Start auch Watchdog im Hintergrund starten |
+| `-WatchdogOnly` | Nur Watchdog starten, keine Server |
+
+## 3. BATS-Guards (tests/spec/llm-pipeline.bats)
+
+- `watchdog-llm-servers.ps1` existiert
+- Health-Prüfung verwendet `localhost:PORT/health`
+- Jeder Server-Eintrag hat Name, Port, Script und Args
+- `install-startup-autostart.ps1` referenziert das Watchdog-Skript
+- Kein `Start-Job` im Watchdog (muss `Start-Process` verwenden, T002276-Lehre)
+
+## 4. Offene Punkte
+
+- **Intune-Freigabe:** Der Watchdog läuft erstmal nur via Startup-Ordner.
+  Sollte eine Intune-Freigabe für den \Llama\Watchdog-Task erfolgen, kann 
+  der Watchdog als systemweiter Scheduled Task registriert werden und
+  unabhängig von Benutzer-Anmeldung laufen.
+- **Remotefähigkeit:** Der Watchdog läuft auf dem Windows-Host. Ein externes
+  Monitoring (z.B. von WSL/fleet aus) per `curl localhost:PORT/health` ist
+  als Ergänzung denkbar, aber nicht Teil dieses Tickets.
+- **Log-Rotation:** Das Log läuft unbegrenzt — bei Bedarf PowerShell-Json-
+  Rotation nachrüsten.

--- a/openspec/changes/fix-llm-server-watchdog/proposal.md
+++ b/openspec/changes/fix-llm-server-watchdog/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: LLM-Server Watchdog
+
+## Context
+
+Der GPU-Host (Korczewski WSL) betreibt drei llama.cpp-Server als Windows-Prozesse:
+
+| Server | Modell | Port |
+|--------|--------|------|
+| Gemma 4 12B (Chat) | gemma-4-12B-it-qat-UD-Q4_K_XL | 8091 |
+| bge-m3 (Embedding) | bge-m3-Q8_0 | 8095 |
+| bge-reranker-v2-m3 (Rerank) | bge-reranker-v2-m3-Q8_0 | 8096 |
+
+**Problem (beobachtet 2026-07-27):** Gemma (:8091) und Reranker (:8096) fielen
+um 13:55 bzw. 13:45 aus und blieben **über drei Stunden tot**, ohne dass
+irgendwo etwas rot wurde. Erst eine manuelle Nachfrage deckte es auf.
+
+**Ursache:** `Get-ScheduledTask -TaskPath '\Llama\*'` liefert auf dem GPU-Host
+eine leere Menge. Die in `scripts/llm/register-scheduled-tasks.ps1`
+vorgesehenen Windows Scheduled Tasks sind nicht (mehr) registriert. Es
+existiert **kein Watchdog**, der einen weggefallenen llama.cpp-Server neu
+startet — unabhängig davon, ob der Ausfall ein Crash, ein GPU-Reset oder ein
+versehentlicher Hard-Kill war.
+
+**Vorgeschichte (T002276):** Der Weg über Windows Scheduled Tasks ist auf
+diesem Host policy-beschränkt (MDM/Intune-verwaltet, AzureAD-joined). Die
+Tasks werden nach erfolgreicher Erstellung still entfernt. Als Workaround
+wurde `install-startup-autostart.ps1` eingeführt, der die Server über den
+Startup-Ordner startet. Dieser Workaround läuft **nur bei Anmeldung** und
+hat keinerlei Überwachung.
+
+## Ansatz
+
+Wir erstellen ein Watchdog-PowerShell-Skript `watchdog-llm-servers.ps1`, das:
+
+1. **Regelmäßig die Health-Endpoints** aller drei Server abfragt
+   (`GET /health` auf :8091, :8095, :8096)
+2. **Tote Server automatisch neu startet** mit den bestehenden Startskripten
+   (`start-*-server.ps1`)
+3. **Restarts protokolliert** (mit Zeitstempel, PID, Exit-Code des alten
+   Prozesses)
+4. **Einen Exit-Code != 0 liefert**, wenn überhaupt kein Server mehr läuft
+   (damit externe Überwachung anschlagen kann)
+
+Der Watchdog wird über den Windows Startup-Ordner gestartet (ähnlich wie der
+bestehende `llm-stack-autostart.cmd`) und läuft als Endlosschleife mit
+konfigurierbarem Poll-Interval (Default 60 s). Er wird als
+**eigenständiger Scheduled Task** nur dann registriert, wenn die Intune-Policy
+dies erlaubt (separater Schritt, kein Blocking des Kern-Fixes).
+
+Als Fallback wird der Watchdog in `install-startup-autostart.ps1` integriert:
+nach dem Start der Server wird eine Watchdog-Instanz im Hintergrund gestartet.
+
+## Abgrenzung
+
+- **kein Eingriff in die Startskripte** — der Watchdog ruft sie nur auf
+- **kein Eingriff in register-scheduled-tasks.ps1** — separate Baustelle
+- **kein Eingriff in den llm-proxy** — dessen Health-Berichterstattung ist
+  ein separates Problem (im Ticket erwähnt)
+- **kein Systemdienst** — bleibt im Benutzerkontext, analog zum bestehenden
+  Startup-Workaround

--- a/openspec/changes/fix-llm-server-watchdog/specs/llm-pipeline.md
+++ b/openspec/changes/fix-llm-server-watchdog/specs/llm-pipeline.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Watchdog hält die LLM-Server des GPU-Hosts am Leben
+
+The LLM stack SHALL be supervised by a watchdog process that detects a dead server
+and restarts it, rather than relying on the login-time autostart alone. The autostart
+shim starts each server exactly once; a server that dies afterwards — VRAM exhaustion,
+driver reset, a crash while loading an oversized prompt — stays dead until a human
+notices. No Scheduled Task under `\Llama\` exists to observe this: the host is
+AzureAD-joined and MDM-managed, and tasks created there are silently removed.
+
+The watchdog SHALL treat a server as dead only when its HTTP health endpoint fails.
+A healthy `/health` response without a matching TCP listener SHALL produce a warning
+and no restart, because that combination describes a server still in its start-up
+window — restarting it would create the very outage the watchdog exists to prevent.
+
+The watchdog SHALL start servers with `Start-Process`, never `Start-Job`. A job is
+bound to the PowerShell session that created it and dies with it.
+
+The watchdog SHALL exit non-zero only when every supervised server is dead. A single
+failed server is the ordinary case the watchdog has just repaired and MUST NOT be
+signalled as a stack-wide failure.
+
+#### Scenario: Ein gestorbener Server wird neu gestartet
+
+- **GIVEN** der Watchdog überwacht bge-m3 (`:8095`), den Reranker (`:8096`) und Gemma (`:8091`)
+- **WHEN** einer der Server nicht mehr auf `GET localhost:<port>/health` mit `status == "ok"` antwortet
+- **THEN** räumt der Watchdog den Port, ruft das zugehörige Startskript per `Start-Process`
+  auf, wartet bis zu 240 Sekunden auf Health und protokolliert alte PID, Grund und neue PID
+
+#### Scenario: Gesunder Server ohne Listener-Eintrag wird nicht angetastet
+
+- **GIVEN** ein Server antwortet auf `/health` mit `status == "ok"`
+- **WHEN** `Get-NetTCPConnection` für seinen Port noch keinen lauschenden Prozess führt
+- **THEN** schreibt der Watchdog eine WARN-Zeile und startet den Server **nicht** neu
+
+#### Scenario: Log-Ausgabe verlässt den Datenpfad der Funktionen
+
+- **GIVEN** die Log-Funktion des Watchdogs schreibt Zeilen, während sie aus einer
+  Funktion aufgerufen wird, die einen Zählwert zurückgibt
+- **WHEN** der Aufrufer diesen Rückgabewert mit der Anzahl der Server vergleicht
+- **THEN** enthält der Rückgabewert ausschließlich den Zählwert und keine Log-Zeilen —
+  `Write-Output` würde sie in den Success-Stream legen und den Vergleich auf ein Array
+  ausweiten, das als Filter statt als Gleichheit ausgewertet wird
+
+#### Scenario: Der Autostart-Shim kann den Watchdog mitstarten
+
+- **GIVEN** `install-startup-autostart.ps1` wird mit `-Watchdog` aufgerufen
+- **WHEN** der Shim im Startup-Ordner geschrieben wird
+- **THEN** enthält er nach den Server-Zeilen eine `start /B`-Zeile für
+  `watchdog-llm-servers.ps1`, damit die Endlosschleife den Shim nicht blockiert
+- **AND** entfernt `-Uninstall` neben dem Shim auch eine noch laufende Watchdog-Instanz

--- a/openspec/changes/fix-llm-server-watchdog/tasks.md
+++ b/openspec/changes/fix-llm-server-watchdog/tasks.md
@@ -6,32 +6,32 @@
 **Aufwand:** 1h (Entwurf) + 0.5h (Review)
 
 Implementiere das Watchdog-Skript gemäß Design:
-- [ ] Parameter: `-PollSeconds` (Default 60), `-NoLoop`, `-Uninstall`
-- [ ] Server-Definitionen: Gemma (:8091), bge-m3 (:8095), Reranker (:8096)
+- [x] Parameter: `-PollSeconds` (Default 60), `-NoLoop`, `-Uninstall`
+- [x] Server-Definitionen: Gemma (:8091), bge-m3 (:8095), Reranker (:8096)
   - Jeder Eintrag: Name, Port, Script-Pfad, Argumente
-- [ ] `Get-HealthStatus(port)`: `GET /health` mit 5s Timeout, erwartet `status == "ok"`
-- [ ] `Test-ServerAlive(port, name)`: Health-Check + Prozess-Existenz via `Get-NetTCPConnection`
-- [ ] `Invoke-ServerRestart(port, name)`:
+- [x] `Get-HealthStatus(port)`: `GET /health` mit 5s Timeout, erwartet `status == "ok"`
+- [x] `Test-ServerAlive(port, name)`: Health-Check + Prozess-Existenz via `Get-NetTCPConnection`
+- [x] `Invoke-ServerRestart(port, name)`:
   - Port räumen (`Get-NetTCPConnection` → `taskkill`)
   - `Start-Process` mit dem Startskript + `-NoWait`
   - Warten auf Health (max 240s, analog zu den Startskripten)
   - Log-Eintrag mit alter PID, Grund, neuer PID
-- [ ] Hauptschleife: alle `$PollSeconds` Sekunden prüfen, tote Server restart
-- [ ] Exit-Code: `1` wenn ALLE Server tot sind
-- [ ] Logging nach `$LlamaDir\watchdog-llm-servers.log`
-- [ ] Pid-Datei nach `$LlamaDir\watchdog.pid`
-- [ ] `-Uninstall`: Watchdog-Prozess killen, Pid-Datei löschen
+- [x] Hauptschleife: alle `$PollSeconds` Sekunden prüfen, tote Server restart
+- [x] Exit-Code: `1` wenn ALLE Server tot sind
+- [x] Logging nach `$LlamaDir\watchdog-llm-servers.log`
+- [x] Pid-Datei nach `$LlamaDir\watchdog.pid`
+- [x] `-Uninstall`: Watchdog-Prozess killen, Pid-Datei löschen
 
 ## T2 — In `install-startup-autostart.ps1` integrieren
 
 **Datei:** `scripts/llm/install-startup-autostart.ps1`
 **Aufwand:** 0.5h
 
-- [ ] Neuen Parameter `-Watchdog` (Switch)
-- [ ] Mit `-Watchdog`: nach Server-Start den Watchdog im Hintergrund starten
-- [ ] Neuen Parameter `-WatchdogOnly`: nur Watchdog starten, keine Server
-- [ ] Shim (`llm-stack-autostart.cmd`) um Watchdog-Zeile ergänzen
-- [ ] Watchdog wird MIT `-PollSeconds 60` und `-NoLoop` NICHT gestartet
+- [x] Neuen Parameter `-Watchdog` (Switch)
+- [x] Mit `-Watchdog`: nach Server-Start den Watchdog im Hintergrund starten
+- [x] Neuen Parameter `-WatchdogOnly`: nur Watchdog starten, keine Server
+- [x] Shim (`llm-stack-autostart.cmd`) um Watchdog-Zeile ergänzen
+- [x] Watchdog wird MIT `-PollSeconds 60` und `-NoLoop` NICHT gestartet
   (es ist eine Endlosschleife — in der .cmd dann `start /B`)
 
 ## T3 — BATS-Guards
@@ -39,15 +39,25 @@ Implementiere das Watchdog-Skript gemäß Design:
 **Datei:** `tests/spec/llm-pipeline.bats`
 **Aufwand:** 0.5h
 
-- [ ] `watchdog-llm-servers.ps1` existiert
-- [ ] Jeder Watchdog-Server-Eintrag hat Name, Port, Script, Args
-- [ ] Health-Prüfung nutzt `localhost:PORT/health`
-- [ ] `install-startup-autostart.ps1` referenziert das Watchdog-Skript
-- [ ] Kein `Start-Job` im Watchdog (T002276-Klasse: `Start-Process` verwenden)
+- [x] `watchdog-llm-servers.ps1` existiert
+- [x] Jeder Watchdog-Server-Eintrag hat Name, Port, Script, Args
+- [x] Health-Prüfung nutzt `localhost:PORT/health`
+- [x] `install-startup-autostart.ps1` referenziert das Watchdog-Skript
+- [x] Kein `Start-Job` im Watchdog (T002276-Klasse: `Start-Process` verwenden)
 
 ## T4 — Deployment auf dem GPU-Host
 
 **Aufwand:** 0.5h
+
+> **Nach dem Merge auszufuehren [T002335].** Der Shim schreibt den `-RepoRoot`-Pfad
+> fest: aus dem Worktree zeigte er nach dem Cleanup ins Leere, mit dem Default-Pfad
+> existiert das Watchdog-Skript erst nach dem Merge. Ein Probelauf wuerde ausserdem
+> den bestehenden Autostart-Shim ueberschreiben. Der Kill-Test trifft den live
+> laufenden Gemma-Server (:8091), auf dem die Factory arbeitet.
+>
+> Bereits verifiziert: PowerShell-Syntax beider Skripte (`Parser::ParseFile`, 0 Fehler)
+> und ein `-NoLoop`-Lauf auf dem Host -> `summary: 3/3 Server healthy`,
+> `initial health check passed`, Exit 0.
 
 - [ ] `install-startup-autostart.ps1 -Watchdog` auf dem Host ausführen
 - [ ] Verifikation: Watchdog-Log zeigt "initial health check passed"

--- a/openspec/changes/fix-llm-server-watchdog/tasks.md
+++ b/openspec/changes/fix-llm-server-watchdog/tasks.md
@@ -1,0 +1,57 @@
+# Tasks: LLM-Server Watchdog
+
+## T1 — Watchdog-Skript erstellen
+
+**Datei:** `scripts/llm/watchdog-llm-servers.ps1`
+**Aufwand:** 1h (Entwurf) + 0.5h (Review)
+
+Implementiere das Watchdog-Skript gemäß Design:
+- [ ] Parameter: `-PollSeconds` (Default 60), `-NoLoop`, `-Uninstall`
+- [ ] Server-Definitionen: Gemma (:8091), bge-m3 (:8095), Reranker (:8096)
+  - Jeder Eintrag: Name, Port, Script-Pfad, Argumente
+- [ ] `Get-HealthStatus(port)`: `GET /health` mit 5s Timeout, erwartet `status == "ok"`
+- [ ] `Test-ServerAlive(port, name)`: Health-Check + Prozess-Existenz via `Get-NetTCPConnection`
+- [ ] `Invoke-ServerRestart(port, name)`:
+  - Port räumen (`Get-NetTCPConnection` → `taskkill`)
+  - `Start-Process` mit dem Startskript + `-NoWait`
+  - Warten auf Health (max 240s, analog zu den Startskripten)
+  - Log-Eintrag mit alter PID, Grund, neuer PID
+- [ ] Hauptschleife: alle `$PollSeconds` Sekunden prüfen, tote Server restart
+- [ ] Exit-Code: `1` wenn ALLE Server tot sind
+- [ ] Logging nach `$LlamaDir\watchdog-llm-servers.log`
+- [ ] Pid-Datei nach `$LlamaDir\watchdog.pid`
+- [ ] `-Uninstall`: Watchdog-Prozess killen, Pid-Datei löschen
+
+## T2 — In `install-startup-autostart.ps1` integrieren
+
+**Datei:** `scripts/llm/install-startup-autostart.ps1`
+**Aufwand:** 0.5h
+
+- [ ] Neuen Parameter `-Watchdog` (Switch)
+- [ ] Mit `-Watchdog`: nach Server-Start den Watchdog im Hintergrund starten
+- [ ] Neuen Parameter `-WatchdogOnly`: nur Watchdog starten, keine Server
+- [ ] Shim (`llm-stack-autostart.cmd`) um Watchdog-Zeile ergänzen
+- [ ] Watchdog wird MIT `-PollSeconds 60` und `-NoLoop` NICHT gestartet
+  (es ist eine Endlosschleife — in der .cmd dann `start /B`)
+
+## T3 — BATS-Guards
+
+**Datei:** `tests/spec/llm-pipeline.bats`
+**Aufwand:** 0.5h
+
+- [ ] `watchdog-llm-servers.ps1` existiert
+- [ ] Jeder Watchdog-Server-Eintrag hat Name, Port, Script, Args
+- [ ] Health-Prüfung nutzt `localhost:PORT/health`
+- [ ] `install-startup-autostart.ps1` referenziert das Watchdog-Skript
+- [ ] Kein `Start-Job` im Watchdog (T002276-Klasse: `Start-Process` verwenden)
+
+## T4 — Deployment auf dem GPU-Host
+
+**Aufwand:** 0.5h
+
+- [ ] `install-startup-autostart.ps1 -Watchdog` auf dem Host ausführen
+- [ ] Verifikation: Watchdog-Log zeigt "initial health check passed"
+- [ ] Verifikation: absichtliches Killen eines Servers → Watchdog restartet ihn
+  - `taskkill /F /PID <gemma-pid>` warten 90s, prüfen ob Server zurück ist
+- [ ] Verifikation: `install-startup-autostart.ps1 -Uninstall` + `-Watchdog`
+  entfernt beide Einträge sauber

--- a/scripts/llm/install-startup-autostart.ps1
+++ b/scripts/llm/install-startup-autostart.ps1
@@ -46,6 +46,12 @@
   gleichzeitig passen nicht auf die Karte.
 .PARAMETER Uninstall
   Entfernt den Startup-Eintrag wieder.
+.PARAMETER Watchdog
+  Haengt nach den Server-Zeilen den Watchdog an den Shim (T002335). Der Autostart
+  startet die Server nur EINMAL; stirbt danach einer, bleibt er ohne Watchdog tot.
+.PARAMETER WatchdogOnly
+  Schreibt einen Shim, der ausschliesslich den Watchdog startet. Sinnvoll, wenn die
+  Server anders hochkommen (manuell, anderes Profil) und nur die Aufsicht fehlt.
 .PARAMETER RepoRoot
   Wurzel des Repos aus Windows-Sicht. Default ist der UNC-Pfad in WSL.
 .EXAMPLE
@@ -56,6 +62,8 @@
 
 param(
   [switch]$Uninstall,
+  [switch]$Watchdog,
+  [switch]$WatchdogOnly,
   [string]$RepoRoot = '\\wsl$\k3d-dev\home\patrick\Bachelorprojekt'
 )
 
@@ -68,6 +76,13 @@ if ($Uninstall) {
     Write-Output "Entfernt: $shim"
   } else {
     Write-Output "Nichts zu entfernen - $shim existiert nicht."
+  }
+  # T002335: Den Shim zu loeschen beendet keinen bereits laufenden Watchdog - er
+  # haengt an keinem Startup-Eintrag mehr, laeuft aber weiter und wuerde Server
+  # neu starten, die man gerade abschalten wollte.
+  $watchdogScript = Join-Path (Join-Path $RepoRoot 'scripts\llm') 'watchdog-llm-servers.ps1'
+  if (Test-Path $watchdogScript) {
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $watchdogScript -Uninstall
   }
   exit 0
 }
@@ -111,18 +126,34 @@ $lines = @(
   'rem Nicht von Hand editieren - Aenderungen gehen beim naechsten Lauf verloren.',
   'rem Entfernen: install-startup-autostart.ps1 -Uninstall'
 )
-foreach ($s in $startups) {
-  # T002264 als Mahnung: dort wurde $Task.Expr statt $Task.Exe gelesen, ein Key
-  # dieses Namens existierte nicht, und PowerShell lieferte still $null - alle
-  # Tasks bekamen ein leeres Executable. Deshalb hier fail-loud statt Vertrauen.
-  if (-not $s.ContainsKey('Script') -or -not $s.ContainsKey('Arguments')) {
-    Write-Error "Startup-Eintrag ohne Script/Arguments-Key: $($s | Out-String)"
+if (-not $WatchdogOnly) {
+  foreach ($s in $startups) {
+    # T002264 als Mahnung: dort wurde $Task.Expr statt $Task.Exe gelesen, ein Key
+    # dieses Namens existierte nicht, und PowerShell lieferte still $null - alle
+    # Tasks bekamen ein leeres Executable. Deshalb hier fail-loud statt Vertrauen.
+    if (-not $s.ContainsKey('Script') -or -not $s.ContainsKey('Arguments')) {
+      Write-Error "Startup-Eintrag ohne Script/Arguments-Key: $($s | Out-String)"
+      exit 1
+    }
+    $full = Join-Path $llmDir $s.Script
+    $line = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}"' -f $full
+    if ($s.Arguments -ne '') { $line += ' ' + $s.Arguments }
+    $lines += $line
+  }
+}
+
+# T002335: Der Watchdog ist eine Endlosschleife. Ohne 'start /B' wuerde der Shim
+# an dieser Zeile stehen bleiben und - im WatchdogOnly-Fall irrelevant, sonst
+# fatal - nachfolgende Zeilen nie erreichen. Deshalb NICHT -NoLoop uebergeben:
+# genau die Endlosschleife ist der Zweck.
+if ($Watchdog -or $WatchdogOnly) {
+  $watchdogScript = Join-Path $llmDir 'watchdog-llm-servers.ps1'
+  if (-not (Test-Path $watchdogScript)) {
+    Write-Error "Watchdog-Skript nicht gefunden: $watchdogScript"
     exit 1
   }
-  $full = Join-Path $llmDir $s.Script
-  $line = 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}"' -f $full
-  if ($s.Arguments -ne '') { $line += ' ' + $s.Arguments }
-  $lines += $line
+  $lines += 'rem Watchdog [T002335] - startet tote Server neu. start /B, weil Endlosschleife.'
+  $lines += ('start /B powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}" -PollSeconds 60' -f $watchdogScript)
 }
 
 Set-Content -Path $shim -Value $lines -Encoding ascii

--- a/scripts/llm/watchdog-llm-servers.ps1
+++ b/scripts/llm/watchdog-llm-servers.ps1
@@ -1,0 +1,229 @@
+<#
+.SYNOPSIS
+  Haelt die drei LLM-Server des Stacks am Leben und startet tote neu.
+.DESCRIPTION
+  Der Autostart (install-startup-autostart.ps1) startet die Server EINMAL bei der
+  Anmeldung. Stirbt danach einer - OOM auf der Karte, Treiber-Reset, Absturz beim
+  Laden eines zu grossen Prompts - bleibt er tot, bis jemand es bemerkt. Genau das
+  war T002335: unter \Llama\ war kein Scheduled Task registriert, und es gab keine
+  zweite Instanz, die den Ausfall haette sehen koennen.
+
+  WARUM KEIN SCHEDULED TASK (T002276, weiterhin gueltig): Der Host ist
+  AzureAD-gejoined und MDM-verwaltet. Tasks unter \Llama\ wurden als "ERFOLGREICH
+  erstellt" gemeldet und waren Minuten spaeter verschwunden; nicht-elevated
+  scheitert die Erstellung direkt. Der Watchdog laeuft deshalb als gewoehnlicher
+  Hintergrundprozess aus dem Startup-Ordner, nicht als Task.
+
+  WARUM Start-Process UND NICHT Start-Job: Ein Job haengt an der PowerShell-
+  Sitzung, die ihn erzeugt hat. Endet die Sitzung, stirbt der Server mit - das war
+  der dritte Befund aus T002276. Der Watchdog wiederholt den Fehler nicht.
+
+  ZWEI BEDINGUNGEN, BEVOR EIN SERVER ALS TOT GILT: HTTP-Health UND ein lauschender
+  Prozess auf dem Port. Antwortet /health nicht, wird neu gestartet. Antwortet
+  /health, ohne dass ein Listener gefunden wird, wird nur gewarnt - das ist das
+  Zeitfenster, in dem ein gerade gestarteter Server schon antwortet, die
+  Verbindungstabelle den Listener aber noch nicht fuehrt. Ein Restart waere dort
+  ein Eigentor: er wuerde den gesunden Server abschiessen.
+.PARAMETER PollSeconds
+  Abfrageintervall der Hauptschleife. Default 60.
+.PARAMETER NoLoop
+  Nur einen Durchlauf pruefen und beenden - fuer manuelle Kontrolle und Tests.
+.PARAMETER Uninstall
+  Beendet eine laufende Watchdog-Instanz (ueber die Pid-Datei) und raeumt sie weg.
+.PARAMETER LlamaDir
+  Verzeichnis fuer Log- und Pid-Datei. Default ist das Gemma-Buildverzeichnis.
+.PARAMETER RepoRoot
+  Wurzel des Repos aus Windows-Sicht (UNC-Pfad nach WSL).
+.EXAMPLE
+  .\scripts\llm\watchdog-llm-servers.ps1 -NoLoop
+.EXAMPLE
+  .\scripts\llm\watchdog-llm-servers.ps1 -Uninstall
+#>
+
+param(
+  [int]$PollSeconds = 60,
+  [switch]$NoLoop,
+  [switch]$Uninstall,
+  [string]$LlamaDir = "C:\Users\PatrickKorczewski\llama-bonsai-cuda13.3",
+  [string]$RepoRoot = '\\wsl$\k3d-dev\home\patrick\Bachelorprojekt'
+)
+
+$ErrorActionPreference = 'Continue'
+
+$LogFile = Join-Path $LlamaDir 'watchdog-llm-servers.log'
+$PidFile = Join-Path $LlamaDir 'watchdog.pid'
+$LlmDir  = Join-Path $RepoRoot 'scripts\llm'
+
+# SSOT dafuer, welche Server zum Stack gehoeren. Die Gemma-Argumente stehen NUR
+# hier und in install-startup-autostart.ps1 - nicht ein drittes Mal im
+# Startskript-Default. T002276 entstand aus genau so einer Duplikation.
+# Warum 262144/q8_0/1 Slot: gemessen unter T002297 - 262144 ist n_ctx_train,
+# q8_0 ist schneller als q4_0 (146,9 vs 138,0 t/s) und ein Slot maximiert den
+# Praefix-Reuse. -NoWait, weil der Watchdog selbst auf Health wartet.
+# gpt-oss-20b (:8097) fehlt bewusst: zwei Chat-Server passen nicht auf die Karte.
+$Servers = @(
+  @{ Name = 'bge-m3';   Port = 8095; Script = 'start-embed-server.ps1';  Args = '-NoWait' },
+  @{ Name = 'Reranker'; Port = 8096; Script = 'start-rerank-server.ps1'; Args = '-NoWait' },
+  @{ Name = 'Gemma';    Port = 8091; Script = 'start-gemma-server.ps1';  Args = '-Ctx 262144 -Slots 1 -KvType q8_0 -NoWait' }
+)
+
+# Write-Host, NICHT Write-Output: Write-Output schreibt in den Success-Stream und
+# waere damit Teil des Rueckgabewerts jeder aufrufenden Funktion. Gemessen am
+# 2026-07-28: Invoke-WatchdogCycle lieferte statt der Zahl ein Array aus allen
+# Log-Zeilen plus der Zahl. Der Vergleich '$alive -eq $Servers.Count' wirkt auf
+# Arrays als FILTER und war zufaellig wahr - bei einem echten Ausfall haette er
+# still falsch entschieden. Log gehoert nie in den Datenpfad.
+function Write-WatchdogLog {
+  param([string]$Message, [string]$Level = 'INFO', [string]$Server = 'watchdog')
+  $line = '[{0}] {1} {2}: {3}' -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Level, $Server, $Message
+  Write-Host $line
+  try { Add-Content -Path $LogFile -Value $line -Encoding utf8 -ErrorAction Stop }
+  catch { Write-Host "[watchdog] Log nicht schreibbar ($LogFile): $($_.Exception.Message)" }
+}
+
+function Get-HealthStatus {
+  param([int]$Port)
+  try {
+    $r = Invoke-RestMethod -Uri "http://localhost:$Port/health" -TimeoutSec 5 -ErrorAction Stop
+    return ($r.status -eq 'ok')
+  } catch {
+    return $false
+  }
+}
+
+function Get-ListenerPid {
+  param([int]$Port)
+  try {
+    $c = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop | Select-Object -First 1
+    if ($c) { return [int]$c.OwningProcess }
+  } catch { }
+  return 0
+}
+
+function Test-ServerAlive {
+  param([int]$Port, [string]$Name)
+  $healthy = Get-HealthStatus -Port $Port
+  $listener = Get-ListenerPid -Port $Port
+  if ($healthy -and $listener -eq 0) {
+    # Kein Restart: der Server antwortet. Fehlt nur der Listener-Eintrag, ist das
+    # das Startfenster - ihn hier abzuschiessen waere schlimmer als das Symptom.
+    Write-WatchdogLog -Server $Name -Level 'WARN' `
+      -Message "health ok, aber kein Listener auf :$Port gefunden - kein Restart (moegliche Startphase)"
+    return $true
+  }
+  return $healthy
+}
+
+function Invoke-ServerRestart {
+  param([int]$Port, [string]$Name, [string]$Script, [string]$ScriptArgs, [string]$Reason)
+
+  $oldPid = Get-ListenerPid -Port $Port
+  if ($oldPid -gt 0) {
+    Write-WatchdogLog -Server $Name -Level 'RESTART' -Message "raeume Port :$Port (PID $oldPid)"
+    & taskkill.exe /F /PID $oldPid 2>&1 | Out-Null
+    Start-Sleep -Seconds 2
+  } else {
+    Write-WatchdogLog -Server $Name -Level 'RESTART' -Message "kein Prozess auf :$Port - Kaltstart"
+  }
+
+  $scriptPath = Join-Path $LlmDir $Script
+  if (-not (Test-Path $scriptPath)) {
+    Write-WatchdogLog -Server $Name -Level 'ERROR' -Message "Startskript nicht erreichbar: $scriptPath"
+    return $false
+  }
+
+  $psArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-WindowStyle', 'Hidden', '-File', $scriptPath)
+  if ($ScriptArgs -ne '') { $psArgs += $ScriptArgs.Split(' ') }
+  # Start-Process, nicht Start-Job (T002276): der Server muss die Watchdog-Sitzung
+  # ueberleben. Das Startskript bekommt -NoWait, den Health-Poll macht der Watchdog.
+  Start-Process -FilePath 'powershell.exe' -ArgumentList $psArgs -WindowStyle Hidden | Out-Null
+
+  # 240s analog zu den Startskripten - Gemma laedt bei 262144 Kontext spuerbar lange.
+  $deadline = (Get-Date).AddSeconds(240)
+  while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 5
+    if (Get-HealthStatus -Port $Port) {
+      $newPid = Get-ListenerPid -Port $Port
+      Write-WatchdogLog -Server $Name -Level 'RESTART' `
+        -Message "neu gestartet - alte PID $oldPid, Grund: $Reason, neue PID $newPid"
+      return $true
+    }
+  }
+  Write-WatchdogLog -Server $Name -Level 'ERROR' `
+    -Message "nach 240s nicht healthy (alte PID $oldPid, Grund: $Reason)"
+  return $false
+}
+
+function Invoke-WatchdogCycle {
+  $alive = 0
+  foreach ($s in $Servers) {
+    # T002264 als Mahnung: dort wurde ein nicht existenter Hashtable-Key gelesen,
+    # PowerShell lieferte still $null und alle Eintraege liefen leer los.
+    foreach ($key in @('Name', 'Port', 'Script', 'Args')) {
+      if (-not $s.ContainsKey($key)) {
+        Write-WatchdogLog -Level 'ERROR' -Message "Server-Eintrag ohne '$key'-Key: $($s | Out-String)"
+        exit 1
+      }
+    }
+    if (Test-ServerAlive -Port $s.Port -Name $s.Name) {
+      $alive++
+    } else {
+      if (Invoke-ServerRestart -Port $s.Port -Name $s.Name -Script $s.Script `
+            -ScriptArgs $s.Args -Reason 'health check failed') { $alive++ }
+    }
+  }
+  $total = $Servers.Count
+  Write-WatchdogLog -Message "summary: $alive/$total Server healthy"
+  return $alive
+}
+
+# ---- Uninstall ---------------------------------------------------------------
+if ($Uninstall) {
+  if (Test-Path $PidFile) {
+    $wpid = (Get-Content $PidFile -ErrorAction SilentlyContinue | Select-Object -First 1)
+    if ($wpid -match '^\d+$') {
+      $proc = Get-Process -Id ([int]$wpid) -ErrorAction SilentlyContinue
+      if ($proc) {
+        Stop-Process -Id ([int]$wpid) -Force -ErrorAction SilentlyContinue
+        Write-WatchdogLog -Message "Watchdog-Instanz PID $wpid beendet"
+      } else {
+        Write-WatchdogLog -Message "Pid-Datei zeigte auf PID $wpid - laeuft nicht mehr"
+      }
+    }
+    Remove-Item $PidFile -Force -ErrorAction SilentlyContinue
+    Write-Output "Entfernt: $PidFile"
+  } else {
+    Write-Output "Nichts zu entfernen - $PidFile existiert nicht."
+  }
+  exit 0
+}
+
+# ---- Lauf --------------------------------------------------------------------
+if (-not (Test-Path $LlamaDir)) {
+  Write-Output "FAILED: LlamaDir nicht erreichbar: $LlamaDir"
+  exit 1
+}
+
+Set-Content -Path $PidFile -Value $PID -Encoding ascii -ErrorAction SilentlyContinue
+
+$alive = Invoke-WatchdogCycle
+if ($alive -eq $Servers.Count) {
+  Write-WatchdogLog -Message 'initial health check passed'
+}
+
+if ($NoLoop) {
+  # Exit 1 nur, wenn ALLE tot sind - ein einzelner Ausfall ist der Normalfall,
+  # den der Watchdog gerade behoben hat, und darf den Aufrufer nicht alarmieren.
+  if ($alive -eq 0) { exit 1 }
+  exit 0
+}
+
+while ($true) {
+  Start-Sleep -Seconds $PollSeconds
+  $alive = Invoke-WatchdogCycle
+  if ($alive -eq 0) {
+    Write-WatchdogLog -Level 'ERROR' -Message 'ALLE Server tot und nicht wiederherstellbar - beende mit Exit 1'
+    Remove-Item $PidFile -Force -ErrorAction SilentlyContinue
+    exit 1
+  }
+}

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -515,3 +515,62 @@ assert_var_not_declared() {
   run bash -c "grep -E 'start-(gptoss|bonsai)' '$REPO/scripts/llm/install-startup-autostart.ps1'"
   [ "$status" -ne 0 ]
 }
+
+# ── [T002335] Watchdog fuer die LLM-Server ────────────────────────────
+#
+# Der Autostart startet die Server EINMAL bei der Anmeldung. Stirbt danach einer,
+# bleibt er tot - unter \Llama\ war kein Scheduled Task registriert, der es haette
+# bemerken koennen. Diese Guards halten fest, was den Watchdog wirksam macht.
+
+@test "T002335: watchdog-llm-servers.ps1 existiert" {
+  [ -f "$REPO/scripts/llm/watchdog-llm-servers.ps1" ]
+}
+
+@test "T002335: jeder Watchdog-Server-Eintrag hat Name, Port, Script und Args" {
+  # Ein fehlender Hashtable-Key liefert in PowerShell still $null (T002264) - der
+  # Eintrag liefe dann mit leerem Skriptpfad los. Deshalb strukturell pruefen.
+  local entries
+  entries=$(grep -cE '@\{ *Name *=.*Port *=.*Script *=.*Args *=' \
+    "$REPO/scripts/llm/watchdog-llm-servers.ps1")
+  [ "$entries" -eq 3 ] || { echo "erwartet 3 vollstaendige Server-Eintraege, gefunden: $entries"; false; }
+}
+
+@test "T002335: der Watchdog prueft localhost:PORT/health" {
+  run grep -qE 'http://localhost:\$Port/health' "$REPO/scripts/llm/watchdog-llm-servers.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002335: install-startup-autostart.ps1 referenziert das Watchdog-Skript" {
+  run grep -q 'watchdog-llm-servers.ps1' "$REPO/scripts/llm/install-startup-autostart.ps1"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002335: der Watchdog nutzt Start-Process, nie Start-Job" {
+  # T002276-Klasse: Start-Job bindet den Server an die erzeugende PowerShell-
+  # Sitzung. Endet sie, stirbt der Server mit - ein Watchdog, der so startet,
+  # produziert genau den Ausfall, den er verhindern soll.
+  # Nur Code pruefen: der <# .. #>-Hilfeblock und die Zeilenkommentare ERKLAEREN,
+  # warum Start-Job falsch ist. Ein ungefiltertes grep bliebe an der Erklaerung
+  # haengen und waere gruen, sobald jemand den Kommentar loescht - also genau
+  # falschherum. awk schneidet den Hilfeblock heraus, grep -v die Kommentarzeilen.
+  local code
+  code="$(awk '/^<#/{s=1} !s{print} /^#>/{s=0}' \
+    "$REPO/scripts/llm/watchdog-llm-servers.ps1" | grep -vE '^[[:space:]]*#')"
+  run bash -c "printf '%s' \"\$1\" | grep -q 'Start-Job'" _ "$code"
+  [ "$status" -ne 0 ] || { echo "Start-Job im Code des Watchdogs gefunden"; false; }
+  run bash -c "printf '%s' \"\$1\" | grep -q 'Start-Process'" _ "$code"
+  [ "$status" -eq 0 ] || { echo "Watchdog startet nicht per Start-Process"; false; }
+}
+
+@test "T002335: Write-WatchdogLog schreibt nicht in den Success-Stream" {
+  # Write-Output waere Teil des Rueckgabewerts jeder aufrufenden Funktion.
+  # Gemessen am 2026-07-28: Invoke-WatchdogCycle lieferte dadurch ein Array aus
+  # Log-Zeilen statt der Anzahl gesunder Server; '$alive -eq $Servers.Count'
+  # wirkt auf Arrays als Filter und war nur zufaellig wahr.
+  local body
+  body="$(awk '/^function Write-WatchdogLog/{s=1} s{print} s&&/^}/{exit}' \
+    "$REPO/scripts/llm/watchdog-llm-servers.ps1")"
+  [ -n "$body" ] || { echo "Write-WatchdogLog nicht gefunden"; false; }
+  run bash -c "printf '%s' \"\$1\" | grep -q 'Write-Output'" _ "$body"
+  [ "$status" -ne 0 ] || { echo "Write-WatchdogLog nutzt Write-Output"; false; }
+}


### PR DESCRIPTION
## Problem

Der Autostart-Shim (`install-startup-autostart.ps1`) startet bge-m3 (`:8095`), den Reranker (`:8096`) und Gemma (`:8091`) genau **einmal** — bei der Anmeldung. Stirbt danach einer (VRAM-Erschöpfung, Treiber-Reset, Absturz beim Laden eines zu großen Prompts), bleibt er tot, bis es jemand bemerkt.

Es gibt keine zweite Instanz, die das sehen könnte: unter `\Llama\` ist kein Scheduled Task registriert. Das ist kein Versehen, sondern die Konsequenz aus T002276 — der Host ist AzureAD-gejoined und MDM-verwaltet, dort angelegte Tasks werden als „erfolgreich erstellt" gemeldet und sind Minuten später verschwunden.

## Lösung

`scripts/llm/watchdog-llm-servers.ps1` — ein Hintergrundprozess aus dem Startup-Ordner (nicht als Task), der die drei Server pollt und tote neu startet.

Drei Entwurfsentscheidungen, die nicht offensichtlich sind:

- **Ein Server gilt erst als tot, wenn `/health` fehlschlägt.** Antwortet `/health` mit `status == "ok"`, ohne dass `Get-NetTCPConnection` einen Listener führt, gibt es nur eine WARN-Zeile und **keinen** Restart. Das ist das Startfenster eines gerade hochfahrenden Servers — ihn dort abzuschießen würde genau den Ausfall erzeugen, den der Watchdog verhindern soll.
- **`Start-Process`, nie `Start-Job`.** Ein Job hängt an der erzeugenden PowerShell-Sitzung und stirbt mit ihr — der dritte Befund aus T002276. Ein BATS-Guard zementiert das.
- **Exit 1 nur, wenn *alle* Server tot sind.** Ein Einzelausfall ist der Normalfall, den der Watchdog gerade repariert hat; ihn zu melden würde das Signal entwerten.

`install-startup-autostart.ps1` bekommt `-Watchdog` (Watchdog nach den Servern anhängen) und `-WatchdogOnly`. Die Watchdog-Zeile läuft mit `start /B`, weil sie eine Endlosschleife ist und den Shim sonst blockieren würde. `-Uninstall` beendet jetzt auch eine laufende Watchdog-Instanz — den Shim allein zu löschen würde sie weiterlaufen lassen, und sie würde Server neu starten, die man gerade abschalten wollte.

## Beim Live-Lauf gefundener Fehler

Der erste `-NoLoop`-Lauf auf dem Host gab die `summary`-Zeile nicht aus. Ursache: `Write-Output` in `Write-WatchdogLog` schreibt in den **Success-Stream** und wurde damit Teil des Rückgabewerts von `Invoke-WatchdogCycle` — statt der Anzahl gesunder Server kam ein Array aus Log-Zeilen plus der Zahl zurück.

`$alive -eq $Servers.Count` wirkt auf Arrays als **Filter** und war deshalb nur zufällig wahr; bei einem echten Ausfall hätte der Vergleich still falsch entschieden. Behoben (`Write-Host`) und mit einem eigenen BATS-Guard festgenagelt. Die strukturellen Guards hätten das nie gefunden — nur der Live-Lauf.

## Tests

Sechs neue Guards in `tests/spec/llm-pipeline.bats` (54/54 grün): Skript existiert, alle drei Server-Einträge vollständig (Name/Port/Script/Args — ein fehlender Hashtable-Key liefert in PowerShell still `$null`, siehe T002264), Health-URL, Referenz aus dem Install-Skript, `Start-Process` statt `Start-Job`, und kein `Write-Output` in der Log-Funktion.

Die beiden letzten Guards klammern den `<# … #>`-Hilfeblock und Kommentarzeilen per `awk`/`grep -v` aus — ein ungefiltertes `grep` wäre an der *Erklärung* hängen geblieben, warum `Start-Job` falsch ist, und wäre grün geworden, sobald jemand den Kommentar löscht. Also genau falschherum.

## Verifikation

- `tests/spec/llm-pipeline.bats` — 54/54 grün
- `task test:changed` — 52/52 pass
- PowerShell-Syntaxprüfung beider Skripte auf dem Host (`Parser::ParseFile`) — 0 Fehler
- `-NoLoop`-Lauf auf dem Host → `summary: 3/3 Server healthy`, `initial health check passed`, Exit 0

## Bewusst offen: T4 (Host-Deployment)

Nicht ausgeführt, mit Begründung im Plan vermerkt:
- Der Shim schreibt den `-RepoRoot`-Pfad fest. Aus dem Worktree zeigte er nach dem Cleanup ins Leere; mit dem Default-Pfad existiert `watchdog-llm-servers.ps1` erst nach dem Merge.
- Ein Probelauf würde den **bestehenden** Autostart-Shim überschreiben; ein anschließendes `-Uninstall` löscht ihn ersatzlos.
- Der Kill-Test aus T4 trifft den live laufenden Gemma-Server (`:8091`), auf dem die Factory arbeitet.

Closes T002335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3HEZD7xnrwFFqqaaggYTS