### PR TITLE
fix(factory): shared-db-Pod-Auswahl filtert auf Phase Running [T002386]

### DIFF
--- a/scripts/batch-gap-analysis.sh
+++ b/scripts/batch-gap-analysis.sh
@@ -8,8 +8,11 @@ ENV="${1:-${ENV:-dev}}"
 CTX="${TICKET_CTX:-fleet}"
 NS="${TICKET_NS:-workspace}"
 
+# [T002386] Phase Running serverseitig filtern — sonst kann ein liegengebliebener
+# Failed/Succeeded-Pod vor dem lebenden sortieren und `kubectl exec` scheitert.
 pod=$(kubectl get pod -n "$NS" --context "$CTX" \
-  -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  -l 'app in (shared-db, shared-db-dev)' \
+  --field-selector status.phase=Running -o name 2>/dev/null | head -1)
 
 if [[ -z "$pod" ]]; then
   echo "ERROR: no shared-db pod found (ns=$NS ctx=$CTX)" >&2

--- a/scripts/factory/conflict-check.sh
+++ b/scripts/factory/conflict-check.sh
@@ -58,7 +58,10 @@ USER="website"
 
 _pgpod() {
   local pod
-  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
+  # [T002386] Phase Running serverseitig filtern — sonst kann ein liegengebliebener
+  # Failed/Succeeded-Pod vor dem lebenden sortieren und `kubectl exec` scheitert.
+  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' \
+    --field-selector status.phase=Running -o name 2>/dev/null | head -1)
   if [[ -z "$pod" ]]; then
     echo '{"error":"no shared-db pod found"}' >&2
     exit 2

--- a/scripts/factory/lib.sh
+++ b/scripts/factory/lib.sh
@@ -27,10 +27,36 @@ factory_resolve() {
   fi
 }
 
+# [T002386] Serverseitig auf Phase Running filtern. kubectl sortiert nach Name,
+# also kann ein liegengebliebener Succeeded/Failed-Pod (Rollout, Node-Drain,
+# Eviction) vor dem lebenden sortieren; `head -1` traf dann zuverlaessig den
+# toten, und jeder Aufruf starb einen Schritt spaeter in `kubectl exec` mit
+# "cannot exec into a container in a completed pod".
+#
+# Das hat am 2026-07-28 die GESAMTE korczewski-Brand fuer den Dispatcher blind
+# gemacht: queue.sh, slots.sh und schedule.sh scheiterten dort ausnahmslos.
+# Sichtbar wurde es nicht, weil schedule.sh den count-Aufruf als
+# `2>/dev/null || echo 0` absichert und den Ausfall damit als "0 belegte Slots"
+# wertet.
+#
+# Dies ist eine eigenstaendige Kopie neben scripts/vda/ticket/_ticket-core.sh —
+# der T002307-Fix dort erreichte diesen Pfad nicht. Guard gegen weitere Kopien:
+# tests/spec/software-factory.bats, "every shared-db pod selection in scripts/".
 factory_pgpod() {
-  local pod
-  pod=$(kubectl get pod -n "$FACTORY_NS" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1)
-  if [[ -z "$pod" ]]; then echo '{"error":"no shared-db pod found"}' >&2; exit 2; fi
+  local pod all
+  pod=$(kubectl get pod -n "$FACTORY_NS" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' \
+    --field-selector status.phase=Running -o name 2>/dev/null | head -1)
+  if [[ -z "$pod" ]]; then
+    # Nur auf dem Fehlerpfad nochmal ungefiltert fragen, um "gar kein Pod" von
+    # "Pods da, keiner Running" zu unterscheiden. Der Happy Path bleibt ein Call.
+    all=$(kubectl get pod -n "$FACTORY_NS" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | tr '\n' ' ')
+    if [[ -n "${all// /}" ]]; then
+      echo "{\"error\":\"no Running shared-db pod in ${FACTORY_NS}; found but not Running: ${all% }\"}" >&2
+    else
+      echo '{"error":"no shared-db pod found"}' >&2
+    fi
+    exit 2
+  fi
   echo "$pod"
 }
 

--- a/scripts/factory/schedule.sh
+++ b/scripts/factory/schedule.sh
@@ -23,8 +23,19 @@ GLOBAL_CAP="${FACTORY_GLOBAL_CAP:-3}"
 # Global concurrency = occupied slots across BOTH brands (separate DBs).
 global_used=0
 for b in mentolder korczewski; do
-  n=$(BRAND="$b" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" count 2>/dev/null || echo 0)
-  global_used=$((global_used + ${n:-0}))
+  # [T002386] Fehler NICHT still als 0 werten. Bis dahin verschluckte
+  # `2>/dev/null || echo 0` jeden Ausfall einer Brand und rechnete sie als leer.
+  # Genau so blieb unbemerkt, dass korczewski wegen eines toten shared-db-Pods
+  # ueber Stunden gar nicht erreichbar war: keine Meldung, keine Warnung, nur
+  # eine Kapazitaetsrechnung, die zu viel Platz auswies.
+  # Fail-open bleibt bewusst (ein Brand-Ausfall darf die andere nicht blockieren),
+  # aber er ist jetzt sichtbar.
+  if ! n=$(BRAND="$b" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/slots.sh" count 2>&1); then
+    echo "schedule: WARN slot count for brand '$b' failed, counting it as 0 — capacity may be overstated: ${n}" >&2
+    n=0
+  fi
+  case "$n" in (''|*[!0-9]*) n=0 ;; esac
+  global_used=$((global_used + n))
 done
 
 plan='[]'

--- a/scripts/mishap-categorize.sh
+++ b/scripts/mishap-categorize.sh
@@ -13,7 +13,10 @@ USER="website"
 _db_update() {
   local ext_id="$1" category="$2"
   local pod
-  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' -o name 2>/dev/null | head -1) || true
+  # [T002386] Phase Running serverseitig filtern — sonst kann ein liegengebliebener
+  # Failed/Succeeded-Pod vor dem lebenden sortieren und `kubectl exec` scheitert.
+  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' \
+    --field-selector status.phase=Running -o name 2>/dev/null | head -1) || true
   if [[ -z "$pod" ]]; then
     echo "mishap-categorize: ERROR no shared-db pod found in namespace $NS (context $CTX)" >&2
     return

--- a/scripts/vda/ticket/_ticket-core.sh
+++ b/scripts/vda/ticket/_ticket-core.sh
@@ -30,8 +30,18 @@ fi
 # [T002307] The pod list is filtered server-side to phase Running. kubectl orders
 # by name, so a leftover Succeeded/Failed `shared-db-<old>` (rollout, node drain,
 # eviction) can sort ahead of the live pod; every caller then died one step later
-# in `kubectl exec` with "cannot exec into a container in a completed pod". All
-# ~25 call sites route through here, so the filter belongs here and nowhere else.
+# in `kubectl exec` with "cannot exec into a container in a completed pod".
+#
+# [T002386] Korrektur der urspruenglichen Annahme: Hier stand "All ~25 call sites
+# route through here, so the filter belongs here and nowhere else." Das stimmt
+# nicht. Die Factory haelt in scripts/factory/lib.sh (factory_pgpod) eine eigene
+# Implementierung, ebenso conflict-check.sh, mishap-categorize.sh und
+# batch-gap-analysis.sh. Alle vier behielten den Bug und legten am 2026-07-28 die
+# gesamte korczewski-Brand fuer den Dispatcher still.
+#
+# Wer eine weitere Pod-Selektion anlegt, braucht den Filter erneut. Der Guard
+# dagegen steht in tests/spec/software-factory.bats unter dem Titel
+# "every shared-db pod selection in scripts/ filters on phase Running".
 _pgpod() {
   local pod all
   pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' \

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -4522,3 +4522,71 @@ $sql
 EOSQL"
   [ -z "$output" ]
 }
+
+# ── [T002386] factory_pgpod muss einen Running-Pod waehlen ────────────────────
+#
+# In workspace-korczewski lagen am 2026-07-28 zwei shared-db-Pods:
+#   shared-db-786c4d5b64-n62db   Failed    (09:20 Uhr)
+#   shared-db-86d7d79f7b-th2mm   Running   (10:04 Uhr)
+#
+# factory_pgpod nahm `-o name | head -1` ohne Phasenfilter. kubectl sortiert nach
+# Name, der Failed-Pod sortiert vor dem lebenden — jeder Aufruf traf also den
+# toten Pod und starb einen Schritt spaeter in `kubectl exec` mit "cannot exec
+# into a container in a completed pod".
+#
+# Folge: Die GESAMTE korczewski-Brand war fuer den Dispatcher blind. queue.sh,
+# slots.sh und schedule.sh scheiterten dort ausnahmslos; 7 offene Tickets konnten
+# nicht dispatcht werden. Weil schedule.sh den Aufruf als
+# `2>/dev/null || echo 0` absichert, wurde der Ausfall als "0 belegte Slots"
+# gewertet — fail-open, ohne Log und ohne Warnung.
+#
+# T002307 hatte denselben Bug bereits in scripts/vda/ticket/_ticket-core.sh
+# behoben, mit dem Kommentar "All ~25 call sites route through here, so the
+# filter belongs here and nowhere else". Das war falsch: Die Factory haelt in
+# lib.sh eine eigene Implementierung.
+
+_t002386_mockdir() {
+  local mockdir; mockdir="$(mktemp -d)"
+  cat > "$mockdir/kubectl" <<'MOCKEOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"get pod"* ]]; then
+  if [[ "$*" == *"--field-selector"*"status.phase=Running"* ]]; then
+    echo "pod/shared-db-live"
+  else
+    # Wie der echte API-Server ohne Filter: der tote Pod sortiert zuerst.
+    echo "pod/shared-db-completed"
+    echo "pod/shared-db-live"
+  fi
+  exit 0
+fi
+exit 0
+MOCKEOF
+  chmod +x "$mockdir/kubectl"
+  echo "$mockdir"
+}
+
+@test "T002386: factory_pgpod skips a completed shared-db pod and returns the Running one" {
+  local mockdir; mockdir="$(_t002386_mockdir)"
+  run env PATH="$mockdir:$PATH" FACTORY_NS=workspace-korczewski FACTORY_CTX=fleet bash -c \
+    'source "'"$REPO_ROOT"'/scripts/factory/lib.sh"; factory_pgpod'
+  rm -rf "$mockdir"
+  [ "$status" -eq 0 ]
+  [ "$output" = "pod/shared-db-live" ]
+}
+
+@test "T002386: every shared-db pod selection in scripts/ filters on phase Running" {
+  # Klassen-Guard statt Einzelfall: T002307 fixte eine Kopie und hielt die Sache
+  # fuer erledigt, waehrend vier weitere Kopien den Bug behielten. Dieser Test
+  # meldet jede kuenftige Kopie ohne Filter rot, egal in welcher Datei.
+  #
+  # Gezaehlt wird pro Datei, nicht pro Zeile: die Selektion darf ueber mehrere
+  # Zeilen umgebrochen sein (so steht sie in _ticket-core.sh).
+  local offenders=""
+  while IFS= read -r f; do
+    grep -q -- "--field-selector status.phase=Running" "$f" || offenders="$offenders $f"
+  done < <(grep -rl "app in (shared-db" "$REPO_ROOT/scripts" --include='*.sh')
+  [ -z "$offenders" ] || {
+    echo "Pod-Selektion ohne Phasenfilter in:$offenders" >&2
+    false
+  }
+}


### PR DESCRIPTION
## Problem

In `workspace-korczewski` lagen zwei `shared-db`-Pods:

```
shared-db-786c4d5b64-n62db   Failed    (09:20 Uhr)
shared-db-86d7d79f7b-th2mm   Running   (10:04 Uhr)
```

`factory_pgpod` (`scripts/factory/lib.sh`) wählte per `-o name | head -1` **ohne Phasenfilter**. kubectl sortiert nach Name, der Failed-Pod sortiert vor dem lebenden — jeder Aufruf traf zuverlässig den toten Pod:

```
$ BRAND=korczewski bash scripts/factory/queue.sh
error: cannot exec into a container in a completed pod; current phase is Failed
```

Damit war die **gesamte korczewski-Brand** für den Dispatcher nicht ansprechbar: `queue.sh`, `slots.sh` und `schedule.sh` scheiterten dort ausnahmslos.

## Warum es niemandem auffiel

`schedule.sh` sicherte den Slot-Count als `2>/dev/null || echo 0` ab. Der Ausfall einer kompletten Brand wurde damit als „0 belegte Slots" gewertet — fail-open, ohne Log, ohne Warnung. Die brandübergreifende Kapazitätsrechnung wies dauerhaft zu viel Platz aus.

## Warum der bestehende Fix nicht griff

T002307 hat exakt diesen Bug in `scripts/vda/ticket/_ticket-core.sh` behoben — mit dem Kommentar *„All ~25 call sites route through here, so the filter belongs here and nowhere else."*

Diese Annahme war falsch. Vier weitere, unabhängige Kopien behielten den Bug:

| Datei | |
|---|---|
| `scripts/factory/lib.sh` | `factory_pgpod` — der akute Fall |
| `scripts/factory/conflict-check.sh` | eigenes `_pgpod` |
| `scripts/mishap-categorize.sh` | inline |
| `scripts/batch-gap-analysis.sh` | inline |

## Fix

Alle vier filtern jetzt serverseitig auf `status.phase=Running`. `factory_pgpod` bekommt zusätzlich die Fehlermeldung aus `_ticket-core.sh`, die „kein Pod" von „Pods da, keiner Running" unterscheidet.

`schedule.sh` meldet einen fehlgeschlagenen Slot-Count jetzt auf stderr, statt ihn still als 0 zu werten. Fail-open bleibt bewusst — ein Brand-Ausfall darf die andere nicht blockieren — ist aber sichtbar.

Der irreführende Kommentar in `_ticket-core.sh` ist korrigiert und verweist auf den Guard.

## Tests

- `T002386: factory_pgpod skips a completed shared-db pod` — verhaltensbasiert mit gestubbtem kubectl, RED vor dem Fix verifiziert
- `T002386: every shared-db pod selection in scripts/ filters on phase Running` — **Klassen-Guard**: meldet jede künftige Kopie ohne Filter rot, egal in welcher Datei. Ohne ihn wiederholt sich genau das, was T002307 passiert ist.
- `T002307`-Bestandstests unverändert grün
- `task test:changed` 52/52, `task freshness:check` exit 0

## Wirkung, ehrlich eingeordnet

Nach dem Fix liefert `BRAND=korczewski bash scripts/factory/queue.sh` gültiges JSON (`[]`) statt eines Fehlers. Die 7 offenen korczewski-Tickets stehen alle auf `triage` und wären ohnehin nicht dispatchbar — kaputt war die **Mechanik**, nicht der Zugang zu wartender Arbeit. Der Fix zählt für die brandübergreifende Kapazitätsrechnung und für jeden künftigen gestagten korczewski-Plan.

Closes T002386