### PR TITLE
chore(agents): sync opencode skills with Claude equivalents [T002395]

### DIFF
--- a/.opencode/skills/opencode-flow-chore/SKILL.md
+++ b/.opencode/skills/opencode-flow-chore/SKILL.md
@@ -9,6 +9,8 @@ description: Use in opencode for maintenance work with no behavior change — do
 
 Eine **Chore**: Wartung ohne Verhaltensänderung. Chores brauchen **keinen** Plan und **keinen** `opencode-flow-execute`-Handoff. Für Features/Fixes stattdessen `opencode-flow-plan` nutzen.
 
+**Sage zu Beginn:** "Ich nutze opencode-flow-chore und führe die Wartung direkt aus."
+
 **EINSTIEG:** `main` — synchronisiert, sauberer Stand
 **AUSSTIEG:** PR gemergt zu `main`, Worktree bereinigt, Kreislauf geschlossen
 
@@ -33,6 +35,11 @@ bash scripts/worktree-create.sh chore/<slug> .worktrees/<slug>
 bash scripts/agent-lock.sh claim branch "chore/<slug>" --worktree "$PWD" --label opencode-flow-chore
 ```
 
+> **`cd` wirkt nur auf Bash (T002357):** Ab hier MÜSSEN alle Datei-Tool-Pfade (Read/Write/Edit)
+> explizit den Worktree-Präfix (`.worktrees/<slug>/...`) tragen. `cd` ändert nur das Bash-cwd,
+> nicht den Bezugspunkt der Datei-Tools — ein zu Session-Beginn im Hauptcheckout korrekter Pfad
+> bleibt syntaktisch gültig und trifft danach still die falsche Arbeitskopie (T002350).
+
 Optional: Minimales Audit-Ticket anlegen via ticket-mcp.
 
 ## Schritt 2: Änderungen vornehmen
@@ -47,6 +54,11 @@ task test:changed
 task freshness:regenerate
 task freshness:check
 ```
+
+> **⚠ S1-Gate-Guard (Chores ohne Plan!):** Chores haben kein Zeilenbudget-Planungsschritt.
+> Berührt die Chore Code-Dateien (`.ts/.svelte/.astro/.sh/.mjs/...`), vor dem Commit den
+> Restbudget-Check aus `verification-block` laufen lassen — bei Restbudget ≤ 0 die Datei
+> **echt verkleinern**, nicht kosmetisch zusammenziehen.
 
 ## Schritt 4: Commit, Push & PR
 
@@ -73,12 +85,19 @@ git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug>
 
 Nur wenn die Chore deploybare Pfade berührt — Mapping in deploy-routing.
 
+## Nachbereitung & Mishap Report
+
+Melde alle aufgetretenen Fehler oder Prozess-Frictionen am Ende über `mishap-tracker`
+(Invoke `mishap-tracker` with your accumulated MISHAP_LOG).
+
 ## Verwandte Skills
 
 | Skill | Beziehung |
 |-------|-----------|
-| `opencode-flow-plan` | Geschwister — Features/Fixes |
+| `opencode-flow-plan` | Geschwister — Features/Fixes (mit Plan + Handoff) statt Chores |
 | `opencode-git-workflow` | **SSOT für Commit/PR/Merge/Cleanup** |
+| `mishap-tracker` | Abschluss — protokolliert Frictions |
+| `using-git-worktrees` | Hintergrund — wird hier durch `scripts/worktree-create.sh` (git-crypt-safe) ersetzt |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
 | `worktree.ts` Plugin | Opencode-native primitive (git-crypt-limited) |
 
@@ -87,6 +106,6 @@ Nur wenn die Chore deploybare Pfade berührt — Mapping in deploy-routing.
 
 | Framework | Availability |
 |-----------|-------------|
-| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
-| **opencode** | Full — native skill for opencode |
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — native skill for opencode. All tools (CLI, MCP) are framework-agnostic |
 | **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -111,6 +111,19 @@ TICKET_STATUS=$(echo "$TICKET_STRUCT" | jq -r '.status // empty')
 - **slot_count > 1:** Pipeline-Modus — auf vollständige Partial-Dispatches warten (Schritt 2.1).
 - **slot_count = 1:** Single-Shot — normale Ausführung.
 
+> **Für `type=task`-Tickets dispatcht die Factory nicht.** Ein `task`-Ticket, das `auto-enqueue`
+> aus `plan_staged` gezogen hat, belegt einen Slot und wird nie bearbeitet — hier immer manuell
+> weiterfahren.
+
+## Schritt 1.8: Ticket freigeben (release hold)
+
+Wenn das Ticket per `stage-plan --hold` gestaged wurde, ist `readiness.execution_released=false`
+gesetzt — das Ticket wird vom Factory-Dispatch zurückgehalten, bis dieser Schritt es freigibt:
+
+```bash
+bash scripts/ticket.sh release-hold --id "$TICKET_ID" || true
+```
+
 ## Schritt 2: Implementierung delegieren
 
 ### Schritt 2.1: Pipeline-Modus — auf Partials warten
@@ -133,22 +146,59 @@ Dann rebasen und alle Partials in Reihenfolge abarbeiten.
 
 ### Schritt 2.2: Implementierung
 
-- Lies den Plan aus `$PLAN_FILE` und `openspec/changes/<slug>/intel.json`
+- Lies den Plan aus `$PLAN_FILE` und **Plan Intel Bundle** `openspec/changes/<slug>/intel.json` (Pflicht-Kontext für den Implementer)
 - Tasks in Reihenfolge; nach jedem Meilenstein Commit + Push
 - Vor PR: Freshness-Artefakte regenerieren
+- Phase-Telemetrie (best-effort):
+  ```
+  ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "entered", driver: "devflow" })
+  ```
+
+## Schritt 2.5: Self-Correcting Loop (optional)
+
+```bash
+bash scripts/devflow-build-loop.sh "$TICKET_ID"
+```
+Läuft **vor** der Verifikation und lokal **vor** dem Push, reduziert die Last auf die CI-Retry-Schleife
+(Schritt 5.5), ersetzt sie aber nicht. Default `MAX_LOOP=3`.
+
+> Bei `abort:escalate-gate|no-progress|max-iterations` wird eskaliert (Ticket-Kommentar) —
+> **kein** blindes Weiter-Pushen.
 
 ## Schritt 3: Lokale Verifikation
+
+Phase-Telemetrie (PFLICHT — das Phase-Chain-Gate erzwingt sie):
+```
+ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "done", driver: "devflow", detail: "Implementierung fertig" })
+ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "entered", driver: "devflow", detail: "task test:changed + freshness" })
+```
 
 ```bash
 task workspace:validate
 task test:changed && task freshness:regenerate && task freshness:check
 ```
 
-## Schritt 4: Code Review
+Nach grünen Tests:
+```
+ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "done", driver: "devflow", detail: "Tests grün · freshness OK" })
+```
+
+## Schritt 3.5: Admin-Menu Placement Gate
+
+Falls neue Admin-Seiten hinzugefügt wurden:
+```bash
+bash scripts/admin-menu-gate.sh
+```
+
+## Schritt 4: Code Review Gate (Mandatory)
+
+Vor dem PR-Merge muss eine unabhängige Überprüfung stattfinden:
 
 ```bash
 delegate(prompt: "Review this PR's changes for bugs, security issues, and style. PR: $(gh-axi pr view --json url -q '.url')", agent: "explore")
 ```
+
+Behebe alle gefundenen Probleme und stelle sicher, dass der Reviewer "Approved" gibt, bevor du fortfährst.
 
 ## Schritt 5: PR erstellen
 
@@ -159,16 +209,42 @@ bash scripts/preflight-pr-scope.sh "<type>(<scope>): <subject> [$TICKET_ID]"
 gh-axi pr create --title "<type>(<scope>): <subject> [$TICKET_ID]" --body "..."
 ```
 
-## Schritt 5.5: CI-Fix-Schleife
+> **⚠️ M1-Lesson (T001899):** Auto-Merge **nicht** vor dem ersten Implementierungs-Push aktivieren.
+> Proposal-Commits auf Feature-Branches triggern den Auto-Merge-Flow und können das Ticket
+> vorzeitig schließen (Merge = Abschluss, T001092). Auto-Merge erst enable, wenn mindestens ein
+> Implementierungs-Commit auf dem Branch liegt.
+
+## Schritt 5.5: CI/CD-Fix-Schleife
+
+Nachdem der PR gepusht ist, überwache CI und behebe Fehler — Auto-Merge ist bereits angefordert
+(Schritt 5) und greift, sobald die Required Checks grün sind.
 
 ```bash
 bash scripts/devflow-ci-watch.sh "$TICKET_ID" "$(gh-axi pr view --json url -q '.url')"
 ```
 
-## Schritt 6: Auto-Merge wenn CI grün
+`devflow-ci-watch.sh` prüft `mergeStateStatus` bereits **vor** dem CI-Poll-Loop und rebased bei
+`DIRTY` gegen `origin/main` (T001408, Finding 2). Bricht der Rebase mit einem Konflikt ab,
+beendet sich das Skript mit Exit-Code 3. In diesem Fall löst der implementierende Subagent
+selbst den Konflikt und ruft das Skript erneut auf.
 
+Seit T001415 (Finding 2) beendet sich `devflow-ci-watch.sh` mit Exit-Code 4, wenn `gh pr view`
+`CONFLICTING` meldet — echte Merge-Konflikte. Auch hier löst der implementierende Subagent
+den Konflikt manuell (`git fetch origin main && git rebase origin/main`, lösen, push).
+
+## Schritt 6: Phase-Chain-Gate & Auto-Merge
+
+> **Merge = Abschluss (T001092):** Das Ticket schließt beim grünen Merge nach `main`. Der
+> Prod-Deploy (Schritt 8) ist entkoppelt und ändert den Ticket-Status **nicht**.
+
+**Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge:**
+Prüft, dass `plan:done`, `implement:entered` und `verify:done` vorliegen:
 ```bash
 bash scripts/ticket.sh assert-phase-chain --id "$TICKET_ID"
+```
+
+Dann Auto-Merge anfordern:
+```bash
 (cd "$MAIN_REPO" && gh-axi pr merge --auto --squash --delete-branch)
 ```
 
@@ -195,11 +271,19 @@ done
 
 ## Schritt 6.5: Ticket abschließen
 
+Der Abschluss selbst — `resolution` ist `shipped` (Feature) oder `fixed` (Fix):
+
+```bash
+./scripts/vda.sh ticket update-status --id "$TICKET_ID" --status done --resolution "$RESOLUTION"
+```
+
 ```
 ticket-mcp: add_pr_link({ id: "$TICKET_ID", pr: "$PR_NUM" })
-ticket-mcp: transition_status({ id: "$TICKET_ID", status: "done", resolution: "shipped" })
 ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "deploy", state: "done", driver: "devflow" })
 ```
+
+> **Claims vor dem Worktree-Remove freigeben** — sonst bleibt ein Lock auf einen Pfad zurück,
+> den es nicht mehr gibt.
 
 ## Schritt 7: Plan archivieren
 
@@ -226,11 +310,16 @@ bash scripts/devflow-post-merge-deploy.sh "$TICKET_ID"
 
 Deploy-Mapping: `.claude/skills/references/deploy-routing.md`.
 
+## Nachbereitung & Mishap Report
+
+Melde alle aufgetretenen Fehler oder Prozess-Frictionen über `mishap-tracker`.
+
 ## Verwandte Skills
 
 | Skill | Beziehung |
 |-------|-----------|
-| `opencode-flow-plan` | Vorgänger |
+| `opencode-flow-plan` | **Vorgänger** — liefert Branch + Plan |
 | `opencode-git-workflow` | SSOT Commit/PR/Merge |
+| `mishap-tracker` | Abschluss — protokolliert Frictions |
 | `background-agents.ts` | Subagent-Routing |
 | `scripts/devflow-post-merge-deploy.sh` | Schritt 8 |

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -24,6 +24,14 @@ Bei jeder Anfrage in diesem Repo, die etwas verändern will. Nutze diesen Skill 
 **AUSSTIEG:** Feature/Fix-Branch mit committiertem Plan auf Remote gepusht, Ticket `plan_staged`
 **Nächster Schritt:** `opencode-flow-execute`
 
+## Schritt −3: Deep Grilling (optional)
+
+Wenn das Feature komplex oder unklar ist, frage den User nach einer Grilling-Session.
+Nutze `lavish` für die Q/A-Session: Erstelle `.lavish/<slug>-grilling.html` mit den Fragen als
+interaktivem Formular (Input-Playbook), öffne es mit `npx -y lavish-axi .lavish/<slug>-grilling.html`
+und poll auf Antworten. Falls durchgeführt, erstelle das Grilling-Ticket via ticket-mcp
+(`create_ticket` mit type=task, title="Grilling: <kurzer-titel>").
+
 ## Schritt −2: Main sync (Pull-First)
 
 ```bash
@@ -43,6 +51,15 @@ git worktree list
 ## Schritt 0: Pfad bestimmen
 
 Wähle Feature, Fix oder Chore. Features/Fixes → dieser Skill. Chores → `opencode-flow-chore` und STOPP.
+
+### Artefakt-Ebene: braucht der Request ein PRD davor?
+
+Die feature/fix/chore-Wahl oben ist die *Pfad*-Wahl durch diese Skill; davor steht die
+*Artefakt*-Wahl (PRD vs. ADR vs. Change-Proposal vs. Chore-Ticket). Entscheidungstabelle:
+- **Neues Feature ohne klares Zielbild** → PRD erstellen (Anforderungsdokument)
+- **Technische Änderung mit Architektur-Impact** → ADR erstellen
+- **Klar umrissene Feature-Änderung** → Change-Proposal (OpenSpec)
+- **Reine Wartung** → Chore-Ticket, kein Spec
 
 ## Feature-Pfad
 
@@ -99,6 +116,10 @@ Setze `TICKET_EXT_ID` (Feld 1) und `TICKET_UUID` (Feld 2) aus der Rückgabe.
 Claims: `agent-lock.sh claim ticket` + `claim branch` mit Label `opencode-flow-plan`.
 
 ### Phase B: Worktree anlegen + Branch pushen (vor Plan-Schreibung)
+
+> **`cd` wirkt nur auf Bash (T002357):** Ab Phase B tragen alle Datei-Tool-Pfade (Read/Write/Edit)
+> zwingend den Worktree-Präfix — `cd` ändert nur das Bash-cwd, nicht den Bezugspunkt der
+> Datei-Tools. Begründung und Prüfbefehl: siehe Claude-Referenz `dev-flow-plan-phases.md`.
 
 🚨 **Pipeline-Prinzip:** Der Branch und Worktree werden JETZT angelegt und gepusht,
 damit Partial-Pläne sofort in die Factory enqueued werden können, während der Planner
@@ -181,8 +202,9 @@ FOR each partial pX (p1, p2, ...):
   └─► Nächstes Partial (oder STOPP wenn alle geschrieben)
 
 NACH dem letzten Partial (Tests):
-  ├─► Schritt C.3: Plan-Qualitäts-Gate
-  │     bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md
+  ├─► Schritt C.3: Plan-Qualitäts-Gate (deterministischer Linter + advisory LLM-QA)
+  │     bash scripts/plan-lint.sh openspec/changes/<slug>/tasks.md || exit 1
+  │     bash scripts/plan-qa-check.sh openspec/changes/<slug>/tasks.md || true   # advisory
   │     bash scripts/openspec.sh validate
   │
   ├─► Schritt C.4: Pgvector-Index aktualisieren
@@ -211,12 +233,54 @@ Zeit │
 - **Ticket-Status:** Während der Pipeline bleibt das Ticket `plan_staged` → `backlog` → `in_progress`. Der Planner muss vor jedem Enqueue prüfen, ob die Factory das Ticket bereits bearbeitet (`in_progress`) — dann kurz pausieren und warten.
 - **Plan-Mutation:** Sobald ein Partial enqueued ist, darf der Planner den Plan für dieses Partial NICHT mehr ändern (Factory hat bereits begonnen). Neue Erkenntnisse fließen via `design.md`-Updates in spätere Partials.
 
+### Guards des Feature-Pfads
+
+- **Brainstorming ist nicht optional** — weder im Feature- noch im Fix-Pfad. Es entscheidet, was
+  überhaupt gebaut wird; ein Plan ohne vorherige Klärung plant die falsche Sache sorgfältig.
+- **Ticket vor Branch** (T001917, T002050): Steht die `TICKET_EXT_ID` fest, trägt der Branch sie
+  als Suffix (`feature/<slug>-T002050`). Existiert noch kein Ticket, wird es **vor** der
+  Worktree-Anlage erstellt. Sonst schlägt `preflight-pr-scope.sh` beim PR fehl.
+- **Disjunkte Partials (D1):** Keine Datei darf in zwei Partials liegen — `scripts/plan-lint.sh`
+  erzwingt das. Das letzte Partial ist **immer** die Tests-Rolle. Obergrenze 9.
+- **Plan-Mutation:** Sobald ein Partial enqueued ist, darf der Planner es nicht mehr ändern.
+- **Qualitäts-Gate vor Design-Assets:** Jedes synchronisierte SVG vor dem Ablegen prüfen —
+  `currentColor` statt `<img>`-Einbettung, keine Stray-Hex-Werte, kein Root-`width/height`,
+  Export-Vollständigkeit. Unpassende Assets werden **verworfen**, nicht mitkopiert (T000756).
+
 ### Fix-Pfad
 
 ## Fix-Pfad
 
+Ein Fix braucht **zwingend einen failing Test**, bevor der Plan geschrieben wird — Rot-Grün ist
+hier harte Voraussetzung, nicht Stilfrage. Der Test gehört nach `tests/spec/<spec-slug>.bats`
+(die Spec aus `openspec/specs/`), nicht in eine neue ticket-nummerierte Datei.
+
 - Lege Bug-Ticket an (via ticket-mcp `create_ticket`), schreibe failing Test, erstelle Plan, stage, commit und push.
 - Hinweis: Erstelle zusätzlich zu `design.md` auch `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` nach der T001304-Delta-Konvention.
+- `--hold`-Pflicht für interaktive Stage-Calls: Der Aufruf von `stage-plan` in diesem Schritt
+  MUSS `--hold` setzen. Dadurch wird das Ticket vom Factory-Dispatch zurückgehalten, bis
+  `opencode-flow-execute` es explizit freigibt.
+
+### Pre-Commit Guard (PFLICHT vor Commit) [T001268]
+
+Bevor der plan-stage Commit läuft, MUSS der Operator verifizieren:
+
+1. **Nicht auf main committen:**
+   ```bash
+   CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+   [ "$CURRENT_BRANCH" != "main" ] || { echo "FATAL: plan-stage commit auf main ist verboten" >&2; exit 1; }
+   ```
+2. **Sauberer Status ist Pflicht:**
+   ```bash
+   [ -z "$(git status --porcelain)" ] || { echo "FATAL: working tree ist nicht sauber" >&2; exit 1; }
+   ```
+3. **Branch stimmt mit agent-lock claim überein:**
+   ```bash
+   LOCK_FILE="$(git rev-parse --git-common-dir)/agent-locks/ticket__${TICKET_EXT_ID}.json"
+   [ -f "$LOCK_FILE" ] || { echo "FATAL: kein ticket-scoped agent-lock-Claim für $TICKET_EXT_ID" >&2; exit 1; }
+   CLAIMED_BRANCH="$(jq -r '.branch' "$LOCK_FILE" 2>/dev/null)"
+   [ "$CLAIMED_BRANCH" = "$CURRENT_BRANCH" ] || { echo "FATAL: branch mismatch" >&2; exit 1; }
+   ```
 
 ## Verwandte Skills
 
@@ -224,15 +288,21 @@ Zeit │
 |-------|-----------|
 | `opencode-git-workflow` | Commit/Push/PR-Schritte |
 | `opencode-flow-execute` | **Nachfolger** — implementiert den Plan |
-| `opencode-flow-chore` | Geschwister — Chores statt Features/Fixes |
+| `opencode-flow-chore` | Geschwister — Chores statt Features/Fixes (direkter Kurzschluss) |
+| `mishap-tracker` | Abschluss — protokolliert Frictions |
 | `background-agents.ts` | Read-only Subagent für Plan-Schreiben |
+| `using-git-worktrees` | Hintergrund — ersetzt durch `scripts/worktree-create.sh` (git-crypt-safe) |
 | `worktree.ts` / `scripts/worktree-create.sh` | Worktree-Erstellung (Wrapper nötig wg. git-crypt) |
 
+## Nachbereitung & Mishap Report
+
+Melde alle aufgetretenen Fehler oder Prozess-Frictionen am Ende über `mishap-tracker`
+(aufrufbar via `bash scripts/hooks/mishap-tracker.sh`).
 
 ## Framework mapping
 
 | Framework | Availability |
 |-----------|-------------|
-| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
-| **opencode** | Full — native skill for opencode |
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — native skill for opencode. All tools (CLI, MCP) are framework-agnostic |
 | **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.opencode/skills/opencode-git-workflow/SKILL.md
+++ b/.opencode/skills/opencode-git-workflow/SKILL.md
@@ -5,6 +5,8 @@ description: Use whenever committing, pushing, creating a PR, or finishing work 
 
 # opencode-git-workflow — vollständiger Git-Lifecycle für dieses Repo (opencode)
 
+**Sage zu Beginn:** "Ich nutze opencode-git-workflow für den Commit/PR-Ablauf."
+
 Dieser Skill ist die **SSOT für Commit → Push → PR → Merge → Cleanup** in opencode. Die `opencode-flow-*`-Skills verweisen auf die Schritte hier statt sie zu duplizieren. Für GitHub-Read/View-Flows `gh-axi` bevorzugen (Repos: `Paddione/Bachelorprojekt`).
 
 ---
@@ -21,8 +23,27 @@ else
   git stash
   git pull --rebase origin main
   git stash pop
+  # Konflikte? Dem User anzeigen und klären.
 fi
 ```
+
+> **Branch-Switch + Stash Race (T001974 Mishap 2).** Niemals
+> `git checkout -b <branch> && git stash pop` in einer einzigen Pipeline
+> verketten. Der `stash pop` kann ausgeführt werden, bevor der
+> Branch-Switch abgeschlossen ist, sodass der Commit auf dem falschen Branch
+> (z. B. `main`) landet. Stattdessen explizit sequenziell mit Error-Check:
+>
+> ```bash
+> git checkout -b fix/my-branch || exit 1   # Branch-Switch abwarten
+> git stash pop || { echo "stash pop failed"; exit 1; }
+> ```
+
+> **Probe-Commit + `--hard` verwirft auch unstaged Dateien (T001454, T002252/T002253).**
+> `--hard` unterscheidet nicht zwischen Commit-Rollback und Working-Tree-Verwurf
+> und reißt unstaged Arbeitsdateien mit. Sicher:
+> ```bash
+> git stash -u && git reset --hard HEAD~1 && git stash pop
+> ```
 
 ---
 
@@ -49,7 +70,10 @@ Kurzform: `task freshness:regenerate` + `task freshness:check` (CI-Äquivalent, 
 - `TICKET_EXT_ID`: z. B. `T001026` — **immer anhängen**
 - Body-Zeilen ebenfalls < 100 Zeichen
 
-**Scope vorab prüfen:** `bash scripts/validate-commit-msg.sh scopes`
+> **Scope vorab gegen SSOT-Allowlist prüfen [T001395]:** `preflight-pr-scope.sh` (Schritt 4) läuft
+> erst kurz vor `gh pr create` — also NACH dem Commit. Ein falsch geratener Scope führt dann zu
+> einem Soft-Reset + Recommit. Vor dem ersten Commit die erlaubte Liste ziehen:
+> `bash scripts/validate-commit-msg.sh scopes`
 
 ### Commit ausführen
 
@@ -60,8 +84,10 @@ BASE_SHA="$(git rev-parse HEAD)"
 
 git add <spezifische Dateien>
 
+# Secret-in-index-Guard (T001210): abbrechen, falls git-crypt-Pfade im Index gelandet sind
 if git diff --cached --name-only | grep -q '^environments/.secrets/'; then
   echo "FATAL: environments/.secrets/** darf nicht gestaged sein (git-crypt)" >&2
+  git diff --cached --name-only | grep '^environments/.secrets/' | sed 's/^/  /' >&2
   exit 1
 fi
 
@@ -125,9 +151,16 @@ EOF
 Nachdem der PR gepusht ist: CI überwachen und Fehler beheben **bevor** gemergt wird. SSOT: `.claude/skills/references/ci-fix-loop.md`.
 
 Kurzfassung:
-1. `gh-axi pr checks <n> --watch`
-2. Bei Fehler: lokal fixen, committen, pushen
-3. Bei `CONFLICTING`: `git fetch origin main && git rebase origin/main && task freshness:regenerate && git add <regenerierte> && git rebase --continue && git push --force-with-lease`
+1. `gh-axi pr checks <n> --watch` — warten bis alle Required Checks grün sind
+2. Bei Fehler: Log lesen, lokal fixen, committen, pushen — Loop wiederholen
+3. Bei `CONFLICTING` PR-Status: `git fetch origin main && git rebase origin/main` → push
+4. Bei `CONFLICTING` nach Auto-Regen: `git fetch origin main && git rebase origin/main && task freshness:regenerate && git add <regenerierte> && git rebase --continue && git push --force-with-lease`
+
+> **Freshness-Auto-Regen-Race [T001395]:** Bleibt ein PR über einen geplanten
+> Freshness-Auto-Regen-Zyklus offen, kippt er auf `CONFLICTING`, ohne dass ein Mensch etwas
+> geändert hat — der Scheduler hat generierte Artefakte auf `main` committet. Kein echter
+> Merge-Konflikt; der Rebase muss dann um `task freshness:regenerate` ergänzt werden, **bevor**
+> gepusht wird.
 
 ---
 
@@ -141,6 +174,7 @@ MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 - **Immer `--squash`**
 - **Immer `--delete-branch`**
 - **`--auto`** — mergt automatisch wenn alle Required Checks grün sind
+- **Race-Hinweis:** `--auto` kehrt sofort zurück; der eigentliche Merge passiert asynchron. CI-Läufe, die durch `edited`-Events (PR-Titel-Edit) getriggert wurden, können noch laufen. `cancel-in-progress` in `ci.yml` wurde so angepasst, dass `edited`-Runs keine laufenden CI-Jobs abbrechen (T002248).
 
 ---
 
@@ -210,12 +244,14 @@ bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 | `opencode-flow-execute` | Feature/Fix-Ablauf (nutzt diesen Skill intern) |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
 | `worktree.ts` Plugin | Opencode-native primitive (git-crypt-limited) |
+| `.claude/skills/references/git-workflow-procedures.md` | Detail-Referenz (Schritt-Übersicht, Fehlertabelle) |
+| `using-git-worktrees` | Worktree korrekt anlegen (git-crypt-safe) |
 
 
 ## Framework mapping
 
 | Framework | Availability |
 |-----------|-------------|
-| **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
-| **opencode** | Full — native skill for opencode |
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — native skill for opencode. All tools (CLI, MCP) are framework-agnostic |
 | **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "brett": "0.41.0",
   "k3d/docs-content": "0.6.0",
-  "website": "1.221.8"
+  "website": "1.221.9"
 }

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.221.9](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.221.8...website-v1.221.9) (2026-07-28)
+
+
+### Bug Fixes
+
+* **scripts:** merge readiness instead of replace in plan-meta set [T002388] ([#3432](https://github.com/Paddione/Bachelorprojekt/issues/3432)) ([98160fc](https://github.com/Paddione/Bachelorprojekt/commit/98160fc420363b35634011843760c1d79f56ee61))
+
 ## [1.221.8](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.221.7...website-v1.221.8) (2026-07-27)
 
 

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
     "node": ">=22.13.0"
   },
   "type": "module",
-  "version": "1.221.8",
+  "version": "1.221.9",
   "private": true,
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Backported ~15 missing patches from Claude `dev-flow-*` and `git-workflow` skills to opencode equivalents
- Skills updated: `opencode-flow-chore`, `opencode-flow-execute`, `opencode-flow-plan`, `opencode-git-workflow`

Backported patches:
- **opencode-flow-chore:** `cd`-warning (T002357), S1-Gate-Guard, mishap-tracker, "Sage zu Beginn"
- **opencode-flow-execute:** release-hold mechanism, phase telemetry, self-correcting loop, admin-menu gate, enhanced CI fix loop (T001408/T001415), Phase-Chain-Gate (T001444), M1-Lesson (T001899), mishap-tracker
- **opencode-flow-plan:** deep grilling, `cd`-warning, `plan-qa-check.sh`, Pre-Commit Guard (T001268), `--hold`-Pflicht, Artefakt-Ebene, Guards section, mishap-tracker
- **opencode-git-workflow:** stash-race (T001974), probe-commit warning (T001454), freshness-auto-regen-race (T001395), cancel-in-progress race (T002248), scope preflight (T001395)

## Test Plan
- [ ] CI grün
- [ ] No functional changes — skill documentation only

[T002395]