### PR TITLE
fix(factory): worktree-write-guard blockiert nicht mehr jeden Write; Anker-Commit gegen Ancestry-Cleanup [T002412]

### DIFF
--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -294,20 +294,15 @@ cmd_claim() {
   # branch claims went stale as soon as the sid check failed, while the ticket
   # claim of the very same session stayed live. [T002267]
   [ "$SCOPE" = "branch" ] && [ -z "$BRANCH" ] && BRANCH="$ID"
-  # `--worktree` absolut speichern. Der Wert wurde bisher roh uebernommen, und die
-  # uebliche Aufrufform ist relativ (`--worktree .worktrees/<slug>`). Ein relativer
-  # Pfad in der Lock-Datei ist aber gegenueber JEDEM spaeteren Leser mehrdeutig — er
-  # gilt nur relativ zum cwd des Claimers:
-  #   - `scripts/hooks/worktree-write-guard.sh` vergleicht ihn gegen einen absoluten
-  #     Zielpfad; er matcht dann nie, und da ein gesetzter eigener Worktree jeden
-  #     Pfad ausserhalb ablehnt, blockiert der Guard JEDEN Write der Session.
-  #   - `_reapable` prueft `[ ! -d "$wt" ]` und wuerde einen lebenden Lock als tot
-  #     einstufen, sobald es aus einem anderen Verzeichnis laeuft.
-  # Bezugspunkt ist `$PWD` und nicht der Repo-Root: ein relativer Pfad ist per
-  # Definition relativ zum Arbeitsverzeichnis des Aufrufers. `git rev-parse
-  # --show-toplevel` waere hier falsch — aus einem Worktree heraus liefert es dessen
-  # Root, nicht den main-Checkout.
-  # Kein `realpath`/`cd`: der Pfad muss zum Claim-Zeitpunkt nicht existieren.  [T002412]
+  # `--worktree` absolut speichern: der Wert wurde bisher roh uebernommen, die
+  # uebliche Aufrufform ist aber relativ (`--worktree .worktrees/<slug>`), und ein
+  # relativer Pfad ist fuer jeden spaeteren Leser mehrdeutig — er gilt nur relativ
+  # zum cwd des Claimers. Folgen im Detail im Kopf von
+  # scripts/hooks/worktree-write-guard.sh; kurz: der Guard sperrt die Session aus
+  # allem aus, und `_reapable` haelt lebende Locks fuer tot. Bezug ist `$PWD` (so ist
+  # ein relativer Pfad definiert), nicht der Repo-Root — aus einem Worktree lieferte
+  # `--show-toplevel` dessen Root statt des main-Checkouts. Kein `realpath`: der Pfad
+  # muss zum Claim-Zeitpunkt nicht existieren.  [T002412]
   case "${WT:-}" in
     ""|"-"|/*) ;;
     *) WT="$PWD/${WT#./}" ;;

--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -294,6 +294,24 @@ cmd_claim() {
   # branch claims went stale as soon as the sid check failed, while the ticket
   # claim of the very same session stayed live. [T002267]
   [ "$SCOPE" = "branch" ] && [ -z "$BRANCH" ] && BRANCH="$ID"
+  # `--worktree` absolut speichern. Der Wert wurde bisher roh uebernommen, und die
+  # uebliche Aufrufform ist relativ (`--worktree .worktrees/<slug>`). Ein relativer
+  # Pfad in der Lock-Datei ist aber gegenueber JEDEM spaeteren Leser mehrdeutig — er
+  # gilt nur relativ zum cwd des Claimers:
+  #   - `scripts/hooks/worktree-write-guard.sh` vergleicht ihn gegen einen absoluten
+  #     Zielpfad; er matcht dann nie, und da ein gesetzter eigener Worktree jeden
+  #     Pfad ausserhalb ablehnt, blockiert der Guard JEDEN Write der Session.
+  #   - `_reapable` prueft `[ ! -d "$wt" ]` und wuerde einen lebenden Lock als tot
+  #     einstufen, sobald es aus einem anderen Verzeichnis laeuft.
+  # Bezugspunkt ist `$PWD` und nicht der Repo-Root: ein relativer Pfad ist per
+  # Definition relativ zum Arbeitsverzeichnis des Aufrufers. `git rev-parse
+  # --show-toplevel` waere hier falsch — aus einem Worktree heraus liefert es dessen
+  # Root, nicht den main-Checkout.
+  # Kein `realpath`/`cd`: der Pfad muss zum Claim-Zeitpunkt nicht existieren.  [T002412]
+  case "${WT:-}" in
+    ""|"-"|/*) ;;
+    *) WT="$PWD/${WT#./}" ;;
+  esac
   # [T002375-p1] Für JEDEN anderen Scope aus dem HEAD füllen. Vorher blieb `branch`
   # bei einem ticket-scoped Claim leer — und der Pre-Commit-Guard aus dev-flow-plan
   # Schritt 5 vergleicht genau dieses Feld mit dem HEAD-Branch. Er schlug damit

--- a/scripts/hooks/worktree-write-guard.sh
+++ b/scripts/hooks/worktree-write-guard.sh
@@ -96,16 +96,37 @@ _my_sid() {
 }
 SID="$(_my_sid)"
 
-MY_WT=""
+# Worktree-Pfade aus den Lock-Dateien gegen den main-Checkout absolut machen.
+# `agent-lock.sh` speichert den `--worktree`-Wert so, wie der Aufrufer ihn uebergibt —
+# und die uebliche Schreibweise ist relativ (`.worktrees/<slug>`). TARGET ist ab
+# Zeile 66 dagegen IMMER absolut. Ohne diese Normalisierung matcht ein relativ
+# gespeicherter Pfad nie, und weil ein gesetztes MY_WT jeden Pfad ausserhalb
+# ablehnt, blockiert der Guard dann JEDEN Schreibzugriff der Session — der Notausgang
+# bleibt die einzige Möglichkeit weiterzuarbeiten. [T002412]
+_abs_wt() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *)  printf '%s\n' "$MAIN_ROOT/${1#./}" ;;
+  esac
+}
+
+MY_WTS=()
 FOREIGN_WT=""
 FOREIGN_SID=""
 for f in "$LOCK_DIR"/*.json; do
   [ -f "$f" ] || continue
   wt="$(_field "$f" worktree)"
   [ -n "$wt" ] || continue
+  [ "$wt" = "-" ] && continue
+  wt="$(_abs_wt "$wt")"
   owner="$(_field "$f" owner_sid)"
   if [ "$owner" = "$SID" ]; then
-    [ -z "$MY_WT" ] && MY_WT="$wt"
+    # ALLE eigenen Claims sammeln, nicht nur den ersten: eine Session darf legitim
+    # mehrere Worktrees halten (z. B. wenn ticket-ops zwei Tickets parallel
+    # dispatcht). Der frühere `[ -z "$MY_WT" ] && MY_WT="$wt"` sperrte sie aus allen
+    # ausser dem zuerst gefundenen aus — und welcher das ist, entscheidet die
+    # Glob-Reihenfolge, also der Ticketname. [T002412]
+    MY_WTS+=("$wt")
   else
     case "$TARGET" in
       "$wt"/*|"$wt") FOREIGN_WT="$wt"; FOREIGN_SID="$owner";;
@@ -113,17 +134,20 @@ for f in "$LOCK_DIR"/*.json; do
   fi
 done
 
-# 2) Eigener Claim gewinnt: nur darunter darf geschrieben werden.
-if [ -n "$MY_WT" ]; then
-  case "$TARGET" in
-    "$MY_WT"/*|"$MY_WT") _allow ;;
-  esac
+# 2) Eigener Claim gewinnt: nur unterhalb der eigenen Worktrees darf geschrieben werden.
+if [ "${#MY_WTS[@]}" -gt 0 ]; then
+  for mw in "${MY_WTS[@]}"; do
+    case "$TARGET" in
+      "$mw"/*|"$mw") _allow ;;
+    esac
+  done
   {
     echo "WORKTREE-GUARD: Schreibzugriff abgelehnt."
     echo "  Pfad:            $TARGET"
-    echo "  Dieser Session gehoert: $MY_WT"
+    echo "  Dieser Session gehoeren:"
+    for mw in "${MY_WTS[@]}"; do echo "    - $mw"; done
     echo "  Der Pfad liegt ausserhalb — vermutlich im Hauptcheckout oder in einem"
-    echo "  fremden Worktree. Ruf denselben Pfad mit dem Praefix '$MY_WT/' erneut auf."
+    echo "  fremden Worktree. Ruf denselben Pfad mit einem der Praefixe oben erneut auf."
     echo "  Grund: 'cd' wirkt nur auf Bash; Edit/Write nehmen absolute Pfade und"
     echo "  treffen sonst still die falsche Arbeitskopie [T002357-M1]."
     echo "  Notausgang (bewusst): WORKTREE_GUARD_BYPASS=1"

--- a/scripts/hooks/worktree-write-guard.sh
+++ b/scripts/hooks/worktree-write-guard.sh
@@ -121,6 +121,15 @@ for f in "$LOCK_DIR"/*.json; do
   wt="$(_abs_wt "$wt")"
   owner="$(_field "$f" owner_sid)"
   if [ "$owner" = "$SID" ]; then
+    # Ein eigener Claim auf einen nicht mehr existierenden Worktree darf die Session
+    # nicht lähmen. Sonst gilt: MY_WTS ist nicht leer, also wird jeder Pfad ausserhalb
+    # abgelehnt — aber der einzige erlaubte Pfad existiert nicht. Die Session kann dann
+    # NIRGENDS mehr schreiben und kommt nur noch über den Notausgang weiter. Genau das
+    # trat am 2026-07-28 ein, als der Worktree zu T002408 während des Laufs entfernt
+    # wurde. Bleibt nach dem Filtern kein eigener Worktree übrig, greift Regel 4
+    # ("ohne Claim ändert sich nichts"); der Schutz gegen FREMDE Claims bleibt
+    # davon unberührt. [T002412]
+    [ -d "$wt" ] || continue
     # ALLE eigenen Claims sammeln, nicht nur den ersten: eine Session darf legitim
     # mehrere Worktrees halten (z. B. wenn ticket-ops zwei Tickets parallel
     # dispatcht). Der frühere `[ -z "$MY_WT" ] && MY_WT="$wt"` sperrte sie aus allen

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -292,8 +292,36 @@ if [ -n "$(find "$WT_PATH" -maxdepth 3 -name pnpm-workspace.yaml -not -path '*/n
 fi
 
 _ok=1   # reached a clean finish — disarm the rollback trap
+
+# Anker-Commit auf einem FRISCH angelegten Branch. [T002412]
+#
+# Ein neuer Branch hat null Commits ueber seiner Basis. Fuer jede Aufraeumlogik, die
+# Loeschbarkeit an Commit-Ancestry festmacht ("ist vollstaendig in main enthalten?"),
+# ist er damit nicht von einem fertig gemergten Branch zu unterscheiden — und
+# `git branch -D` plus `git worktree remove --force` raeumen ihn ab, waehrend noch
+# jemand darin arbeitet.
+#
+# Belegt am 2026-07-28: zwei Worktrees wurden im Abstand von Sekunden angelegt. Der
+# zu T002407 trug bereits einen Commit und ueberlebte; der zu T002408 hatte keinen und
+# wurde mitten im Lauf samt Branch entfernt (verifiziert: nicht in `git worktree list`,
+# `git branch --list` leer, nie auf origin). Welcher Aufrufer es war, liess sich nicht
+# rekonstruieren — `cleanup.sh` und `auto-chore-plan.sh` scheiden aus, beide loeschen
+# nur explizit uebergebene bzw. eigene Pfade. Der Anker wirkt unabhaengig davon:
+# er macht den Branch fuer JEDE Ancestry-Pruefung sichtbar als "nicht enthalten".
+#
+# Best-effort und bewusst nicht fatal: schlaegt der Commit fehl, ist der Worktree
+# trotzdem brauchbar. `--no-verify`, weil der Commit keine Dateien traegt — es gibt
+# nichts zu linten oder auf Secrets zu scannen, und ein Hook-Fehlschlag darf die
+# Worktree-Erstellung nicht scheitern lassen.
 if [ "$BRANCH_EXISTS" -eq 1 ]; then
     echo "worktree-create: $WT_PATH ready on existing branch $BRANCH"
 else
+    if git -C "$WT_PATH" commit --allow-empty --no-verify -q \
+         -m "chore: anchor branch $BRANCH [skip ci]" 2>/dev/null; then
+        echo "worktree-create: Anker-Commit gesetzt (schuetzt vor Ancestry-basiertem Cleanup)" >&2
+    else
+        echo "worktree-create: WARNUNG — Anker-Commit fehlgeschlagen; der Branch hat null" >&2
+        echo "  Commits ueber $BASE und kann von Aufraeumlogik als 'gemergt' geloescht werden." >&2
+    fi
     echo "worktree-create: $WT_PATH ready on branch $BRANCH (base $BASE)"
 fi

--- a/tests/spec/dev-flow-plan.bats
+++ b/tests/spec/dev-flow-plan.bats
@@ -197,8 +197,13 @@ _wg_run() {  # $1=lockdir $2=sid $3=zielpfad  -> setzt status/output
   local ld; ld="$BATS_TEST_TMPDIR/locks-a"; mkdir -p "$ld"
   # Der Worktree muss UNTER dem Repo-Root liegen — reale Worktrees tun das
   # (.worktrees/<slug>), und Regel 1 laesst alles ausserhalb bewusst durch.
-  # Das Verzeichnis muss nicht existieren, verglichen werden Praefixe.
+  # Das Verzeichnis muss seit T002412 EXISTIEREN: ein eigener Claim auf einen
+  # geloeschten Worktree wird uebersprungen, damit eine Session sich nicht selbst
+  # aussperrt, wenn ihr Worktree unter ihr weggeraeumt wird. Frueher stand hier
+  # "muss nicht existieren, verglichen werden Praefixe" — das galt nur, solange
+  # der Guard tote eigene Claims noch mitzaehlte.
   local mywt="$REPO/.worktrees/t002375-p2-mine"
+  mkdir -p "$mywt"
   _wg_lock "$ld" branch__probe "sid-mine" "$mywt"
 
   # Positiv-Anker: innerhalb des eigenen Worktrees MUSS es durchgehen.
@@ -238,6 +243,7 @@ _wg_run() {  # $1=lockdir $2=sid $3=zielpfad  -> setzt status/output
 @test "T002375-p2: WORKTREE_GUARD_BYPASS=1 laesst den Schreibzugriff durch" {
   local ld; ld="$BATS_TEST_TMPDIR/locks-d"; mkdir -p "$ld"
   local mywt="$REPO/.worktrees/t002375-p2-mine"
+  mkdir -p "$mywt"   # seit T002412: tote eigene Worktrees zaehlen nicht mehr
   _wg_lock "$ld" branch__probe "sid-mine" "$mywt"
 
   # Positiv-Anker: ohne Bypass wird derselbe Aufruf abgelehnt.
@@ -262,4 +268,142 @@ for tool in ('Write', 'Edit'):
 print('ok')
 \""
   [ "$status" -eq 0 ] || { echo "$output"; false; }
+}
+
+@test "T002412: ein RELATIV gespeicherter Worktree-Pfad wird gegen den Repo-Root aufgeloest" {
+  # Der Kern des Bugs: agent-lock.sh speicherte '--worktree .worktrees/<slug>' roh,
+  # der Guard macht den Zielpfad aber absolut. Ohne Normalisierung matcht der
+  # eigene Worktree NIE — und weil ein gesetzter eigener Worktree jeden Pfad
+  # ausserhalb ablehnt, blockierte der Guard damit JEDEN Write der Session.
+  local ld; ld="$BATS_TEST_TMPDIR/locks-t002412-rel"; mkdir -p "$ld"
+
+  # Bezugspunkt ist der MAIN-Checkout, nicht $REPO: der Guard loest relative
+  # Lock-Pfade ueber `git rev-parse --git-common-dir` auf, weil Worktrees per
+  # Konvention unter <main>/.worktrees/<slug> liegen und er das Arbeitsverzeichnis
+  # des Claimers nicht kennen kann. Laeuft dieser Test selbst aus einem Worktree,
+  # sind $REPO und MAIN verschieden — dann muss das Fixture unter MAIN liegen.
+  local main_root; main_root="$(cd "$(git -C "$REPO" rev-parse --git-common-dir)/.." && pwd)"
+  local mywt="$main_root/.worktrees/t002412-relativ"
+  mkdir -p "$mywt"
+  _wg_lock "$ld" branch__probe "sid-mine" ".worktrees/t002412-relativ"   # RELATIV
+
+  # Der eigentliche Fall: im eigenen Worktree muss geschrieben werden duerfen,
+  # obwohl der Lock den Pfad relativ fuehrt.
+  _wg_run "$ld" "sid-mine" "$mywt/datei.txt"
+  local rc_inner="$status" out_inner="$output"
+
+  # Positiv-Anker gegen ein vakuoses Bestehen: der Guard muss ueberhaupt noch
+  # blocken. Waere die Normalisierung so kaputt, dass MY_WTS leer bleibt, ginge
+  # die Pruefung oben ebenfalls durch — dann aber auch diese hier, und sie faellt.
+  # Muss VOR dem Aufraeumen laufen: ohne das Verzeichnis gilt der Claim als tot.
+  _wg_run "$ld" "sid-mine" "$main_root/scripts/irgendwas.sh"
+  local rc_outer="$status" out_outer="$output"
+
+  rmdir "$mywt" 2>/dev/null || true
+
+  [ "$rc_inner" -eq 0 ] || { echo "relativ gespeicherter eigener Worktree wurde abgelehnt: $out_inner"; false; }
+  [ "$rc_outer" -ne 0 ] || { echo "Guard blockt gar nicht mehr — Normalisierung wirkungslos: $out_outer"; false; }
+}
+
+@test "T002412: ALLE eigenen Claims werden geehrt, nicht nur der erste" {
+  # Eine Session darf legitim mehrere Worktrees halten (ticket-ops dispatcht
+  # mehrere Tickets parallel). Frueher gewann der zuerst gefundene Lock, und
+  # welcher das ist, entscheidet allein die Glob-Reihenfolge der Dateinamen.
+  local ld; ld="$BATS_TEST_TMPDIR/locks-t002412-multi"; mkdir -p "$ld"
+  local wt_a="$REPO/.worktrees/t002412-aaa" wt_b="$REPO/.worktrees/t002412-zzz"
+  mkdir -p "$wt_a" "$wt_b"
+  _wg_lock "$ld" ticket__aaa "sid-mine" "$wt_a"
+  _wg_lock "$ld" ticket__zzz "sid-mine" "$wt_b"
+
+  # Beide muessen durchgehen — der zweite ist der, den die alte Logik verlor.
+  _wg_run "$ld" "sid-mine" "$wt_a/x.txt"
+  [ "$status" -eq 0 ] || { echo "erster eigener Worktree abgelehnt: $output"; false; }
+  _wg_run "$ld" "sid-mine" "$wt_b/x.txt"
+  [ "$status" -eq 0 ] || { echo "ZWEITER eigener Worktree abgelehnt (der alte Bug): $output"; false; }
+
+  # Positiv-Anker: ausserhalb beider wird weiterhin abgelehnt, und die Meldung
+  # nennt beide Worktrees.
+  _wg_run "$ld" "sid-mine" "$REPO/scripts/irgendwas.sh"
+  [ "$status" -ne 0 ] || { echo "ausserhalb beider Worktrees wurde NICHT abgelehnt"; false; }
+  [[ "$output" == *"$wt_a"* && "$output" == *"$wt_b"* ]] \
+    || { echo "Meldung nennt nicht beide eigenen Worktrees: $output"; false; }
+}
+
+@test "T002412: ein eigener Claim auf einen GELOESCHTEN Worktree laehmt die Session nicht" {
+  # Am 2026-07-28 wurde der Worktree zu T002408 waehrend des Laufs entfernt. Der
+  # Lock blieb stehen und zeigte ins Leere — die Session konnte danach nirgends
+  # mehr schreiben, obwohl ihr Worktree gar nicht mehr existierte.
+  local ld; ld="$BATS_TEST_TMPDIR/locks-t002412-dead"; mkdir -p "$ld"
+  local lebend="$REPO/.worktrees/t002412-lebend"
+  mkdir -p "$lebend"
+
+  # Positiv-Anker zuerst: mit einem LEBENDEN eigenen Claim blockt der Guard.
+  _wg_lock "$ld" ticket__lebend "sid-mine" "$lebend"
+  _wg_run "$ld" "sid-mine" "$REPO/scripts/irgendwas.sh"
+  [ "$status" -ne 0 ] || { echo "Vorbedingung: lebender Claim haette blocken muessen"; false; }
+
+  # Jetzt derselbe Aufbau, aber der geclaimte Worktree existiert nicht.
+  local ld2; ld2="$BATS_TEST_TMPDIR/locks-t002412-dead2"; mkdir -p "$ld2"
+  _wg_lock "$ld2" ticket__tot "sid-mine" "$REPO/.worktrees/t002412-nie-angelegt"
+  _wg_run "$ld2" "sid-mine" "$REPO/scripts/irgendwas.sh"
+  [ "$status" -eq 0 ] || { echo "toter eigener Claim sperrt die Session aus: $output"; false; }
+}
+
+@test "T002412: ein FREMDER Claim schuetzt seinen Worktree auch ohne existierendes Verzeichnis" {
+  # Abgrenzung zum Test darueber: die Existenzpruefung gilt NUR fuer eigene
+  # Claims. Ein fremder Claim darf nicht dadurch entwertet werden, dass sein
+  # Verzeichnis (noch) nicht angelegt ist — sonst oeffnet die Lockerung ein Loch.
+  local ld; ld="$BATS_TEST_TMPDIR/locks-t002412-foreign"; mkdir -p "$ld"
+  local fremdwt="$REPO/.worktrees/t002412-fremd-ohne-dir"
+  _wg_lock "$ld" ticket__fremd "sid-other" "$fremdwt"
+
+  # Positiv-Anker: ausserhalb des fremden Worktrees bleibt alles erlaubt.
+  _wg_run "$ld" "sid-mine" "$REPO/scripts/irgendwas.sh"
+  [ "$status" -eq 0 ] || { echo "ohne eigenen Claim faelschlich abgelehnt: $output"; false; }
+
+  _wg_run "$ld" "sid-mine" "$fremdwt/design.md"
+  [ "$status" -ne 0 ] || { echo "fremder Claim ohne Verzeichnis schuetzt nicht mehr: $output"; false; }
+}
+
+@test "T002412: agent-lock.sh speichert --worktree absolut" {
+  local ld; ld="$BATS_TEST_TMPDIR/locks-t002412-abs"; mkdir -p "$ld"
+  run env AGENT_LOCK_DIR="$ld" bash -c \
+    "cd '$REPO' && bash scripts/agent-lock.sh claim ticket T999412 \
+       --label probe --worktree .worktrees/t002412-abs --branch chore/probe"
+  [ "$status" -eq 0 ] || { echo "claim fehlgeschlagen: $output"; false; }
+
+  local f="$ld/ticket__T999412.json"
+  [ -f "$f" ] || { echo "Lock-Datei fehlt: $f"; false; }
+  local wt; wt="$(sed -n 's/.*"worktree": *"\([^"]*\)".*/\1/p' "$f" | head -1)"
+
+  # Positiv-Anker: das Feld ist ueberhaupt gefuellt (sonst bestuende die
+  # Negativ-Aussage unten vakuos).
+  [ -n "$wt" ] || { echo "worktree-Feld ist leer"; false; }
+  case "$wt" in
+    /*) : ;;
+    *) echo "worktree wurde relativ gespeichert: $wt"; false ;;
+  esac
+}
+
+@test "T002412: worktree-create.sh setzt einen Anker-Commit nur auf NEUEN Branches" {
+  # Ein frischer Branch hat null Commits ueber seiner Basis und ist damit fuer
+  # jede Ancestry-basierte Aufraeumlogik von einem gemergten nicht zu
+  # unterscheiden. Der Anker macht ihn sichtbar als "nicht enthalten".
+  local s="$REPO/scripts/worktree-create.sh"
+  [ -f "$s" ] || { echo "worktree-create.sh fehlt"; false; }
+
+  # Positiv-Anker: die Verzweigung auf BRANCH_EXISTS existiert ueberhaupt —
+  # ohne sie waere die Aussage "nur auf neuen Branches" gegenstandslos.
+  grep -q 'BRANCH_EXISTS' "$s" || { echo "BRANCH_EXISTS-Verzweigung fehlt"; false; }
+  grep -q -- '--allow-empty' "$s" || { echo "kein Anker-Commit im Skript"; false; }
+
+  # Der Anker-Commit darf NUR im else-Zweig (neuer Branch) stehen: die Zeile mit
+  # --allow-empty muss NACH der 'ready on existing branch'-Meldung kommen.
+  local ln_existing ln_anchor
+  ln_existing="$(grep -n 'ready on existing branch' "$s" | head -1 | cut -d: -f1)"
+  ln_anchor="$(grep -n -- '--allow-empty' "$s" | head -1 | cut -d: -f1)"
+  [ -n "$ln_existing" ] && [ -n "$ln_anchor" ] \
+    || { echo "Ankerzeilen nicht gefunden (existing=$ln_existing anchor=$ln_anchor)"; false; }
+  [ "$ln_anchor" -gt "$ln_existing" ] \
+    || { echo "Anker-Commit steht nicht im else-Zweig: anchor=$ln_anchor existing=$ln_existing"; false; }
 }


### PR DESCRIPTION
## Problem

`scripts/hooks/worktree-write-guard.sh` konnte eine Session **vollständig aussperren** — jeder `Write`/`Edit` wurde abgelehnt, der einzige Ausweg war `WORKTREE_GUARD_BYPASS=1`. Drei unabhängige Fehler:

1. **Relative Lock-Pfade matchten nie.** Der Guard macht den Zielpfad absolut (Zeile 66), las `worktree` aber roh aus der Lock-JSON. `agent-lock.sh` speicherte den `--worktree`-Wert ungeprüft, und die übliche Aufrufform ist relativ (`.worktrees/<slug>`). Da ein gesetzter eigener Worktree jeden Pfad außerhalb ablehnt, blockierte der Guard damit alles.
2. **Nur der erste eigene Claim zählte.** `[ -z "$MY_WT" ] && MY_WT="$wt"` — welcher das ist, entschied die Glob-Reihenfolge der Lock-Dateinamen. Eine Session darf legitim mehrere Worktrees halten (`ticket-ops` dispatcht mehrere Tickets parallel) und war aus allen bis auf einen ausgesperrt.
3. **Ein toter eigener Claim lähmte die Session.** Wird der geclaimte Worktree entfernt, zeigt der Lock ins Leere: `MY_WTS` ist nicht leer, also wird alles außerhalb abgelehnt — aber der einzige erlaubte Pfad existiert nicht mehr.

Fall 3 ist am 2026-07-28 real eingetreten: der Worktree zu T002408 wurde während eines laufenden Planungsagenten entfernt.

## Änderungen

**`scripts/hooks/worktree-write-guard.sh`**
- Lock-Pfade werden gegen den main-Checkout absolut gemacht (`_abs_wt`).
- `MY_WTS` sammelt **alle** eigenen Claims; die Ablehnungsmeldung nennt sie alle.
- Eigene Claims auf nicht existierende Worktrees werden übersprungen. Bleibt keiner übrig, greift Regel 4 („ohne Claim ändert sich nichts").
- **Die Existenzprüfung gilt ausschließlich für eigene Claims.** Ein fremder Claim schützt seinen Pfad weiterhin auch ohne existierendes Verzeichnis — sonst öffnete die Lockerung ein Loch. Eigener Test dafür.

**`scripts/agent-lock.sh`** — `--worktree` wird beim Claim absolut gespeichert (Bezug `$PWD`; `--show-toplevel` wäre falsch, es liefert aus einem Worktree dessen Root). Behebt die Ursache, statt nur beim Lesen zu reparieren.

**`scripts/worktree-create.sh`** — neu angelegte Branches bekommen einen leeren Anker-Commit. Ein frischer Branch hat null Commits über seiner Basis und ist für jede Ancestry-basierte Aufräumlogik nicht von einem gemergten zu unterscheiden. Best-effort und nicht fatal; `--no-verify`, weil der Commit keine Dateien trägt.

## Zum Verursacher der Löschung

`cleanup.sh` wurde zunächst verdächtigt und ist es **nicht**: es sucht keine Kandidaten, sondern löscht die ihm übergebenen `--branch`/`--worktree` nach Pipeline-Ende (einziger Aufrufer `pipeline.mjs:658`); das `--force` ist dort beabsichtigt. `auto-chore-plan.sh` räumt nur sein eigenes `acp-`-Präfix ab. Der Verursacher ist unbekannt — der Anker-Commit wirkt unabhängig davon.

Bewusste Grenze: ein **existierender** Branch mit null Commits bekommt keinen Anker. Fremde Branches werden nicht angefasst.

## Tests

Sechs neue in `tests/spec/dev-flow-plan.bats`, je mit Positiv-Anker gegen vakuoses Bestehen. Alle 34 grün, `test:code-quality` 52/52, `agent-lock-*` und `worktree-divergence-guard-T002387` ohne Regression.

Zwei bestehende T002375-p2-Tests mussten angepasst werden: sie legten ihre Fixtures bewusst nicht an („Das Verzeichnis muss nicht existieren, verglichen werden Praefixe"). Diese Annahme gilt durch Fix 3 nicht mehr — der Kommentar ist korrigiert statt still überschrieben.

`task test:all` lief lokal nicht durch: `vitest` ist im Worktree nicht auflösbar (node_modules sind Symlinks, `pnpm install` dort verboten). Umgebungslimit, kein Testfehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsKw8iaEthX3gwRuUGiZC5