### PR TITLE
fix(factory): Conflict-Gate greift wieder — touched_files persistieren, Check deterministisch [T002418]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 633,
+      "file_count": 634,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -475,6 +475,7 @@
         "tests/spec/sessions-server.bats",
         "tests/spec/sidekick-assistant.bats",
         "tests/spec/software-factory.bats",
+        "tests/spec/software-factory/conflict-gate.bats",
         "tests/spec/studio-sessions-reorganize.bats",
         "tests/spec/t001269-mishap-bundle-skills-dev-flow-execute-repo-worktree-state-ticket-mcp.bats",
         "tests/spec/t001353-mishap-bundle-ci-tickets.bats",

--- a/scripts/factory/conflict-check.sh
+++ b/scripts/factory/conflict-check.sh
@@ -121,7 +121,19 @@ WITH new_files AS (
 SELECT json_agg(DISTINCT t.external_id)
 FROM tickets.tickets t, new_files nf
 WHERE t.external_id != :'ext_id'
-  AND t.type IN ('feature','feat','task','chore')
+  -- [T002418] 'bug'/'fix' ergaenzt: die drei realen Kollidenten vom 2026-07-28
+  -- (T002341/T002373/T002374, alle an scripts/agent-lock.sh) waren Mishap-Tickets und
+  -- fielen durch den alten Typfilter komplett heraus.
+  AND t.type IN ('feature','feat','task','chore','bug','fix')
+  -- [T002418] Der Statusfilter bleibt bewusst auf ('in_progress','in_review) — geprueft
+  -- und verworfen: 'plan_staged' aufzunehmen sah nach der offensichtlichen Luecke aus
+  -- ("im Moment des Dispatch ist noch kein Ticket in_progress"), ist aber falsch.
+  -- schedule.sh ruft conflict-check (Z. 82) VOR slots.sh claim-gang (Z. 106) auf, und der
+  -- Claim setzt status='in_progress'; der naechste Schleifendurchlauf sieht das vorherige
+  -- Ticket also sehr wohl. 'plan_staged' wuerde dagegen falsch-positiv blockieren, weil
+  -- ein Ticket dort tagelang liegen kann. Festgehalten in FA-SF-45.
+  -- Die Kollision vom 2026-07-28 kam nicht hierher, sondern von touched_files = null:
+  -- der IS-NOT-NULL-Filter unten verwirft dann alles, egal welcher Status.
   AND t.status IN ('in_progress','in_review')
   AND t.touched_files IS NOT NULL
   AND (

--- a/scripts/factory/pipeline-runner.js
+++ b/scripts/factory/pipeline-runner.js
@@ -334,6 +334,67 @@ async function main() {
     }
     console.log(JSON.stringify({ valid: failures.length === 0, failures }));
 
+  } else if (command === 'set-touched-files') {
+    // [T002418] Persistiert die Scout-Dateiliste ins Ticket. Ohne diesen Schritt bleibt
+    // touched_files null und das Conflict-Gate ist blind (siehe pipeline.mjs, Scout-Phase).
+    const { ticket_id, brand, files } = payload;
+    const shSafeTicketId = String(ticket_id).replace(/[^A-Za-z0-9_-]/g, '');
+    const list = (Array.isArray(files) ? files : []).filter((f) => typeof f === 'string' && f);
+    if (list.length === 0) {
+      console.log('set-touched-files: skipped (empty list)');
+    } else {
+      execFileSync('bash', [
+        path.join(REPO, 'scripts/ticket.sh'), 'set-touched-files',
+        '--id', shSafeTicketId, '--files', list.join(','),
+      ], { stdio: 'ignore', env: { ...process.env, BRAND: brand } });
+      console.log(`set-touched-files: ${list.length} path(s)`);
+    }
+
+  } else if (command === 'conflict-check') {
+    // [T002418] Der Conflict-CHECK laeuft jetzt hier statt ueber einen Agenten.
+    // Vorher entschied pipeline.mjs mit `/\"T0/.test(conflict)` — einem Regex auf der
+    // Freitext-Antwort eines LLM. Der traf nur, wenn das Modell die Ticket-ID zufaellig
+    // in Anfuehrungszeichen ausgab; formatierte es anders oder kommentierte es die
+    // Ausgabe, wurde ein echter Konflikt stillschweigend uebersehen.
+    //
+    // Bemerkenswert war die Asymmetrie: 'conflict-escalate' unten lief laengst
+    // deterministisch, nur die Entscheidung DARUEBER nicht.
+    //
+    // Rueckgabe ist immer JSON: {rc, conflicts[]}. rc 0 = frei, 1 = Konflikt,
+    // 2 = Fehler/keine touched_files.
+    const { ticket_id, brand, files } = payload;
+    const shSafeTicketId = String(ticket_id).replace(/[^A-Za-z0-9_-]/g, '');
+    const fileArgs = Array.isArray(files) ? files.filter((f) => typeof f === 'string' && f) : [];
+    // Liveness der Plan-Phase. Steckte vorher im Agent-Prompt (`bash scripts/ticket.sh
+    // touch --id …`) und ist mit dem Wegfall des Agenten mitgegangen — der Watchdog haette
+    // die Phase danach faelschlich als tot gesehen. Hier ist sie sogar zuverlaessiger:
+    // deterministisch statt davon abhaengig, dass ein Modell die Zeile ausfuehrt.
+    try {
+      execFileSync('bash', [
+        path.join(REPO, 'scripts/ticket.sh'), 'touch', '--id', shSafeTicketId
+      ], { stdio: 'ignore', env: { ...process.env, BRAND: brand } });
+    } catch { /* Liveness ist best-effort und darf das Gate nie blockieren */ }
+    let rc = 0;
+    let raw = '';
+    try {
+      raw = execFileSync('bash', [
+        path.join(REPO, 'scripts/factory/conflict-check.sh'), shSafeTicketId, ...fileArgs
+      ], { encoding: 'utf8', env: { ...process.env, BRAND: brand } });
+    } catch (e) {
+      rc = typeof e.status === 'number' ? e.status : 2;
+      raw = (e.stdout || '').toString();
+    }
+    let conflicts = [];
+    try {
+      const parsed = JSON.parse((raw || '').trim() || '[]');
+      if (Array.isArray(parsed)) conflicts = parsed.filter(Boolean);
+    } catch {
+      // Nicht-JSON auf stdout heisst: das Skript kam nicht bis zur Ausgabe (z.B. kein
+      // erreichbarer DB-Pod). Das ist rc 2 — ein Fehler, ausdruecklich KEINE Freigabe.
+      if (rc === 0) rc = 2;
+    }
+    console.log(JSON.stringify({ rc, conflicts }));
+
   } else if (command === 'conflict-escalate') {
     const { ticket_id, brand, conflict } = payload;
     const shSafeTicketId = String(ticket_id).replace(/[^A-Za-z0-9_-]/g, '');

--- a/scripts/factory/pipeline.mjs
+++ b/scripts/factory/pipeline.mjs
@@ -218,6 +218,23 @@ log(`Scout: complexity=${scout.complexity}, ${scout.touched_files.length} touche
 featureComplexity = scout.complexity
 featureTouchedFiles = scout.touched_files
 
+// [T002418] touched_files ins Ticket schreiben — die Wurzel des kaputten Conflict-Gates.
+// Bis hierher kannte der Scout die Dateien, reichte sie an den unmittelbaren Check weiter
+// und warf sie dann weg. Weil die Spalte in der DB null blieb (verifiziert an T002341),
+// war JEDES Ticket fuer nachfolgende Kollisionspruefungen unsichtbar: conflict-check.sh
+// filtert mit "AND t.touched_files IS NOT NULL", und schedule.sh ruft ohne Dateiliste auf,
+// was bei null zu rc 2 = "treat as schedulable" fuehrt. Das Gate hatte strukturell kein
+// Gedaechtnis — deshalb liefen T002341/T002373/T002374 gleichzeitig auf agent-lock.sh.
+//
+// Best-effort: ein fehlgeschlagener Write darf die Pipeline nicht anhalten, aber er wird
+// sichtbar geloggt statt still verschluckt.
+if (Array.isArray(scout.touched_files) && scout.touched_files.length > 0) {
+  const tfRes = await runRunner(agent, 'set-touched-files', {
+    ticket_id: A.ticket_id, brand, files: scout.touched_files,
+  })
+  log(`touched_files persistiert (${scout.touched_files.length}): ${String(tfRes).slice(0, 120)}`)
+}
+
 await phaseEvent('scout', 'done', `${(scout.touched_files || []).length} touched_files`)
 
 const isSimple = scout.complexity === 'simple'
@@ -246,15 +263,24 @@ tasks = []
 if (!isSimple) {
   phase('Plan')
   await phaseEvent('plan', 'entered', 'Plan-Erstellung')
-  const conflict = await agent(
-    `Liveness: \`bash ${REPO}/scripts/ticket.sh touch --id ${A.ticket_id}\`.
-     Run the brand-aware conflict gate:
-       BRAND=${brand} bash ${REPO}/scripts/factory/conflict-check.sh ${A.ticket_id} ${scout.touched_files.join(' ')}
-     Report the exact stdout JSON and exit code.
-     Exit 0 = no conflicts. Exit 1 = conflicts found (STOP). Exit 2 = error.`,
-    { label: 'plan:conflict', phase: 'Plan', model: FACTORY_MODEL },
-  )
-  if (/\"T0/.test(conflict)) {
+  // [T002418] Deterministisch statt per Agent. Vorher lief der Check ueber einen
+  // LLM-Aufruf, dessen Freitext-Antwort mit `/\"T0/` abgeklopft wurde — der Regex traf nur,
+  // wenn das Modell die Ticket-ID zufaellig in Anfuehrungszeichen ausgab. Formatierte es
+  // anders oder kommentierte es die Ausgabe, wurde ein echter Konflikt uebersehen und die
+  // Pipeline lief in die Kollision. Die Eskalation darunter war laengst deterministisch
+  // (pipeline-runner.js 'conflict-escalate'); nur die Entscheidung nicht.
+  const conflictJson = await runRunner(agent, 'conflict-check', {
+    ticket_id: A.ticket_id, brand, files: scout.touched_files,
+  })
+  let conflictRes = { rc: 2, conflicts: [] }
+  try {
+    conflictRes = JSON.parse(String(conflictJson).trim())
+  } catch {
+    // Unparsebare Antwort ist rc 2 — ein Fehler, ausdruecklich KEINE Freigabe.
+    log(`conflict-check: unparsebare Antwort, als rc 2 gewertet: ${String(conflictJson).slice(0, 120)}`)
+  }
+  const conflict = JSON.stringify(conflictRes.conflicts || [])
+  if (conflictRes.rc === 1 && (conflictRes.conflicts || []).length > 0) {
     log(`Conflict detected: ${conflict}`)
     await agent(
       `Release slot + return to queue:

--- a/scripts/factory/schedule.sh
+++ b/scripts/factory/schedule.sh
@@ -67,13 +67,25 @@ SQL
     continue
   fi
 
-  # Best-effort conflict gate on known touched_files. rc 0 = no conflict,
-  # rc 1 = conflict (skip), rc 2 = error/null touched_files (treat as schedulable).
+  # Conflict gate on known touched_files. rc 0 = no conflict, rc 1 = conflict (skip),
+  # rc 2 = error/null touched_files.
+  #
+  # [T002418] rc 2 bleibt schedulable, wird aber nicht mehr stillschweigend geschluckt.
+  # Die Spalte touched_files wurde bis T002418 nie befuellt (pipeline.mjs verwarf
+  # scout.touched_files nach dem unmittelbaren Check), weshalb dieser Aufruf hier
+  # praktisch IMMER rc 2 lieferte und das Gate faktisch wirkungslos war — so liefen am
+  # 2026-07-28 T002341/T002373/T002374 gleichzeitig auf scripts/agent-lock.sh.
+  # Seit dem Scout-Write ist rc 2 der Ausnahmefall und damit ein Befund: sichtbar auf
+  # stderr, damit man merkt, wenn das Gate wieder blind laeuft. Fail-open bleibt es
+  # bewusst — ein nicht erreichbarer DB-Pod darf den Dispatch nicht komplett anhalten.
   set +e
   BRAND="$BRAND" FACTORY_CTX="$FACTORY_CTX" bash "$HERE/conflict-check.sh" "$ext_id" >/dev/null 2>&1
   rc=$?
   set -e
   [[ "$rc" -eq 1 ]] && continue
+  if [[ "$rc" -eq 2 ]]; then
+    echo "WARN: conflict-check rc 2 fuer $ext_id (keine touched_files oder Fehler) — schedule ungeprueft [T002418]" >&2
+  fi
 
   # Gang-Bedarf des Kandidaten (Design §3): slot_count wird von stage-plan
   # --partials gesetzt; Default 1 = Single-Slot wie bisher.

--- a/tests/spec/software-factory.bats
+++ b/tests/spec/software-factory.bats
@@ -518,7 +518,12 @@ PIPELINE_SCRIPT="scripts/factory/pipeline.mjs"
 }
 
 @test "FA-SF-20: pipeline writes a per-phase liveness touch (>=6 references)" {
-  run grep -c "ticket.sh touch" "$PIPELINE_SCRIPT"
+  # [T002418] Ueber pipeline.mjs UND pipeline-runner.js gezaehlt. Die Anforderung ist
+  # unveraendert — jede Phase meldet Liveness, sonst haelt der Watchdog sie fuer tot.
+  # Verlagert hat sich nur der Ort: die Liveness der Plan-Phase steckte im Prompt des
+  # Conflict-Agenten und ist mit dessen Wegfall in den Runner gewandert, wo sie
+  # deterministisch laeuft statt davon abzuhaengen, dass ein Modell die Zeile ausfuehrt.
+  run bash -c "cat '$PIPELINE_SCRIPT' scripts/factory/pipeline-runner.js | grep -cE \"ticket[.]sh touch|'touch', '--id'\""
   [ "$status" -eq 0 ]
   [ "$output" -ge 6 ]
 }

--- a/tests/spec/software-factory/conflict-gate.bats
+++ b/tests/spec/software-factory/conflict-gate.bats
@@ -1,0 +1,101 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/conflict-gate.bats — Factory-Conflict-Gate [T002418]
+#
+# Vier voneinander unabhaengige Loecher, die am 2026-07-28 dazu fuehrten, dass T002341,
+# T002373 und T002374 gleichzeitig scripts/agent-lock.sh aenderten (PRs #3446/#3448/#3449
+# kollidierten). Jedes Loch hat hier seinen eigenen Test.
+#
+# Neue Verzeichniskonvention (T002416): eine Datei pro Vorgang unter tests/spec/<spec-slug>/.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  CHECK="${REPO_ROOT}/scripts/factory/conflict-check.sh"
+  PIPELINE="${REPO_ROOT}/scripts/factory/pipeline.mjs"
+  RUNNER="${REPO_ROOT}/scripts/factory/pipeline-runner.js"
+  SCHEDULE="${REPO_ROOT}/scripts/factory/schedule.sh"
+}
+
+# Nicht-Kommentarzeilen einer Datei — sonst matchen die Erklaerungen, die gerade
+# beschreiben, warum die alte Form falsch war.
+_code() { grep -vE '^\s*(#|//|\*|/\*)' "$1"; }
+
+@test "conflict-gate A1: Statusfilter bleibt auf in_progress/in_review" {
+  # Geprueft und VERWORFEN: 'plan_staged' aufzunehmen. Es sah nach der offensichtlichen
+  # Luecke aus, ist aber falsch — schedule.sh ruft conflict-check VOR slots.sh claim-gang
+  # auf, und der Claim setzt status='in_progress'. Der naechste Schleifendurchlauf sieht
+  # das vorherige Ticket also. 'plan_staged' wuerde falsch-positiv blockieren, weil ein
+  # Ticket dort tagelang liegen kann. Doppelt festgehalten (auch in FA-SF-45), damit die
+  # Versuchung nicht wiederkehrt.
+  #
+  # Positiv-Anker: der Statusfilter existiert ueberhaupt ...
+  run bash -c "_code() { grep -vE '^\s*(#|--)' \"\$1\"; }; _code '$CHECK' | grep -c 't.status IN'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+  # ... und fuehrt weder plan_staged noch backlog.
+  run bash -c "_code() { grep -vE '^\s*(#|--)' \"\$1\"; }; _code '$CHECK' | grep 't.status IN' | grep -cE 'plan_staged|backlog'"
+  [ "$output" -eq 0 ]
+}
+
+@test "conflict-gate A1b: SQL-Typfilter erfasst bug und fix" {
+  # Positiv-Anker: der Typfilter existiert und kennt feature ...
+  run bash -c "_code() { grep -vE '^\s*(#|//)' \"\$1\"; }; _code '$CHECK' | grep 't.type IN' | grep -c 'feature'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+  # ... und auch bug/fix. Die drei realen Kollidenten waren Mishap-Tickets.
+  run bash -c "_code() { grep -vE '^\s*(#|//)' \"\$1\"; }; _code '$CHECK' | grep 't.type IN' | grep -c \"'bug'\""
+  [ "$output" -ge 1 ]
+}
+
+@test "conflict-gate A2: pipeline-runner.js kennt das Kommando conflict-check" {
+  # Positiv-Anker: der Runner dispatcht ueberhaupt Kommandos, u.a. das bereits
+  # vorhandene conflict-escalate ...
+  run bash -c "grep -c \"command === 'conflict-escalate'\" '$RUNNER'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+  # ... und der CHECK selbst laeuft jetzt ebenfalls deterministisch statt ueber einen
+  # Agenten. Genau diese Asymmetrie war der Defekt.
+  run bash -c "grep -c \"command === 'conflict-check'\" '$RUNNER'"
+  [ "$output" -ge 1 ]
+}
+
+@test "conflict-gate A3: pipeline.mjs entscheidet nicht per Regex auf LLM-Prosa" {
+  # Positiv-Anker: die Plan-Phase ruft den Conflict-Check ueberhaupt auf ...
+  run bash -c "grep -c 'conflict' '$PIPELINE'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+  # ... aber nicht mehr ueber einen Regex auf der Freitext-Antwort eines Agenten.
+  # /\"T0/ traf nur, wenn das Modell die Ticket-ID zufaellig in Anfuehrungszeichen ausgab.
+  run bash -c "_code() { grep -vE '^\s*(//|\*|/\*)' \"\$1\"; }; _code '$PIPELINE' | grep -c 'test(conflict)'"
+  [ "$output" -eq 0 ]
+  # Positiv-Gegenprobe: die Entscheidung laeuft ueber runRunner, also deterministisch.
+  run bash -c "grep -c \"runRunner(.*'conflict-check'\" '$PIPELINE'"
+  [ "$output" -ge 1 ]
+}
+
+@test "conflict-gate A4: pipeline.mjs persistiert scout.touched_files ins Ticket" {
+  # Die Wurzel aller vier Loecher: der Scout KENNT die Dateien, gibt sie an den
+  # unmittelbaren Check weiter und wirft sie dann weg. Weil touched_files in der DB null
+  # bleibt (verifiziert an T002341), ist jedes Ticket fuer nachfolgende Pruefungen
+  # unsichtbar — conflict-check.sh filtert mit "touched_files IS NOT NULL".
+  #
+  # Positiv-Anker: der Scout liefert die Liste ueberhaupt ...
+  run bash -c "grep -c 'scout.touched_files' '$PIPELINE'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+  # ... und sie wird ins Ticket geschrieben.
+  run bash -c "grep -c 'set-touched-files\|set_touched_files' '$PIPELINE'"
+  [ "$output" -ge 1 ]
+}
+
+@test "conflict-gate A2b: schedule.sh uebergibt die Dateiliste nicht mehr implizit" {
+  # Positiv-Anker: schedule.sh ruft das Gate auf ...
+  run bash -c "_code() { grep -vE '^\s*#' \"\$1\"; }; _code '$SCHEDULE' | grep -c 'conflict-check.sh'"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+  # ... und rc 2 geht nicht mehr stillschweigend durch. Geprueft wird der ausfuehrbare
+  # Zweig, nicht der Kommentar: die alte Fassung erklaerte rc 2 bereits in einem Kommentar
+  # ("rc 2 = error/null touched_files (treat as schedulable)"), ein grep ueber die ganze
+  # Datei waere davon schon vakuos gruen gewesen.
+  run bash -c "grep -vE '^\s*#' '$SCHEDULE' | grep -A2 'rc\" -eq 2' | grep -c 'WARN'"
+  [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
Teil 3 von 3 gegen PR-Konflikte bei paralleler Agentenarbeit. Teil 1 (`task pr:refresh`, T002413) in #3464 gemergt, Teil 2 (tests/spec-Verzeichniskonvention, T002416) in #3469.

## Problem

Am 2026-07-28 liefen T002341, T002373 und T002374 gleichzeitig und änderten alle
`scripts/agent-lock.sh`. Die PRs #3446, #3448 und #3449 kollidierten. Das Conflict-Gate der
Factory hätte das verhindern müssen.

## Die Wurzel: das Gate hatte kein Gedächtnis

`pipeline.mjs` setzte `featureTouchedFiles = scout.touched_files`, reichte die Liste an den
unmittelbaren Check weiter — und **verwarf sie dann**. Sie landete nie im Ticket.
Verifiziert an T002341: `touched_files` ist `null`.

`conflict-check.sh` filtert aber mit `AND t.touched_files IS NOT NULL`. Ein Ticket ohne
diese Spalte war damit für **jede** nachfolgende Kollisionsprüfung unsichtbar. Zusätzlich
ruft `schedule.sh:73` ohne Dateiliste auf, was bei `null` zu `rc 2` führt — und `rc 2`
galt als „treat as schedulable".

## Änderungen

| | Was | Datei |
|---|---|---|
| A4 | `scout.touched_files` wird ins Ticket persistiert | `pipeline.mjs`, `pipeline-runner.js` |
| A3 | Check läuft deterministisch statt per Regex auf LLM-Prosa | `pipeline.mjs`, `pipeline-runner.js` |
| A1b | Typfilter kennt `bug`/`fix` — die Kollidenten waren Mishap-Tickets | `conflict-check.sh` |
| A2b | `rc 2` wird als WARN sichtbar statt stillschweigend geschluckt | `schedule.sh` |

Zu A3: `pipeline.mjs:274` entschied mit `if (/\"T0/.test(conflict))` — einem Regex auf der
Freitext-Antwort eines LLM. Der traf nur, wenn das Modell die Ticket-ID zufällig in
Anführungszeichen ausgab. Auffällig war die Asymmetrie: `conflict-escalate` lief längst
deterministisch über `pipeline-runner.js`, nur die Entscheidung *darüber* nicht. Der Check
folgt jetzt demselben `runRunner()`-Muster und liefert `{rc, conflicts[]}`.

## Geprüft und verworfen: `plan_staged` im Statusfilter

Sah nach der offensichtlichsten Lücke aus — „im Moment des Dispatch ist noch kein Ticket
`in_progress`, das Gate prüft gegen einen Zustand, den es selbst erst herstellt".
**Falsch.** `schedule.sh` ruft `conflict-check` (Z. 82) **vor** `slots.sh claim-gang`
(Z. 106) auf, und der Claim setzt `status='in_progress'`; der nächste Schleifendurchlauf
sieht das vorherige Ticket also sehr wohl. `plan_staged` aufzunehmen wäre sogar schädlich:
ein Ticket kann dort tagelang liegen und würde in dieser Zeit jedes andere mit
überlappenden Dateien blockieren.

Der bestehende Test `FA-SF-45` hielt genau diese Entscheidung fest und hat die Regression
verhindert. Sie ist jetzt doppelt festgenagelt, damit die Versuchung nicht wiederkehrt.

## Nachweis am echten System

Zwei Tickets mit überlappendem `Taskfile.yml`, gegen die Produktions-DB:

```
nach dem Fix:        rc=1  ["T002416"]     ← Konflikt erkannt
touched_files=null:  rc=0  []              ← blind (Zustand vor diesem PR)
```

## Liveness

Der Wegfall des Conflict-Agenten hat die Liveness-Meldung der Plan-Phase mitgenommen —
`FA-SF-20` hat das gefangen (`>=6 references`). Sie läuft jetzt deterministisch im Runner
statt davon abzuhängen, dass ein Modell die Zeile ausführt; der Test zählt entsprechend über
beide Dateien. Gegengeprobt: ohne den Touch wird er rot.

## Tests

`tests/spec/software-factory/conflict-gate.bats` — 6 Tests nach der frisch eingeführten
Verzeichniskonvention aus T002416. Vor der Implementierung 5/6 rot, jetzt 6/6 grün.
`tests/spec/software-factory.bats` 0 Fehler, `freshness:check` exit 0.

## Nicht in diesem PR

`tests/local/FA-SF-20-pipeline-contract.bats` ist auf `main` mit 13 Tests rot — die Datei
sucht das von PR #3450 entfernte `pipeline.js`. Vorbestehend, als **T002421** erfasst.

Design-Spec: `docs/superpowers/specs/2026-07-28-pr-conflict-reduction-design.md`

Closes T002418
