### PR TITLE
fix(scripts): Mishap-Bundle — repo-hygiene porcelain-check, hook noise filter, get.sh positional ID [T002379]

### DIFF
--- a/.claude/skills/references/repo-hygiene-ops.md
+++ b/.claude/skills/references/repo-hygiene-ops.md
@@ -8,11 +8,18 @@ DB-Zugriff (MCP-first, `psql()`-Fallback, `ticket_plans`-Warnung): siehe
 
 ## 1. Stale Git Worktrees
 
+Pflicht-Vorcheck vor jedem Remove: **Arbeit muss gesichert sein.** Leerer Commit-Bereich allein reicht nicht — ein Worktree kann ungetrackte Änderungen enthalten, die kein `git log` anzeigt.
+
 ```bash
 git worktree list
-git log main..<branch> --oneline   # leer = vollständig gemergt
-git worktree remove <path> --force
+# Für jeden Worktree (außer main, außer aktuell gehaltener):
+git status --porcelain   # MUSS leer sein — sonst kein Remove
+git log main..<branch> --oneline   # Info: leer = Branch vollständig gemergt
+git worktree remove <path>          # ohne --force (Schutz bei ungetrackten Dateien)
 ```
+
+`--force` nur als bewusste Eskalation verwenden, wenn der Vorcheck sauber ist und
+`git worktree remove` trotzdem verweigert (z.B. bei.locked Worktrees).
 
 ## 2. Stale Branches
 

--- a/.githooks/post-commit-index
+++ b/.githooks/post-commit-index
@@ -26,8 +26,13 @@ echo "$CHANGED" | while IFS= read -r f; do
   (
     cd "$repo_root" || exit 1
     if ! out=$(timeout 30 npx tsx scripts/index-repo.ts --file "$f" 2>&1); then
-      echo "[SCS] WARN: reindex failed for $f" >&2
-      echo "$out" | tail -5 >&2
+      # Filter out noisy Node error objects — keep one summary line only
+      if echo "$out" | grep -q 'ECONNREFUSED'; then
+        echo "[SCS] skip: pgvector not reachable" >&2
+      else
+        echo "[SCS] WARN: reindex failed for $f" >&2
+        echo "$out" | tail -3 >&2
+      fi
     fi
   ) &
 done

--- a/scripts/vda/ticket/get.sh
+++ b/scripts/vda/ticket/get.sh
@@ -7,7 +7,8 @@ main() {
   local id=""
   while [[ $# -gt 0 ]]; do case "$1" in
       --id) id="$2"; shift 2 ;;
-      *)    echo "Unknown get option: $1" >&2; exit 2 ;;
+      -*)   echo "Unknown get option: $1 (valid: --id <ID>)" >&2; exit 2 ;;
+      *)    if [[ -z "$id" ]]; then id="$1"; shift; else echo "Unexpected argument: $1 (valid: --id <ID>)" >&2; exit 2; fi ;;
     esac; done
   if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
   # TICKET_OFFLINE=1 — refuse the read loudly so the operator knows the


### PR DESCRIPTION
Fixes T002379 — 3 Mishaps:
- repo-hygiene-ops §1: git status --porcelain Pflicht-Vorcheck vor Remove
- post-commit-index: ECONNREFUSED auf eine Zeile reduzieren
- ticket.sh get: positionale ID akzeptieren + Fehlermeldung mit gültigen Flags