### PR TITLE
fix(scripts): collision-window — D1-D4 behoben: UUID-SIDs, committete Divergenz, Blob-Filter, --branch-Modus [T002444]

### DIFF
--- a/.claude/skills/references/session-coordination.md
+++ b/.claude/skills/references/session-coordination.md
@@ -96,6 +96,9 @@ bash scripts/agent-collision.sh check --staged
 # Prüfe staged + unstaged Änderungen
 bash scripts/agent-collision.sh check --all
 
+# Prüfe die eigene Branch-Divergenz (praeventiver Modus, auch bei sauberem Working Tree)
+bash scripts/agent-collision.sh check --branch
+
 # Stille Prüfung (exit code only)
 bash scripts/agent-collision.sh check --quiet
 ```

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 599,
+      "file_count": 600,
       "files": [
         "tests/.gitignore",
         "tests/README.md",

--- a/openspec/changes/archive/2026-07-28-collision-window/design.md
+++ b/openspec/changes/archive/2026-07-28-collision-window/design.md
@@ -1,0 +1,179 @@
+---
+ticket_id: T002444
+plan_ref: openspec/changes/collision-window/tasks.md
+status: active
+date: 2026-07-28
+---
+
+# Design: agent-collision.sh — Sichtfenster reparieren
+
+_Ticket: T002444 · Spec: `openspec/specs/software-factory.md` → Requirement „Agent-Kollisionserkennung bei parallelen Edits"_
+
+## Problem
+
+`scripts/agent-collision.sh` (T000882) läuft im `.githooks/pre-commit` und soll warnen, wenn eine
+andere lebende Session dieselbe Datei in Arbeit hat. Er meldet praktisch nie etwas — nicht weil es
+keine Kollisionen gibt, sondern weil zwei unabhängige Filter sich zu einer Trefferquote nahe null
+multiplizieren.
+
+Das blieb unbemerkt, weil ein stiller Detektor nicht von einem sauberen Repo zu unterscheiden ist.
+Erst der belegte Vorfall vom 2026-07-28 — drei Worktrees gleichzeitig an `scripts/agent-lock.sh` —
+machte sichtbar, dass die Warnung nie kam.
+
+## Befunde
+
+Alle vier Punkte sind gemessen, nicht abgeleitet. Messbasis: 23 aktive Worktrees, 11 Lock-Dateien
+mit Worktree-Pfad, Stand 2026-07-28.
+
+### D1 — Harness-SIDs gelten als tot
+
+`scripts/agent-collision.sh:_sid_alive` ist eine Kopie von `scripts/agent-lock.sh:_sid_alive`, die
+den Fix aus **T001268** nicht mitbekommen hat. Das Original behandelt nicht-numerische SIDs als
+lebendig, weil `pgrep -s` nur POSIX-Session-IDs auflöst und Harness-SIDs (`CLAUDE_SESSION_ID`)
+UUIDs sind:
+
+```bash
+# scripts/agent-lock.sh:64 — mit Fix
+case "$1" in *[!0-9]*) return 0;; esac
+pgrep -s "$1" >/dev/null 2>&1
+
+# scripts/agent-collision.sh:26 — Kopie ohne Fix
+pgrep -s "$1" >/dev/null 2>&1
+```
+
+Wirkung: **jeder** Claude-Code-Peer wird als tot klassifiziert und übersprungen. Gemessen meldet
+`agent-collision.sh` null von elf Peers als lebendig, während `agent-lock.sh list` dieselben als
+`live` führt.
+
+Der Kopf von `agent-collision.sh` erklärt ausdrücklich, dieselben Overrides wie `agent-lock.sh` zu
+ehren. Die Absicht war Spiegelung; T001268 patchte nur eine der beiden Kopien.
+
+### D2 — Sichtfenster umfasst nur uncommitted Arbeit
+
+Die Peer-Menge stammt aus `git -C "$wt" diff --name-only HEAD` plus `--cached`, also ausschließlich
+dem Working Tree. Die `dev-flow-*`-Skills committen jedoch früh und mehrfach (Scaffold-Commit,
+Plan-Stage-Commit, dann Implementierung). Wenige Minuten nach Arbeitsbeginn ist ein Peer wieder
+unsichtbar.
+
+| Messung über 23 Worktrees | Dateien |
+|---|---|
+| `main...HEAD` — tatsächliche in-flight Arbeit | 154 |
+| `diff HEAD` + `--cached` — was der Detektor sieht | 3 |
+
+Für den belegten Vorfall: die drei Kollidenten an `scripts/agent-lock.sh`
+(`chore/fix-ticket-tracking-T002279`, `chore/mishap-T002341`, `chore/mishap-T002374`) haben
+sämtlich **null** uncommitted Änderungen an der Datei. Sichtbar waren 0 von 3.
+
+### D3 — Squash-gemergte Branches warnen weiter
+
+Nach einem Squash-Merge sind die Branch-Commits keine Ancestors von `main`; `main...HEAD` listet die
+Dateien unverändert weiter, obwohl die Arbeit längst in `main` steht. Gemessen sind **3 von 11**
+Kandidaten-Paaren blob-identisch zu `main` — reine Fehlalarme, also genau die Sorte Rauschen, die
+Warnungen unglaubwürdig macht.
+
+### D4 — nur reaktiv
+
+Der Detektor greift im pre-commit-Hook, also nachdem geschrieben wurde. Für die Frage „arbeitet
+gerade jemand an dem, was ich anfassen will?" — der Zeitpunkt in `dev-flow-plan` Schritt −1 —
+existiert kein Aufruf.
+
+## Lösung
+
+Alle Änderungen bleiben in `scripts/agent-collision.sh`. `scripts/agent-lock.sh` wird **nicht**
+angefasst: dort arbeiten aktuell drei Worktrees, eine Extraktion in eine gemeinsame Bibliothek
+würde einen Vier-Wege-Konflikt provozieren. Die Drift-Ursache wird stattdessen durch einen
+Guard-Test adressiert.
+
+### D1 — Nicht-numerisch-Zweig spiegeln
+
+Die drei Zeilen aus `agent-lock.sh:64` werden übernommen, mit Verweis auf T001268 und auf den
+Guard-Test. Der Zweig greift ausschließlich für nicht-numerische SIDs; numerische SIDs bleiben
+`pgrep`-verifiziert, damit tote Sessions weiterhin tot sind.
+
+### D2 — Peer-Menge erweitern
+
+```
+peer_files = union(
+  git -C $wt diff --name-only $base...HEAD,   # committete Branch-Divergenz
+  git -C $wt diff --name-only HEAD,           # unstaged
+  git -C $wt diff --name-only --cached        # staged
+)
+```
+
+**Drei-Punkt ist Pflicht.** Der naheliegende Zwei-Punkt-Diff (`git diff main HEAD`) wurde gemessen
+und verworfen: er zieht alles mit, was `main` seit dem Fork dazubekommen hat, und liefert 52–386
+Dateien pro Worktree statt 0–13.
+
+`$base` wird als `main` aufgelöst. Schlägt das fehl (detached HEAD, fehlender Branch), entfällt nur
+der committete Anteil; der Working-Tree-Anteil läuft weiter. Degradation statt Ausfall.
+
+### D3 — Blob-Filter
+
+Für jede Datei, die nach Schnittmengenbildung übrig ist, wird `HEAD:<datei>` im Peer-Worktree gegen
+`main:<datei>` verglichen. Bei Gleichheit ist nichts offen, der Eintrag entfällt. Der Vergleich
+läuft nur auf der kleinen Schnittmenge, nicht auf allen Peer-Dateien — die Kosten sind
+vernachlässigbar.
+
+### D4 — `--branch`-Modus
+
+Ein weiterer Modus neben `--staged` und `--all`. Die eigene Dateimenge wird zu
+`main...HEAD ∪ diff HEAD ∪ --cached`, die Peer-Seite bleibt identisch. Damit ist der Detektor vor
+Arbeitsbeginn nutzbar, ohne ein zweites Skript.
+
+### Unverändert
+
+- **fail-open** bleibt das Grundprinzip: jeder Git-Aufruf, der fehlschlägt, gilt als „keine Daten"
+  und blockt nie. `AGENT_COLLISION_STRICT=1` bleibt der einzige Weg zum harten Block.
+- Der `linguist-generated`-Filter aus **T002375-p6** bleibt, Quelle bleibt `.gitattributes`.
+- Keine Cluster- oder DB-Abhängigkeit; das Skript bleibt reines lokales Bash und damit CI-tauglich.
+- `scripts/factory/conflict-check.sh` bleibt unberührt. Es beantwortet eine andere Frage
+  (Factory-Dispatch-Gate über deklarierte `touched_files`) und wird hier nicht mitverändert.
+
+## Restrauschen
+
+Nach dem Fix und nach dem bestehenden Generated-Filter bleiben repo-weit **5 Dateien in 7 von 23
+Worktrees** übrig:
+
+| Datei | Worktrees |
+|---|---|
+| `scripts/agent-lock.sh` | 3 |
+| `tests/spec/ci-cd.bats` | 2 |
+| `scripts/vda/ticket/update-status.sh` | 2 |
+| `.claude/skills/references/ticket-ops-procedures.md` | 2 |
+| `.claude/skills/references/mcp-tool-guide.md` | 2 |
+
+Das ist Signal, kein Rauschen. Eine zusätzliche Drossel ist nicht nötig.
+
+## Test-Strategie
+
+Zwei Eigenschaften dieses Bugs bestimmen den Testaufbau.
+
+**Der bestehende Test umgeht die brechende Zeile.** `tests/unit/agent-collision.bats` setzt in jedem
+Fall `AGENT_LOCK_FAKE_ALIVE`; dieser Override greift in `_sid_alive` vor dem `pgrep`-Pfad. Der
+D1-Test muss ihn deshalb weglassen und mit einer echten UUID arbeiten — sonst prüft er erneut am
+Defekt vorbei.
+
+**Der Drift-Guard muss verhaltensbasiert sein.** Ein Grep auf `*[!0-9]*` bliebe grün, wenn jemand
+die Bedingung umformuliert. Stattdessen bekommen beide Skripte dieselbe UUID-SID vorgelegt und
+müssen dasselbe Urteil fällen: `agent-lock.sh list` meldet `live`, `agent-collision.sh` meldet die
+Kollision. Bricht eine der Kopien, divergieren die Urteile.
+
+Ergänzend gilt die Positiv-Anker-Pflicht aus **T002356-M1**: Der D3-Fall („identischer Blob warnt
+nicht") wäre bei kaputtem Detektor trivial wahr. Der Anker — „divergenter Blob warnt sehr wohl" —
+steht deshalb im selben Test und davor.
+
+Neue Datei nach **T002416**: `tests/spec/software-factory/collision-window.bats`, ein Verzeichnis
+pro SSOT-Spec, eine Datei pro Vorgang. Die Sammeldatei `tests/spec/software-factory.bats` wird nicht
+erweitert.
+
+## Abgrenzung
+
+Nicht Teil dieses Changes:
+
+- **Semantische Kollisionen** — zwei Worktrees, die in verschiedenen Dateien dasselbe oder
+  Widersprüchliches tun. Seit T002416 („ein Verzeichnis pro Spec") mergen solche Fälle
+  konfliktfrei und sind für jede pfadbasierte Erkennung unsichtbar. Eigenes Ticket, hängt
+  sinnvollerweise an T002423.
+- **Merge-Arbitrierung** — die kurative Auflösung bei ≥3 kollidierenden PRs ist T002423.
+- **Dedup der Helferfunktionen** nach `scripts/lib/` — bewusst zurückgestellt wegen der drei
+  offenen Worktrees an `agent-lock.sh`.

--- a/openspec/changes/archive/2026-07-28-collision-window/proposal.md
+++ b/openspec/changes/archive/2026-07-28-collision-window/proposal.md
@@ -1,0 +1,60 @@
+# Proposal: collision-window
+
+## Why
+
+`scripts/agent-collision.sh` läuft seit T000882 im `.githooks/pre-commit` und soll warnen, wenn eine
+andere lebende Session dieselbe Datei in Arbeit hat. Er meldet praktisch nie etwas — und das sah bis
+jetzt aus wie ein Repo ohne Kollisionen.
+
+Am 2026-07-28 arbeiteten drei Worktrees gleichzeitig an `scripts/agent-lock.sh`
+(`chore/fix-ticket-tracking-T002279`, `chore/mishap-T002341`, `chore/mishap-T002374`). Keine Warnung
+kam. Die Nachmessung zeigt zwei unabhängige Filter, die sich zu einer Trefferquote nahe null
+multiplizieren:
+
+- **Harness-SIDs gelten als tot.** `_sid_alive` in `agent-collision.sh` ist eine Kopie derselben
+  Funktion aus `agent-lock.sh`, die den Fix aus **T001268** nicht mitbekommen hat. Dort werden
+  nicht-numerische SIDs als lebendig behandelt, weil `pgrep -s` nur POSIX-Session-IDs auflöst und
+  Claude-Code-Sessions UUIDs registrieren. Die Kopie ruft direkt `pgrep -s` auf. Gemessen: **null
+  von elf** Peers werden als lebendig erkannt, während `agent-lock.sh list` dieselben als `live`
+  führt.
+- **Das Sichtfenster endet am Working Tree.** Die Peer-Menge kommt aus `git diff --name-only HEAD`
+  plus `--cached`. Die `dev-flow-*`-Skills committen aber früh und mehrfach; wenige Minuten nach
+  Arbeitsbeginn ist ein Peer wieder unsichtbar. Gemessen über 23 Worktrees: **154 Dateien** sind
+  tatsächlich in Arbeit, **3** davon sieht der Detektor. Von den drei Kollidenten oben waren **0
+  von 3** sichtbar.
+
+Dass es unbemerkt blieb, hat einen eigenen Grund: `tests/unit/agent-collision.bats` setzt in jedem
+Test `AGENT_LOCK_FAKE_ALIVE`, und dieser Override greift in `_sid_alive` **vor** dem `pgrep`-Pfad.
+Die Suite umgeht strukturell genau die Zeile, die produktiv bricht.
+
+## What
+
+Vier Änderungen, alle in `scripts/agent-collision.sh`. `scripts/agent-lock.sh` bleibt unangetastet —
+dort arbeiten aktuell drei Worktrees, und eine Extraktion in eine gemeinsame Bibliothek würde einen
+Vier-Wege-Konflikt provozieren. Gegen erneute Drift steht stattdessen ein Guard-Test.
+
+- **Nicht-numerische SIDs als lebendig behandeln** — den Zweig aus `agent-lock.sh` spiegeln, mit
+  Verweis auf T001268. Numerische SIDs bleiben `pgrep`-verifiziert, damit tote Sessions tot bleiben.
+- **Peer-Menge um committete Branch-Divergenz erweitern** — `main...HEAD` zusätzlich zu unstaged und
+  staged. Der Drei-Punkt-Operator ist Pflicht: der Zwei-Punkt-Diff wurde gemessen und verworfen, er
+  zieht den gesamten `main`-Fortschritt seit dem Fork mit (52–386 statt 0–13 Dateien pro Worktree).
+- **Blob-Filter gegen squash-gemergte Branches** — nach einem Squash-Merge listet `main...HEAD` die
+  Dateien weiter, obwohl die Arbeit in `main` steht. Ist der Blob im Peer identisch mit dem in
+  `main`, entfällt der Eintrag. Gemessen wären das sonst **3 von 11** Fehlalarmen.
+- **`--branch`-Modus** — prüft die eigene Branch-Divergenz statt der staged Files und macht den
+  Detektor damit **vor** Arbeitsbeginn nutzbar, nicht erst im pre-commit.
+
+Unverändert bleiben das fail-open-Prinzip (`AGENT_COLLISION_STRICT=1` bleibt der einzige harte
+Block), der `linguist-generated`-Filter aus T002375-p6 und die Freiheit von Cluster- und
+DB-Abhängigkeiten.
+
+Nach dem Fix bleiben repo-weit **5 Dateien in 7 von 23 Worktrees** als Warnung übrig — Signal, kein
+Rauschen. Eine zusätzliche Drossel ist nicht nötig.
+
+**Out of scope:** semantische Kollisionen (zwei Worktrees, die in *verschiedenen* Dateien
+Widersprüchliches tun — seit T002416 mergen die konfliktfrei und sind für jede pfadbasierte
+Erkennung unsichtbar; eigenes Ticket, hängt an T002423); Merge-Arbitrierung bei ≥3 PRs (T002423);
+Dedup der Helferfunktionen nach `scripts/lib/`; `scripts/factory/conflict-check.sh`, das die andere
+Frage beantwortet (Factory-Dispatch-Gate über deklarierte `touched_files`).
+
+_Ticket: T002444_

--- a/openspec/changes/archive/2026-07-28-collision-window/specs/software-factory.md
+++ b/openspec/changes/archive/2026-07-28-collision-window/specs/software-factory.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Agent-Kollisionserkennung bei parallelen Edits
+
+The system SHALL detect when a live peer agent has in-flight modifications to the same files as the
+current session. In-flight means the union of the peer's committed branch divergence
+(`<base>...HEAD`, three-dot), its unstaged changes and its staged changes — a peer that has already
+committed its work MUST still be reported. Peer liveness SHALL follow the same rule as
+`agent-lock.sh`: non-numeric (harness-provided) session IDs count as alive because `pgrep -s` cannot
+resolve them; numeric session IDs remain `pgrep`-verified. Files whose blob in the peer worktree is
+identical to the blob in the base branch SHALL be dropped, so squash-merged branches stop warning.
+`--staged` checks staged files, `--all` additionally unstaged, `--branch` the current session's own
+committed branch divergence. On collision: exit 1 with a `COLLISION` line naming the file;
+`--quiet` suppresses the lines but keeps the exit code; dead or own sessions are ignored. Every git
+operation that fails degrades to "no data" (fail-open, exit 0) rather than blocking.
+
+#### Scenario: Überlappende Staged-Datei ergibt Kollision
+- **GIVEN** Peer-Session 2222 ist als lebendig markiert und hat `shared.txt` in Worktree B modifiziert; Session 1111 staged `shared.txt` in Worktree A
+- **WHEN** `agent-collision.sh check --staged` in Worktree A ausgeführt wird
+- **THEN** Exit 1; Ausgabe enthält `COLLISION` und `shared.txt`; `--quiet` gibt Exit 1 ohne Ausgabe
+
+#### Scenario: Tote Session und fehlender Worktree sind fail-open
+- **GIVEN** Peer-Session 2222 ist NICHT in `AGENT_LOCK_FAKE_ALIVE` (tot); oder Peer-Worktree-Pfad existiert nicht mehr
+- **WHEN** `agent-collision.sh check --staged` ausgeführt wird
+- **THEN** Exit 0 in beiden Fällen; eigene SID (1111) als Peer-Claim ergibt ebenfalls Exit 0 (keine Selbst-Kollision)
+
+#### Scenario: Harness-SID ohne pgrep-Auflösung gilt als lebendig
+- **GIVEN** ein Peer-Claim mit nicht-numerischer Session-ID (UUID) und einer überlappenden Datei; `AGENT_LOCK_FAKE_ALIVE` ist NICHT gesetzt
+- **WHEN** `agent-collision.sh check --staged` ausgeführt wird
+- **THEN** Exit 1 mit `COLLISION`; eine numerische, nicht existente Session-ID ergibt unter denselben Bedingungen Exit 0
+
+#### Scenario: Committete Peer-Arbeit ist sichtbar
+- **GIVEN** der Peer hat seine Änderung an `shared.txt` bereits committed, sein Working Tree ist sauber
+- **WHEN** `agent-collision.sh check --staged` mit derselben Datei staged ausgeführt wird
+- **THEN** Exit 1 mit `COLLISION` und `shared.txt`; eine committete Peer-Änderung an einer anderen Datei ergibt Exit 0
+
+#### Scenario: Squash-gemergter Peer warnt nicht mehr
+- **GIVEN** der Peer hat `shared.txt` committed und derselbe Inhalt steht inzwischen über einen eigenen Commit in `main`, sodass die Blobs identisch sind
+- **WHEN** `agent-collision.sh check --staged` ausgeführt wird
+- **THEN** Exit 0; solange der Peer-Blob dagegen von `main` abweicht, ergibt derselbe Aufruf Exit 1
+
+#### Scenario: --branch prüft die eigene Branch-Divergenz
+- **GIVEN** die eigene Änderung an `shared.txt` ist bereits committed und nichts ist staged; ein lebender Peer hat dieselbe Datei in Arbeit
+- **WHEN** `agent-collision.sh check --branch` ausgeführt wird
+- **THEN** Exit 1 mit `shared.txt`; `--staged` ergibt im selben Zustand Exit 0; `--branch --quiet` gibt Exit 1 ohne Ausgabe; ein fehlender Peer-Worktree ergibt Exit 0

--- a/openspec/changes/archive/2026-07-28-collision-window/tasks.md
+++ b/openspec/changes/archive/2026-07-28-collision-window/tasks.md
@@ -1,0 +1,141 @@
+---
+title: "collision-window — Implementation Plan"
+ticket_id: T002444
+domains: [bachelorprojekt-test]
+status: completed
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# collision-window — Implementation Plan
+
+_Ticket: T002444 · Design: `openspec/changes/collision-window/design.md`_
+
+## File Structure
+
+| Datei | Ist | Budget |
+|---|---|---|
+| `scripts/agent-collision.sh` | 121 | 379 |
+| `tests/spec/software-factory/collision-window.bats` | 228 | — (`.bats` unterliegt keinem S1-Limit) |
+| `openspec/changes/collision-window/specs/software-factory.md` | neu | — |
+
+`scripts/agent-collision.sh` ist nicht gebaselined; wirksame Schwelle ist das statische
+`.sh`-Limit 500. Die geplanten Änderungen liegen bei rund 40 Zeilen, das Budget ist damit
+komfortabel. Kein Split nötig.
+
+`scripts/agent-lock.sh` wird bewusst **nicht** angefasst — drei offene Worktrees
+(`chore/fix-ticket-tracking-T002279`, `chore/mishap-T002341`, `chore/mishap-T002374`) ändern die
+Datei bereits. Die Drift-Ursache adressiert stattdessen der Guard-Test in Task 1.
+
+## Task 1 — RED bestätigen
+
+Der Test liegt bereits auf dem Branch (Fix-Pfad-Pflicht: failing Test vor Plan). Dieser Schritt
+bestätigt nur, dass er aus den richtigen Gründen rot ist, bevor irgendetwas implementiert wird.
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/software-factory/collision-window.bats
+# expected: FAIL — 6 von 8 rot (D1 ohne Override, D1-Drift-Guard, D2, D3, D4 ×2)
+```
+
+Die zwei grünen Tests sind Absicht: „numerisch-toter Peer bleibt tot" und „committete
+Peer-Änderung an anderer Datei" sichern ab, dass der Fix nicht über sein Ziel hinausschießt. Sie
+müssen am Ende grün bleiben.
+
+- [ ] Lauf ausgeführt, 6 rot / 2 grün bestätigt
+- [ ] Jeder Fehlschlag sitzt auf einer Defekt-Assertion, nicht auf einem Fixture-Fehler
+
+## Task 2 — D1: Harness-SIDs als lebendig behandeln
+
+In `scripts/agent-collision.sh`, Funktion `_sid_alive`: den Zweig aus `scripts/agent-lock.sh:64`
+spiegeln. Er gehört **nach** die `AGENT_LOCK_FAKE_ALIVE`-Abfrage und **vor** den `pgrep`-Aufruf,
+damit die Test-Overrides weiter Vorrang haben.
+
+```bash
+  # Spiegelt scripts/agent-lock.sh:_sid_alive [T001268]: nicht-numerische SIDs sind
+  # harness-vergebene Session-IDs (CLAUDE_SESSION_ID), die `pgrep -s` nicht aufloesen
+  # kann. Bei Aenderung dort HIER nachziehen — Guard: der Drift-Test in
+  # tests/spec/software-factory/collision-window.bats vergleicht beide Urteile.
+  case "$1" in *[!0-9]*) return 0;; esac
+```
+
+Numerische SIDs bleiben `pgrep`-verifiziert; tote Sessions bleiben tot.
+
+- [ ] Zweig ergänzt, Kommentar mit T001268-Verweis gesetzt
+- [ ] `bats tests/spec/software-factory/collision-window.bats` — die drei D1-Tests grün
+- [ ] `bats tests/unit/agent-collision.bats` — alle 8 Bestandstests weiter grün
+
+## Task 3 — D2: Peer-Menge um committete Divergenz erweitern
+
+In `cmd_check`, in der Peer-Schleife: die Peer-Dateimenge wird zur Vereinigung aus committeter
+Branch-Divergenz, unstaged und staged. Der Drei-Punkt-Operator ist zwingend — der Zwei-Punkt-Diff
+wurde gemessen und verworfen (er zieht den `main`-Fortschritt seit dem Fork mit, 52–386 statt
+0–13 Dateien pro Worktree).
+
+```bash
+  # Drei-Punkt gegen den Merge-Base: nur was DIESER Branch geaendert hat.
+  # Schlaegt die Aufloesung von main fehl (detached HEAD, fehlender Branch), entfaellt
+  # nur der committete Anteil — der Working-Tree-Anteil laeuft weiter (fail-open).
+  peer="$( { git -C "$wt" diff --name-only main...HEAD 2>/dev/null; \
+             git -C "$wt" diff --name-only HEAD 2>/dev/null; \
+             git -C "$wt" diff --cached --name-only 2>/dev/null; } | sed '/^$/d' | sort -u )"
+```
+
+- [ ] Peer-Menge erweitert, fail-open beim Auflösen des Base-Refs erhalten
+- [ ] `bats … collision-window.bats` — beide D2-Tests grün
+- [ ] Gegenprobe von Hand im echten Repo: `bash scripts/agent-collision.sh check --all` meldet
+      `scripts/agent-lock.sh` als Kollision mit den drei bekannten Worktrees
+
+## Task 4 — D3: Blob-Filter gegen squash-gemergte Peers
+
+Nach der Schnittmengenbildung, vor der Ausgabe: für jede Kollisionsdatei den Blob im
+Peer-Worktree gegen den in `main` vergleichen. Sind sie gleich, ist die Arbeit bereits in `main`
+und der Eintrag entfällt. Der Vergleich läuft nur auf der Schnittmenge, nicht auf allen
+Peer-Dateien.
+
+```bash
+  # Squash-Merge: die Peer-Commits sind keine Ancestors von main, main...HEAD listet die
+  # Datei weiter — aber wenn der Blob identisch ist, ist nichts mehr offen.
+  # Fehlschlagende rev-parse (Datei in main nicht vorhanden) => behalten, nicht verwerfen.
+  peer_blob="$(git -C "$wt" rev-parse "HEAD:$file" 2>/dev/null || true)"
+  main_blob="$(git rev-parse "main:$file" 2>/dev/null || true)"
+  [ -n "$peer_blob" ] && [ "$peer_blob" = "$main_blob" ] && continue
+```
+
+Die Richtung des fail-open ist hier bewusst umgekehrt: bei unklarer Datenlage wird **behalten**,
+also gewarnt. Ein Fehlalarm ist billiger als eine verschwiegene Kollision.
+
+- [ ] Blob-Filter ergänzt
+- [ ] `bats … collision-window.bats` — D3-Test grün, inklusive seines Positiv-Ankers
+
+## Task 5 — D4: `--branch`-Modus
+
+In der Argument-Schleife von `cmd_check` neben `--staged` und `--all`. Im Modus `branch` wird die
+eigene Dateimenge zur Vereinigung aus `main...HEAD`, unstaged und staged; die Peer-Seite bleibt
+unverändert. Der Usage-String am Ende von `main()` wird mitgezogen.
+
+Nach der Implementierung `.claude/skills/references/session-coordination.md` um den neuen Modus
+ergänzen (Abschnitt „Agent-Collision"), damit die Skill-Referenz nicht hinter dem Skript
+zurückbleibt.
+
+- [ ] `--branch` implementiert, Usage-String ergänzt
+- [ ] `bats … collision-window.bats` — beide D4-Tests grün
+- [ ] `session-coordination.md` um `--branch` ergänzt
+
+## Task 6 — Abschluss-Verifikation
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/software-factory/collision-window.bats
+tests/unit/lib/bats-core/bin/bats tests/unit/agent-collision.bats
+task test:inventory
+task test:changed
+task freshness:regenerate
+task freshness:check
+```
+
+- [ ] Alle 8 Tests der neuen Datei grün, alle 8 Bestandstests grün
+- [ ] `website/src/data/test-inventory.json` regeneriert und mitcommittet
+- [ ] `docs/code-quality/baseline.json` hat **keine** neuen Keys
+- [ ] `bash scripts/openspec.sh validate` grün

--- a/openspec/specs/software-factory.md
+++ b/openspec/specs/software-factory.md
@@ -339,7 +339,17 @@ The system SHALL parse a skill YAML frontmatter for `hooks.pre` and `hooks.post`
 
 ### Requirement: Agent-Kollisionserkennung bei parallelen Edits
 
-The system SHALL detect when a live peer agent (identified via `AGENT_LOCK_FAKE_ALIVE` / real session IDs) has in-flight modifications to the same files as the current session. `--staged` prüft staged Files, `--all` zusätzlich unstaged; bei Kollision Exit 1 mit `COLLISION`-Ausgabe und Dateiname; `--quiet` unterdrückt Ausgabezeilen, behält aber den Exit-Code; tote oder eigene Sessions werden ignoriert (fail-open).
+The system SHALL detect when a live peer agent has in-flight modifications to the same files as the
+current session. In-flight means the union of the peer's committed branch divergence
+(`<base>...HEAD`, three-dot), its unstaged changes and its staged changes — a peer that has already
+committed its work MUST still be reported. Peer liveness SHALL follow the same rule as
+`agent-lock.sh`: non-numeric (harness-provided) session IDs count as alive because `pgrep -s` cannot
+resolve them; numeric session IDs remain `pgrep`-verified. Files whose blob in the peer worktree is
+identical to the blob in the base branch SHALL be dropped, so squash-merged branches stop warning.
+`--staged` checks staged files, `--all` additionally unstaged, `--branch` the current session's own
+committed branch divergence. On collision: exit 1 with a `COLLISION` line naming the file;
+`--quiet` suppresses the lines but keeps the exit code; dead or own sessions are ignored. Every git
+operation that fails degrades to "no data" (fail-open, exit 0) rather than blocking.
 
 #### Scenario: Überlappende Staged-Datei ergibt Kollision
 - **GIVEN** Peer-Session 2222 ist als lebendig markiert und hat `shared.txt` in Worktree B modifiziert; Session 1111 staged `shared.txt` in Worktree A
@@ -351,7 +361,25 @@ The system SHALL detect when a live peer agent (identified via `AGENT_LOCK_FAKE_
 - **WHEN** `agent-collision.sh check --staged` ausgeführt wird
 - **THEN** Exit 0 in beiden Fällen; eigene SID (1111) als Peer-Claim ergibt ebenfalls Exit 0 (keine Selbst-Kollision)
 
----
+#### Scenario: Harness-SID ohne pgrep-Auflösung gilt als lebendig
+- **GIVEN** ein Peer-Claim mit nicht-numerischer Session-ID (UUID) und einer überlappenden Datei; `AGENT_LOCK_FAKE_ALIVE` ist NICHT gesetzt
+- **WHEN** `agent-collision.sh check --staged` ausgeführt wird
+- **THEN** Exit 1 mit `COLLISION`; eine numerische, nicht existente Session-ID ergibt unter denselben Bedingungen Exit 0
+
+#### Scenario: Committete Peer-Arbeit ist sichtbar
+- **GIVEN** der Peer hat seine Änderung an `shared.txt` bereits committed, sein Working Tree ist sauber
+- **WHEN** `agent-collision.sh check --staged` mit derselben Datei staged ausgeführt wird
+- **THEN** Exit 1 mit `COLLISION` und `shared.txt`; eine committete Peer-Änderung an einer anderen Datei ergibt Exit 0
+
+#### Scenario: Squash-gemergter Peer warnt nicht mehr
+- **GIVEN** der Peer hat `shared.txt` committed und derselbe Inhalt steht inzwischen über einen eigenen Commit in `main`, sodass die Blobs identisch sind
+- **WHEN** `agent-collision.sh check --staged` ausgeführt wird
+- **THEN** Exit 0; solange der Peer-Blob dagegen von `main` abweicht, ergibt derselbe Aufruf Exit 1
+
+#### Scenario: --branch prüft die eigene Branch-Divergenz
+- **GIVEN** die eigene Änderung an `shared.txt` ist bereits committed und nichts ist staged; ein lebender Peer hat dieselbe Datei in Arbeit
+- **WHEN** `agent-collision.sh check --branch` ausgeführt wird
+- **THEN** Exit 1 mit `shared.txt`; `--staged` ergibt im selben Zustand Exit 0; `--branch --quiet` gibt Exit 1 ohne Ausgabe; ein fehlender Peer-Worktree ergibt Exit 0
 
 ### Requirement: Inter-Agent Message Channel
 
@@ -3672,3 +3700,5 @@ The system SHALL enforce authentication on all coaching-session pages and API en
 <!-- merged from change delta software-factory.md (0df5d2f19300) -->
 
 <!-- merged from change delta software-factory.md (7fa4daed6311) -->
+
+<!-- merged from change delta software-factory.md (e6fd0834ae76) -->

--- a/scripts/agent-collision.sh
+++ b/scripts/agent-collision.sh
@@ -28,6 +28,11 @@ _sid_alive() {
   if [ -n "${AGENT_LOCK_FAKE_ALIVE+x}" ]; then
     case " $AGENT_LOCK_FAKE_ALIVE " in *" $1 "*) return 0;; *) return 1;; esac
   fi
+  # Spiegelt scripts/agent-lock.sh:_sid_alive [T001268]: nicht-numerische SIDs sind
+  # harness-vergebene Session-IDs (CLAUDE_SESSION_ID), die `pgrep -s` nicht aufloesen
+  # kann. Bei Aenderung dort HIER nachziehen — Guard: der Drift-Test in
+  # tests/spec/software-factory/collision-window.bats vergleicht beide Urteile.
+  case "$1" in *[!0-9]*) return 0;; esac
   pgrep -s "$1" >/dev/null 2>&1
 }
 
@@ -59,12 +64,17 @@ _drop_generated() {
 cmd_check() {
   local mode=staged quiet=0
   while [ $# -gt 0 ]; do case "$1" in
-    --staged) mode=staged;; --all) mode=all;; --quiet) quiet=1;; *) ;;
+    --staged) mode=staged;; --all) mode=all;; --branch) mode=branch;; --quiet) quiet=1;; *) ;;
   esac; shift; done
 
   local own; own="$(git diff --cached --name-only 2>/dev/null)"
   if [ "$mode" = "all" ]; then
     own="$(printf '%s\n%s\n' "$own" "$(git diff --name-only HEAD 2>/dev/null)")"
+  fi
+  if [ "$mode" = "branch" ]; then
+    own="$( { git diff --name-only main...HEAD 2>/dev/null; \
+              git diff --name-only HEAD 2>/dev/null; \
+              git diff --cached --name-only 2>/dev/null; } | sed '/^$/d' | sort -u )"
   fi
   own="$(printf '%s\n' "$own" | sed '/^$/d' | sort -u)"
   # [T002375-p6] Generierte Artefakte aus der Kollisionspruefung nehmen. Sie werden von
@@ -91,12 +101,28 @@ cmd_check() {
     wt="$(_field "$f" worktree)"
     [ -n "$wt" ] && [ "$wt" != "-" ] && [ -d "$wt" ] || continue
     git -C "$wt" rev-parse --git-dir >/dev/null 2>&1 || continue
-    peer="$( { git -C "$wt" diff --name-only HEAD 2>/dev/null; \
+    # Drei-Punkt gegen den Merge-Base: nur was DIESER Branch geaendert hat.
+    # Schlaegt die Aufloesung von main fehl (detached HEAD, fehlender Branch), entfaellt
+    # nur der committete Anteil — der Working-Tree-Anteil laeuft weiter (fail-open).
+    peer="$( { git -C "$wt" diff --name-only main...HEAD 2>/dev/null; \
+               git -C "$wt" diff --name-only HEAD 2>/dev/null; \
                git -C "$wt" diff --cached --name-only 2>/dev/null; } | sed '/^$/d' | sort -u )"
     peer="$(_drop_generated "$peer")"
     [ -n "$peer" ] || continue
     while IFS= read -r file; do
       [ -n "$file" ] || continue
+      # Squash-Merge: die Peer-Commits sind keine Ancestors von main, main...HEAD listet die
+      # Datei weiter — aber wenn der Blob identisch ist, ist nichts mehr offen.
+      # Fehlschlagende rev-parse (Datei in main nicht vorhanden) => behalten, nicht verwerfen.
+      # WICHTIG: nur ueberspringen, wenn der Peer KEINE uncommitteten Aenderungen an der Datei
+      # hat (sonst waere HEAD:file == main:file obwohl der Peer aktiv aendert). [T002444]
+      peer_blob="$(git -C "$wt" rev-parse "HEAD:$file" 2>/dev/null || true)"
+      main_blob="$(git rev-parse "main:$file" 2>/dev/null || true)"
+      if [ -n "$peer_blob" ] && [ "$peer_blob" = "$main_blob" ] && \
+         ! git -C "$wt" diff --name-only HEAD -- "$file" 2>/dev/null | grep -q . && \
+         ! git -C "$wt" diff --cached --name-only -- "$file" 2>/dev/null | grep -q .; then
+        continue
+      fi
       if printf '%s\n' "$peer" | grep -qxF "$file"; then
         found=1
         if [ "$quiet" -eq 0 ]; then
@@ -115,7 +141,7 @@ main() {
   local cmd="${1:-}"; shift 2>/dev/null || true
   case "$cmd" in
     check) cmd_check "$@";;
-    *) echo "Usage: agent-collision.sh check [--staged|--all] [--quiet]" >&2; return 2;;
+    *) echo "Usage: agent-collision.sh check [--staged|--all|--branch] [--quiet]" >&2; return 2;;
   esac
 }
 main "$@"


### PR DESCRIPTION
## Zusammenfassung

Behebt vier Defekte in scripts/agent-collision.sh (T002444), die dazu führten, dass Kollisionen zwischen parallelen Agent-Sessions strukturell nicht erkannt wurden.

## Änderungen

### D1 — Harness-SIDs (UUID) als lebendig behandeln
- `_sid_alive`: Nicht-numerische SIDs (z.B. CLAUDE_SESSION_ID als UUID) gelten als lebendig, Spiegel der Logik aus `agent-lock.sh:_sid_alive` [T001268]

### D2 — Committete Peer-Arbeit in die Kollisionsprüfung einbeziehen
- `cmd_check`: Peer-Menge um `main...HEAD` (Drei-Punkt-Diff) erweitert — committete Branch-Divergenz wird jetzt erkannt

### D3 — Blob-Filter gegen Squash-Merge-Fehlalarme
- `cmd_check`: Nach der Schnittmengenbildung vergleicht der Blob des Peers mit main — identische Blobs (squash-gemergte Branches) werden korrekt gefiltert
- Guard: Filter greift nur, wenn der Peer keine uncommitteten Änderungen an der Datei hat

### D4 — Präventiver `--branch`-Modus
- Neuer `--branch`-Modus: prüft Branch-Divergenz statt staged Files — auch bei sauberem Working Tree
- `session-coordination.md`: `--branch` dokumentiert

## Tests
- 8 neue Spec-Tests in `tests/spec/software-factory/collision-window.bats`: alle grün
- 8 bestehende Unit-Tests in `tests/unit/agent-collision.bats`: unverändert grün
- `task test:changed`: 93 spec + 11 openspec + 52 quality — alle grün
- `task freshness:check`: OK