### PR TITLE
docs(skills): --branch-Modus von agent-collision.sh dokumentieren [T002444]

### DIFF
--- a/.claude/skills/references/session-coordination.md
+++ b/.claude/skills/references/session-coordination.md
@@ -89,6 +89,14 @@ ANDEREN lebenden Session im Worktree geändert werden. Der `.githooks/pre-commit
 es automatisch auf (`agent-collision.sh check --staged`). Mit `AGENT_COLLISION_STRICT=1`
 wird der Commit bei Kollision abgelehnt.
 
+Drei Prüfmodi, je nachdem WAS erfasst werden soll:
+
+| Modus | Prüft | Wann nutzen |
+|-------|-------|-------------|
+| `--staged` (default) | Nur `git add`-Dateien | Pre-Commit-Hook |
+| `--all` | Staged + unstaged (Working Tree) | Vor `git commit -a` |
+| `--branch` | **Alles** was der Branch je geändert hat (committed + staged + unstaged via `main...HEAD`) | Präventiv, auch bei sauberem WT |
+
 ```bash
 # Prüfe ob staged Dateien mit anderen Sessions kollidieren
 bash scripts/agent-collision.sh check --staged
@@ -102,6 +110,17 @@ bash scripts/agent-collision.sh check --branch
 # Stille Prüfung (exit code only)
 bash scripts/agent-collision.sh check --quiet
 ```
+
+**Wichtig:** `--branch` heisst NICHT Branch-Erstellung. Der Name kommt vom
+Drei-Punkt-Diff `git diff --name-only main...HEAD`, der exakt die Dateien zeigt,
+die dieser Branch seit Abzweigen von main geändert hat — egal ob committed oder nicht.
+Das Skript erstellt oder wechselt nie einen Branch.
+
+**Empfohlener Workflow [T002444]:**
+1. Vor dem Plan-Schreiben (`opencode-flow-plan`): `agent-collision.sh check --branch`
+2. Pre-Commit-Hook: `agent-collision.sh check --staged`
+3. Vor dem PR-Erstellen: `agent-collision.sh check --branch` (stellt sicher, dass
+   Merge-Konflikte mit anderen Branches früh erkannt werden)
 
 Erkenntnis: Liest die Lock-Dateien aus `agent-lock.sh` Registry JSON und vergleicht
 `git diff --name-only HEAD` aller lebenden Worktrees. Reine lokale Bash — kein Cluster.

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -124,6 +124,17 @@ gesetzt — das Ticket wird vom Factory-Dispatch zurückgehalten, bis dieser Sch
 bash scripts/ticket.sh release-hold --id "$TICKET_ID" || true
 ```
 
+## Schritt 1.9: Kollisions-Check vor der Implementierung ⚡ [T002444]
+
+Bevor du mit der Implementierung beginnst, prüfe ob andere Sessions parallel an denselben
+Dateien arbeiten. Anders als der Pre-Commit-Hook (der `--staged` nutzt und nur staged Dateien
+prüft) erfasst `--branch` ALLE Dateien, die dein Branch jemals verändert hat — egal ob
+committed, staged oder Working-Tree-Änderungen:
+
+```bash
+bash scripts/agent-collision.sh check --branch || echo "⚠ Achtung: Kollision mit anderen Sessions — vor dem Commit koordinieren!"
+```
+
 ## Schritt 2: Implementierung delegieren
 
 ### Schritt 2.1: Pipeline-Modus — auf Partials warten

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -48,6 +48,21 @@ bash scripts/agent-msg.sh read --unread
 git worktree list
 ```
 
+## Schritt −0.5: Kollisions-Check vor der Planung ⚡ [T002444]
+
+Bevor du mit der Planung beginnst, prüfe, ob **andere Sessions bereits auf deinem Ziel-Branch**
+oder an denselben Dateien arbeiten. Der `--branch`-Modus von `agent-collision.sh` erkennt
+Kollisionen mit parallelen Sessions AUCH DANN, wenn dein Working Tree sauber ist:
+
+```bash
+# Prüft ob andere Sessions Daten derselben Dateien bearbeiten
+bash scripts/agent-collision.sh check --branch || echo "⚠ Kollision erkannt — mit anderen Sessions koordinieren!"
+```
+
+Anders als `--staged` (braucht `git add`) und `--all` (braucht uncommittete Änderungen) findet
+`--branch` ALLES was dein Branch jemals angefasst hat — egal ob committed, staged oder unstaged.
+Bei Kollisionswarnung: mit den betroffenen Sessions abstimmen, bevor der Plan geschrieben wird.
+
 ## Schritt 0: Pfad bestimmen
 
 Wähle Feature, Fix oder Chore. Features/Fixes → dieser Skill. Chores → `opencode-flow-chore` und STOPP.


### PR DESCRIPTION
Der `--branch`-Modus von `scripts/agent-collision.sh` kam mit T002444 (PR #3496), blieb aber undokumentiert. Diese Aenderung traegt die Doku an drei Stellen nach.

## Was dazukommt

| Datei | Ergaenzung |
|---|---|
| `.claude/skills/references/session-coordination.md` | Tabelle der drei Pruefmodi (`--staged` / `--all` / `--branch`) + empfohlener Workflow |
| `.opencode/skills/opencode-flow-plan/SKILL.md` | Schritt −0.5: Kollisions-Check vor der Planung |
| `.opencode/skills/opencode-flow-execute/SKILL.md` | Schritt 1.9: Kollisions-Check vor der Implementierung |

## Der eigentliche Punkt

`--branch` heisst **nicht** Branch-Erstellung — der Name kommt vom Drei-Punkt-Diff `git diff --name-only main...HEAD`. Das Skript erstellt oder wechselt nie einen Branch. Der Nutzen gegenueber `--staged`/`--all`: es erkennt Kollisionen auch bei **sauberem Working Tree**, weil es alles erfasst, was der Branch seit dem Abzweigen von main angefasst hat.

## Verifikation

Gegen `scripts/agent-collision.sh` geprueft — alle vier dokumentierten Flags existieren (Zeile 67), `--branch` nutzt tatsaechlich `main...HEAD` plus Working Tree (Zeile 75). Reine Doku, kein Verhaltensdelta.

`tests/spec/agent-skills.bats` 18/18 gruen (der 250-Zeilen-Guard greift nur fuer `.claude/skills/`, nicht fuer `.opencode/`), `tests/spec/harness-workflow-split.bats` 14/14 gruen, `task freshness:check` gruen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAPmoht3PYrfYpnNkMD4yg