### PR TITLE
fix(test): add bats_require_minimum_version 1.5.0 to ticket-grill.bats

### DIFF
--- a/tests/unit/ticket-grill.bats
+++ b/tests/unit/ticket-grill.bats
@@ -3,6 +3,8 @@
 # from --answer pairs, and the per-question merge SQL shape (ADD COLUMN IF NOT EXISTS +
 # COALESCE(...) || jsonb_build_object(...)). kubectl is mocked; no live cluster.
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   TICKET="$BATS_TEST_DIRNAME/../../scripts/ticket.sh"
   MOCKDIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Fix BW02 BATS warnings on CI: `tests/unit/ticket-grill.bats` uses `run --separate-stderr` (flags on `run`) but was missing `bats_require_minimum_version 1.5.0`.

This causes all 3 open PRs (`chore/loc-gates-headroom-T002452`, `chore/wave2-T002342`, `feature/task-context-channel-T002420`) to fail BATS Unit + Quality Gates with BW02 warnings that exit code 1.

## Test Plan

- `./tests/unit/lib/bats-core/bin/bats tests/unit/ticket-grill.bats` passes (14/14), no BW02 warnings
- CI BATS Unit + Quality Gates should turn green on affected PRs after merging this fix to main