### PR TITLE
fix(scripts): agent-collision.sh diff gegen origin/main statt main [T002455]

### DIFF
--- a/scripts/agent-collision.sh
+++ b/scripts/agent-collision.sh
@@ -72,7 +72,13 @@ cmd_check() {
     own="$(printf '%s\n%s\n' "$own" "$(git diff --name-only HEAD 2>/dev/null)")"
   fi
   if [ "$mode" = "branch" ]; then
-    own="$( { git diff --name-only main...HEAD 2>/dev/null; \
+    # [T002455] origin/main statt main: der lokale main-Ref kann hinter origin/main liegen,
+    # sodass main...HEAD eine zu alte Merge-Base verwendet. Ein Peer-Worktree auf aktuellem
+    # origin/main zeigt dann alle zwischenzeitlich gemergten Commits als vermeintlich eigene
+    # Änderungen — Fehlalarme. Fallback auf main bei detached HEAD / fehlendem Remote.
+    local base_ref="main"
+    git rev-parse --verify origin/main >/dev/null 2>&1 && base_ref="origin/main"
+    own="$( { git diff --name-only "${base_ref}...HEAD" 2>/dev/null; \
               git diff --name-only HEAD 2>/dev/null; \
               git diff --cached --name-only 2>/dev/null; } | sed '/^$/d' | sort -u )"
   fi
@@ -102,9 +108,12 @@ cmd_check() {
     [ -n "$wt" ] && [ "$wt" != "-" ] && [ -d "$wt" ] || continue
     git -C "$wt" rev-parse --git-dir >/dev/null 2>&1 || continue
     # Drei-Punkt gegen den Merge-Base: nur was DIESER Branch geaendert hat.
-    # Schlaegt die Aufloesung von main fehl (detached HEAD, fehlender Branch), entfaellt
+    # [T002455] origin/main statt main (analog own-Seite oben), Fallback auf main.
+    # Schlaegt die Aufloesung fehl (detached HEAD, fehlender Branch), entfaellt
     # nur der committete Anteil — der Working-Tree-Anteil laeuft weiter (fail-open).
-    peer="$( { git -C "$wt" diff --name-only main...HEAD 2>/dev/null; \
+    local peer_base="main"
+    git -C "$wt" rev-parse --verify origin/main >/dev/null 2>&1 && peer_base="origin/main"
+    peer="$( { git -C "$wt" diff --name-only "${peer_base}...HEAD" 2>/dev/null; \
                git -C "$wt" diff --name-only HEAD 2>/dev/null; \
                git -C "$wt" diff --cached --name-only 2>/dev/null; } | sed '/^$/d' | sort -u )"
     peer="$(_drop_generated "$peer")"

--- a/tests/spec/agent-lock-session-identity.bats
+++ b/tests/spec/agent-lock-session-identity.bats
@@ -200,6 +200,13 @@ _unset_claude_harness_env() {
 
 @test "T002261-M1: cmd_release emits stderr diagnostic on SID mismatch" {
   AGENT_LOCK_DIR="$(mktemp -d)"; export AGENT_LOCK_DIR
+  # [T002456] Harness-Variablen abbauen: eine aktive Claude-Code-Session exportiert
+  # CLAUDE_CODE_SESSION_ID und CLAUDECODE real, was die Tool-Klassen-Ableitung
+  # beeinflusst. Ohne diesen Aufruf schlägt `_detect_tool` in _write_lock auf "claude"
+  # statt "gemini" — der Lock wird mit tool=claude angelegt, was den Same-Tool-Fallback
+  # triggert (selbst wenn T002447 ihn aus cmd_release entfernt hat, bleibt die Pfad-Abhängigkeit
+  # in _write_lock bestehen und der Lock-Content spiegelt die falsche Tool-Klasse).
+  _unset_claude_harness_env
   # Claim the lock with explicit SID + tool (AGENT_LOCK_TOOL overrides ambient)
   AGENT_LOCK_TOOL=claude AGENT_LOCK_SID="session-A" \
     bash "$LOCK" claim ticket T002261-m1 --label test-release
@@ -417,6 +424,12 @@ JSON
 
 @test "T002373-M2: cmd_release verweigert Release ohne --force wenn owner SID lebt" {
   AGENT_LOCK_DIR="$(mktemp -d)"; export AGENT_LOCK_DIR
+  # [T002456] Harness-Variablen abbauen: analog T002261-M1 oben — ambient exportiertes
+  # CLAUDE_CODE_SESSION_ID würde in _write_lock die falsche Tool-Klasse hinterlassen,
+  # und in _my_sid via AGENT_LOCK_SID_ENVS die owner_sid auf den Harness-Wert statt
+  # den Test-Override setzen. Die Priority-Order (AGENT_LOCK_SID zuerst) schützt
+  # _my_sid, aber _unset_claude_harness_env macht die Isolation explizit.
+  _unset_claude_harness_env
   export AGENT_LOCK_FAKE_ALIVE="ghost-sid-99999"
   # Claim as "ghost-sid-99999" (marked alive via fake), with explicit tool
   AGENT_LOCK_TOOL=claude AGENT_LOCK_SID="ghost-sid-99999" \


### PR DESCRIPTION
## Summary

`agent-collision.sh` verglich mit `diff --name-only main...HEAD` gegen den **lokalen** `main`-Ref. Liegt dieser hinter `origin/main`, wandert die Merge-Base zurück — ein Peer-Worktree auf aktuellem `origin/main` zeigt dann alle zwischenzeitlich gemergten Commits als vermeintliche Änderungen.

**Fix:** `origin/main` priorisieren, Fallback auf `main`. Betrifft both own-side (Zeile 75) und peer-side (Zeile 107) der Drei-Punkt-Diffs.

## Test Plan

```bash
tests/unit/lib/bats-core/bin/bats tests/unit/agent-collision.bats
```