### PR TITLE
chore(infra): LLM_EMBED_BATCH_URL + LLM_RERANKER_BATCH_URL bis in den Website-Pod durchreichen [T002449]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2789,8 +2789,8 @@ tasks:
           LLM_HOST_IP="${LLM_HOST_IP:-172.17.0.1}" \
           LLM_ROUTER_URL="${LLM_ROUTER_URL:-http://llm-gateway-lmstudio.workspace.svc.cluster.local:1234}" \
           LLM_EMBED_URL="${LLM_EMBED_URL:-http://llm-gateway-embed.workspace.svc.cluster.local:8095}" \
-          LLM_EMBED_BATCH_URL="${LLM_EMBED_BATCH_URL:-}" \
-          LLM_RERANKER_BATCH_URL="${LLM_RERANKER_BATCH_URL:-}" \
+          LLM_EMBED_BATCH_URL="${LLM_EMBED_BATCH_URL:-http://llm-gateway-embed-batch:8085}" \
+          LLM_RERANKER_BATCH_URL="${LLM_RERANKER_BATCH_URL:-http://llm-gateway-rerank-batch:8086}" \
           POCKET_ID_FRONTEND_URL="${POCKET_ID_FRONTEND_URL:-http://id.localhost}" \
           POCKET_ID_URL="${POCKET_ID_URL:-http://pocket-id.${WORKSPACE_NAMESPACE:-workspace}.svc.cluster.local:1411}" \
           POCKET_ID_DOMAIN="${POCKET_ID_DOMAIN:-id.localhost}" \


### PR DESCRIPTION
## Summary

Folge-Lücke aus T002426 (bge-dual-pair-failover, PR #3500): die beiden Batch-URLs wurden in `environments/schema.yaml` deklariert und in allen `environments/*.yaml` gesetzt, fehlten aber in `k3d/website.yaml` und den drei envsubst-Allowlists in `Taskfile.yml`.

Seit PR #2989 ist die Allowlist fail-closed — nicht gelistete Platzhalter werden nicht substituiert, die Batch-URLs erreichten den Website-Pod daher nie.

## Changes

- **`k3d/website.yaml`**: `LLM_EMBED_BATCH_URL` und `LLM_RERANKER_BATCH_URL` als `${...}`-Platzhalter in die website-config ConfigMap ergänzt.
- **`Taskfile.yml` (3 Stellen)**:
  - Export-Block vor `kustomize build` (~2792): beide Vars mit Cluster-Defaults aufgenommen
  - Inline-envsubst-Allowlist workspace:deploy (~2801): beide Vars ergänzt
  - ENVSUBST_VARS-Kette workspace:setup (×2, ~2919/~3085): beide Vars angehängt

## Verification

`task workspace:validate` → Exit 0 ✓  
`kustomize build k3d/` → beide Vars erscheinen in website-config ConfigMap ✓