### PR TITLE
feat(scripts): mishap-categorize erden — bestehende Kategorien als LLM-Prompt-Kontext [T002401]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 626,
+      "file_count": 627,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -411,6 +411,7 @@
         "tests/spec/merge-arbitration/detect-threshold.bats",
         "tests/spec/merge-arbitration/synthesize-syntax-gate.bats",
         "tests/spec/mishap-bundle-2026-06-30.bats",
+        "tests/spec/mishap-categorize-erden.bats",
         "tests/spec/mishap-t002422.bats",
         "tests/spec/monitoring-alerts.bats",
         "tests/spec/newsletter-system.bats",

--- a/openspec/changes/brain-ingest-pruefen/proposal.md
+++ b/openspec/changes/brain-ingest-pruefen/proposal.md
@@ -1,0 +1,29 @@
+---
+title: "brain-ingest-transform: prüfen ob Erdung Nutzen bringt"
+domains: [scripts, docs]
+ticket_id: T002404
+status: active
+parent_feature: T002397
+---
+
+# brain-ingest-transform erden?
+
+**Ticket:** T002404
+
+## Aufgabe
+
+**Dies ist eine Prüfung, keine Umsetzung.** `scripts/brain-ingest-transform.sh`
+schreibt Repo-Dokumente fürs Brain-Wiki um. Die Frage: entstehen im Wiki
+inkonsistente Querverweise/Dubletten, die durch Kenntnis bereits ingestierter
+Seiten vermeidbar wären?
+
+## Methode
+
+1. Bestands-Wiki-Seiten analysieren (Liste aus Brain-Repo)
+2. Prüfen: gibt es echte Inkonsistenzen?
+3. Falls ja → Stufe 1: Liste vorhandener Seiten als Prompt-Kontext
+4. Falls nein → Ticket als `obsolete` schließen
+
+## Ergebnis
+
+Ein Ticket-Kommentar mit dem Prüf-Ergebnis, kein Code.

--- a/openspec/changes/brain-ingest-pruefen/tasks.md
+++ b/openspec/changes/brain-ingest-pruefen/tasks.md
@@ -1,0 +1,27 @@
+---
+title: "brain-ingest-transform prüfen — Implementation Plan"
+ticket_id: T002404
+domains: [scripts, docs]
+status: active
+parent_feature: T002397
+---
+
+# brain-ingest-transform prüfen
+
+_Ticket: T002404_
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | brain-ingest-pruefung | impl | — (reine Untersuchung) | — |
+
+### p1 — brain-ingest-pruefung
+
+**Rolle:** impl — Prüfung, ob Erdung Nutzen bringt. Kein Code, nur Analyse.
+
+1. Bestands-Wiki-Seiten aus Paddione/brain analysieren
+2. Auf inkonsistente Querverweise/Dubletten prüfen
+3. Ergebnis als Ticket-Kommentar:
+   - Falls ja: Stufe 1 vorschlagen (Liste vorhandener Seiten im Prompt)
+   - Falls nein: Ticket auf `obsolete` setzen
+
+**Ergebnis:** Ticket-Kommentar mit Prüfungsergebnis, kein Code-Change.

--- a/openspec/changes/health-goals-erden/proposal.md
+++ b/openspec/changes/health-goals-erden/proposal.md
@@ -1,0 +1,25 @@
+---
+title: "health-goals-llm-fill erden: Goal-Registry als Kontext"
+domains: [scripts]
+ticket_id: T002402
+status: active
+parent_feature: T002397
+---
+
+# health-goals-llm-fill erden
+
+**Ticket:** T002402
+
+## Problem
+
+`scripts/health-goals-llm-fill.sh` füllt Health-Goal-Felder per LLM ohne Kenntnis
+der bereits definierten Ziele → inkonsistente Formulierungen.
+
+## Lösung
+
+Stufe 1: Vorhandene Goal-Definitionen (gleicher Präfix-Bereich) vor dem Aufruf laden
+und als Stilvorlage + Abgrenzung mitgeben.
+
+## Randbedingung
+
+Kontextmenge auf Flash-Tier-Budget im llm-proxy prüfen (CTX_MARGIN in server.mjs).

--- a/openspec/changes/health-goals-erden/tasks.md
+++ b/openspec/changes/health-goals-erden/tasks.md
@@ -1,0 +1,29 @@
+---
+title: "health-goals-llm-fill erden — Implementation Plan"
+ticket_id: T002402
+domains: [scripts]
+status: active
+parent_feature: T002397
+---
+
+# health-goals-llm-fill erden
+
+_Ticket: T002402_
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | health-goals-kontext | impl | `scripts/health-goals-llm-fill.sh` | — |
+| p2 | tests | test | `tests/spec/health-goals-erden.bats` | p1 |
+
+### p1 — health-goals-kontext
+
+1. Goal-Registry des gleichen Präfix-Bereichs vor LLM-Aufruf laden
+2. Als `[EXISTING_GOALS]`-Block in Prompt schreiben
+3. Kontext-Budget prüfen: nicht CTX_MARGIN des llm-proxy sprengen
+
+### p2 — tests
+
+1. Test: Prompt enthält Nachbarziele des gleichen Präfix
+2. Test: Kontext-Payload unter Budget-Grenze
+
+**Files:** `scripts/health-goals-llm-fill.sh`, `tests/spec/health-goals-erden.bats`

--- a/openspec/changes/k1-vektorspeicher/proposal.md
+++ b/openspec/changes/k1-vektorspeicher/proposal.md
@@ -1,0 +1,23 @@
+---
+title: "K1 visualisieren: Vektorspeicher (pgvector in shared-db)"
+domains: [infra, database]
+ticket_id: T002431
+status: active
+---
+
+# K1: Vektorspeicher visualisieren
+
+**Ticket:** T002431
+
+## Aufgabe
+
+Die pgvector-Komponente in der shared-db analysieren und als Diagramm darstellen:
+- Welche Tabellen existieren (code_embeddings, knowledge.chunks, Coaching-Knowledge, OpenSpec-Embeddings)?
+- Wer schreibt (SCS-Indexer, openspec-embed.mjs, post-commit-Hook, ingest-json-core.ts)?
+- Wer liest (/api/codesearch, /api/openspec/search, search-similar.mjs)?
+- Welche Vektorräume (bge-m3, voyage-multilingual-2) pro Tabelle?
+- Welche Tabellen sind leer, welche gemischt (MixedEmbeddingModelError)?
+
+## Ergebnis
+
+Diagramm mit beschrifteten Ein-/Ausgangskanten + Liste toter Kanten.

--- a/openspec/changes/k1-vektorspeicher/tasks.md
+++ b/openspec/changes/k1-vektorspeicher/tasks.md
@@ -1,0 +1,29 @@
+---
+title: "K1 Vektorspeicher — Implementation Plan"
+ticket_id: T002431
+domains: [infra, database]
+status: active
+---
+
+# K1: Vektorspeicher visualisieren
+
+_Ticket: T002431_
+
+## Partial Plan
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | analyse-vektorraeume | impl | `docs/superpowers/specs/2026-07-28-sdlc-cockpit-design.md` | — |
+
+### p1 — analyse-vektorraeume
+
+**Rolle:** impl — pgvector-Tabellen analysieren und Diagramm erstellen
+
+1. Tabellenliste aus information_schema holen (pgvector-Erweiterung)
+2. Pro Tabelle: Embedding-Model, Dimension, Distanzmass, Zeilenanzahl
+3. Schreiber und Leser pro Tabelle identifizieren (Code-Analyse)
+4. Tote Kanten markieren (leere Tabellen, ungenutzte Schreiber)
+5. Diagramm mit Mermaid oder ASCII in `docs/superpowers/specs/` ablegen
+6. Gemischte Modelle pro Tabelle prüfen → MixedEmbeddingModelError-Bedingung dokumentieren
+
+**Files:** `docs/superpowers/specs/2026-07-28-sdlc-cockpit-design.md`

--- a/openspec/changes/mishap-categorize-erden/proposal.md
+++ b/openspec/changes/mishap-categorize-erden/proposal.md
@@ -1,0 +1,21 @@
+---
+title: "mishap-categorize erden: ähnliche Mishaps als Cluster-Kontext"
+domains: [scripts]
+ticket_id: T002401
+status: active
+parent_feature: T002397
+---
+
+# mishap-categorize erden
+
+**Ticket:** T002401
+
+## Problem
+
+`scripts/mishap-categorize.sh` sortiert Mishaps in Kategorien ohne Kenntnis
+bestehender Kategorien → Beinahe-Duplikate mit abweichender Benennung.
+
+## Lösung
+
+Stufe 1: Bereits vergebene Kategorien vor dem LLM-Aufruf laden und als Prompt-Block
+`[EXISTING_CATEGORIES]` mitgeben. Macht aus Klassifikation ein Einordnen in Taxonomie.

--- a/openspec/changes/mishap-categorize-erden/tasks.md
+++ b/openspec/changes/mishap-categorize-erden/tasks.md
@@ -1,0 +1,29 @@
+---
+title: "mishap-categorize erden — Implementation Plan"
+ticket_id: T002401
+domains: [scripts]
+status: active
+parent_feature: T002397
+---
+
+# mishap-categorize erden
+
+_Ticket: T002401_
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | mishap-categorize-kontext | impl | `scripts/mishap-categorize.sh` | — |
+| p2 | tests | test | `tests/spec/mishap-categorize-erden.bats` | p1 |
+
+### p1 — mishap-categorize-kontext
+
+1. Bestehende Kategorien (Mishap-Tabelle aus DB oder Enum-Liste) vor LLM-Aufruf laden
+2. Prompt um `[EXISTING_CATEGORIES]`-Block erweitern
+3. Fallback: bei DB-Fehler Enum-Fallback-Liste nutzen
+
+### p2 — tests
+
+1. Test: Kategorie-Prompt enthält bestehende Einträge
+2. Test: DB-Fehler → Enum-Fallback
+
+**Files:** `scripts/mishap-categorize.sh`, `tests/spec/mishap-categorize-erden.bats`

--- a/openspec/changes/release-notes-erden/proposal.md
+++ b/openspec/changes/release-notes-erden/proposal.md
@@ -1,0 +1,26 @@
+---
+title: "release-notes erden: Ticket-Kontext zu gemergten PRs"
+domains: [scripts]
+ticket_id: T002403
+status: active
+parent_feature: T002397
+---
+
+# release-notes erden
+
+**Ticket:** T002403
+
+## Problem
+
+`scripts/vda/release-notes.sh` formuliert Release Notes aus PR-Titeln ohne das
+Warum — Ticket-Beschreibung, Typ und Areas fehlen.
+
+## Lösung
+
+Stufe 1: Zu jeder gemergten PR das Ticket laden (ID via `[T00XXXX]` im Titel),
+Typ/Areas/Beschreibung als Prompt-Kontext mitgeben → Notes gruppieren nach Bereich.
+
+## Fallback
+
+Deterministischer Pfad muss erhalten bleiben: fällt Ticket-Abfrage aus, werden
+Notes weiterhin erzeugt, nur ohne Kontext.

--- a/openspec/changes/release-notes-erden/tasks.md
+++ b/openspec/changes/release-notes-erden/tasks.md
@@ -1,0 +1,31 @@
+---
+title: "release-notes erden — Implementation Plan"
+ticket_id: T002403
+domains: [scripts]
+status: active
+parent_feature: T002397
+---
+
+# release-notes erden
+
+_Ticket: T002403_
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | release-notes-kontext | impl | `scripts/vda/release-notes.sh` | — |
+| p2 | tests | test | `tests/spec/release-notes-erden.bats` | p1 |
+
+### p1 — release-notes-kontext
+
+1. PR-Titel parsen: `[T00XXXX]` → Ticket-ID extrahieren
+2. Ticket-Daten (Typ, Areas, Beschreibung) per ticket-mcp laden
+3. Als `[TICKET_CONTEXT]`-Block in Prompt schreiben
+4. Fallback: Ticket-Abfrage schlägt fehl → Kontext leer, Skript läuft trotzdem
+
+### p2 — tests
+
+1. Test: Prompt enthält Ticket-Daten für PR mit `[T00XXX]`-Tag
+2. Test: PR ohne Tag → kein Kontext, kein Fehler
+3. Test: DB-Fehler → Kontext leer, Skript läuft weiter
+
+**Files:** `scripts/vda/release-notes.sh`, `tests/spec/release-notes-erden.bats`

--- a/openspec/changes/remove-keycloak-sidecar/proposal.md
+++ b/openspec/changes/remove-keycloak-sidecar/proposal.md
@@ -1,0 +1,36 @@
+---
+title: "keycloak-MCP-Sidecar aus claude-code-mcp-monolith entfernen"
+domains: [infra]
+ticket_id: T002311
+status: active
+---
+
+# keycloak-MCP-Sidecar aus claude-code-mcp-monolith entfernen
+
+**Ticket:** T002311
+
+## Problem
+
+`k3d/default/claude-code-mcp-monolith-deploy.yaml` definiert einen `keycloak`-Container,
+der gegen `http://keycloak.workspace.svc.cluster.local:8080` läuft. Die Plattform nutzt
+Pocket ID als OIDC-Provider — einen Keycloak-Service gibt es nicht. Der Container kann
+seine Readiness-Probe nie erfüllen.
+
+Beleg: `kubectl get pod -l app=claude-code-mcp-monolith` zeigt 55 Restarts in 18 Tagen.
+
+## Lösung
+
+1. Restarts pro Container aufschlüsseln, um den keycloak-Container zu bestätigen
+2. `keycloak`-Container aus dem Deployment entfernen
+3. Secret `KEYCLOAK_ADMIN_PASSWORD` aus `claude-code-secrets` als obsolet markieren oder
+   entfernen
+
+## Risiken
+
+- Falls irgendein anderer Container den Keycloak-Sidecar via localhost erwartet, muss
+  vorher die Unabhängigkeit bestätigt werden. (Vermutlich kein Konsument — der Container
+  war nie healthy.)
+
+## Nicht im Scope
+
+- Umstellung auf einen Pocket-ID-fähigen MCP-Server (separates Ticket, falls gewünscht)

--- a/openspec/changes/remove-keycloak-sidecar/specs/remove-keycloak-sidecar.md
+++ b/openspec/changes/remove-keycloak-sidecar/specs/remove-keycloak-sidecar.md
@@ -1,0 +1,40 @@
+---
+title: "keycloak-MCP-Sidecar entfernen — Spec"
+domains: [infra]
+ticket_id: T002311
+status: active
+---
+
+# keycloak-MCP-Sidecar entfernen — Spec
+
+## Diagnose
+
+### GIVEN
+Das Deployment `claude-code-mcp-monolith` läuft mit 55+ Restarts.
+
+### WHEN
+Die Restarts pro Container werden aufgeschlüsselt.
+
+### THEN
+`kubectl get pod -l app=claude-code-mcp-monolith -o jsonpath` zeigt, ob der
+`keycloak`-Container der alleinige oder Hauptverursacher der Restarts ist.
+
+## Entfernung
+
+### GIVEN
+Der keycloak-Container ist als Restart-Verursacher bestätigt.
+
+### WHEN
+Der Container wird aus dem Deployment entfernt.
+
+### THEN
+1. `keycloak`-Container-Spezifikation aus `claude-code-mcp-monolith-deploy.yaml` löschen
+2. Secret `claude-code-secrets/KEYCLOAK_ADMIN_PASSWORD` als DEPRECATED markieren
+3. Pod-Restarts nach dem Rollout auf null bestätigen
+
+### Acceptance
+- `kubectl get pod -l app=claude-code-mcp-monolith` zeigt 0 Restarts nach dem Rollout
+- `kubectl logs <pod> -c keycloak` schlägt fehl (Container existiert nicht mehr) — das
+  ist der erwartete Zustand
+- Das Secret wird nicht gelöscht, nur dokumentiert als obsolet (kann später in einem
+  separaten Chore entfernt werden)

--- a/openspec/changes/remove-keycloak-sidecar/tasks.md
+++ b/openspec/changes/remove-keycloak-sidecar/tasks.md
@@ -1,0 +1,51 @@
+---
+title: "keycloak-MCP-Sidecar entfernen — Implementation Plan"
+ticket_id: T002311
+domains: [infra]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# keycloak-MCP-Sidecar entfernen — Implementation Plan
+
+_Ticket: T002311_
+
+## File Structure
+
+```
+CHANGED:
+  k3d/default/claude-code-mcp-monolith-deploy.yaml   — keycloak-Container entfernen
+  docs/agent-guide/secrets/deprecated.md              — KEYCLOAK_ADMIN_PASSWORD als DEPRECATED
+```
+
+## Partial Plan
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | remove-keycloak | impl | `k3d/default/claude-code-mcp-monolith-deploy.yaml` | — |
+| p2 | verify | test | `tests/spec/remove-keycloak-sidecar.bats` | p1 |
+
+### p1 — remove-keycloak
+
+**Rolle:** impl — Container und Secret-Referenz entfernen
+
+1. Restarts pro Container aufschlüsseln: `kubectl get pod -l app=claude-code-mcp-monolith -o jsonpath`
+2. `keycloak`-Container aus dem Deployment YAML entfernen
+3. Secret `KEYCLOAK_ADMIN_PASSWORD` in DEPRECATED-Doku aufnehmen
+4. Rollout auslösen und Restarts auf 0 bestätigen
+
+**Files:** `k3d/default/claude-code-mcp-monolith-deploy.yaml`
+
+### p2 — verify
+
+**Rolle:** test — Verifikation der Änderung
+
+1. Test: Container existiert nicht mehr im Deployment
+2. Test: Secret ist in deprecated.md gelistet
+3. Test: Pod hat 0 Restarts nach Rollout
+
+**Files:** `tests/spec/remove-keycloak-sidecar.bats`

--- a/openspec/changes/scout-llm-fallback-erden/proposal.md
+++ b/openspec/changes/scout-llm-fallback-erden/proposal.md
@@ -1,0 +1,32 @@
+---
+title: "scout-llm-fallback erden — Kontext für den Ratemodus"
+domains: [scripts, factory]
+ticket_id: T002400
+status: active
+---
+
+# scout-llm-fallback erden
+
+**Ticket:** T002400
+
+## Problem
+
+`scripts/factory/scout-llm-fallback.sh` springt genau dann ein, wenn die deterministische
+Scout-Analyse nichts gefunden hat — also im schwierigsten Fall. Ausgerechnet dort arbeitet
+es heute ohne Kontext: das LLM bekommt einen leeren Prompt und muss Ticket-Titel und
+-Beschreibung allein interpretieren.
+
+## Lösung
+
+**Stufe 1 (Boden):** Relevante OpenSpec-Specs und ähnliche Tickets vor dem LLM-Aufruf
+holen und als Kontextblock in den Prompt schreiben. `find_similar` aus `scout.sh` ist im
+selben Verzeichnis bereits vorhanden und kann wiederverwendet werden.
+
+**Stufe 2 (Decke, optional):** Eine optionale Tool-Runde über llama.cpps `GET /tools` /
+`POST /tools` (Dateisuche, Spec-Lookup). Fällt die Tool-Treue aus, degradiert das System
+auf Stufe 1 statt auf Raten.
+
+## Nicht im Scope
+
+- Allgemeine Agent-Schleife im llm-proxy (T002397)
+- Erdung der anderen 6 Proxy-Konsumenten (eigene Tickets: T002401-T002404)

--- a/openspec/changes/scout-llm-fallback-erden/specs/scout-llm-fallback.md
+++ b/openspec/changes/scout-llm-fallback-erden/specs/scout-llm-fallback.md
@@ -1,0 +1,50 @@
+---
+title: "scout-llm-fallback erden — Spec"
+domains: [scripts, factory]
+ticket_id: T002400
+status: active
+---
+
+# scout-llm-fallback erden — Spec
+
+## Stufe 1 — Retrieval-Kontext
+
+### GIVEN
+Das Skript `scripts/factory/scout-llm-fallback.sh` wird aufgerufen, weil die
+deterministische Scout-Analyse keinen Treffer geliefert hat.
+
+### WHEN
+Vor dem LLM-Aufruf werden relevante Kontextdokumente geladen.
+
+### THEN
+1. `find_similar` (aus `scout.sh`, selbes Verzeichnis) wird mit der Ticket-ID
+   aufgerufen → liefert ähnliche Tickets + OpenSpec-Spec-Chunks
+2. Die Ergebnisse werden als Prompt-Block `[CONTEXT]` formatiert:
+   - Ähnliche Tickets (ID, Titel, Status, Kurzbeschreibung)
+   - Relevante Spec-Sections (Slug, Section-Title, Text)
+3. Der Prompt wird erst an das LLM gesendet, wenn der Kontext vollständig geladen ist
+
+### Acceptance
+- Ein Ticket ohne ähnliche Vorgänger erzeugt einen leeren Kontextblock (kein Fehler)
+- `find_similar`-Timeout (5s) führt zu leerem Kontext + WARN-Log, nicht zu Abbruch
+- Der LLM-Prompt enthält den Kontext als separaten Abschnitt vor der eigentlichen Frage
+
+## Stufe 2 — Optionale Tool-Runde (Decke)
+
+### GIVEN
+Der LLM-Prozessor empfängt eine Antwort mit `tool_calls`.
+
+### WHEN
+Im Prompt wurde eine Tool-Liste deklariert (Dateisuche, Spec-Lookup), und das Modell
+fordert ein Tool auf.
+
+### THEN
+1. Der Tool-Call wird an `POST /tools` des lokalen llama.cpp gesendet
+2. Das Ergebnis wird als `[TOOL_RESULT]` an das Modell zurückgegeben
+3. Maximal **eine** Tool-Runde (keine Schleife)
+4. Enthält die Antwort erneut `tool_calls` → wird ignoriert, die letzte Antwort ohne
+   Tool-Call wird verwendet
+
+### Non-Goals
+- Keine mehrstufige Agentenschleife
+- Keine persistenten Tool-Sessions

--- a/openspec/changes/scout-llm-fallback-erden/tasks.md
+++ b/openspec/changes/scout-llm-fallback-erden/tasks.md
@@ -1,0 +1,54 @@
+---
+title: "scout-llm-fallback erden — Implementation Plan"
+ticket_id: T002400
+domains: [scripts, factory]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: T002397
+depends_on_plans: []
+---
+
+# scout-llm-fallback erden — Implementation Plan
+
+_Ticket: T002400_
+
+## File Structure
+
+```
+CHANGED:
+  scripts/factory/scout-llm-fallback.sh   — Kontext-Retrieval vor LLM-Aufruf
+NEW:
+  tests/spec/scout-llm-fallback-erden.bats — Tests für Kontext-Retrieval + Tool-Fallback
+```
+
+## Partial Plan
+
+| id | file | role | target_files | depends_on |
+|----|------|------|--------------|------------|
+| p1 | scout-llm-retrieval | impl | `scripts/factory/scout-llm-fallback.sh` | — |
+| p2 | tests | test | `tests/spec/scout-llm-fallback-erden.bats` | p1 |
+
+### p1 — scout-llm-retrieval
+
+**Rolle:** impl — Kontext-Retrieval in scout-llm-fallback.sh einbauen
+
+1. `find_similar` aus `scout.sh` in `scout-llm-fallback.sh` integrieren (oder als shared lib auslagern)
+2. Prompt-Template um `[CONTEXT]`-Block erweitern: ähnliche Tickets + Spec-Chunks
+3. Timeout-Handling (5s): bei Timeout leerer Kontext + WARN statt Abbruch
+4. Stufe 2: optionalen Tool-Call über `POST /tools` an lokalen llama.cpp
+5. Tool-Runden-Limit: max 1 Runde, dann Fallback auf Antwort ohne Tool
+
+**Files:** `scripts/factory/scout-llm-fallback.sh`
+
+### p2 — tests
+
+**Rolle:** test — BATS-Tests für Stufe 1 + 2
+
+1. Test: Ticket ohne ähnliche Vorgänger → leerer Kontextblock, kein Fehler
+2. Test: `find_similar`-Timeout → WARN + leerer Kontext
+3. Test: LLM-Prompt enthält `[CONTEXT]`-Abschnitt
+4. Test: Stufe 2 — Tool-Call wird gesendet, max 1 Runde, dann Fallback
+
+**Files:** `tests/spec/scout-llm-fallback-erden.bats`

--- a/scripts/mishap-categorize.sh
+++ b/scripts/mishap-categorize.sh
@@ -34,6 +34,24 @@ SQL
   echo "mishap-categorize: category='${category}' set for ${ext_id}" >&2
 }
 
+_fetch_existing_categories() {
+  local pod
+  pod=$(kubectl get pod -n "$NS" --context "$CTX" -l 'app in (shared-db, shared-db-dev)' \
+    --field-selector status.phase=Running -o name 2>/dev/null | head -1) || true
+  if [[ -z "$pod" ]]; then
+    echo "mishap-categorize: WARN no shared-db pod for category fetch" >&2
+    return 1
+  fi
+  kubectl exec -i "$pod" -n "$NS" --context "$CTX" -c postgres -- \
+    psql -U "$USER" -d "$DB" -qtA -v ON_ERROR_STOP=1 <<'SQL' 2>/dev/null || true
+SELECT substring(name from 6) FROM tickets.tags WHERE name LIKE 'kind:%' ORDER BY name;
+SQL
+}
+
+_build_enum_fallback() {
+  printf '%s\n' 'CI-Konflikt' 'Gate-Fehler' 'API-Fehler' 'Scout-Qualität' 'Deploy-Fehler' 'Spec-Lücke' 'Test-Lücke' 'Sonstige'
+}
+
 if [[ $# -lt 3 ]]; then
   echo "Usage: $0 <external_id> <title> <description>" >&2
   exit 0
@@ -83,9 +101,21 @@ if [[ "$best_count" -gt 0 ]]; then
   exit 0
 fi
 
+# Fetch existing categories from DB for context grounding
+existing_categories=$(_fetch_existing_categories 2>/dev/null || true)
+if [[ -z "$existing_categories" ]]; then
+  existing_categories=$(_build_enum_fallback)
+  echo "mishap-categorize: using enum fallback for existing categories" >&2
+fi
+
 if [[ -n "${DEEPSEEK_API_KEY:-}" ]]; then
   base_url="${DEEPSEEK_BASE_URL:-https://api.deepseek.com/v1}"
-  prompt="Classify this mishap into exactly one category: CI-Konflikt, Gate-Fehler, API-Fehler, Scout-Qualität, Deploy-Fehler, Spec-Lücke, Test-Lücke, Sonstige. Reply with only the category name, no punctuation, no explanation.
+  prompt="You are categorizing a mishap report. Below are existing categories already in use. Choose exactly ONE from this list — do NOT invent new category names.
+
+[EXISTING_CATEGORIES]
+$(echo "$existing_categories" | while read -r c; do echo "- $c"; done)
+
+Classify this mishap into exactly one of the EXISTING_CATEGORIES above. If none fits perfectly, pick the closest match. Reply with only the category name, no punctuation, no explanation.
 
 Title: ${title}
 Description: ${desc}"
@@ -102,7 +132,10 @@ Description: ${desc}"
 
   if [[ -n "$llm_response" ]]; then
     llm_response="$(echo "$llm_response" | tr -d '[:punct:]' | xargs)"
-    valid=('CI-Konflikt' 'Gate-Fehler' 'API-Fehler' 'Scout-Qualität' 'Deploy-Fehler' 'Spec-Lücke' 'Test-Lücke' 'Sonstige')
+    valid=()
+    while IFS= read -r vc; do
+      [[ -n "$vc" ]] && valid+=("$vc")
+    done <<< "$existing_categories"
     for vc in "${valid[@]}"; do
       if [[ "${llm_response,,}" == "${vc,,}" ]]; then
         category="$vc"

--- a/tests/spec/mishap-categorize-erden.bats
+++ b/tests/spec/mishap-categorize-erden.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# tests/spec/mishap-categorize-erden.bats
+# T002401 — mishap-categorize erden: bestehende Kategorien als Prompt-Kontext
+
+load 'test_helper'
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO/scripts/mishap-categorize.sh"
+}
+
+# ── p2.1: Prompt enthält bestehende Einträge ──────────────────────────────────
+
+@test "T002401: _fetch_existing_categories function exists" {
+  [ -f "$SCRIPT" ]
+  run grep -q '^_fetch_existing_categories()' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002401: _build_enum_fallback function exists" {
+  [ -f "$SCRIPT" ]
+  run grep -q '^_build_enum_fallback()' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002401: existing categories are fetched before LLM call" {
+  [ -f "$SCRIPT" ]
+  # The _fetch_existing_categories call must appear BEFORE the DEEPSEEK_API_KEY check
+  local cat_line
+  cat_line=$(grep -n '_fetch_existing_categories' "$SCRIPT" | head -1 | cut -d: -f1)
+  local api_line
+  api_line=$(grep -n 'DEEPSEEK_API_KEY' "$SCRIPT" | grep -v '^[[:space:]]*#' | head -1 | cut -d: -f1)
+  [ -n "$cat_line" ]
+  [ -n "$api_line" ]
+  [ "$cat_line" -lt "$api_line" ]
+}
+
+@test "T002401: LLM prompt contains [EXISTING_CATEGORIES] block" {
+  [ -f "$SCRIPT" ]
+  run grep -F '[EXISTING_CATEGORIES]' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002401: prompt uses dynamic existing_categories variable (not hardcoded list)" {
+  [ -f "$SCRIPT" ]
+  # The prompt block should contain a while-read loop on $existing_categories
+  run grep -F '$(echo "$existing_categories"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+# ── p2.2: DB-Fehler → Enum-Fallback ───────────────────────────────────────────
+
+@test "T002401: enum fallback is used when existing_categories is empty" {
+  [ -f "$SCRIPT" ]
+  # Check the fallback pattern: if existing_categories is empty, call _build_enum_fallback
+  run grep -F 'existing_categories=$(_build_enum_fallback)' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002401: valid array is built dynamically from existing_categories" {
+  [ -f "$SCRIPT" ]
+  # The valid array should be built from $existing_categories, not hardcoded
+  run grep -F '<<< "$existing_categories"' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002401: enum fallback includes all canonical categories" {
+  [ -f "$SCRIPT" ]
+  for cat in 'CI-Konflikt' 'Gate-Fehler' 'API-Fehler' 'Scout-Qualität' 'Deploy-Fehler' 'Spec-Lücke' 'Test-Lücke' 'Sonstige'; do
+    run grep -F "'$cat'" "$SCRIPT"
+    [ "$status" -eq 0 ] || { echo "Missing enum category: $cat" >&2; false; }
+  done
+}
+
+@test "T002401: keyword-matching path is unchanged (still exists before LLM fallback)" {
+  [ -f "$SCRIPT" ]
+  # The keyword matching loop must still exist
+  run grep -F 'best_count=0' "$SCRIPT"
+  [ "$status" -eq 0 ]
+  run grep -F 'keyword match →' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002401: _db_update still references kind: prefix for tag insertion" {
+  [ -f "$SCRIPT" ]
+  run grep -F "'kind:'" "$SCRIPT"
+  [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2472,6 +2472,12 @@
     "kind": "shell"
   },
   {
+    "id": "mishap-categorize-erden",
+    "file": "tests/spec/mishap-categorize-erden.bats",
+    "category": "mishap-categorize-erden",
+    "kind": "shell"
+  },
+  {
     "id": "mishap-t002422",
     "file": "tests/spec/mishap-t002422.bats",
     "category": "mishap-t002422",


### PR DESCRIPTION
## T002401: mishap-categorize erden

**STUFE 1**: Bereits kategorisierte Mishaps vor dem LLM-Aufruf aus der DB holen und als `[EXISTING_CATEGORIES]`-Block im Prompt mitgeben.

### Änderungen
- `_fetch_existing_categories()` — DB-Query für kind:%-Tags
- `_build_enum_fallback()` — Enum-Fallback bei DB-Fehlern
- Prompt mit `[EXISTING_CATEGORIES]`-Context
- Dynamisches valid-Array
- 10 BATS-Tests ✅