### PR TITLE
feat(scripts): release-notes erden: Ticket-Kontext zu gemergten PRs [T002403]

### DIFF
--- a/openspec/changes/release-notes-erden/proposal.md
+++ b/openspec/changes/release-notes-erden/proposal.md
@@ -1,0 +1,26 @@
+---
+title: "release-notes erden: Ticket-Kontext zu gemergten PRs"
+domains: [scripts]
+ticket_id: T002403
+status: active
+parent_feature: T002397
+---
+
+# release-notes erden
+
+**Ticket:** T002403
+
+## Problem
+
+`scripts/vda/release-notes.sh` formuliert Release Notes aus PR-Titeln ohne das
+Warum — Ticket-Beschreibung, Typ und Areas fehlen.
+
+## Lösung
+
+Stufe 1: Zu jeder gemergten PR das Ticket laden (ID via `[T00XXXX]` im Titel),
+Typ/Areas/Beschreibung als Prompt-Kontext mitgeben → Notes gruppieren nach Bereich.
+
+## Fallback
+
+Deterministischer Pfad muss erhalten bleiben: fällt Ticket-Abfrage aus, werden
+Notes weiterhin erzeugt, nur ohne Kontext.

--- a/openspec/changes/release-notes-erden/specs/dev-flow-plan.md
+++ b/openspec/changes/release-notes-erden/specs/dev-flow-plan.md
@@ -1,0 +1,15 @@
+# Spec Delta: release-notes-erden
+
+### Requirement: Release notes generator enriches LLM prompt with ticket context
+
+`scripts/vda/release-notes.sh` MUST extract ticket IDs matching `[T00XXXX]` from merged PR titles and fetch ticket details via `bash scripts/ticket.sh get --id <TICKET_ID>`. When valid ticket data is returned, it MUST append a `[TICKET_CONTEXT]` block to the prompt containing ticket ID, type, title, areas, and description.
+
+#### Scenario: PR title contains ticket ID tag
+- **GIVEN** a PR title containing `[T002403]`
+- **WHEN** release notes narrative generation runs
+- **THEN** ticket details are loaded and included in `[TICKET_CONTEXT]` in the prompt
+
+#### Scenario: Ticket query fails or PR has no tag
+- **GIVEN** a PR title without a ticket tag OR a failing ticket query
+- **WHEN** release notes narrative generation runs
+- **THEN** execution proceeds gracefully without adding ticket context or failing the script

--- a/scripts/vda/release-notes.sh
+++ b/scripts/vda/release-notes.sh
@@ -3,7 +3,7 @@
 # Usage: release-notes.sh <generate|publish-github|publish-changelog|help> [args]
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 source "${SCRIPT_DIR}/lib/vda-core.sh"
 
 _show_help() {
@@ -216,9 +216,37 @@ _deepseek_narrative() {
     return 1
   fi
   local base_url="${DEEPSEEK_BASE_URL:-https://api.deepseek.com/v1}"
+
+  local ticket_context=""
+  while IFS= read -r title; do
+    if [[ -z "$title" ]]; then
+      continue
+    fi
+    local re='\[(T[0-9]{5,6})\]'
+    if [[ "$title" =~ $re ]]; then
+      local ticket_id="${BASH_REMATCH[1]}"
+      local ticket_json
+      ticket_json=$(bash "${SCRIPT_DIR}/ticket.sh" get --id "$ticket_id" 2>/dev/null) || true
+      if [[ -n "$ticket_json" ]] && jq -e '.id // .external_id' <<<"$ticket_json" &>/dev/null; then
+        local t_type t_title t_desc t_areas
+        t_type=$(jq -r '.type // "unknown"' <<<"$ticket_json")
+        t_title=$(jq -r '.title // ""' <<<"$ticket_json")
+        t_desc=$(jq -r '.description // ""' <<<"$ticket_json")
+        t_areas=$(jq -r '.areas // [] | join(", ")' <<<"$ticket_json")
+        
+        ticket_context+=$'- Ticket '"${ticket_id}"$' ('"${t_type}"$'): '"${t_title}"$'\n  Areas: '"${t_areas}"$'\n  Description: '"${t_desc}"$'\n'
+      fi
+    fi
+  done <<<"$pr_titles"
+
+  local context_block=""
+  if [[ -n "$ticket_context" ]]; then
+    context_block=$'\n[TICKET_CONTEXT]\n'"${ticket_context}"
+  fi
+
   local prompt="Fasse diese gemergten PRs zu einer kurzen, user-freundlichen 'Was ist neu'-Einleitung im Markdown-Format zusammen. Nutze Aufzählungen, fokussiere auf Nutzerwert. Maximal 3-4 Sätze.
 PRs:
-${pr_titles}"
+${pr_titles}${context_block}"
 
   local llm_response
   llm_response=$(curl -s --max-time 30 "${base_url}/chat/completions" \
@@ -416,4 +444,6 @@ main() {
   esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/spec/release-notes-erden.bats
+++ b/tests/spec/release-notes-erden.bats
@@ -1,0 +1,182 @@
+#!/usr/bin/env bats
+# tests/spec/release-notes-erden.bats
+# Ticket: T002403 / openspec/changes/release-notes-erden/tasks.md
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/vda/release-notes.sh"
+}
+
+@test "release-notes: deepseek narrative prompt includes ticket context when [T00XXX] tag is present" {
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="$TEST_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  cat <<'EOF' > "$MOCK_BIN/ticket.sh"
+#!/usr/bin/env bash
+if [[ "$1" == "get" && "$3" == "T002403" ]]; then
+  echo '{"id":"c307b1fb","external_id":"T002403","type":"chore","title":"release-notes erden: Ticket-Kontext","description":"Detailed ticket description here","areas":["scripts","tools"]}'
+  exit 0
+fi
+echo '{}'
+EOF
+  chmod +x "$MOCK_BIN/ticket.sh"
+
+  run bash -c "
+    export PATH=\"$MOCK_BIN:\$PATH\"
+    export SCRIPT_DIR=\"$MOCK_BIN\"
+    pr_titles=\"feat(scripts): add feature [T002403]\"
+    DEEPSEEK_API_KEY=\"mock-key\"
+    DEEPSEEK_BASE_URL=\"http://127.0.0.1:59999\"
+    
+    # Mock vda-core.sh inside MOCK_BIN/lib
+    mkdir -p \"$MOCK_BIN/lib\"
+    cat <<'INNEREOF' > \"$MOCK_BIN/lib/vda-core.sh\"
+vda_header() { :; }
+vda_error() { echo \"[ERROR] \$*\" >&2; }
+vda_warn() { echo \"[WARN] \$*\" >&2; }
+vda_success() { echo \"[OK] \$*\"; }
+vda_dry_run() { echo \"[DRY_RUN] \$*\"; }
+INNEREOF
+
+    source \"$SCRIPT\"
+
+    curl() {
+      shift
+      local payload=\"\"
+      while [[ \$# -gt 0 ]]; do
+        if [[ \"\$1\" == \"-d\" ]]; then
+          payload=\"\$2\"
+          break
+        fi
+        shift
+      done
+
+      if [[ \"\$payload\" =~ \"[TICKET_CONTEXT]\" ]]; then
+        echo '{\"choices\":[{\"message\":{\"content\":\"Captured prompt with ticket context\"}}]}'
+      else
+        echo '{\"choices\":[{\"message\":{\"content\":\"No ticket context found\"}}]}'
+      fi
+    }
+
+    _deepseek_narrative \"\$pr_titles\"
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Captured prompt with ticket context"* ]]
+
+  rm -rf "$TEST_DIR"
+}
+
+@test "release-notes: PR without [T00XXX] tag handles gracefully without context" {
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="$TEST_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  cat <<'EOF' > "$MOCK_BIN/ticket.sh"
+#!/usr/bin/env bash
+echo '{}'
+EOF
+  chmod +x "$MOCK_BIN/ticket.sh"
+
+  run bash -c "
+    export PATH=\"$MOCK_BIN:\$PATH\"
+    export SCRIPT_DIR=\"$MOCK_BIN\"
+    pr_titles=\"feat(scripts): add feature without tag\"
+    DEEPSEEK_API_KEY=\"mock-key\"
+    DEEPSEEK_BASE_URL=\"http://127.0.0.1:59999\"
+
+    mkdir -p \"$MOCK_BIN/lib\"
+    cat <<'INNEREOF' > \"$MOCK_BIN/lib/vda-core.sh\"
+vda_header() { :; }
+vda_error() { echo \"[ERROR] \$*\" >&2; }
+vda_warn() { echo \"[WARN] \$*\" >&2; }
+vda_success() { echo \"[OK] \$*\"; }
+vda_dry_run() { echo \"[DRY_RUN] \$*\"; }
+INNEREOF
+    
+    source \"$SCRIPT\"
+
+    curl() {
+      shift
+      local payload=\"\"
+      while [[ \$# -gt 0 ]]; do
+        if [[ \"\$1\" == \"-d\" ]]; then
+          payload=\"\$2\"
+          break
+        fi
+        shift
+      done
+
+      if [[ \"\$payload\" =~ \"[TICKET_CONTEXT]\" ]]; then
+        echo '{\"choices\":[{\"message\":{\"content\":\"FAIL: context found\"}}]}'
+      else
+        echo '{\"choices\":[{\"message\":{\"content\":\"SUCCESS: no ticket context\"}}]}'
+      fi
+    }
+
+    _deepseek_narrative \"\$pr_titles\"
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SUCCESS: no ticket context"* ]]
+
+  rm -rf "$TEST_DIR"
+}
+
+@test "release-notes: ticket lookup DB error handles gracefully without context or failing script" {
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="$TEST_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+
+  cat <<'EOF' > "$MOCK_BIN/ticket.sh"
+#!/usr/bin/env bash
+echo "DB Connection Error: database unreachable" >&2
+exit 1
+EOF
+  chmod +x "$MOCK_BIN/ticket.sh"
+
+  run bash -c "
+    export PATH=\"$MOCK_BIN:\$PATH\"
+    export SCRIPT_DIR=\"$MOCK_BIN\"
+    pr_titles=\"fix(db): handle failure [T009999]\"
+    DEEPSEEK_API_KEY=\"mock-key\"
+    DEEPSEEK_BASE_URL=\"http://127.0.0.1:59999\"
+
+    mkdir -p \"$MOCK_BIN/lib\"
+    cat <<'INNEREOF' > \"$MOCK_BIN/lib/vda-core.sh\"
+vda_header() { :; }
+vda_error() { echo \"[ERROR] \$*\" >&2; }
+vda_warn() { echo \"[WARN] \$*\" >&2; }
+vda_success() { echo \"[OK] \$*\"; }
+vda_dry_run() { echo \"[DRY_RUN] \$*\"; }
+INNEREOF
+    
+    source \"$SCRIPT\"
+
+    curl() {
+      shift
+      local payload=\"\"
+      while [[ \$# -gt 0 ]]; do
+        if [[ \"\$1\" == \"-d\" ]]; then
+          payload=\"\$2\"
+          break
+        fi
+        shift
+      done
+
+      if [[ \"\$payload\" =~ \"[TICKET_CONTEXT]\" ]]; then
+        echo '{\"choices\":[{\"message\":{\"content\":\"FAIL: context found\"}}]}'
+      else
+        echo '{\"choices\":[{\"message\":{\"content\":\"SUCCESS: fallback without context\"}}]}'
+      fi
+    }
+
+    _deepseek_narrative \"\$pr_titles\"
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"SUCCESS: fallback without context"* ]]
+
+  rm -rf "$TEST_DIR"
+}


### PR DESCRIPTION
### Summary
Enriches narrative release notes prompt in `scripts/vda/release-notes.sh` with ticket details (type, title, areas, description) loaded via `scripts/ticket.sh get --id <TICKET_ID>` when a PR title contains `[T00XXXX]`.

### Verification
- Ran `task test:changed`
- Ran `task freshness:regenerate` and `task freshness:check`
- Unit tested with `npx bats tests/spec/release-notes-erden.bats` (3/3 passing)