### PR TITLE
chore(scripts): Erden — release-notes Ticket-Kontext + brain-ingest Prüfung [T002402][T002403][T002404]

### DIFF
--- a/openspec/changes/brain-ingest-pruefen/tasks.md
+++ b/openspec/changes/brain-ingest-pruefen/tasks.md
@@ -1,0 +1,13 @@
+---
+title: "brain-ingest-pruefen — Ergebnis"
+ticket_id: T002404
+status: completed
+---
+
+# brain-ingest-transform — Prüfung abgeschlossen
+
+**Frage:** Entstehen im Wiki inkonsistente Querverweise oder Dubletten, die durch Kenntnis der bereits ingestierten Seiten vermeidbar wären?
+
+**Antwort: Nein.** `scripts/brain-ingest-transform.sh` übergibt bereits `slugs_json` (Argument 4, Zeile 22) als vollständige Liste aller Wiki-Slugs an das LLM (Zeile 65: `Slugs: ${SLUGS_JSON}`). Das LLM hat damit Kenntnis aller existierenden Seiten und kann konsistente `[[wikilinks]]` setzen.
+
+**Entscheidung:** Keine Erdung notwendig. Ticket wird als `obsolete` geschlossen.

--- a/openspec/changes/release-notes-erden/tasks.md
+++ b/openspec/changes/release-notes-erden/tasks.md
@@ -1,0 +1,11 @@
+---
+title: "release-notes-erden — Implementation"
+ticket_id: T002403
+status: completed
+---
+
+# release-notes-erden — Stufe 1 umgesetzt
+
+**Was:** `scripts/vda/release-notes.sh` lädt jetzt pro PR das zugehörige Ticket aus der DB (via `[T00XXXX]`-Pattern im PR-Titel) und nutzt Typ und Areas für bessere Sektions-Gruppierung.
+
+**Implementierung:** Neue `_ticket_context()`-Funktion mit deterministischem Fallback — bei DB-Ausfall wird wie bisher der konventionelle Commit-Typ aus dem PR-Titel erkannt.

--- a/scripts/vda/release-notes.sh
+++ b/scripts/vda/release-notes.sh
@@ -41,6 +41,30 @@ _get_last_tag() {
   echo "$tag"
 }
 
+_ticket_context() {
+  # Extract ticket ID from PR title [T00XXXX] and look up type/areas/description
+  # from the database. Falls back to empty string on any failure.
+  local title="$1" tid
+  if [[ "$title" =~ \[(T[0-9]{6})\] ]]; then
+    tid="${BASH_REMATCH[1]}"
+    # Try vda ticket get first, then psql fallback
+    local ticket_json
+    if command -v vda.sh &>/dev/null; then
+      ticket_json=$("${SCRIPT_DIR}/vda.sh" ticket get --id "$tid" --json 2>/dev/null || true)
+    fi
+    if [[ -z "$ticket_json" ]] && command -v psql &>/dev/null; then
+      ticket_json=$(psql -t -A -h "${PGHOST:-localhost}" -p "${PGPORT:-5432}" \
+        -d "${PGDATABASE:-bachelorprojekt}" -U "${PGUSER:-postgres}" \
+        -c "SELECT json_build_object('type', type, 'areas', areas, 'description', left(description,200)) FROM tickets.tickets WHERE external_id='$tid'" 2>/dev/null || true)
+    fi
+    if [[ -n "$ticket_json" ]]; then
+      echo "$ticket_json"
+      return 0
+    fi
+  fi
+  return 1
+}
+
 _get_tag_date() {
   local tag="$1"
   git log -1 --format=%cI "$tag" 2>/dev/null || date -Iseconds
@@ -137,10 +161,22 @@ _build_deterministic_notes() {
       local pr_num
       pr_num=$(jq -r ".[$i].number" <<<"$prs_json" 2>/dev/null || echo "?")
       if [[ -n "$title" ]]; then
-        local typ section
-        typ=$(_detect_type "$title")
-        section=$(_ensure_type_key "$typ")
-        _append "$section" "- ${title} (#${pr_num})"
+        local ticket_context typ section
+        ticket_context=$(_ticket_context "$title")
+        if [[ -n "$ticket_context" ]]; then
+          typ=$(jq -r '.type // "chore"' <<<"$ticket_context" 2>/dev/null || echo "chore")
+          local areas desc
+          areas=$(jq -r '.areas // ""' <<<"$ticket_context" 2>/dev/null || echo "")
+          desc=$(jq -r '.description // ""' <<<"$ticket_context" 2>/dev/null || echo "")
+          section=$(_ensure_type_key "$typ")
+          local line="- ${title} (#${pr_num})"
+          [[ -n "$areas" ]] && line+=" [${areas}]"
+          _append "$section" "$line"
+        else
+          typ=$(_detect_type "$title")
+          section=$(_ensure_type_key "$typ")
+          _append "$section" "- ${title} (#${pr_num})"
+        fi
       fi
       i=$((i + 1))
     done


### PR DESCRIPTION
## Erden — Kleine Skripte Bundle

### T002403 — release-notes: Ticket-Kontext aus DB
- `_ticket_context()` extrahiert `[T00XXXX]` aus PR-Titel und lädt type/areas aus DB
- Deterministischer Fallback: bei DB-Ausfall konventioneller Commit-Typ wie bisher

### T002404 — brain-ingest-transform: Prüfung
- Keine Erdung nötig — `slugs_json` übergibt bereits alle Wiki-Slugs
- Ticket obsolete geschlossen

### T002402 — health-goals-llm-fill
- Bereits done

Closes T002402, T002403, T002404