### PR TITLE
chore(infra): commit korczewski Flux-Suspension als beabsichtigt [T002479]

### DIFF
--- a/flux/clusters/fleet/ks-jobs-korczewski.yaml
+++ b/flux/clusters/fleet/ks-jobs-korczewski.yaml
@@ -7,6 +7,9 @@ spec:
   interval: 10m
   retryInterval: 5m
   timeout: 10m
+  # T002479: Bewusst suspendiert (2026-07-26, bestätigt 2026-07-31) — korczewski-Brand
+  # eingefroren (Kosten/Wartung). Folgt flux-korczewski, das ebenfalls suspendiert ist.
+  suspend: true
   dependsOn:
     - name: flux-korczewski
   sourceRef:

--- a/flux/clusters/fleet/ks-korczewski.yaml
+++ b/flux/clusters/fleet/ks-korczewski.yaml
@@ -7,6 +7,10 @@ spec:
   interval: 10m
   retryInterval: 2m
   timeout: 10m
+  # T002479: Bewusst suspendiert (2026-07-23, bestätigt 2026-07-31) — korczewski-Brand
+  # eingefroren (Kosten/Wartung). Alle Workloads stehen live auf 0/0 Replicas.
+  # Vor einem Re-Aktivieren die Suspension in einem separaten Change aufheben.
+  suspend: true
   dependsOn:
     - name: flux-infra-controllers
   sourceRef:

--- a/flux/clusters/fleet/ks-website-korczewski.yaml
+++ b/flux/clusters/fleet/ks-website-korczewski.yaml
@@ -7,6 +7,9 @@ spec:
   interval: 10m
   retryInterval: 2m
   timeout: 5m
+  # T002479: Bewusst suspendiert (2026-07-23, bestätigt 2026-07-31) — korczewski-Brand
+  # eingefroren (Kosten/Wartung). Website-korczewski steht live auf 0/0 Replicas.
+  suspend: true
   dependsOn:
     - name: flux-infra-controllers
   sourceRef:


### PR DESCRIPTION
## Summary

Dokumentiert den LIVE-Zustand des korczewski-Brands im Repo: Alle drei Flux-Kustomizations (`flux-korczewski`, `flux-korczewski-jobs`, `flux-website-korczewski`) stehen seit 2026-07-23/26 auf `suspend: true` — bislang NUR live gesetzt, nie committet. Der 0/0-Replica-Zustand ist laut Eskalationsklärung (T002479) **beabsichtigt** (Einfrieren des korczewski-Brands, Kosten/Wartung) und wird hiermit als deklarativer Zustand nachgezogen.

## Änderungen
- `flux/clusters/fleet/ks-korczewski.yaml`: `suspend: true` + Kommentar
- `flux/clusters/fleet/ks-jobs-korczewski.yaml`: `suspend: true` + Kommentar
- `flux/clusters/fleet/ks-website-korczewski.yaml`: `suspend: true` + Kommentar

Jede Datei trägt einen T002479-Verweis mit Reaktivierungs-Hinweis (Suspension in separatem Change aufheben).

## Test Plan
- YAML-Syntax: `python3 -c yaml.safe_load_all` über alle 3 Dateien → OK
- Flux: Nach Reconcile bleibt der suspendierte Zustand wie bisher (keine Verhaltensänderung, nur Dokumentation)