### PR TITLE
fix(ops): identifiziere Firewall-Regeln über den vollen Programmpfad [T002496]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 652,
+      "file_count": 653,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -382,6 +382,7 @@
         "tests/spec/fix-ticket-tracking-T002279.bats",
         "tests/spec/fixtures/make-partial-plan.sh",
         "tests/spec/fleet-operations.bats",
+        "tests/spec/fleet-operations/firewall-program-match.bats",
         "tests/spec/fleet-operations/powershell-ascii-only.bats",
         "tests/spec/fleet-operations/wg-gpu-pod-cidr.bats",
         "tests/spec/g-cq02-any-types.bats",

--- a/scripts/llm/harden-gpu-firewall.ps1
+++ b/scripts/llm/harden-gpu-firewall.ps1
@@ -52,6 +52,11 @@ param(
 
   [string]$RuleName = 'llama-bge-wg-mesh',
 
+  # Angezeigter Regelname. Default wird aus RuleName abgeleitet, damit ein Lauf
+  # fuer einen anderen Build (z. B. Gemma auf :8091) nicht faelschlich "bge"
+  # in der Firewall-Uebersicht stehen laesst.
+  [string]$DisplayName = "$RuleName (wg-mesh only)",
+
   [switch]$WhatIfOnly
 )
 
@@ -66,15 +71,23 @@ if (-not (Test-Path $Program)) {
   throw "Binary nicht gefunden: $Program"
 }
 
-$leaf = Split-Path $Program -Leaf
-$dir  = Split-Path $Program -Parent
+# Identitaet einer Binary ist ihr VOLLSTAENDIGER Pfad, nichts anderes (T002496).
+#
+# Eine fruehere Fassung matchte ueber den Basename des Elternverzeichnisses. Bei
+# ...\llama-b10090-13.3\llama-server.exe ergab das ein eindeutiges Muster und
+# funktionierte - aber nur zufaellig. Der bonsai-Build liegt unter
+# ...\llama-bonsai-cuda13.3\bin\llama-server.exe; dort ist der Basename "bin", das
+# Muster wird zu "*bin*llama-server.exe" und trifft jeden parallel installierten
+# llama-Build mit bin-Unterordner. Darunter llama-b9553-cuda13, dessen Regeln
+# BLOCK sind: das Skript haette eine Sperre entfernt statt sie zu erhalten.
+#
+# Die Firewall speichert Programmpfade in Kleinschreibung und teils mit
+# abweichender Schreibung der Verzeichnisse, deshalb wird beidseitig normalisiert.
+$normalizedProgram = $Program.ToLowerInvariant()
 
 function Get-RulesForProgram {
-  # Der Vergleich laeuft ueber das Elternverzeichnis, weil mehrere llama-Builds
-  # parallel installiert sind und alle dieselbe llama-server.exe heissen. Nur die
-  # Regeln des uebergebenen Builds duerfen angefasst werden.
   Get-NetFirewallApplicationFilter |
-    Where-Object { $_.Program -like "*$([System.IO.Path]::GetFileName($dir))*$leaf" } |
+    Where-Object { $null -ne $_.Program -and $_.Program.ToLowerInvariant() -eq $normalizedProgram } |
     ForEach-Object { $_ | Get-NetFirewallRule } |
     Where-Object { $_.Direction -eq 'Inbound' }
 }
@@ -96,7 +109,7 @@ if (Get-NetFirewallRule -Name $RuleName -ErrorAction SilentlyContinue) {
   Remove-NetFirewallRule -Name $RuleName
 }
 New-NetFirewallRule -Name $RuleName `
-  -DisplayName 'llama-server bge (wg-mesh only)' `
+  -DisplayName $DisplayName `
   -Direction Inbound -Action Allow -Protocol TCP `
   -LocalPort $Ports -RemoteAddress $MeshSubnet -Program $Program `
   -Profile Any -Enabled True | Out-Null

--- a/tests/spec/fleet-operations/firewall-program-match.bats
+++ b/tests/spec/fleet-operations/firewall-program-match.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# firewall-program-match.bats — Guard fuer T002496.
+#
+# PRUEFMODUS: Quelltext. Ausnahmefall der Test-Resultats-Konvention (T002448-M4):
+# die Laufzeit liegt auf einem Windows-Host mit Firewall-Cmdlets, den die
+# Linux-CI nicht erreicht. Ein Laufzeit-Test waere hier nicht ausfuehrbar, ein
+# Nachbau der Matching-Logik wuerde nur den Nachbau pruefen.
+#
+# HINTERGRUND: harden-gpu-firewall.ps1 identifizierte die zu verwaltenden Regeln
+# ueber den Basename des ELTERNVERZEICHNISSES der Binary:
+#
+#     $_.Program -like "*$([System.IO.Path]::GetFileName($dir))*$leaf"
+#
+# Bei der bge-Binary (…\llama-b10090-13.3\llama-server.exe) ergab das das
+# eindeutige Muster "*llama-b10090-13.3*llama-server.exe" — das Skript lief
+# korrekt, aber aus dem falschen Grund. Der bonsai-Build liegt unter
+# …\llama-bonsai-cuda13.3\bin\llama-server.exe; der Basename ist dort schlicht
+# "bin", das Muster wird zu "*bin*llama-server.exe" und trifft JEDEN parallel
+# installierten llama-Build mit bin-Unterordner — darunter llama-b9553-cuda13,
+# dessen Regeln BLOCK sind. Das Skript haette also eine Sperre entfernt.
+#
+# Die einzig tragfaehige Identitaet einer Binary ist ihr vollstaendiger Pfad.
+
+setup() {
+  PROJECT_DIR="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  SCRIPT="${PROJECT_DIR}/scripts/llm/harden-gpu-firewall.ps1"
+}
+
+@test "harden-gpu-firewall.ps1 exists and takes a -Program parameter" {
+  # Positiv-Anker fuer beide folgenden Tests: ohne ihn bestuenden die
+  # Negativ-Aussagen unten trivial, sobald die Datei fehlt oder umbenannt wird.
+  [ -f "$SCRIPT" ]
+  grep -q '\[string\]\$Program' "$SCRIPT"
+}
+
+@test "firewall rule matching never derives identity from the parent directory name" {
+  [ -f "$SCRIPT" ]   # Positiv-Anker
+  run grep -n 'GetFileName(\$dir)' "$SCRIPT"
+  [ "$status" -ne 0 ] || {
+    echo "rule matching uses the parent directory basename — collides with other" >&2
+    echo "llama builds that share a 'bin' subfolder (T002496):" >&2
+    echo "$output" >&2
+    return 1
+  }
+}
+
+@test "firewall rule matching compares against the full program path" {
+  [ -f "$SCRIPT" ]   # Positiv-Anker
+  # Der Vergleich muss den uebergebenen -Program-Wert selbst heranziehen,
+  # normalisiert, statt ein aus Teilen gebautes Wildcard-Muster.
+  grep -qE '\$_\.Program.*-(i?eq|like)[[:space:]]+\$(Program|normalizedProgram|programPath)' "$SCRIPT" || {
+    echo "no direct comparison of \$_.Program against the -Program argument found" >&2
+    grep -n '\$_\.Program' "$SCRIPT" >&2 || true
+    return 1
+  }
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2310,6 +2310,12 @@
     "kind": "shell"
   },
   {
+    "id": "fleet-operations/firewall-program-match",
+    "file": "tests/spec/fleet-operations/firewall-program-match.bats",
+    "category": "fleet-operations",
+    "kind": "shell"
+  },
+  {
     "id": "fleet-operations/powershell-ascii-only",
     "file": "tests/spec/fleet-operations/powershell-ascii-only.bats",
     "category": "fleet-operations",


### PR DESCRIPTION
## Warum

`harden-gpu-firewall.ps1` (aus #3562) bestimmte die zu verwaltenden Regeln über den Basename des **Elternverzeichnisses** der Binary:

```powershell
$_.Program -like "*$([System.IO.Path]::GetFileName($dir))*$leaf"
```

Bei der bge-Binary (`…\llama-b10090-13.3\llama-server.exe`) ergab das das eindeutige Muster `*llama-b10090-13.3*llama-server.exe`. Das Skript lief korrekt — **aber aus dem falschen Grund**: die Eindeutigkeit war ein Zufall des Verzeichnislayouts.

Der bonsai-Build (Gemma auf `:8091`) liegt unter `…\llama-bonsai-cuda13.3\`**`bin`**`\llama-server.exe`. Dort ist der Basename schlicht `bin`, das Muster wird zu `*bin*llama-server.exe` — und trifft **jeden** parallel installierten llama-Build mit `bin`-Unterordner. Auf dem Host sind das:

| Build | Regeln |
|---|---|
| `llama-bonsai-cuda13.3\bin\` | Allow (Ziel) |
| `llama-b9957-cuda13\bin\` | Allow |
| `llama-b9553-cuda13\bin\` | **Block** |

Das Skript hätte also beim Härten von Gemma eine **Block-Regel entfernt** — eine Sperre gelockert statt sie zu erhalten. Aufgefallen beim Vorbereiten des T002496-Laufs, **vor** der Anwendung auf den Host.

## Was sich ändert

- **Vergleich gegen den vollen `-Program`-Pfad**, beidseitig lowercase-normalisiert (die Windows-Firewall speichert Programmpfade kleingeschrieben). Der vollständige Pfad ist die einzige tragfähige Identität einer Binary; alles andere ist eine Heuristik, die von der Verzeichnisstruktur abhängt.
- **`-DisplayName` ist jetzt parametrisiert** und wird aus `-RuleName` abgeleitet. Bisher stand dort hart `llama-server bge (wg-mesh only)` — bei einem Gemma-Lauf hätte die Firewall-Übersicht dauerhaft „bge" angezeigt.
- **`tests/spec/fleet-operations/firewall-program-match.bats`** — Guard gegen die Rückkehr der Verzeichnis-Heuristik, mit Positiv-Anker (T002356-M1).

## Prüfmodus des Guards

Quelltextbasiert, als dokumentierter Ausnahmefall der Test-Resultats-Konvention (T002448-M4): Die Laufzeit liegt auf einem Windows-Host mit Firewall-Cmdlets, den die Linux-CI nicht erreicht. Ein Nachbau der Matching-Logik in BATS würde nur den Nachbau prüfen. Der Header der Testdatei benennt das.

## Verifikation

- `tests/spec/fleet-operations/` — 9/9 grün (3 neu, 6 bestehend)
- PowerShell-Parse-Check gegen die geänderte Datei — `Syntax OK`
- `task test:inventory`, `task freshness:check` — grün
- Der ASCII-Guard aus #3562 hat während dieser Änderung **erneut** angeschlagen (Ellipsen in den neuen Kommentaren) und sie vor dem Commit abgefangen

Refs T002496.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbrcxJTj2utVC7NZX7ybvW