### PR TITLE
fix(website): 12 rote Vitest-Tests auf main grün [T002497]

### DIFF
--- a/website/src/lib/auth.test.ts
+++ b/website/src/lib/auth.test.ts
@@ -80,10 +80,46 @@ describe('getLoginUrl', () => {
     expect(url).toContain(encodeURIComponent('/api/auth/callback'));
   });
 
-  it('echoes the supplied state parameter', async () => {
+  // [T002497] Bis 372729d7d reichte getLoginUrl das Argument als state-Parameter
+  // durch; der Test hiess entsprechend "echoes the supplied state parameter".
+  // Seither ist das Argument ein returnTo, das INTERN unter einem zufällig
+  // erzeugten state hinterlegt wird — Pocket ID v2.11.0 weist states unter
+  // 8 Zeichen ab. Der alte Test blieb stehen und war seit dem 27.07. rot.
+  it('erzeugt einen zufälligen state und echot das returnTo NICHT', async () => {
     const m = await loadModule();
-    const url = m.getLoginUrl('csrf-token-123');
-    expect(url).toContain('state=csrf-token-123');
+    const url = m.getLoginUrl('/admin/tickets');
+    const state = new URL(url).searchParams.get('state');
+
+    // Positiv-Anker: ohne state wäre die Negativ-Aussage unten vakuos.
+    expect(state).toBeTruthy();
+    expect(state!.length).toBeGreaterThanOrEqual(8); // Pocket-ID-v2.11-Mindestlänge
+    expect(url).not.toContain('/admin/tickets');
+    expect(url).not.toContain(encodeURIComponent('/admin/tickets'));
+  });
+
+  it('zwei Aufrufe erzeugen verschiedene states', async () => {
+    const m = await loadModule();
+    const a = new URL(m.getLoginUrl('/a')).searchParams.get('state');
+    const b = new URL(m.getLoginUrl('/b')).searchParams.get('state');
+    expect(a).not.toBe(b);
+  });
+
+  // Der eigentliche Vertrag zwischen getLoginUrl und dem Callback — bisher
+  // ungetestet, obwohl er entscheidet, wohin ein Nutzer nach dem Login landet.
+  it('hinterlegt das returnTo abrufbar unter dem erzeugten state, einmalig', async () => {
+    const m = await loadModule();
+    const state = new URL(m.getLoginUrl('/admin/tickets')).searchParams.get('state')!;
+
+    expect(m.consumeReturnTo(state)).toBe('/admin/tickets');
+    // consume heisst consume: der zweite Abruf muss leer ausgehen, sonst wäre
+    // ein state wiederverwendbar.
+    expect(m.consumeReturnTo(state)).toBeUndefined();
+  });
+
+  it('ohne returnTo wird nichts hinterlegt', async () => {
+    const m = await loadModule();
+    const state = new URL(m.getLoginUrl()).searchParams.get('state')!;
+    expect(m.consumeReturnTo(state)).toBeUndefined();
   });
 });
 

--- a/website/src/lib/tickets/__tests__/migrate-type-vocabulary.test.ts
+++ b/website/src/lib/tickets/__tests__/migrate-type-vocabulary.test.ts
@@ -28,12 +28,21 @@ describe('applyTypeVocabularyMigration', () => {
     expect(update).toBeGreaterThan(add);
   });
 
-  it('der CHECK trägt alle dreizehn Werte', async () => {
+  // [T002497] Der Test hiess "der CHECK trägt alle dreizehn Werte" und prüfte
+  // toHaveLength(13). Mit dem incident-Typ (T002407) wurden es 14, und der Test
+  // war seit dem 29.07. rot. Die Zahl steckte in Name UND Assertion — zwei
+  // Stellen, die auseinanderlaufen können. Der Name führt sie jetzt nicht mehr.
+  //
+  // Die Längenprüfung bleibt trotzdem, als Positiv-Anker: wäre TICKET_TYPES
+  // leer, liefe die Schleife darunter null Mal und der Test bestünde vakuos.
+  // Sie ist bewusst exakt und kein >=, damit ein Hinzufügen oder Entfernen von
+  // Typen hier sichtbar wird statt still durchzugehen.
+  it('der CHECK trägt jeden Wert aus TICKET_TYPES', async () => {
     const { pool, statements } = fakePool();
     await applyTypeVocabularyMigration(pool);
     const check = statements.find((s) => s.includes('ADD CONSTRAINT tickets_type_check'))!;
 
-    expect(TICKET_TYPES).toHaveLength(13);
+    expect(TICKET_TYPES).toHaveLength(14); // 11 Conventional-Commit-Typen + 3 Altwerte
     for (const t of TICKET_TYPES) expect(check).toContain(`'${t}'`);
   });
 

--- a/website/src/lib/tickets/migrate-type-vocabulary.ts
+++ b/website/src/lib/tickets/migrate-type-vocabulary.ts
@@ -4,7 +4,7 @@
 // 576/600 Zeilen am S1-Budget steht — T002329.
 import type { Pool, PoolClient } from 'pg';
 
-// Dual-Vokabular: der CHECK akzeptiert die zehn neuen Werte UND die drei Altwerte.
+// Dual-Vokabular: der CHECK akzeptiert die elf neuen Werte UND die drei Altwerte.
 // Das entkoppelt DB-Migration (reist im Website-Image) und Skript-Deploy (kommt mit
 // dem Merge sofort auf dem Host an) — die beiden Zeitpunkte fallen zwangsläufig
 // auseinander, und solange beide Namensräume gültig sind, ist das Fenster folgenlos.

--- a/website/src/pages/api/auth/callback.test.ts
+++ b/website/src/pages/api/auth/callback.test.ts
@@ -10,6 +10,18 @@ vi.mock('../../../lib/auth', () => ({
   })),
   isAdmin: vi.fn(() => mockIsAdmin),
   setSessionCookie: vi.fn(() => 'workspace_session=sess-123; Path=/; HttpOnly; SameSite=Lax'),
+  // [T002497] Seit dem Umbau auf zufällige OIDC-states (372729d7d) ruft der
+  // Callback consumeReturnTo(state) auf, um das beim Login hinterlegte returnTo
+  // aus dem Store zu holen. Fehlt der Export im Mock, wirft vitest bereits in
+  // callback.ts:60 — vor jeder Assertion, weshalb ALLE zehn Tests dieser Datei
+  // fielen und die returnTo-Allowlist damit ungeprüft blieb.
+  //
+  // undefined ist hier die richtige Antwort, nicht bloß die bequeme: die Tests
+  // übergeben den returnTo direkt als state-Parameter. Ein leerer Store lässt
+  // den Fallback `consumeReturnTo(rawState) || rawState` greifen, sodass genau
+  // der Wert in die Allowlist-Prüfung läuft, den der Test setzt. Würde der Mock
+  // stattdessen einen Wert liefern, prüften die Tests ihn statt ihrer Eingabe.
+  consumeReturnTo: vi.fn(() => undefined),
 }));
 
 import { GET } from './callback';


### PR DESCRIPTION
`Vitest (website)` ist ein **required check**. Die Suite war auf `main` rot und blockierte damit jeden PR, der sie zur Ausführung brachte — konkret #3563 (Cockpit K7).

Reproduziert auf reinem `origin/main @6b565c158` in einem frischen Worktree, **ohne** Feature-Änderungen. Alle drei Ursachen sind Tests, die einer Implementierungsänderung nicht nachgezogen wurden.

## 1. `callback.test.ts` — 10 von 10 Tests (das Dringendste)

```
Error: [vitest] No "consumeReturnTo" export is defined on the "../../../lib/auth" mock.
❯ Module.GET src/pages/api/auth/callback.ts:60:28
```

Der Umbau auf zufällige OIDC-states (`372729d7d`, 27.07.) führte `consumeReturnTo` ein; der `vi.mock` kannte es nicht und warf schon in `callback.ts:60` — **vor jeder Assertion**. Damit war die returnTo-Allowlist gegen offene Redirects (`//evil.com`, `/\evil.com`, `javascript:`) seit über einer Woche ungeprüft.

**Entwarnung zur Implementierung:** die Schutzwirkung selbst war intakt. `resolvedReturnTo` läuft in Zeile 87 durch `resolveReturnTo()` — auch auf dem Store-Pfad. Nachgesehen, kein Bug im Produktionscode.

Der Mock liefert bewusst `() => undefined`: die Tests übergeben den returnTo direkt als `state`, und ein leerer Store lässt den Fallback `consumeReturnTo(rawState) || rawState` greifen — so läuft genau der Testwert in die Allowlist. Ein Mock mit Rückgabewert würde stattdessen *ihn* prüfen statt der Eingabe.

**Mutations-Gegenprobe:** mit entschärfter Allowlist (`if (true)`) werden 3 der 10 Tests rot, darunter der `javascript:`-Schema-Test. Die Prüfung greift wieder — sie ist nicht bloß formal grün.

## 2. `auth.test.ts` — `echoes the supplied state parameter`

Das Argument von `getLoginUrl` ist seit `372729d7d` ein `returnTo`, das intern unter einem zufälligen state hinterlegt wird (Pocket ID v2.11.0 weist states unter 8 Zeichen ab). Der Test prüfte ein Verhalten, das es nicht mehr gibt.

Ersetzt durch vier Tests auf den tatsächlichen Vertrag:
- state ist zufällig und ≥ 8 Zeichen, das returnTo steht **nicht** in der URL
- zwei Aufrufe liefern verschiedene states
- das returnTo ist unter dem state abrufbar — **genau einmal** (consume heißt consume)
- ohne returnTo wird nichts hinterlegt

Der Store-Pfad war bisher komplett ungetestet, obwohl er entscheidet, wohin ein Nutzer nach dem Login landet.

## 3. `migrate-type-vocabulary.test.ts` — `der CHECK trägt alle dreizehn Werte`

Mit dem `incident`-Typ (T002407) wurden es 14. Die Zahl stand in **Name und Assertion** — zwei Stellen, die auseinanderlaufen können; der Name führt sie jetzt nicht mehr. Die Längenprüfung bleibt als Positiv-Anker (leeres `TICKET_TYPES` ließe die Schleife null Mal laufen) und bleibt exakt statt `>=`, damit Änderungen am Vokabular sichtbar werden. Der veraltete Quellkommentar „zehn neuen Werte" ist auf elf korrigiert.

## Warum es erst jetzt auffiel

Die CI führt Vitest nur für PRs aus, deren Änderungen die betroffenen Tests selektieren. #3561 lief am 01.08. um 12:46 grün durch, weil er nur eine generierte JSON anfasste. #3563 ändert `cockpit.astro` und zieht die volle Suite.

## Verifikation

```
vorher:  Tests  12 failed | 2784 passed
nachher: Tests  2796 passed | 80 skipped (2876)
```

- `task freshness:check` — exit 0
- S1-Restbudget: 647 / 793 / 839 / 855 Zeilen frei
- Mutations-Gegenprobe an der Allowlist bestanden

Ticket: T002497