### PR TITLE
fix(test): kit-assets-Guard flutet /tmp und killt die Spec-Suite [T002499]

### DIFF
--- a/tests/spec/sdlc-cockpit/kit-assets-in-image.bats
+++ b/tests/spec/sdlc-cockpit/kit-assets-in-image.bats
@@ -19,11 +19,26 @@ setup() {
   cd "$REPO" || return 1
 }
 
-# Bildet `COPY website/ .` (WORKDIR /app) nach: nur der website-Teilbaum landet
-# im Ziel, Symlinks werden als Symlinks übernommen.
+# Bildet `COPY website/ .` (WORKDIR /app) nach: der website-Teilbaum landet im
+# Ziel, Symlinks werden als Symlinks übernommen.
+#
+# [T002499] Kopiert wird NUR public/, nicht website/. — und das ist eine
+# Korrektheits-, keine Sparmaßnahme. `cp -r website/.` zog in CI 606 MB mit:
+# website/node_modules ist lokal ein Symlink aufs Haupt-node_modules (der Test
+# lief in 0,59 s), nach `pnpm install` in CI aber ein echtes Verzeichnis. Da
+# BATS_TEST_TMPDIR unter /tmp liegt und `task test:spec` die Suite mit
+# `bats -j $(nproc)` PARALLEL fährt, lief /tmp voll und die anderen Worker
+# starben mit "parallel: Is the disk full?" — die Suite brach bei wechselnden
+# Testzahlen ab (61 bzw. 515 von 2510), ohne dass dieser Test selbst rot wurde.
+#
+# Für die Aussage des Tests ist public/ äquivalent: die geprüften Symlinks
+# liegen unter public/cockpit/ und behalten ihre relative Tiefe. $T/public/
+# cockpit/kit -> ../../../.lavish/kit zeigt auf $T/../.lavish/kit und ist im
+# Sandbox-Pfad genauso tot wie /app/public/cockpit/kit -> /.lavish/kit im Image.
 _simulate_website_copy() {
   local dest="$1"
-  cp -r website/. "$dest/" 2>/dev/null || true
+  mkdir -p "$dest/public"
+  cp -r website/public/. "$dest/public/" 2>/dev/null || true
 }
 
 @test "T002466: Kit-Assets sind im Image-Layout auflösbar, nicht nur im Checkout" {


### PR DESCRIPTION
`main` ist rot. Nicht durch einen fehlgeschlagenen Test — die Suite **bricht ab**:

```
parallel: Error: Cannot append to buffer file in /tmp.
parallel: Error: Is the disk full?
# bats warning: Executed 61 instead of expected 2510 tests
```

Der Abbruchpunkt variiert zwischen Läufen (**61** und **515** gemessen). Das ist die Signatur eines Ressourcen-Abbruchs, nicht eines deterministischen Testfehlers.

## Ursache

Der Guard aus T002466 bildet die Docker-COPY-Semantik nach und tat das mit `cp -r website/.`.

| | `website/node_modules` | kopiertes Volumen | Laufzeit |
|---|---|---|---|
| **lokal** | Symlink aufs Haupt-`node_modules` | ~30 MB | 0,59 s |
| **CI** (nach `pnpm install`) | echtes Verzeichnis | **606 MB** | Disk voll |

`BATS_TEST_TMPDIR` liegt unter `/tmp`, und `task test:spec` fährt die Suite mit `bats -j $(nproc)` **parallel**. Während dieser eine Worker kopierte, starben die anderen an der vollen Disk — **ohne dass der verursachende Test selbst rot wurde**.

Die naheliegende Entlastung „der Test läuft alphabetisch spät (~2400 von 2510), der Abbruch passiert bei 61" greift deshalb nicht: GNU `parallel` verteilt ihn auf einen früh startenden Worker. Ich bin dieser Fehlannahme zunächst selbst aufgesessen.

## Fix

Nur `website/public/` kopieren. Für die Aussage des Tests äquivalent: die geprüften Symlinks liegen unter `public/cockpit/` und behalten ihre relative Tiefe.

```
$T/public/cockpit/kit -> ../../../.lavish/kit   ⇒  $T/../.lavish/kit      (tot)
/app/public/cockpit/kit -> ../../../.lavish/kit ⇒  /.lavish/kit           (tot)
```

`node_modules`, `dist` und `src` sind für die Frage ohne Belang.

**623 MB → 4,9 MB.**

## Warum es im PR nicht auffiel

PRs fahren `test:spec:changed` (nur betroffene Dateien), `main` fährt die volle `test:spec`. PR #3563 war mit allen 12 Checks grün; der Defekt schlug erst im post-merge-Lauf zu.

## Verifikation

- Test weiterhin grün
- **Mutations-Gegenprobe**: ohne die `COPY .lavish/`-Zeilen im Dockerfile wird er weiterhin rot — er misst also noch das Richtige
- Repo-weit kein weiterer Test mit rekursivem `cp` aus `website/`

## Lehre über diesen Fall hinaus

Ein `cp -r` in einem BATS-Test kostet lokal und in CI völlig Unterschiedliches, sobald im Pfad ein Symlink liegt, der in CI ein echtes Verzeichnis ist. Und `/tmp` ist bei paralleler Ausführung eine **geteilte** Ressource: ein einzelner Test kann die ganze Suite umbringen, ohne selbst zu scheitern.

Ticket: T002499