### PR TITLE
chore(ci): Factory-Job sharden und schnelle Gates vorziehen [T002500]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,15 +158,77 @@ jobs:
           ./tests/unit/lib/bats-core/bin/bats \
             tests/unit/manifests.bats tests/unit/changed-manifests.bats
 
-  test-factory:
-    # tests/spec/*.bats + OpenSpec validation + setup-go for the
-    # mcp-task-runner build (needed by test:spec). All spec tests skip
-    # live-DB cases without a cluster (CI-safe). [T002182]
-    # Scoped to the changed specs on PRs, full suite on push-to-main. [T002245]
-    name: Factory + OpenSpec + Guards
+  # ── Factory: schneller Gate-Job, dann geshardete Spec-Suite, dann Aggregator ──
+  #
+  # [T002500] Vorher war das EIN Job mit ~400s, dem kritischen Pfad jedes PRs
+  # (zweitlaengster Job: 165s). Zwei Probleme, beide hier behoben:
+  #
+  #   1. Die billigen Gates (OpenSpec-Validierung: 1s) standen HINTER der
+  #      6-Minuten-BATS-Suite und liefen bei deren Fehlschlag gar nicht mehr.
+  #      Eine kaputte Spec meldete sich also erst nach sechs Minuten — oder,
+  #      wenn vorher ein Test rot wurde, ueberhaupt nicht.
+  #   2. Die Suite ist durchsatz-, nicht tail-gebunden (~537s CPU-Arbeit).
+  #      Mehr `bats -j` auf EINEM Runner war ausgereizt; der einzige Hebel
+  #      sind mehr Runner. Details in scripts/spec-shard.sh.
+  #
+  # Der Aggregator `test-factory` behaelt den Namen "Factory + OpenSpec + Guards",
+  # weil genau dieser String als Required Status Check in der Branch Protection
+  # von main haengt. Eine nackte Matrix haette ihn in "… (1)".."… (4)" umbenannt
+  # und jeden PR dauerhaft blockiert.
+
+  test-factory-openspec:
+    # Die billigen, hochsignalhaften Gates — laufen parallel zu den Shards und
+    # melden nach ~30s statt nach ~400s.
+    name: Factory OpenSpec + Guards (fast)
+    if: github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+
+      - name: Fetch origin/main for diffing (shallow)
+        run: git fetch --no-tags --prune --depth=1 origin main:refs/remotes/origin/main
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: OpenSpec validation
+        run: npm run test:openspec
+
+      - name: Agent setup replay reminder
+        run: |
+          changed=$(git diff --name-only origin/main...HEAD || true)
+          if echo "$changed" | grep -Eq '^(.opencode/agent-models.jsonc|scripts/factory/review-[^/]+\.prompt\.md|scripts/factory/provider-router\.js|AGENTS.md)$'; then
+            echo "::warning::Agenten-Setup geändert — lokal 'task factory:eval:replay' ausführen"
+          fi
+
+  test-factory-shard:
+    # tests/spec/*.bats + setup-go fuer den mcp-task-runner-Build (von test:spec
+    # gebraucht). Alle Spec-Tests ueberspringen Live-DB-Faelle ohne Cluster
+    # (CI-safe). [T002182]
+    # Auf PRs auf die geaenderten Specs gescopt, volle Suite bei push-to-main. [T002245]
+    name: Factory spec shard ${{ matrix.shard }}
     if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      # fail-fast: false ist Absicht. Bricht ein Shard ab, sollen die anderen
+      # zu Ende laufen — sonst sieht man pro Lauf nur die Fehler EINES Shards
+      # und braucht fuer eine rote Suite so viele CI-Runden wie Shards.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      SPEC_SHARD: ${{ matrix.shard }}
+      SPEC_SHARDS: 4
     steps:
       - uses: actions/checkout@v7
         with:
@@ -196,15 +258,16 @@ jobs:
       - name: Create CI dummy secrets
         run: bash scripts/ci-dummy-secrets.sh
 
-      # T002245: On PRs run only the spec bats matching the diff (task
-      # test:spec:changed → scripts/find-changed-tests.sh spec), the same
-      # scoping the unit job uses. NOT the pre-T002182 hardcoded file list —
-      # the shared-harness/workflow/Taskfile fallbacks widen to the full suite,
-      # and push-to-main still runs ALL of tests/spec/*.bats, so a regression
-      # cannot rot undetected on main (the T002182 failure mode).
-      # Fail closed: if origin/main is unreachable the diff would be empty and
-      # silently select nothing — run everything instead.
-      - name: Spec BATS suite
+      # PyYAML wird VON den G-CD01-Assertions gebraucht (tests/spec/ci-cd.bats
+      # macht `import yaml`), muss also vor der Suite stehen. Bis T002500 stand
+      # dieser Step dahinter und trug nichts bei — dass die Assertions trotzdem
+      # liefen, lag allein daran, dass ubuntu-latest PyYAML vorinstalliert hat.
+      - name: Install PyYAML for CI-CD guard assertions
+        run: python3 -m pip install --quiet pyyaml
+
+      # Fail closed: ist origin/main nicht erreichbar, waere der Diff leer und
+      # wuerde still nichts auswaehlen — dann lieber alles laufen lassen.
+      - name: Spec BATS suite (shard ${{ matrix.shard }}/4)
         env:
           IS_PR: ${{ github.event_name == 'pull_request' }}
         run: |
@@ -215,19 +278,33 @@ jobs:
             task test:spec
           fi
 
-      - name: OpenSpec validation
-        run: npm run test:openspec
-
-      # PyYAML is needed by the G-CD01 assertions, which parse build-website.yml.
-      - name: Install PyYAML for CI-CD guard assertions
-        run: python3 -m pip install --quiet pyyaml
-
-      - name: Agent setup replay reminder
+  test-factory:
+    # Aggregator. Traegt den Required-Check-Namen und ist fail-closed: alles,
+    # was nicht exakt "success" ist, laesst ihn scheitern. Das ist wesentlich —
+    # in der Branch Protection zaehlt ein UEBERSPRUNGENER Required Check als
+    # bestanden. Ein Aggregator ohne always() wuerde bei fehlgeschlagenen
+    # needs uebersprungen und damit das Gate lautlos oeffnen.
+    name: Factory + OpenSpec + Guards
+    if: always() && github.event.action != 'edited'
+    needs: [test-factory-openspec, test-factory-shard]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate shard + gate results
+        env:
+          OPENSPEC_RESULT: ${{ needs.test-factory-openspec.result }}
+          SHARDS_RESULT: ${{ needs.test-factory-shard.result }}
         run: |
-          changed=$(git diff --name-only origin/main...HEAD || true)
-          if echo "$changed" | grep -Eq '^(.opencode/agent-models.jsonc|scripts/factory/review-[^/]+\.prompt\.md|scripts/factory/provider-router\.js|AGENTS.md)$'; then
-            echo "::warning::Agenten-Setup geändert — lokal 'task factory:eval:replay' ausführen"
+          echo "OpenSpec + Guards : $OPENSPEC_RESULT"
+          echo "Spec shards (1-4) : $SHARDS_RESULT"
+          # SHARDS_RESULT ist das Aggregat ueber ALLE Matrix-Legs — 'success'
+          # nur, wenn jeder einzelne Shard erfolgreich war.
+          if [ "$OPENSPEC_RESULT" = "success" ] && [ "$SHARDS_RESULT" = "success" ]; then
+            echo "Alle Factory-Gates gruen."
+            exit 0
           fi
+          echo "::error::Factory-Gates nicht gruen (openspec=$OPENSPEC_RESULT shards=$SHARDS_RESULT)"
+          exit 1
 
   # ── End scoped test jobs ──────────────────────────────────────────
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -768,15 +768,28 @@ tasks:
         fi
 
   test:spec:
-    desc: "Run the offline-safe spec bats (tests/spec/, rekursiv). Builds mcp-task-runner fresh if go is available (best-effort). Live-DB cases skip without a reachable cluster, so this is CI-safe."
+    desc: "Run the offline-safe spec bats (tests/spec/, rekursiv). Builds mcp-task-runner fresh if go is available (best-effort). Live-DB cases skip without a reachable cluster, so this is CI-safe. SPEC_SHARD/SPEC_SHARDS laeuft nur die eigene Partition (siehe scripts/spec-shard.sh)."
     cmds:
       - task: test:spec:build-mcp-runner
-      # `-r tests/spec/` statt `tests/spec/*.bats` [T002416]: der Glob erfasst NUR die
-      # oberste Ebene. Seit der Verzeichniskonvention liegen neue Tests unter
-      # tests/spec/<spec-slug>/ — die waeren mit dem Glob stillschweigend nie gelaufen,
-      # was schlimmer ist als ein roter Test. `-r` erfasst beide Formen, deshalb koennen
-      # die 139 Bestandsdateien auf der obersten Ebene liegen bleiben.
-      - ./tests/unit/lib/bats-core/bin/bats -j $(nproc 2>/dev/null || echo 2) --no-parallelize-within-files -r tests/spec/
+      - |
+        # `find` statt `bats -r tests/spec/` [T002500]: die Shard-Aufteilung braucht eine
+        # explizite Dateiliste. Der rekursive Fang bleibt identisch zu `-r` — und damit
+        # auch die Eigenschaft aus T002416, dass Tests unter tests/spec/<spec-slug>/
+        # miterfasst werden. Ein flacher Glob wuerde sie stillschweigend auslassen, was
+        # schlimmer waere als ein roter Test.
+        FILES=$(find tests/spec -name '*.bats' -type f | LC_ALL=C sort)
+        if [ "${SPEC_SHARDS:-1}" -gt 1 ]; then
+          FILES=$(printf '%s\n' "$FILES" | bash scripts/spec-shard.sh --shard "${SPEC_SHARD:?SPEC_SHARD fehlt}" --of "$SPEC_SHARDS")
+          echo "→ Shard ${SPEC_SHARD}/${SPEC_SHARDS}: $(printf '%s' "$FILES" | grep -c .) Dateien"
+        fi
+        # Leere Auswahl ist ein Fehler, kein No-op. Ein still gruener Leerlauf saehe
+        # aus wie eine bestandene Suite, obwohl nichts lief — genau die Klasse von
+        # Fehler, die das Sharding einfuehren kann und die niemand bemerkt.
+        if [ "$(printf '%s' "$FILES" | grep -c .)" -eq 0 ]; then
+          echo "test:spec: FEHLER — keine Spec-Dateien ausgewaehlt" >&2
+          exit 1
+        fi
+        ./tests/unit/lib/bats-core/bin/bats -j $(nproc 2>/dev/null || echo 2) --no-parallelize-within-files $FILES
 
   test:spec:changed:
     desc: "Run only the spec bats matching the files changed vs origin/main (scripts/find-changed-tests.sh spec). Falls back to the full suite when a shared harness/workflow/Taskfile changed. [T002245]"
@@ -802,7 +815,20 @@ tasks:
           echo "→ Running changed spec tests ($SELECTED of $TOTAL):"
         fi
         echo "$CHANGED_FILES"
-        ./tests/unit/lib/bats-core/bin/bats $CHANGED_FILES
+        # [T002500] Sharding auch hier, denn der teure Fall laeuft ueber DIESEN Pfad:
+        # aendert ein PR ci.yml/Taskfile.yml oder ein geteiltes Harness, faellt
+        # find-changed-tests.sh fail-closed auf die volle Suite zurueck (~400s).
+        if [ "${SPEC_SHARDS:-1}" -gt 1 ]; then
+          CHANGED_FILES=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/spec-shard.sh --shard "${SPEC_SHARD:?SPEC_SHARD fehlt}" --of "$SPEC_SHARDS")
+          # Anders als bei test:spec ist ein leerer Shard hier legitim: eine
+          # diff-gescopte Auswahl kann weniger Dateien haben als es Shards gibt.
+          if [ "$(printf '%s' "$CHANGED_FILES" | grep -c .)" -eq 0 ]; then
+            echo "→ Shard ${SPEC_SHARD}/${SPEC_SHARDS}: keine Dateien in dieser Partition"
+            exit 0
+          fi
+          echo "→ Shard ${SPEC_SHARD}/${SPEC_SHARDS}: $(printf '%s' "$CHANGED_FILES" | grep -c .) Dateien"
+        fi
+        ./tests/unit/lib/bats-core/bin/bats -j $(nproc 2>/dev/null || echo 2) --no-parallelize-within-files $CHANGED_FILES
 
   test:mcp-tooling:
     desc: "Guardrail: ticket-mcp tools <-> mcp-tool-guide.md <-> skill-critical verbs (hard)"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 655,
+      "file_count": 656,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -351,6 +351,7 @@
         "tests/spec/ci-cd/mishap-t002425.bats",
         "tests/spec/ci-cd/pr-refresh-batch.bats",
         "tests/spec/ci-cd/spec-dir-convention.bats",
+        "tests/spec/ci-cd/spec-shard-partition.bats",
         "tests/spec/ci-cd/test-inventory-coverage.bats",
         "tests/spec/coaching-sessions-polish-guide.bats",
         "tests/spec/code-quality.bats",
@@ -2992,7 +2993,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 596,
+      "file_count": 597,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3503,6 +3504,7 @@
         "scripts/setup-dev-env.sh",
         "scripts/setup.sh",
         "scripts/skill-orchestrator.sh",
+        "scripts/spec-shard.sh",
         "scripts/staging-db-anonymize.sh",
         "scripts/staging-id.sh",
         "scripts/start-comfyui.sh",

--- a/scripts/spec-shard.sh
+++ b/scripts/spec-shard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Partitioniert eine Liste von .bats-Dateien (stdin, eine pro Zeile) in
+# --of M gleich schwere Buckets und gibt die Dateien von --shard N aus.
+#
+# Warum ueberhaupt: `Factory + OpenSpec + Guards` war mit ~400s der kritische
+# Pfad jedes PRs (zweitlaengster Job: 165s). Die Suite ist durchsatz-, nicht
+# tail-gebunden — rund 537s CPU-Arbeit. Mehr `bats -j` auf EINEM Runner ist
+# damit ausgereizt (gemessen: zusaetzliche Within-File-Parallelisierung machte
+# den Lauf 7% langsamer, weil die Maschine auf Datei-Ebene schon saettigt).
+# Der einzige verbleibende Hebel sind mehr Runner, also Sharding. [T002500]
+#
+# Gewichtung nach `@test`-Anzahl, nicht nach Dateizahl: tests/spec/software-factory.bats
+# haelt allein 495 der ~2300 Testfaelle (115s seriell). Ein Round-Robin ueber
+# Dateinamen wuerde die schweren Dateien zufaellig verteilen, und der unglueckliche
+# Shard bestimmt dann die Wall-Clock des gesamten Jobs — das Sharding brraechte
+# dann fast nichts.
+#
+# Der Algorithmus (LPT: longest processing time first) MUSS deterministisch sein.
+# Jeder der M CI-Jobs berechnet die Partition unabhaengig aus demselben Repo-Stand;
+# waeren die Ergebnisse nicht bitgleich, liefen Dateien doppelt oder — schlimmer —
+# gar nicht, und der Lauf saehe trotzdem gruen aus.
+#
+# Usage:
+#   find tests/spec -name '*.bats' | bash scripts/spec-shard.sh --shard 2 --of 4
+#   find tests/spec -name '*.bats' | bash scripts/spec-shard.sh --verify --of 4
+
+set -euo pipefail
+
+SHARD=""
+TOTAL=""
+VERIFY=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --shard) SHARD="${2:-}"; shift 2 ;;
+    --of)    TOTAL="${2:-}"; shift 2 ;;
+    --verify) VERIFY=true; shift ;;
+    -h|--help)
+      grep '^# ' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "spec-shard: unbekanntes Argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$TOTAL" ] || ! [[ "$TOTAL" =~ ^[0-9]+$ ]] || [ "$TOTAL" -lt 1 ]; then
+  echo "spec-shard: --of <positive Zahl> erforderlich" >&2
+  exit 2
+fi
+
+if ! $VERIFY; then
+  if [ -z "$SHARD" ] || ! [[ "$SHARD" =~ ^[0-9]+$ ]] || [ "$SHARD" -lt 1 ] || [ "$SHARD" -gt "$TOTAL" ]; then
+    echo "spec-shard: --shard muss zwischen 1 und $TOTAL liegen (war: '${SHARD:-}')" >&2
+    exit 2
+  fi
+fi
+
+# Eingabe einlesen, leere Zeilen weg, sortieren. Das Sortieren ist Teil des
+# Determinismus-Kontrakts: `find` liefert Verzeichniseintraege in Inode-Reihenfolge,
+# die zwischen zwei Checkouts derselben Commit-SHA abweichen kann.
+INPUT=$(grep -v '^[[:space:]]*$' | LC_ALL=C sort -u || true)
+
+if [ -z "$INPUT" ]; then
+  exit 0
+fi
+
+# Gewicht je Datei = Anzahl @test-Bloecke, mindestens 1. Eine nicht lesbare oder
+# testfreie Datei faellt so nicht aus der Partition heraus — sie wiegt nur wenig.
+WEIGHTED=$(
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    n=$(grep -c '^[[:space:]]*@test' "$f" 2>/dev/null || true)
+    [ -n "$n" ] && [ "$n" -gt 0 ] 2>/dev/null || n=1
+    printf '%s\t%s\n' "$n" "$f"
+  done <<< "$INPUT"
+)
+
+# LPT-Greedy in awk: absteigend nach Gewicht, jede Datei in den aktuell
+# leichtesten Bucket. Bei Gewichtsgleichheit entscheidet der Pfad (sort -k2),
+# bei Bucket-Gleichstand der niedrigste Index — beides rein deterministisch.
+PARTITION=$(
+  printf '%s\n' "$WEIGHTED" \
+    | LC_ALL=C sort -k1,1nr -k2,2 \
+    | awk -v total="$TOTAL" '
+        BEGIN { FS = "\t"; for (i = 1; i <= total; i++) load[i] = 0 }
+        {
+          best = 1
+          for (i = 2; i <= total; i++) if (load[i] < load[best]) best = i
+          load[best] += $1
+          print best "\t" $2
+        }
+      '
+)
+
+# Extraktion eines Shards aus der Partition. Bewusst als Funktion, damit
+# --verify EXAKT denselben Pfad prueft, den CI spaeter benutzt. Verifizierte
+# man stattdessen die interne Partition, bliebe ein Fehler in genau diesem
+# Filter unentdeckt — und der aeussert sich als stiller Dateiverlust: der Shard
+# laeuft gruen durch, weil die verschluckten Tests nie ausgefuehrt wurden.
+_extract_shard() { # $1 = Shard-Index
+  printf '%s\n' "$PARTITION" | awk -F'\t' -v s="$1" '$1 == s { print $2 }'
+}
+
+if $VERIFY; then
+  in_count=$(printf '%s\n' "$INPUT" | grep -c .)
+  union=$(for i in $(seq 1 "$TOTAL"); do _extract_shard "$i"; done)
+  union_lines=$(printf '%s\n' "$union" | grep -c .)
+  union_uniq=$(printf '%s\n' "$union" | LC_ALL=C sort -u | grep -c .)
+
+  if [ "$in_count" -ne "$union_lines" ] || [ "$in_count" -ne "$union_uniq" ]; then
+    echo "spec-shard: FEHLER — Shard-Ausgaben unvollstaendig oder ueberlappend (in=$in_count ausgegeben=$union_lines eindeutig=$union_uniq)" >&2
+    exit 1
+  fi
+  if [ "$(printf '%s\n' "$union" | LC_ALL=C sort)" != "$(printf '%s\n' "$INPUT")" ]; then
+    echo "spec-shard: FEHLER — Vereinigung der Shards weicht von der Eingabemenge ab" >&2
+    exit 1
+  fi
+
+  echo "spec-shard: OK — $in_count Dateien restlos und ueberschneidungsfrei auf $TOTAL Shards verteilt"
+  for i in $(seq 1 "$TOTAL"); do
+    echo "  shard $i: $(_extract_shard "$i" | grep -c .) Dateien"
+  done
+  exit 0
+fi
+
+_extract_shard "$SHARD"

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -923,16 +923,21 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
   }
 }
 
-# ── T002182: CI-Gate — test-factory job invokes full tests/spec/*.bats glob ──
+# ── T002182: CI-Gate — the spec-suite job invokes the full tests/spec glob ──
 # Regression guard: the factory job must NOT enumerate a hand-picked subset of
 # spec files, because any file not in the list runs in no required check and
 # can rot on main undetected (observed: T002163, T002167, image-drift).
+#
+# [T002500] Der gepruefte Job heisst seit dem Sharding `test-factory-shard` —
+# dort laeuft die Suite. `test-factory` ist nur noch der Aggregator, der den
+# Required-Check-Namen traegt und keine Tests selbst ausfuehrt. Die Schutzabsicht
+# ist unveraendert: WER die Spec-Suite faehrt, muss sie vollstaendig fahren.
 
 @test "T002182: ci.yml test-factory job uses task test:spec (full glob)" {
   local ci="$REPO_ROOT/.github/workflows/ci.yml"
-  # Extract the test-factory job steps between its header and the next job
+  # Extract the spec-suite job steps between its header and the next job
   local block
-  block=$(awk '/^  test-factory:/{flag=1; next} /^  [a-z]/ && flag {exit} flag' "$ci")
+  block=$(awk '/^  test-factory-shard:/{flag=1; next} /^  [a-z]/ && flag {exit} flag' "$ci")
   # Must invoke task test:spec, not enumerate individual .bats files
   echo "$block" | grep -qE 'task test:spec|tests/spec/\*\.bats' || {
     echo "FAIL: test-factory job does not use task test:spec or tests/spec/*.bats glob."
@@ -942,7 +947,7 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
     return 1
   }
   # Must NOT list individual .bats filenames in a way that excludes others
-  ! echo "$block" | grep -qE 'tests/spec/[a-z].*\.bats' || {
+  ! echo "$block" | grep -v '^[[:space:]]*#' | grep -qE 'tests/spec/[a-z0-9_-]+\.bats' || {
     echo "FAIL: test-factory job still enumerates individual spec files."
     echo "      Use 'task test:spec' to run the full tests/spec/*.bats glob."
     return 1
@@ -957,7 +962,8 @@ sys.exit(0 if s and 'always()' in str(s[0].get('if','')) else 1)
 @test "T002245: test-factory keeps a non-PR full-suite path for the spec bats" {
   local ci="$REPO_ROOT/.github/workflows/ci.yml"
   local block
-  block=$(awk '/^  test-factory:/{flag=1; next} /^  [a-z]/ && flag {exit} flag' "$ci")
+  # [T002500] siehe Kommentar an T002182 oben: die Suite lebt in test-factory-shard.
+  block=$(awk '/^  test-factory-shard:/{flag=1; next} /^  [a-z]/ && flag {exit} flag' "$ci")
 
   # Scoping is optional; if present it must be gated on the event being a PR.
   if echo "$block" | grep -qF 'task test:spec:changed'; then

--- a/tests/spec/ci-cd/spec-shard-partition.bats
+++ b/tests/spec/ci-cd/spec-shard-partition.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+#
+# Guards fuer das Sharding der Spec-BATS-Suite [T002500].
+#
+# Pruefmodus (Konvention T002448-M4): GEMISCHT, und zwar bewusst.
+#   - Die Tests zu scripts/spec-shard.sh pruefen echtes Laufzeitverhalten
+#     (`run`, $output, $status) — das Skript hat beobachtbaren Output.
+#   - Die Tests zur ci.yml-Struktur parsen die Workflow-Datei. Das ist der
+#     zulaessige Ausnahmefall: die Aussage "der Required-Check-Name bleibt
+#     erhalten" und "Step A steht vor Step B" manifestiert sich ausschliesslich
+#     im Konfigurationstext; es gibt kein Kommando, dessen Ergebnis man messen
+#     koennte, ohne GitHub Actions selbst laufen zu lassen.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SHARD_SH="$REPO_ROOT/scripts/spec-shard.sh"
+  CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+}
+
+_all_spec_files() {
+  cd "$REPO_ROOT" && find tests/spec -name '*.bats' -type f | LC_ALL=C sort
+}
+
+@test "T002500: spec-shard.sh existiert und ist ausfuehrbar" {
+  [ -f "$SHARD_SH" ]
+  [ -x "$SHARD_SH" ]
+}
+
+@test "T002500: --verify meldet eine restlose, ueberschneidungsfreie Partition" {
+  run bash -c "cd '$REPO_ROOT' && find tests/spec -name '*.bats' -type f | bash '$SHARD_SH' --verify --of 4"
+  [ "$status" -eq 0 ]
+  # Auf die konkrete Zeile einschraenken statt unqualifiziert im Gesamtoutput
+  # zu suchen — der Gesamtoutput enthaelt Pfade, die den Worktree-Namen tragen.
+  echo "$output" | grep -q '^spec-shard: OK'
+}
+
+@test "T002500: die Vereinigung aller Shards ist exakt die Eingabemenge" {
+  input="$(_all_spec_files)"
+  [ -n "$input" ]
+  union=$(
+    for s in 1 2 3 4; do
+      printf '%s\n' "$input" | bash "$SHARD_SH" --shard "$s" --of 4
+    done | LC_ALL=C sort
+  )
+  # Positiv-Anker zuerst (T002356-M1): die Union darf nicht leer sein, sonst
+  # waere die folgende Gleichheit auch bei einem voellig kaputten Skript erfuellt,
+  # falls die Eingabe je leer liefe.
+  [ "$(printf '%s\n' "$union" | grep -c .)" -gt 100 ]
+  [ "$(printf '%s\n' "$union")" = "$(printf '%s\n' "$input")" ]
+}
+
+@test "T002500: kein Shard enthaelt eine Datei doppelt oder aus einem anderen Shard" {
+  input="$(_all_spec_files)"
+  union_lines=$(
+    for s in 1 2 3 4; do
+      printf '%s\n' "$input" | bash "$SHARD_SH" --shard "$s" --of 4
+    done | grep -c .
+  )
+  uniq_lines=$(
+    for s in 1 2 3 4; do
+      printf '%s\n' "$input" | bash "$SHARD_SH" --shard "$s" --of 4
+    done | LC_ALL=C sort -u | grep -c .
+  )
+  [ "$union_lines" -gt 100 ]
+  [ "$union_lines" -eq "$uniq_lines" ]
+}
+
+@test "T002500: die Partition ist deterministisch (zwei Laeufe, identisches Ergebnis)" {
+  input="$(_all_spec_files)"
+  a=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 2 --of 4)
+  b=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 2 --of 4)
+  [ -n "$a" ]
+  [ "$a" = "$b" ]
+}
+
+@test "T002500: unsortierte Eingabe ergibt dieselbe Partition wie sortierte" {
+  # find liefert Verzeichniseintraege in Inode-Reihenfolge; die kann zwischen
+  # zwei Checkouts derselben SHA abweichen. Waere die Partition davon abhaengig,
+  # liefen Dateien doppelt oder gar nicht — und der Lauf saehe gruen aus.
+  input="$(_all_spec_files)"
+  sorted=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 3 --of 4)
+  shuffled=$(printf '%s\n' "$input" | LC_ALL=C sort -r | bash "$SHARD_SH" --shard 3 --of 4)
+  [ -n "$sorted" ]
+  [ "$sorted" = "$shuffled" ]
+}
+
+@test "T002500: die Shards sind nach @test-Anzahl balanciert (schwerster <= 1.5x leichtester)" {
+  input="$(_all_spec_files)"
+  weights=()
+  for s in 1 2 3 4; do
+    files=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard "$s" --of 4)
+    w=0
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      n=$(grep -c '^[[:space:]]*@test' "$REPO_ROOT/$f" 2>/dev/null || echo 0)
+      w=$((w + n))
+    done <<< "$files"
+    weights+=("$w")
+  done
+  min=${weights[0]}; max=${weights[0]}
+  for w in "${weights[@]}"; do
+    [ "$w" -lt "$min" ] && min=$w
+    [ "$w" -gt "$max" ] && max=$w
+  done
+  # Positiv-Anker: es muss ueberhaupt Gewicht geben.
+  [ "$min" -gt 0 ]
+  [ $((max * 2)) -le $((min * 3)) ]
+}
+
+@test "T002500: ungueltige --shard/--of-Werte werden abgewiesen" {
+  run bash -c "echo tests/spec/ci-cd.bats | bash '$SHARD_SH' --shard 5 --of 4"
+  [ "$status" -ne 0 ]
+  run bash -c "echo tests/spec/ci-cd.bats | bash '$SHARD_SH' --shard 0 --of 4"
+  [ "$status" -ne 0 ]
+  run bash -c "echo tests/spec/ci-cd.bats | bash '$SHARD_SH' --shard 1 --of 0"
+  [ "$status" -ne 0 ]
+  # Positiv-Anker (T002356-M1): der gueltige Fall MUSS durchlaufen, sonst waeren
+  # die drei Ablehnungen oben auch bei einem Skript erfuellt, das immer scheitert.
+  run bash -c "echo tests/spec/ci-cd.bats | bash '$SHARD_SH' --shard 1 --of 1"
+  [ "$status" -eq 0 ]
+}
+
+@test "T002500: ci.yml behaelt den Required-Check-Namen 'Factory + OpenSpec + Guards'" {
+  # Genau dieser String haengt in der Branch Protection von main. Eine nackte
+  # Matrix haette ihn in "… (1)".."… (4)" umbenannt und jeden PR blockiert.
+  run python3 -c "
+import yaml, sys
+wf = yaml.safe_load(open('$CI_YML'))
+names = [j.get('name') for j in wf['jobs'].values()]
+assert 'Factory + OpenSpec + Guards' in names, 'Required-Check-Name fehlt: %r' % (names,)
+agg = wf['jobs']['test-factory']
+assert agg['name'] == 'Factory + OpenSpec + Guards', agg['name']
+assert 'strategy' not in agg, 'Aggregator darf keine Matrix haben (wuerde den Namen suffixen)'
+print('OK')
+"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx 'OK'
+}
+
+@test "T002500: der Aggregator ist fail-closed (always() + needs + Result-Pruefung)" {
+  # Ohne always() wuerde er bei fehlgeschlagenen needs UEBERSPRUNGEN — und ein
+  # uebersprungener Required Check zaehlt in der Branch Protection als bestanden.
+  run python3 -c "
+import yaml
+wf = yaml.safe_load(open('$CI_YML'))
+agg = wf['jobs']['test-factory']
+cond = str(agg.get('if', ''))
+assert 'always()' in cond, 'if fehlt always(): %r' % cond
+needs = agg['needs']
+assert 'test-factory-shard' in needs and 'test-factory-openspec' in needs, needs
+body = ' '.join(str(s.get('run', '')) for s in agg['steps'])
+assert 'exit 1' in body, 'Aggregator scheitert nie'
+for var in ('OPENSPEC_RESULT', 'SHARDS_RESULT'):
+    assert var in body, 'Result %s wird nicht geprueft' % var
+print('OK')
+"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx 'OK'
+}
+
+@test "T002500: PyYAML wird VOR der Spec-BATS-Suite installiert" {
+  # tests/spec/ci-cd.bats macht `import yaml`. Bis T002500 stand der Install-Step
+  # dahinter und trug nichts bei — dass es trotzdem lief, lag allein an der
+  # Vorinstallation auf ubuntu-latest.
+  run python3 -c "
+import yaml
+wf = yaml.safe_load(open('$CI_YML'))
+steps = wf['jobs']['test-factory-shard']['steps']
+names = [str(s.get('name', '')) for s in steps]
+pyyaml = next(i for i, n in enumerate(names) if 'PyYAML' in n)
+suite  = next(i for i, n in enumerate(names) if 'Spec BATS suite' in n)
+assert pyyaml < suite, 'PyYAML (%d) steht hinter der Suite (%d)' % (pyyaml, suite)
+print('OK')
+"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx 'OK'
+}
+
+@test "T002500: der Shard-Job reicht SPEC_SHARD/SPEC_SHARDS passend zur Matrix durch" {
+  run python3 -c "
+import yaml
+wf = yaml.safe_load(open('$CI_YML'))
+job = wf['jobs']['test-factory-shard']
+shards = job['strategy']['matrix']['shard']
+assert len(shards) > 1, shards
+assert job['strategy'].get('fail-fast') is False, 'fail-fast muss false sein'
+env = job['env']
+assert int(env['SPEC_SHARDS']) == len(shards), (env['SPEC_SHARDS'], shards)
+assert 'matrix.shard' in str(env['SPEC_SHARD']), env['SPEC_SHARD']
+print('OK')
+"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qx 'OK'
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2118,6 +2118,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/spec-shard-partition",
+    "file": "tests/spec/ci-cd/spec-shard-partition.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/test-inventory-coverage",
     "file": "tests/spec/ci-cd/test-inventory-coverage.bats",
     "category": "ci-cd",


### PR DESCRIPTION
## Problem

`Factory + OpenSpec + Guards` ist mit **~400s** der kritische Pfad jedes PRs — der zweitlängste Job braucht 165s. Gemessen an PR #3557:

| Job | Dauer |
|---|---|
| **Factory + OpenSpec + Guards** | **407s** |
| BATS Unit + Quality Gates | 165s |
| Vitest (website) | 88s |
| alle übrigen | ≤ 85s |

Zwei Ursachen:

1. **Reihenfolge.** Die OpenSpec-Validierung (1s) stand *hinter* der 6-Minuten-BATS-Suite und lief bei deren Fehlschlag gar nicht mehr. Eine kaputte Spec meldete sich erst nach sechs Minuten — oder überhaupt nicht.
2. **Durchsatz.** Die Suite ist nicht tail-, sondern durchsatzgebunden (~537s CPU-Arbeit). Mehr `bats -j` auf *einem* Runner war ausgereizt; gegengemessen war zusätzliche Within-File-Parallelisierung sogar 7 % langsamer.

## Änderung

- **`test-factory-openspec`** — neuer, parallel laufender Job für die billigen Gates. Meldet nach ~30s statt ~400s.
- **`test-factory-shard`** — die Spec-Suite über eine 4er-Matrix. `scripts/spec-shard.sh` partitioniert deterministisch nach `@test`-Anzahl (LPT-Greedy): **630/630/629/629** Tests.
- **`test-factory`** — Aggregator, behält den Namen und führt selbst keine Tests aus.
- **PyYAML** wandert vor die Suite: `tests/spec/ci-cd.bats` macht `import yaml`, lief bisher also nur zufällig durch (ubuntu-latest hat PyYAML vorinstalliert).

### Zwei Entwurfsentscheidungen, die nicht offensichtlich sind

**Der Aggregator behält exakt den Namen `Factory + OpenSpec + Guards`**, weil genau dieser String als Required Status Check an `main` hängt. Eine nackte Matrix hätte ihn zu `… (1)`…`… (4)` gemacht und jeden PR dauerhaft blockiert. Er ist **fail-closed** (`always()` + explizite Result-Prüfung): ein *übersprungener* Required Check zählt in der Branch Protection als bestanden, ein Aggregator ohne `always()` würde das Gate bei fehlgeschlagenen `needs` lautlos öffnen.

**Gewichtung nach `@test`-Anzahl statt Round-Robin**, weil `software-factory.bats` allein 495 der ~2300 Fälle hält (115s seriell). Eine gleichmäßige Dateiverteilung hätte den Gewinn verpuffen lassen.

## Messung

| | vorher | nachher |
|---|---|---|
| Suite lokal (Wall-Clock) | 218s | **115s** |
| schwerster Shard | — | 115s (= `software-factory.bats`) |

Der verbleibende Boden ist `software-factory.bats`: 495 Tests in einer Datei, mit `--no-parallelize-within-files` unteilbar. Dessen Aufteilung ist die naheliegende Folgearbeit — hier bewusst nicht mitgenommen.

Das Flag `--no-parallelize-within-files` bleibt trotz Messung (`software-factory.bats` 115s → 62s, identische Ergebnismenge). Ein grüner Lauf ist kein Beweis für Freiheit von Shared-State; bei einem Required Check ist der sichere Faktor 2,7 mehr wert als ein gewagter Faktor 3,2.

## Verifikation

- `tests/spec/ci-cd/spec-shard-partition.bats` — 12 neue Guards, jeweils mutationsgetestet (stiller Dateiverlust, `always()` entfernt, PyYAML-Reihenfolge, Job umbenannt → alle rot wie erwartet).
- Volle Spec-Suite im Worktree: **2296 Tests, 0 neue Fehlschläge** gegenüber der `main`-Baseline.
- `task freshness:check` grün, S1-Ratchet 0 blocking.
- `T002182`/`T002245`-Guards auf den Shard-Job umgezogen — Schutzabsicht unverändert, Nicht-Vakuosität nachgewiesen.
