### PR TITLE
fix(test): T002250-Gates grün — grep-Pattern mit -e, M1 vom Prerequisite-Exitcode entkoppelt [T002511]

### DIFF
--- a/tests/spec/mishap-docker-wsl-T002250.bats
+++ b/tests/spec/mishap-docker-wsl-T002250.bats
@@ -1,6 +1,11 @@
 #!/usr/bin/env bats
 # tests/spec/mishap-docker-wsl-T002250.bats
 # T002250 — Mishap-Bundle: environment/docker-wsl
+#
+# Prüfmodus [T002448-M4]: M1 ist Resultat-Verifikation (setup.sh wird ausgeführt,
+# geprüft wird die geschriebene config.json). M2 ist Source-Verifikation — die
+# Ausnahme für CI-Konfiguration: dass ein Workflow bzw. ein docker-run-Aufruf ein
+# bestimmtes Flag trägt, manifestiert sich ausschliesslich im Quelltext.
 
 load 'test_helper'
 
@@ -16,23 +21,34 @@ setup() {
   # Create a mock config.json containing credsStore
   echo '{"auths":{"ghcr.io":{}},"credsStore":"desktop.exe"}' > "$mock_home/.docker/config.json"
   
-  # Run setup.sh with mock HOME and WSL env
+  # Run setup.sh with mock HOME and WSL env.
+  # Der Exitcode wird BEWUSST nicht assertet: setup.sh --check bündelt in ihm die
+  # Prerequisite-Prüfung (kubectl/docker/k3d/kustomize/yq + laufender Docker-Daemon)
+  # und liefert auf einem CI-Runner zwangsläufig 1 — mit dem credsStore-Fix hat das
+  # nichts zu tun. Geprüft wird deshalb die Wirkung, nicht der Sammel-Exitcode.
+  # [T002511]
   HOME="$mock_home" WSL_DISTRO_NAME="test-wsl" run bash "$REPO/scripts/setup.sh" --check
-  [ "$status" -eq 0 ]
-  
+
   # Verify config.json exists and credsStore is removed
   [ -f "$mock_home/.docker/config.json" ]
   local creds
   creds=$(jq -r '.credsStore // empty' "$mock_home/.docker/config.json")
   [ -z "$creds" ]
-  
+  # Positiv-Anker [T002356-M1]: die Datei wurde umgeschrieben, nicht geleert oder
+  # zerstört. Ohne ihn wäre "credsStore ist leer" auch bei kaputtem JSON grün.
+  local auths
+  auths=$(jq -r '.auths | keys[]' "$mock_home/.docker/config.json")
+  [ "$auths" = "ghcr.io" ]
+
   rm -rf "$mock_home"
 }
 
 @test "T002250-M2: renovate workflow has --dns 1.1.1.1" {
   local workflow="$REPO/.github/workflows/renovate.yml"
   [ -f "$workflow" ]
-  run grep -q -E '--dns[[:space:]]+1\.1\.1\.1' "$workflow"
+  # '-e' ist hier PFLICHT: das Pattern beginnt mit '--', ohne '-e' parst grep es
+  # als Long-Option und bricht mit Exit 2 ab ("invalid option"). [T002511]
+  run grep -q -E -e '--dns[[:space:]]+1\.1\.1\.1' "$workflow"
   [ "$status" -eq 0 ]
 }
 
@@ -40,6 +56,7 @@ setup() {
   local script="$REPO/scripts/factory/sandbox-run.sh"
   [ -f "$script" ]
   # We should check if the script runs docker run with --dns 1.1.1.1 when WSL is detected or if it is configured
-  run grep -q -E '--dns[[:space:]]+1\.1\.1\.1' "$script"
+  # '-e' siehe oben — Pattern beginnt mit '--'. [T002511]
+  run grep -q -E -e '--dns[[:space:]]+1\.1\.1\.1' "$script"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Problem

Drei Tests in \`tests/spec/mishap-docker-wsl-T002250.bats\` waren auf \`main\` rot, obwohl die geprüfte Implementierung existiert.

**M2 (2 Tests)** — `grep -q -E '--dns[[:space:]]+1\.1\.1\.1'`: Das Pattern beginnt mit `--`, grep parst es als Long-Option und bricht mit Exit 2 ab (`invalid option`). Die Implementierung ist längst da: `.github/workflows/renovate.yml:147`, `scripts/factory/sandbox-run.sh:43`.

**M1** — assertete `status -eq 0` von `scripts/setup.sh --check`. Das Skript bündelt darin die Prerequisite-Prüfung (kubectl/docker/k3d/kustomize/yq + laufender Docker-Daemon) und liefert auf einem GitHub-Runner zwangsläufig 1. Der Test koppelte damit die credsStore-Assertion an fremde Vorbedingungen — lokal grün, in CI rot.

## Fix

- `-e` vor beide Patterns (beendet die Optionsparsung).
- M1 assertet den Exitcode nicht mehr, sondern die **Wirkung** (credsStore entfernt) — Test-Resultats-Konvention T002448-M4 — plus **Positiv-Anker** (`.auths` überlebt, T002356-M1).
- Header-Kommentar dokumentiert den Prüfmodus je Test.

## Verifikation

```
1..3
ok 1 T002250-M1: setup.sh removes credsStore in WSL
ok 2 T002250-M2: renovate workflow has --dns 1.1.1.1
ok 3 T002250-M2: sandbox-run.sh runs docker with --dns 1.1.1.1 in WSL
```

M1 zusätzlich mit reduziertem `PATH` (ohne k3d/kustomize) gegengeprüft — bleibt grün.

Ticket: T002511