### PR TITLE
fix(scripts): WT_SKIP_NAME_CHECK im zweiten Guard respektieren, printf-Format mit -- entkoppeln [T002512]

### DIFF
--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -203,12 +203,20 @@ fi
 # 1) Skeleton without checkout — never runs the smudge filter, so it cannot fail
 #    on git-crypt paths.
 # === T002471-M4: Branch-Name-Guard ===
-# Prüft, ob die Ticket-ID im Branch-Namen gross geschrieben ist
-_ticket_id=$(echo "$BRANCH" | grep -oE '[tT][0-9]{6,}' | head -1 || true)
-if [[ -n "$_ticket_id" && "$_ticket_id" != "${_ticket_id^^}" ]]; then
-  echo "ERROR: Ticket-ID im Branch-Namen '$BRANCH' ist kleingeschrieben." >&2
-  echo "  Verwende ${_ticket_id^^} statt $_ticket_id." >&2
-  exit 1
+# Prüft, ob die Ticket-ID im Branch-Namen gross geschrieben ist.
+# WT_SKIP_NAME_CHECK MUSS hier genauso greifen wie beim Guard weiter oben
+# (Zeile ~45): dieser zweite Guard wurde später ergänzt und kannte die
+# dokumentierte Notfall-Umgehung nicht — sie war damit wirkungslos, weil der
+# erste Guard sie zwar respektierte, dieser dann aber trotzdem abbrach.
+# [T002512]
+if [ "${WT_SKIP_NAME_CHECK:-0}" != "1" ]; then
+  _ticket_id=$(echo "$BRANCH" | grep -oE '[tT][0-9]{6,}' | head -1 || true)
+  if [[ -n "$_ticket_id" && "$_ticket_id" != "${_ticket_id^^}" ]]; then
+    echo "ERROR: Ticket-ID im Branch-Namen '$BRANCH' ist kleingeschrieben." >&2
+    echo "  Verwende ${_ticket_id^^} statt $_ticket_id." >&2
+    echo "  Umgehung (nur im Notfall): WT_SKIP_NAME_CHECK=1 bash $0 ..." >&2
+    exit 1
+  fi
 fi
 # === Ende T002471-M4 ===
 if [ "$BRANCH_EXISTS" -eq 1 ]; then

--- a/tests/spec/plan-partials-embedding/coverage-gate.bats
+++ b/tests/spec/plan-partials-embedding/coverage-gate.bats
@@ -41,14 +41,17 @@ teardown() { rm -rf "$TMP"; }
 }
 
 @test "countLocalActivePlans zaehlt nur active-status Plaene" {
-  # Set up test changes dir with mixed statuses
+  # Set up test changes dir with mixed statuses.
+  # 'printf --' ist hier PFLICHT: das Format beginnt mit '---' (YAML-Frontmatter),
+  # ohne das '--' parst bash-printf es als Option und bricht mit Exit 2 ab
+  # ("printf: --: invalid option"). [T002512]
   mkdir -p "$TMP/openspec/changes/plan-a" "$TMP/openspec/changes/plan-b" "$TMP/openspec/changes/plan-c" "$TMP/openspec/changes/plan-d" "$TMP/openspec/changes/archive/old-plan"
-  printf '---\ntitle: A\nstatus: planning\n---\n# A\n\nTasks\n' > "$TMP/openspec/changes/plan-a/tasks.md"
-  printf '---\ntitle: B\nstatus: plan_staged\n---\n# B\n\nTasks\n' > "$TMP/openspec/changes/plan-b/tasks.md"
-  printf '---\ntitle: C\nstatus: archived\n---\n# C\n\nTasks\n' > "$TMP/openspec/changes/plan-c/tasks.md"
-  printf '---\ntitle: D\nstatus: done\n---\n# D\n\nTasks\n' > "$TMP/openspec/changes/plan-d/tasks.md"
+  printf -- '---\ntitle: A\nstatus: planning\n---\n# A\n\nTasks\n' > "$TMP/openspec/changes/plan-a/tasks.md"
+  printf -- '---\ntitle: B\nstatus: plan_staged\n---\n# B\n\nTasks\n' > "$TMP/openspec/changes/plan-b/tasks.md"
+  printf -- '---\ntitle: C\nstatus: archived\n---\n# C\n\nTasks\n' > "$TMP/openspec/changes/plan-c/tasks.md"
+  printf -- '---\ntitle: D\nstatus: done\n---\n# D\n\nTasks\n' > "$TMP/openspec/changes/plan-d/tasks.md"
   # Archive subdir should be skipped
-  printf '---\ntitle: Old\nstatus: planning\n---\n# Old\n\nTasks\n' > "$TMP/openspec/changes/archive/old-plan/tasks.md"
+  printf -- '---\ntitle: Old\nstatus: planning\n---\n# Old\n\nTasks\n' > "$TMP/openspec/changes/archive/old-plan/tasks.md"
 
   run node --input-type=module -e "
     import { countLocalActivePlans } from '$REPO/scripts/openspec-embed.mjs';


### PR DESCRIPTION
## Problem

Zwei rote Tests auf `main`, die kein anderer offener PR abdeckt.

**1. `T002470: WT_SKIP_NAME_CHECK=1 laesst einen verletzenden Namen durch`**

`scripts/worktree-create.sh` hat **zwei** Branch-Namens-Guards:
- Zeile ~45 — der dokumentierte, respektiert `WT_SKIP_NAME_CHECK`
- Zeile ~205 (`T002471-M4`) — später ergänzt, kannte die Escape-Hatch nicht und brach mit `exit 1` ab

Die dokumentierte Notfall-Umgehung war dadurch wirkungslos: Guard 1 ließ durch, Guard 2 brach ab.

**2. `countLocalActivePlans zaehlt nur active-status Plaene`**

`coverage-gate.bats:46` — `printf '---\ntitle: …'`. Das Format beginnt mit `--`, bash-printf parst es als Option: `printf: --: invalid option`, Exit 2. Dieselbe Fehlerklasse wie der grep-Bug aus T002511.

## Fix

- Zweiter Guard teilt jetzt dieselbe `WT_SKIP_NAME_CHECK`-Bedingung und nennt die Umgehung in der Fehlermeldung.
- `printf --` in allen fünf betroffenen Zeilen, mit Kommentar zur Ursache.

## Verifikation

Beide Dateien vollständig grün (22 Tests, vorher 2 rot).

Ticket: T002512