### PR TITLE
fix(test): Hold-Gate-Guard über Blob-Hashes statt git diff gegen den Arbeitsbaum [T002519]

### DIFF
--- a/tests/spec/software-factory/ticket-lifecycle.bats
+++ b/tests/spec/software-factory/ticket-lifecycle.bats
@@ -577,8 +577,39 @@ SH
 }
 
 @test "T002327: das Hold-Gate aus T002272 bleibt unangetastet (queue.sh unveraendert)" {
-  run bash -c "cd '$REPO' && git diff --exit-code origin/main -- scripts/factory/queue.sh"
-  [ "$status" -eq 0 ] || { echo "queue.sh wurde veraendert — das Hold-Gate ist tabu"; false; }
+  # Verglichen werden die BLOB-HASHES an beiden Revisionen, nicht per `git diff`.
+  # [T002519]
+  #
+  # Vorher: `git diff --exit-code origin/main -- scripts/factory/queue.sh`. Zwei
+  # Fehler in einer Zeile:
+  #   1. `git diff <commit> -- <pfad>` vergleicht den Commit gegen den
+  #      ARBEITSBAUM, nicht gegen HEAD — jede Verunreinigung durch einen
+  #      nebenlaeufigen Test faellt dem Guard zur Last.
+  #   2. `[ "$status" -eq 0 ]` unterscheidet nicht zwischen "Diff nicht leer" und
+  #      "git-Kommando fehlgeschlagen". Beides ergab dieselbe Meldung.
+  #
+  # Auf dem depth-1-Checkout in CI (actions/checkout + `git fetch --depth=1
+  # origin main`) trat der zweite Fall ein: der Test war auf main reproduzierbar
+  # rot (zwei unabhaengige Laeufe), waehrend queue.sh nachweislich seit #3527
+  # unveraendert und zwischen den beteiligten SHAs identisch war — und die
+  # gesamte Shard-Menge lokal gruen durchlief, ohne queue.sh anzufassen.
+  #
+  # Blob-Hashes brauchen nur die beiden Baeume (in einem --depth=1-Fetch
+  # vorhanden), nie eine Merge-Base, und ignorieren den Arbeitsbaum.
+  local path="scripts/factory/queue.sh" ref_blob head_blob
+  ref_blob="$(cd "$REPO" && git rev-parse "origin/main:$path" 2>&1)" || {
+    skip "origin/main:$path nicht aufloesbar ($ref_blob) — kein Urteil moeglich"
+  }
+  head_blob="$(cd "$REPO" && git rev-parse "HEAD:$path" 2>&1)" || {
+    echo "HEAD:$path nicht aufloesbar: $head_blob" >&2; return 1
+  }
+  [ "$head_blob" = "$ref_blob" ] || {
+    echo "queue.sh wurde veraendert — das Hold-Gate ist tabu" >&2
+    echo "  origin/main: $ref_blob" >&2
+    echo "  HEAD:        $head_blob" >&2
+    (cd "$REPO" && git diff "origin/main" HEAD -- "$path" | head -40) >&2
+    return 1
+  }
 }
 
 # ── [T002407-M7] Container-Lifecycle: plan_staged, Recycling, Treiber-Idempotenz ──#


### PR DESCRIPTION
## Problem

`T002327: das Hold-Gate aus T002272 bleibt unangetastet (queue.sh unveraendert)` war auf `main` **reproduzierbar rot** — in zwei unabhängigen Läufen (`30713732960`, `30713963074`), der zweite auf stillstehendem `main`. Damit war es kein Rennen mit einem parallelen Merge.

**Belegt, dass der Inhalt nicht die Ursache war:**
- `scripts/factory/queue.sh` ist seit #3527 (T002407) unverändert
- zwischen den beteiligten SHAs identisch
- die **gesamte Shard-4-Menge** (55 Dateien, 528 Tests) läuft lokal grün durch, und `queue.sh` hat danach denselben Hash — kein nebenläufiger Test fasst sie an

## Zwei Konstruktionsfehler in einer Zeile

```bash
run bash -c "cd '$REPO' && git diff --exit-code origin/main -- scripts/factory/queue.sh"
[ "$status" -eq 0 ] || { echo "queue.sh wurde veraendert — das Hold-Gate ist tabu"; false; }
```

1. **`git diff <commit> -- <pfad>` vergleicht gegen den ARBEITSBAUM**, nicht gegen `HEAD`. Jede Verunreinigung durch einen nebenläufigen Test fällt dem Guard zur Last.
2. **Der Statuscheck unterscheidet nicht** zwischen „Diff nicht leer" und „git-Kommando fehlgeschlagen" — beides ergibt `status != 0` und dieselbe Meldung. Auf dem `depth-1`-Checkout in CI (`actions/checkout` + `git fetch --depth=1 origin main`) trat der zweite Fall ein, und die Meldung behauptete trotzdem eine Inhaltsänderung. `$output` wurde nie ausgegeben, also war die Ursache aus dem Log nicht ablesbar.

## Fix

Verglichen werden die **Blob-Hashes** an beiden Revisionen. Das braucht nur die zwei Bäume (in einem `--depth=1`-Fetch vorhanden), nie eine Merge-Base, und ignoriert den Arbeitsbaum vollständig.

- Nicht auflösbares `origin/main` → `skip` statt Falschaussage
- Bei echter Abweichung nennt die Meldung beide Hashes **und** den Diff

## Verifikation

```
# unverändert
ok 1 T002327: das Hold-Gate … (queue.sh unveraendert)

# mit tatsächlich geänderter queue.sh (Wegwerf-Commit)
not ok 1 T002327: das Hold-Gate … (queue.sh unveraendert)
#   origin/main: 3e58e9370dd9f7db3fa0097d2e185a4982df912a
#   HEAD:        0956daebf44c5d21e277f78e4252bc04fd71df1a

# nach dem Zurücksetzen wieder grün
ok 1
```

## Kontext

Dieser Test lief **zum ersten Mal überhaupt auf `main`**: er entstand mit dem T002503-Split (#3584), und Unterverzeichnis-Tests liefen wegen T002518 auf keinem PR. Der Split hat ihn also aus der PR-Abdeckung genommen und gleichzeitig erstmals dem `main`-Lauf ausgesetzt — der Defekt war vorher schlicht unsichtbar.

Ticket: T002519