### PR TITLE
fix(scripts): Fetch-TTL-Guard für cmd_reap-Netzwerk-Fetch [T002502]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 684,
+      "file_count": 685,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -319,6 +319,7 @@
         "tests/spec/agent-collision-false-positives.bats",
         "tests/spec/agent-library.bats",
         "tests/spec/agent-lock-claim-persist.bats",
+        "tests/spec/agent-lock-fetch-guard.bats",
         "tests/spec/agent-lock-force-claim.bats",
         "tests/spec/agent-lock-session-identity.bats",
         "tests/spec/agent-roster.bats",

--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 # scripts/agent-lock.sh — cross-tool session-coordination lock registry. [T000510]
 # One JSON file per claim under $AGENT_LOCK_DIR (shared gitdir's agent-locks/).
-# Test overrides: AGENT_LOCK_DIR, AGENT_LOCK_SID, AGENT_LOCK_FAKE_ALIVE, AGENT_LOCK_TOOL.
+# Test overrides: AGENT_LOCK_DIR, AGENT_LOCK_SID, AGENT_LOCK_FAKE_ALIVE, AGENT_LOCK_TOOL,
+# AGENT_LOCK_FETCH_TTL.
 set -uo pipefail
 
 AGENT_LOCK_TTL="${AGENT_LOCK_TTL:-1800}"
 AGENT_LOCK_GRACE="${AGENT_LOCK_GRACE:-120}"
+# [T002502] Netzwerk-Fetch in cmd_reap wird auf hoechstens einen pro TTL-Fenster
+# begrenzt. `git fetch --prune origin` ist ein Roundtrip (~1.4s lokal, auf CI mit
+# cold git-Refs deutlich mehr), und cmd_reap laeuft als pre-claim reap bei JEDEM
+# claim. agent-lock-claim-persist.bats (Test 4: 30 Runden claim+reap) kostete dadurch
+# ~92s lokal bzw. ~310s auf CI-Shard 4. Der Remote-Ref-Stand muss nicht
+# sekundengenau sein: ein fetch alle 300s reicht fuer die verwaiste-Branch-Pruefung.
+AGENT_LOCK_FETCH_TTL="${AGENT_LOCK_FETCH_TTL:-300}"
 
 # Harness-Session-Variablen in Prüfreihenfolge: CLAUDE_CODE_SESSION_ID zuerst. [T002375-p1]
 _AGENT_LOCK_SID_ENVS="CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID"
@@ -434,7 +442,21 @@ cmd_reap() {
   # 2) prune git worktree admin entries for gone directories
   git worktree prune 2>/dev/null || true
   # 2b) prune stale remote-tracking refs (branches deleted on GitHub after merge)
-  git fetch --prune origin 2>/dev/null || true
+  #     [T002502] TTL-Guard: fetch hoechstens einmal pro AGENT_LOCK_FETCH_TTL. Der
+  #     Marker liegt im Lock-Dir (nicht in /tmp), damit parallele Worktrees/Repos
+  #     unabhaengig getaktet werden und Tests mit eigenem AGENT_LOCK_DIR isoliert
+  #     bleiben. AGENT_LOCK_FETCH_TTL=0 erzwingt den fetch bei jedem reap (Debug).
+  #     Fehlt der Marker, ist der fetch faellig (erster reap des Lock-Dirs).
+  local _fetch_marker _fetch_age
+  _fetch_marker="$(_lock_dir)/.last-fetch"
+  _fetch_age=0
+  if [ -f "$_fetch_marker" ]; then
+    _fetch_age=$(( $(date +%s) - $(stat -c %Y "$_fetch_marker" 2>/dev/null || echo 0) ))
+  fi
+  if [ "${AGENT_LOCK_FETCH_TTL:-300}" -eq 0 ] || [ ! -f "$_fetch_marker" ] || [ "$_fetch_age" -ge "${AGENT_LOCK_FETCH_TTL:-300}" ]; then
+    git fetch --prune origin 2>/dev/null || true
+    touch "$_fetch_marker" 2>/dev/null || true
+  fi
   # 2c) delete local branches that were squash-merged into main (upstream gone)
   for br in $(git branch --merged main 2>/dev/null | sed 's/^[* ]*//' | grep -v '^main$'); do
     # skip branches that have a live agent-lock claim (e.g. dev-flow-plan in progress) [T001448 M3]

--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -7,12 +7,8 @@ set -uo pipefail
 
 AGENT_LOCK_TTL="${AGENT_LOCK_TTL:-1800}"
 AGENT_LOCK_GRACE="${AGENT_LOCK_GRACE:-120}"
-# [T002502] Netzwerk-Fetch in cmd_reap wird auf hoechstens einen pro TTL-Fenster
-# begrenzt. `git fetch --prune origin` ist ein Roundtrip (~1.4s lokal, auf CI mit
-# cold git-Refs deutlich mehr), und cmd_reap laeuft als pre-claim reap bei JEDEM
-# claim. agent-lock-claim-persist.bats (Test 4: 30 Runden claim+reap) kostete dadurch
-# ~92s lokal bzw. ~310s auf CI-Shard 4. Der Remote-Ref-Stand muss nicht
-# sekundengenau sein: ein fetch alle 300s reicht fuer die verwaiste-Branch-Pruefung.
+# [T002502] cmd_reap-Fetch (pre-claim reap bei JEDEM claim) max 1x pro TTL-Fenster:
+# ohne Guard kostete claim-persist.bats Test 4 ~92s lokal / ~310s auf CI-Shard 4.
 AGENT_LOCK_FETCH_TTL="${AGENT_LOCK_FETCH_TTL:-300}"
 
 # Harness-Session-Variablen in Prüfreihenfolge: CLAUDE_CODE_SESSION_ID zuerst. [T002375-p1]
@@ -23,13 +19,10 @@ _AGENT_LOCK_TOOL_MARKER_ENVS="CLAUDECODE CLAUDE_CODE"
 _now() { date +%s; }
 
 _my_sid() {
-  # Harness-stable env wins (Claude Code / opencode expose a session id for
-  # telemetry that survives across bash tool calls). The test override
-  # AGENT_LOCK_SID stays as a second layer (CI / unit tests). Only fall back
-  # to the per-call Unix SID when neither harness env nor test override is
-  # set — that path is the source of the cross-call drift bug. [T001268]
-  # [T002375-p1] Die Harness exportiert CLAUDE_CODE_SESSION_ID, nicht CLAUDE_SESSION_ID.
-  # SID-Check: Harness-Env wins, then test override, then Unix SID. [T001268]
+  # Harness-stable env wins (Claude Code / opencode expose a session id surviving
+  # bash tool calls); AGENT_LOCK_SID override stays as second layer (CI/unit tests);
+  # per-call Unix-SID is the fallback and the source of the drift bug. [T001268]
+  # [T002375-p1] Harness exportiert CLAUDE_CODE_SESSION_ID, nicht CLAUDE_SESSION_ID.
   if [ -n "${AGENT_LOCK_SID:-}" ]; then printf '%s\n' "$AGENT_LOCK_SID"; return; fi
   local _v
   for _v in $_AGENT_LOCK_SID_ENVS; do
@@ -121,33 +114,23 @@ _reapable() {
   sid="$(_lock_field "$f" owner_sid)"; wt="$(_lock_field "$f" worktree)"
   hb="$(_lock_field "$f" heartbeat_at)"; ct="$(_lock_field "$f" created_at)"; now="$(_now)"
   br="$(_lock_field "$f" branch)"
-  # Age reference for the pid-dead/sid-dead grace checks below: prefer the
-  # heartbeat (reflects the last confirmed-live refresh) and fall back to
-  # created_at only for old claim files that predate the heartbeat_at field.
-  # [T001582-M1] Using created_at alone wrongly reaped claims that were
-  # refreshed recently but originally created long ago.
+  # Age base for grace checks: heartbeat first (last confirmed-live refresh),
+  # created_at fallback for pre-heartbeat claim files. [T001582-M1]
   local age_base="${hb:-${ct:-0}}"
   # 0) A CONFIRMED-ALIVE SID ALWAYS WINS — even if the worktree path is stale
-  #    or missing, a live session owns the claim. Reapability only kicks in
-  #    when the SID is dead (or, as a last resort, when no SID is recorded). [T001384]
+  #    or missing, a live session owns the claim. [T001384]
   if [ -n "$sid" ] && _sid_alive "$sid"; then
-    # [T002392-M3] Heartbeat-TTL-Check auch bei lebendiger SID (non-numeric
-    # UUIDs gelten immer als "alive" — aber wenn der Heartbeat alt ist, ist der
-    # Halter wirklich tot und nur die UUID im Lock uebrig). Ohne diesen Check
-    # wuerde reap nie einen solchen Lock aufraeumen, weil der SID-Fruehrueck-
-    # kehr nie zum PID-/Heartbeat-Teil vordringt.
+    # [T002392-M3] Heartbeat-TTL-Check auch bei lebendiger SID: non-numeric UUIDs
+    # gelten immer als "alive" — ein alter Heartbeat zeigt aber einen toten Halter.
     if [ -n "$hb" ] && [ "$(( now - hb ))" -gt "$AGENT_LOCK_TTL" ]; then
       _reap_log "$f" heartbeat-ttl; return 0
     fi
     return 1
   fi
   # 0b) Worktree+branch match beats a dead/mismatched SID: a session RESUME
-  #     starts a new process with a different SID (and possibly a different
-  #     PID), which would otherwise fall through to the pid-dead/sid-dead reap
-  #     paths below and delete a claim that is still very much live — the
-  #     worktree is sitting right there, checked out on the exact branch the
-  #     claim recorded. Verify liveness via that filesystem/git state instead
-  #     of trusting the volatile SID. [T002204]
+  #     starts a new process with a different SID (and possibly PID), which
+  #     would otherwise fall through to the pid-dead/sid-dead reap paths below.
+  #     Verify liveness via the filesystem/git state instead. [T002204]
   if [ -n "$wt" ] && [ "$wt" != "-" ] && [ -d "$wt" ] && [ -n "$br" ]; then
     local wt_branch
     wt_branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
@@ -442,11 +425,9 @@ cmd_reap() {
   # 2) prune git worktree admin entries for gone directories
   git worktree prune 2>/dev/null || true
   # 2b) prune stale remote-tracking refs (branches deleted on GitHub after merge)
-  #     [T002502] TTL-Guard: fetch hoechstens einmal pro AGENT_LOCK_FETCH_TTL. Der
-  #     Marker liegt im Lock-Dir (nicht in /tmp), damit parallele Worktrees/Repos
-  #     unabhaengig getaktet werden und Tests mit eigenem AGENT_LOCK_DIR isoliert
-  #     bleiben. AGENT_LOCK_FETCH_TTL=0 erzwingt den fetch bei jedem reap (Debug).
-  #     Fehlt der Marker, ist der fetch faellig (erster reap des Lock-Dirs).
+  #     [T002502] TTL-Guard: fetch max 1x pro AGENT_LOCK_FETCH_TTL (Marker im
+  #     Lock-Dir, isoliert je AGENT_LOCK_DIR; TTL=0 erzwingt, fehlender Marker
+  #     = faellig).
   local _fetch_marker _fetch_age
   _fetch_marker="$(_lock_dir)/.last-fetch"
   _fetch_age=0

--- a/tests/spec/agent-lock-fetch-guard.bats
+++ b/tests/spec/agent-lock-fetch-guard.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# tests/spec/agent-lock-fetch-guard.bats
+# SSOT: scripts/agent-lock.sh (cmd_reap, Schritt 2b)
+# Ticket: T002502
+#
+# Regression-Suite fuer den Netzwerk-Fetch-TTL-Guard in cmd_reap().
+#
+# Hintergrund: cmd_reap() laeuft als pre-claim reap bei JEDEM claim (Zeile 255)
+# und in der Reap-Schleife von agent-lock-claim-persist.bats (Test 4: 30 Runden
+# claim+reap). Vor T002502 kostete `git fetch --prune origin` bei jedem Aufruf
+# ~1.4s (lokal) bzw. deutlich mehr auf CI (cold git-Refs, 2-Kern-Runner) — 60
+# Fetches in einer Datei machten Shard 4 der Factory-Suite ~310s lang. Der Guard
+# begrenzt den fetch auf einen pro AGENT_LOCK_FETCH_TTL (Default 300s) mit einem
+# Marker im Lock-Dir.
+#
+# Diese Suite prueft: (1) der Guard existiert im Quellcode (statischer Check,
+# gleiche Konvention wie T001384-D3), (2) der Marker wird beim ersten reap
+# angelegt, (3) ein frischer Marker verhindert den naechsten fetch, (4) ein
+# abgelaufener Marker laesst den fetch wieder laufen, (5) AGENT_LOCK_FETCH_TTL=0
+# erzwingt den fetch (Debug-Pfad).
+#
+# setup_file statt setup: alle Tests teilen EIN Lock-Dir (und damit EINEN
+# Marker), sodass die Datei auf CI genau EINEN git fetch kostet statt einen
+# pro Test. Die Marker-Verhaltenstests (G3-G5) manipulieren den Zeitstempel
+# bewusst und stellen ihn vor dem naechsten Test zurueck.
+
+setup_file() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  export AGENT_LOCK_DIR
+  AGENT_LOCK_DIR="$(mktemp -d)"
+  # Einmaliger echter claim legt den Marker an (der fetch im ersten reap).
+  bash "$REPO/scripts/agent-lock.sh" claim ticket T002502-file-probe --label probe
+}
+
+teardown_file() {
+  rm -rf "$AGENT_LOCK_DIR" 2>/dev/null || true
+}
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  LOCK="$REPO/scripts/agent-lock.sh"
+  unset CLAUDE_CODE_SESSION_ID
+  export CLAUDE_SESSION_ID="claude-t002502-suite"
+  unset AGENT_LOCK_SID
+  export AGENT_LOCK_FETCH_TTL="${AGENT_LOCK_FETCH_TTL:-300}"
+}
+
+teardown() {
+  # Marker-Zustand fuer den naechsten Test neutralisieren: frisch setzen,
+  # damit G3/G4/G5 unabhaengig voneinander laufen.
+  touch "$AGENT_LOCK_DIR/.last-fetch" 2>/dev/null || true
+}
+
+@test "T002502-G1: cmd_reap referenziert den Fetch-TTL-Guard im Quellcode" {
+  # Statischer Check analog T001384-D3: der Guard MUSS da sein, sonst ist der
+  # Fix nicht vorhanden. Gesucht wird die TTL-Variable und der Marker-Pfad.
+  grep -Eq 'AGENT_LOCK_FETCH_TTL' "$LOCK"
+  grep -Eq '\.last-fetch' "$LOCK"
+}
+
+@test "T002502-G2: reap ohne Marker legt den .last-fetch-Marker an" {
+  rm -f "$AGENT_LOCK_DIR/.last-fetch"
+  bash "$LOCK" reap
+  [ -f "$AGENT_LOCK_DIR/.last-fetch" ]
+}
+
+@test "T002502-G3: frischer Marker unterbricht den fetch-Zyklus (kein Refresh)" {
+  # Marker kuenstlich auf "vor 60s" setzen — innerhalb des 300s-Fensters.
+  # Ein reap darf den Zeitstempel NICHT aktualisieren (kein fetch).
+  OLD_TS="$(date +%s)"
+  touch -d "@$((OLD_TS - 60))" "$AGENT_LOCK_DIR/.last-fetch"
+  bash "$LOCK" reap
+  NEW_TS="$(stat -c %Y "$AGENT_LOCK_DIR/.last-fetch")"
+  [ "$NEW_TS" -eq "$((OLD_TS - 60))" ]
+}
+
+@test "T002502-G4: abgelaufener Marker loest wieder einen fetch aus (Refresh)" {
+  # Marker kuenstlich auf "vor 600s" setzen — ausserhalb des 300s-Fensters.
+  # Ein reap MUSS den Zeitstempel aktualisieren (fetch laeuft wieder).
+  OLD_TS="$(date +%s)"
+  touch -d "@$((OLD_TS - 600))" "$AGENT_LOCK_DIR/.last-fetch"
+  bash "$LOCK" reap
+  NEW_TS="$(stat -c %Y "$AGENT_LOCK_DIR/.last-fetch")"
+  [ "$NEW_TS" -gt "$((OLD_TS - 600))" ]
+}
+
+@test "T002502-G5: AGENT_LOCK_FETCH_TTL=0 erzwingt den fetch bei jedem reap" {
+  # Debug-Pfad: TTL=0 muss den Marker bei jedem reap aktualisieren, auch wenn
+  # er frisch ist. Das verhindert, dass der Guard den fetch komplett abschaltet.
+  export AGENT_LOCK_FETCH_TTL=0
+  OLD_TS="$(date +%s)"
+  touch -d "@$OLD_TS" "$AGENT_LOCK_DIR/.last-fetch"
+  bash "$LOCK" reap
+  NEW_TS="$(stat -c %Y "$AGENT_LOCK_DIR/.last-fetch")"
+  [ "$NEW_TS" -ge "$OLD_TS" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1932,6 +1932,12 @@
     "kind": "shell"
   },
   {
+    "id": "agent-lock-fetch-guard",
+    "file": "tests/spec/agent-lock-fetch-guard.bats",
+    "category": "agent-lock-fetch-guard",
+    "kind": "shell"
+  },
+  {
     "id": "agent-lock-force-claim",
     "file": "tests/spec/agent-lock-force-claim.bats",
     "category": "agent-lock-force-claim",


### PR DESCRIPTION
## Summary

**Ticket:** T002502

`cmd_reap()` läuft als pre-claim reap bei **jedem** `agent-lock.sh claim` (Zeile 263) und führt dabei ungegated `git fetch --prune origin` aus. In `agent-lock-claim-persist.bats` (Test 4: 30 Runden claim+reap) summieren sich die Fetches zu ~92s lokal bzw. ~310s auf CI-Shard 4 (60 Fetches pro Datei, cold git-Refs auf 2-Kern-Runner).

**Fix:** Fetch-TTL-Guard — `git fetch` höchstens einmal pro `AGENT_LOCK_FETCH_TTL` (Default 300s), Marker `.last-fetch` im Lock-Dir (pro `AGENT_LOCK_DIR` isoliert, damit Worktrees/Repo-Tests unabhängig takten). `AGENT_LOCK_FETCH_TTL=0` erzwingt den Fetch (Debug).

**Nebenbei:** agent-lock.sh musste unter das S1-500-Zeilen-Limit zurück (498) — Kommentar-Verdichtung, keine Logikänderung.

## Changes

- `scripts/agent-lock.sh`: Fetch-TTL-Guard (+24/−2), danach S1-Verdichtung (−19)
- `tests/spec/agent-lock-fetch-guard.bats`: neue Regression-Suite (5 Tests: statischer Guard-Check, Marker-Anlage, frisch/abgelaufen, TTL=0-Erzwingung)
- Freshness-Artefakte (test-inventory.json, repo-index.json) regeneriert

## Test Plan

- `bats tests/spec/agent-lock-fetch-guard.bats` — 5/5 grün (7.4s)
- Alle agent-lock-Suiten: 33/33 grün; claim-persist von ~92s → 58.7s
- `task test:changed` — EXIT 0
- `task freshness:check` — EXIT 0
- `task workspace:validate` — EXIT 0