### PR TITLE
fix(scripts): gh-axi emittiert kein JSON — Arbitration auf gh umstellen [T002516]

### DIFF
--- a/docs/superpowers/specs/2026-07-28-merge-arbitration-design.md
+++ b/docs/superpowers/specs/2026-07-28-merge-arbitration-design.md
@@ -55,9 +55,9 @@ nutzbar und ohne die anderen testbar ist.
 
 | Komponente | Aufgabe | Schreibt | Braucht |
 |---|---|---|---|
-| `scripts/arbitration/detect.sh` | Cluster-Erkennung über offene PRs, gibt JSON aus | nichts | `gh-axi`, `git` |
+| `scripts/arbitration/detect.sh` | Cluster-Erkennung über offene PRs, gibt JSON aus | nichts | `gh`-CLI (`--json`), `git` |
 | `scripts/arbitration/synthesize.mjs` | JSON rein → `{merged, confidence, rationale, per_pr_notes}` raus | nichts | llm-proxy |
-| `scripts/arbitration/apply.sh` | Synthese-PR **oder** Eskalation | GitHub, Ticket-DB | `gh-axi`, `ticket.sh` |
+| `scripts/arbitration/apply.sh` | Synthese-PR **oder** Eskalation | GitHub, Ticket-DB | `gh`-CLI (`--json`), `ticket.sh` |
 
 `detect.sh` ist allein wertvoll: manuell aufgerufen zeigt es die aktuellen Kollisionen,
 bevor ein LLM beteiligt ist. `synthesize.mjs` ist rein funktional und damit ohne Cluster,
@@ -75,7 +75,7 @@ Der self-hosted Runner ist nicht Bequemlichkeit, sondern Bedingung: der llm-prox
 ## Datenfluss
 
 ```
-gh-axi pr list (open)
+gh pr list --json (open)
    │  pro PR: git diff --name-only origin/main...origin/<head>
    │          + isDraft, statusCheckRollup, labels, Ticket-ID aus Titel
    ▼

--- a/scripts/arbitration/apply.sh
+++ b/scripts/arbitration/apply.sh
@@ -16,14 +16,15 @@
 # Ausgang ohne Exit-Code-Interpretation unterscheiden können.
 #
 # Env overrides (für Tests/Fixtures):
-#   GH_AXI               - gh-Wrapper-Binary (Default: gh-axi)
+#   GH_AXI               - gh-CLI-Binary (Default: gh; gh-axi kann kein JSON
+#                          emittieren — siehe detect.sh)
 #   TICKET_SH            - Kommando für Ticket-Erstellung (Default: scripts/ticket.sh)
 #   SYNTHESIZE           - Pfad zu synthesize.mjs (Default: neben diesem Skript)
 #   SHARED_STATE         - Risiko-Pfadliste (Default: scripts/factory/shared-state-paths.txt)
 #   CONFIDENCE_THRESHOLD - Eskalationsschwelle (Default: 0.8)
 set -uo pipefail
 
-GH_AXI="${GH_AXI:-gh-axi}"
+GH_AXI="${GH_AXI:-gh}"
 TICKET_SH="${TICKET_SH:-scripts/ticket.sh}"
 SYNTHESIZE="${SYNTHESIZE:-$(dirname "$0")/synthesize.mjs}"
 SHARED_STATE="${SHARED_STATE:-scripts/factory/shared-state-paths.txt}"
@@ -49,7 +50,7 @@ check_idempotent() {
   "$GH_AXI" pr list --state open --json title,labels,headRefName 2>/dev/null | jq -e \
     --arg branch "$branch" \
     '.[] | select((.headRefName // "") == $branch)
-         | select((.labels.nodes // []) | any(.name == "arbitration"))' >/dev/null 2>&1
+         | select((.labels // []) | any(.name == "arbitration"))' >/dev/null 2>&1
 }
 
 check_risk_path() {

--- a/scripts/arbitration/detect.sh
+++ b/scripts/arbitration/detect.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-GH_AXI="${GH_AXI:-gh-axi}"
+# gh-axi kann kein JSON emittieren (emittiert Tabellen) — für die maschinen-
+# lesbare PR-Liste braucht es das echte gh-CLI. Override für Tests möglich.
+GH_AXI="${GH_AXI:-gh}"
 GIT_ATTR="${GIT_ATTR:-.gitattributes}"
 
 merge_ours_patterns() {
@@ -36,7 +38,7 @@ eligible() {
   local is_draft="$1" ci_state="$2" labels_json="$3"
   [ "$is_draft" = "true" ] && return 1
   [ "$ci_state" != "SUCCESS" ] && [ "$ci_state" != "NEUTRAL" ] && [ "$ci_state" != "" ] && return 1
-  if echo "$labels_json" | jq -e '.nodes | map(.name) | contains(["arbitration"])' >/dev/null 2>&1; then
+  if echo "$labels_json" | jq -e 'map(.name) | contains(["arbitration"])' >/dev/null 2>&1; then
     return 1
   fi
   return 0
@@ -88,7 +90,7 @@ main() {
       else
         if [ "$is_draft" = "true" ]; then
           ineligible_reason="draft"
-        elif echo "$labels_json" | jq -e '.nodes | map(.name) | contains(["arbitration"])' >/dev/null 2>&1; then
+        elif echo "$labels_json" | jq -e 'map(.name) | contains(["arbitration"])' >/dev/null 2>&1; then
           ineligible_reason="arbitration_label"
         else
           ineligible_reason="ci_red"
@@ -114,7 +116,7 @@ main() {
         --arg reason "$ineligible_reason" \
         '. += [{"pr": $entry, "eligible": $eligible, "ineligible_reason": $reason}]')
     done <<< "$files"
-  done < <(echo "$prs" | jq -r '.[] | [.number, .headRefName, .headRefOid, (.isDraft|tostring), (.labels|tostring), (.statusCheckRollup.state // ""), .title] | @tsv')
+  done < <(echo "$prs" | jq -r '.[] | [.number, .headRefName, .headRefOid, (.isDraft|tostring), (.labels|tostring), (.statusCheckRollup // [] | if any(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED") then "FAILURE" elif length == 0 then "" elif all(.status == "COMPLETED" and (.conclusion == "SUCCESS" or .conclusion == "NEUTRAL" or .conclusion == "SKIPPED")) then "SUCCESS" else "" end), .title] | @tsv')
 
   local clusters=()
   local cluster_idx=0

--- a/tests/spec/merge-arbitration/apply-idempotency.bats
+++ b/tests/spec/merge-arbitration/apply-idempotency.bats
@@ -77,7 +77,7 @@ STUB
   cat > "$PATH_STUB/gh-axi" <<STUB
 #!/usr/bin/env bash
 case "\$1 \$2" in
-  "pr list") echo '[{"number":9999,"headRefName":"chore/merge-arbitration-${KEY_V1:0:12}","labels":{"nodes":[{"name":"arbitration"}]},"title":"merge-arbitration [${KEY_V1:0:12}]"}]' ;;
+  "pr list") echo '[{"number":9999,"headRefName":"chore/merge-arbitration-${KEY_V1:0:12}","labels":[{"name":"arbitration"}],"title":"merge-arbitration [${KEY_V1:0:12}]"}]' ;;
   "pr create") echo "SHOULD NOT BE CALLED"; exit 1 ;;
   *) exit 0 ;;
 esac
@@ -101,7 +101,7 @@ STUB
   cat > "$PATH_STUB/gh-axi" <<STUB
 #!/usr/bin/env bash
 case "\$1 \$2" in
-  "pr list") echo '[{"number":9999,"headRefName":"chore/merge-arbitration-${KEY_V1:0:12}","labels":{"nodes":[{"name":"arbitration"}]},"title":"merge-arbitration [${KEY_V1:0:12}]"}]' ;;
+  "pr list") echo '[{"number":9999,"headRefName":"chore/merge-arbitration-${KEY_V1:0:12}","labels":[{"name":"arbitration"}],"title":"merge-arbitration [${KEY_V1:0:12}]"}]' ;;
   "pr create") echo "https://example.invalid/pr/2"; exit 0 ;;
   "pr comment") exit 0 ;;
   *) exit 0 ;;

--- a/tests/spec/merge-arbitration/detect-clustering.bats
+++ b/tests/spec/merge-arbitration/detect-clustering.bats
@@ -21,11 +21,11 @@ teardown() {
   cat > "$PATH_STUB/gh-axi" <<'STUB'
 #!/usr/bin/env bash
 echo '[
-  {"number":1001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr1 [T0001]"},
-  {"number":1002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr2 [T0002]"},
-  {"number":1003,"headRefName":"pr3","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr3 [T0003]"},
-  {"number":1004,"headRefName":"pr4","headRefOid":"HEAD","isDraft":true,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr4 [T0004]"},
-  {"number":1005,"headRefName":"pr5","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[{"name":"arbitration"}]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr5 [T0005]"}
+  {"number":1001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr1 [T0001]"},
+  {"number":1002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr2 [T0002]"},
+  {"number":1003,"headRefName":"pr3","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr3 [T0003]"},
+  {"number":1004,"headRefName":"pr4","headRefOid":"HEAD","isDraft":true,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr4 [T0004]"},
+  {"number":1005,"headRefName":"pr5","headRefOid":"HEAD","isDraft":false,"labels":[{"name":"arbitration"}],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr5 [T0005]"}
 ]'
 STUB
   chmod +x "$PATH_STUB/gh-axi"

--- a/tests/spec/merge-arbitration/detect-generated-exclusion.bats
+++ b/tests/spec/merge-arbitration/detect-generated-exclusion.bats
@@ -24,9 +24,9 @@ teardown() {
   cat > "$PATH_STUB/gh-axi" <<'STUB'
 #!/usr/bin/env bash
 echo '[
-  {"number":3001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr1 [T0001]"},
-  {"number":3002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr2 [T0002]"},
-  {"number":3003,"headRefName":"pr3","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr3 [T0003]"}
+  {"number":3001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr1 [T0001]"},
+  {"number":3002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr2 [T0002]"},
+  {"number":3003,"headRefName":"pr3","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr3 [T0003]"}
 ]'
 STUB
   chmod +x "$PATH_STUB/gh-axi"
@@ -47,9 +47,9 @@ STUB
   cat > "$PATH_STUB/gh-axi" <<'STUB2'
 #!/usr/bin/env bash
 echo '[
-  {"number":4001,"headRefName":"pr4","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr4 [T0004]"},
-  {"number":4002,"headRefName":"pr5","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr5 [T0005]"},
-  {"number":4003,"headRefName":"pr6","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr6 [T0006]"}
+  {"number":4001,"headRefName":"pr4","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr4 [T0004]"},
+  {"number":4002,"headRefName":"pr5","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr5 [T0005]"},
+  {"number":4003,"headRefName":"pr6","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr6 [T0006]"}
 ]'
 STUB2
   PATH="$PATH_STUB:$PATH" GH_AXI=gh-axi run bash "$DETECT"

--- a/tests/spec/merge-arbitration/detect-threshold.bats
+++ b/tests/spec/merge-arbitration/detect-threshold.bats
@@ -21,8 +21,8 @@ teardown() {
   cat > "$PATH_STUB/gh-axi" <<'STUB'
 #!/usr/bin/env bash
 echo '[
-  {"number":2001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr1 [T0001]"},
-  {"number":2002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr2 [T0002]"}
+  {"number":2001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr1 [T0001]"},
+  {"number":2002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr2 [T0002]"}
 ]'
 STUB
   chmod +x "$PATH_STUB/gh-axi"
@@ -36,9 +36,9 @@ STUB
   cat > "$PATH_STUB/gh-axi" <<'STUB3'
 #!/usr/bin/env bash
 echo '[
-  {"number":2001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr1 [T0001]"},
-  {"number":2002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr2 [T0002]"},
-  {"number":2003,"headRefName":"pr3","headRefOid":"HEAD","isDraft":false,"labels":{"nodes":[]},"statusCheckRollup":{"state":"SUCCESS"},"title":"fix: pr3 [T0003]"}
+  {"number":2001,"headRefName":"pr1","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr1 [T0001]"},
+  {"number":2002,"headRefName":"pr2","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr2 [T0002]"},
+  {"number":2003,"headRefName":"pr3","headRefOid":"HEAD","isDraft":false,"labels":[],"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}],"title":"fix: pr3 [T0003]"}
 ]'
 STUB3
   PATH="$PATH_STUB:$PATH" GH_AXI=gh-axi GIT_ATTR=/dev/null run bash "$DETECT"


### PR DESCRIPTION
## Summary

**Root cause:** `scripts/arbitration/detect.sh` and `apply.sh` called `"$GH_AXI" pr list --json ...` with the default `GH_AXI=gh-axi`. But gh-axi (v0.1.22) **never emits JSON** — `pr list` prints a human-readable table and `api` prints `key: value` lines. Every run therefore hit `jq: parse error: Invalid numeric literal at line 1` → `Found 0 cluster(s)` → Merge Arbitration **never judged**, independent of the runner being up.

**Second latent defect:** even with a JSON-capable CLI, the scripts parsed a **GraphQL shape** (`labels.nodes`, `statusCheckRollup.state`) that real `gh pr list --json` does not produce (it emits REST arrays: `labels:[{name}]`, `statusCheckRollup:[{status,conclusion,__typename}]`). The test stubs encoded that fictional shape, so tests passed while production was dead.

**Fix:**
- Default `GH_AXI` to `gh` (the real CLI, same convention as `scripts/factory/babysit-prs.sh:72`); env override kept for tests.
- `detect.sh`: parse `labels` as array (`map(.name)`); derive ci_state from `statusCheckRollup` array (FAILURE on red conclusion, "" empty, SUCCESS only when all completed green — pending stays eligible, matching the fail-open design).
- `apply.sh`: `check_idempotent` reads `.labels // []` instead of `.labels.nodes`.
- Test stubs in `tests/spec/merge-arbitration/*` updated to emit the real `gh` REST shapes.
- Design doc updated (`gh-axi` → `gh`).

Runner-side root cause (host reboot left the GitHub Actions runner service stopped; unit re-enabled 2026-08-01 23:05) was already fixed operationally — this PR closes the code-side blocker.

## Test Plan
- `bash tests/unit/lib/bats-core/bin/bats tests/spec/merge-arbitration/` → 6/6 ok
- `task test:changed` → 52 pass
- `task freshness:check` → clean, no generated drift
- Live `bash scripts/arbitration/detect.sh` with real `gh` → clean `[]`, no jq parse errors (previously `jq: parse error` + `[: : integer expression expected`)