### PR TITLE
chore(plans): Endpunkt-Karte und K6-Blocker klären, K4/K6 parallel planbar [T002463]

### DIFF
--- a/openspec/changes/cockpit-auth-schnitt/specs/sdlc-cockpit.md
+++ b/openspec/changes/cockpit-auth-schnitt/specs/sdlc-cockpit.md
@@ -76,24 +76,64 @@ protection removed at the edge is restored at the API.
 - **THEN** the response carries an `error` field
 - **AND** an empty result set remains distinguishable from a failure (D13)
 
-### Requirement: The adapter's base address follows its host context
+### Requirement: The adapter resolves each endpoint's host separately
 
-The system SHALL resolve the data adapter's base address from the context it
-runs in: the website's own origin when served from the admin page, the local
-daemon when served standalone. The address SHALL NOT be a fixed constant.
+The system SHALL decide **per endpoint** which host serves it, not by a single
+base address for all of them. Each endpoint SHALL declare whether its data is
+available from the website, only from the local daemon, or from both.
 
-This closes the open remainder of K7 — the adapter currently hardcodes
-`http://127.0.0.1:49152`, which is a foreign origin for a page served from the
-website.
+A single base switch is not sufficient and would break the admin page: of the
+eight endpoints the adapter requests today, the website serves only three
+(`portfolio`, `pods-list`, `factory-control`). Switching the base wholesale
+would leave five panels on `404`.
 
-#### Scenario: Served from the admin page
+The split follows from where the data actually lives, not from preference:
 
-- **GIVEN** the cockpit is served from the website's admin area
-- **WHEN** the adapter requests data
+| Endpoint | Source | Available from |
+|---|---|---|
+| `portfolio`, `pods-list`, `factory-control` | database, kubectl, factory | website (exists today) |
+| `epics` | ticket database | website (buildable) |
+| `styles` | repository files | website (buildable) |
+| `ci` | GitHub API | website (buildable) |
+| `agents` | local agent locks in the checkout's `git-common-dir` | **local daemon only** |
+| `models` | local model health ports on `127.0.0.1` | **local daemon only** |
+
+`agents` and `models` are not merely unbuilt on the website — they read state
+that exists only on a developer machine. They SHALL remain daemon-only.
+
+#### Scenario: A website-backed endpoint is served by the website
+
+- **GIVEN** the cockpit is served from the admin area
+- **WHEN** the adapter requests an endpoint the website serves
 - **THEN** it addresses the website's own origin
 
-#### Scenario: Served standalone
+#### Scenario: A daemon-only endpoint is not silently requested from the website
+
+- **GIVEN** the cockpit is served from the admin area
+- **WHEN** a panel needs a daemon-only endpoint
+- **THEN** the adapter does not request it from the website
+- **AND** the panel reports that the source is unavailable in this context,
+  rather than showing an empty result (D13)
+
+#### Scenario: Standalone serves everything from the daemon
 
 - **GIVEN** the cockpit is served as a standalone page
-- **WHEN** the adapter requests data
+- **WHEN** the adapter requests any endpoint
 - **THEN** it addresses the local daemon
+
+### Requirement: The website reaches Brain through an explicit ingress policy
+
+The system SHALL carry a NetworkPolicy that allows ingress from the `website`
+namespace to the `brain` pod on its container port. Without it the request is
+dropped: the `workspace` namespace carries `allow-intra-namespace-ingress` with
+an empty pod selector, which denies everything from outside by default. Every
+other service the website reaches has such a policy
+(`allow-website-to-{shared-db,pocket-id,nextcloud,vaultwarden,docuseal}-ingress`);
+`brain` is the one that is missing.
+
+#### Scenario: The website reaches the Brain service
+
+- **GIVEN** the website pod and the brain pod are running
+- **WHEN** the website requests the brain service on its container port
+- **THEN** the connection succeeds
+- **AND** it does not pass through the `oauth2-proxy` edge

--- a/openspec/changes/cockpit-auth-schnitt/tasks.md
+++ b/openspec/changes/cockpit-auth-schnitt/tasks.md
@@ -40,6 +40,43 @@ in die SSOT `openspec/specs/sdlc-cockpit.md`.
 Begründung und Belege: siehe `proposal.md`. Die verbindlichen Zusagen stehen in
 `specs/sdlc-cockpit.md`.
 
+## Parallelität von K4 und K6
+
+Beide sind **unabhängig planbar und umsetzbar**. Das war nicht selbstverständlich
+und ist das Ergebnis von zwei Klärungen:
+
+**1. Keiner der beiden hängt am K7-Rest.** Der Adapter braucht keine globale
+Basis-Umschaltung, sondern eine Karte pro Endpunkt (siehe `specs/`). K4 und K6
+tragen ihre neuen Endpunkte einfach als „Website" ein. Ob `agents` und `models`
+je auf die Website wandern, bleibt davon unberührt — sie können es nicht, weil
+sie lokalen Zustand lesen.
+
+**2. K6s Blocker ist identifiziert.** Es fehlt eine NetworkPolicy nach dem
+gelebten Muster; kein Entwurfsproblem.
+
+### Geteilte Dateien — die eine echte Kollisionsstelle
+
+| Datei | K4 | K6 | Kollision |
+|---|---|---|---|
+| `website/src/pages/api/admin/cockpit/` | neue Schreib-Endpunkte | `brain.ts` | keine — verschiedene Dateien |
+| `k3d/network-policies.yaml` | — | brain-Policy | keine |
+| `.lavish/kit/panel.js` | Aktions-Slot (D4) | Kontext-Slot | möglich, verschiedene Funktionen |
+| **`.lavish/kit/adapter.js`** | Schreibmethoden + Endpunkt-Karte | `brain()` | **ja** |
+
+Die Kollision in `adapter.js` liegt an genau zwei Stellen: dem Funktionsblock
+und der Zeile im `return`-Objekt. Sie ist **bekannt, klein und trivial
+auflösbar** — beide Blöcke behalten. Genau dieser Konflikt trat bei K5 und K9
+auf und war in Minuten gelöst.
+
+Sie wird bewusst **nicht** durch Vorziehen eines gemeinsamen Vorlaufs vermieden:
+das würde eine Abhängigkeit zwischen zwei sonst unabhängigen Kindern schaffen,
+um einen Zweizeilen-Konflikt zu sparen. Wer zuerst merged, gewinnt; der zweite
+rebased.
+
+> `file_locks` im Plan-Frontmatter hilft hier **nicht** — das Feld wird zwar
+> geschrieben und beim Frontmatter-Setzen geprüft, aber von keinem Scheduler
+> ausgewertet. Es dokumentiert, es koordiniert nicht.
+
 ## Folgeschritte in den Kind-Tickets
 
 **K4 (T002463)** — setzt Klasse A um:
@@ -56,13 +93,51 @@ Begründung und Belege: siehe `proposal.md`. Die verbindlichen Zusagen stehen in
 
 - Website-API liest `brain.workspace.svc.cluster.local`, erzwingt `isAdmin`
 - Kontext-Slot der Panels mit Brain-Verweisen füllen
-- **Vorbedingung:** der interne Weg ist heute nicht durchgängig (Egress erlaubt,
-  Verbindung scheitert dennoch — Port 80 „refused", 8787 Timeout, Pod läuft).
-  Ursache cluster-seitig klären, bevor K6 dispatched wird.
+- **Erster Task: die fehlende NetworkPolicy.** Ursache geklärt — im
+  `workspace`-Namespace wirkt `allow-intra-namespace-ingress` mit leerem
+  `podSelector` als Default-Deny für alles von außerhalb. Für jeden Dienst, den
+  die Website erreichen darf, existiert eine eigene Policy nach striktem Muster;
+  für `brain` fehlt sie. Ergänzung in `k3d/network-policies.yaml`:
 
-**K7-Nachtrag (T002466, bereits gemergt)** — der offene Punkt 4 bekommt hiermit
-seine Antwort: der Adapter löst seine Basis-Adresse aus dem Host-Kontext auf,
-statt `http://127.0.0.1:49152` fest zu verdrahten. Umzusetzen mit K4.
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-website-to-brain-ingress
+  namespace: workspace
+spec:
+  podSelector:
+    matchLabels:
+      app: brain
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: website
+      ports:
+        - port: 8787      # Container-Port; der Service mappt 80 -> 8787
+          protocol: TCP
+```
+
+  Vorbild: `allow-website-to-vaultwarden-ingress` in derselben Datei. Der
+  Service ist gesund (Endpoint `10.42.3.194:8787`, Selector passt, Pod 1/1) —
+  es fehlt allein die Erlaubnis.
+
+**K7-Nachtrag (T002466, bereits gemergt)** — der offene Punkt 4 zerfällt in zwei
+Teile, und nur der kleinere gehört zu K4:
+
+- **Endpunkt-Karte statt Basis-Konstante** (mit K4): der Adapter entscheidet pro
+  Endpunkt, welcher Host ihn bedient. Klein, und Voraussetzung dafür, dass K4
+  und K6 ihre neuen Website-Endpunkte überhaupt ansprechen können.
+- **Fehlende Endpunkte auf der Website nachbauen** (eigener Vorgang, später):
+  `epics`, `styles` und `ci` sind dort noch nicht vorhanden. Solange sie fehlen,
+  bleiben sie in der Karte auf „Daemon". `agents` und `models` bleiben
+  **dauerhaft** dort — sie lesen lokalen Zustand.
+
+Die ursprüngliche Formulierung „der Adapter löst seine Basis-Adresse aus dem
+Host-Kontext auf" war zu grob: die Website bedient heute nur drei der acht
+Endpunkte. Ein globaler Umschalter hätte fünf Panels auf `404` gestellt.
 
 ## Verify
 


### PR DESCRIPTION
Nachtrag zu `cockpit-auth-schnitt` (#3602). Zwei Klärungen, ohne die K4 und K6 **nicht** unabhängig planbar gewesen wären.

## 1. Der Adapter braucht eine Endpunkt-Karte, keinen Basis-Schalter

Die vorherige Fassung sagte, der Adapter löse seine Basis-Adresse aus dem Host-Kontext auf. **Das war zu grob und hätte die Admin-Seite beschädigt.** Von den acht Endpunkten, die der Adapter anspricht, bedient die Website heute nur drei — ein globaler Umschalter hätte **fünf Panels auf 404** gestellt.

Die Aufteilung folgt daraus, wo die Daten wirklich liegen:

| Endpunkt | Quelle | Verfügbar von |
|---|---|---|
| `portfolio`, `pods-list`, `factory-control` | DB, kubectl, Factory | Website (existiert) |
| `epics` | Ticket-DB | Website (baubar) |
| `styles` | Repo-Dateien | Website (baubar) |
| `ci` | GitHub-API | Website (baubar) |
| `agents` | Agent-Locks im `git-common-dir` | **nur Daemon** |
| `models` | Modell-Ports auf `127.0.0.1` | **nur Daemon** |

`agents` und `models` sind nicht bloß ungebaut — sie lesen Zustand, den es nur auf einem Entwicklerrechner gibt. Sie bleiben dauerhaft beim Daemon.

Damit zerfällt der K7-Rest in ein kleines Stück (die Karte, mit K4) und ein späteres Thema (fehlende Endpunkte nachbauen). **Keines blockiert K4 oder K6.**

## 2. K6s Blocker ist eine fehlende NetworkPolicy

Im Namespace `workspace` wirkt `allow-intra-namespace-ingress` mit leerem `podSelector` als **Default-Deny für alles von außen**. Für jeden Dienst, den die Website erreichen darf, existiert eine eigene Policy nach striktem Muster — `allow-website-to-{shared-db,pocket-id,nextcloud,vaultwarden,docuseal}-ingress`. **Für `brain` fehlt sie.** Der Timeout auf 8787 ist das erwartete Verhalten einer verworfenen Verbindung.

Der Service ist gesund: Endpoint `10.42.3.194:8787`, Selector passt, Pod 1/1 seit 9 Tagen. Das fertige Manifest steht als erster Task im Plan.

## Parallelität — die eine echte Kollisionsstelle

Beide Kinder teilen genau eine Datei: `.lavish/kit/adapter.js`, und dort genau zwei Stellen (Funktionsblock plus eine Zeile im `return`-Objekt). Der Konflikt ist **bekannt und trivial** — beide Blöcke behalten, wie bei K5/K9 erlebt und dort in Minuten gelöst.

Bewusst **kein** gemeinsamer Vorlauf: das würde eine Abhängigkeit zwischen zwei sonst unabhängigen Kindern schaffen, um einen Zweizeilen-Konflikt zu sparen.

> Notiert ist auch, dass `file_locks` im Plan-Frontmatter hier **nicht** hilft: das Feld wird geschrieben und beim Frontmatter-Setzen geprüft, aber von keinem Scheduler ausgewertet. Es dokumentiert, es koordiniert nicht.

## DoR

`T002465` (K6) `offene_fragen_geklaert` → `true`. Beide Kinder sind damit planungsreif und können parallel geplant werden.

## Verifikation

- `openspec.sh validate` → OK
- `freshness:check` → grün
- Beide Kind-Tickets tragen die Klärung als Kommentar

Nebenbefund als **T002529** erfasst: `check-commit-vs-diff.sh` empfiehlt in seiner Fehlermeldung den Scope `chore(plan):`, den `validate-commit-msg.sh` seit T002328 ablehnt (`plan` → `plans`). Wer der Empfehlung folgt, läuft garantiert in einen zweiten Fehlschlag — hier live passiert.

Ticket: T002463
