### PR TITLE
chore(scripts): Mishap-Fixes M2/M4/M5/M6/M8/M9/M10 aus T002498

### DIFF
--- a/.claude/skills/references/repo-hygiene-ops.md
+++ b/.claude/skills/references/repo-hygiene-ops.md
@@ -121,6 +121,22 @@ TICKET_ID=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oiE 'T[0-9]{6}' | head -1 
   > # SQUASH=$(git log origin/main --grep="<TICKET_ID>" --format='%cI' -1)
   > # [ -n "$SQUASH" ] || { echo "FAIL: kein Squash-Commit gefunden"; exit 1; }
   > ```
+  > **Leere Antwort ist KEIN Urteil [T002498-M5]:** Der Timestamp-Verifikation fehlt der
+  > Fall „Antwort fehlt ganz". Schlägt der vorangegangene `gh`-Aufruf fehl (z.B.
+  > `error connecting to api.github.com`), ist `$m` LEER — und „leer = offen" würde einen
+  > Merge-Watch fälschlich als „kein Wissen" statt als Fehler behandeln. Eine Watch-Schleife
+  > der Form `grep -q '^merged=nein' || { echo GEMERGT; break; }` wertet dieselbe leere Antwort
+  > als Erfolg (beobachtet bei PR #3563: open + DIRTY, gemeldet als gemergt). Gemeinsamer
+  > Nenner aller drei Fälle (0 Checks, leeres Log, leere Antwort): **die auswertende Logik muss
+  > eine LEERE Antwort von einer NEGATIVEN unterscheiden.** Korrektes Muster — erst die leere
+  > Antwort abfangen und explizit NICHT urteilen, dann auf das positive Signal prüfen, nie auf
+  > die Abwesenheit des negativen:
+  > ```bash
+  > raw=$(gh pr view <number> --json mergedAt 2>/dev/null)
+  > [ -n "$raw" ] || { echo "API-Fehler — KEIN Urteil, erneut versuchen"; exit 1; }
+  > m=$(printf '%s' "$raw" | jq -r '.mergedAt')
+  > [ -n "$m" ] && [ "$m" != "null" ] || { echo "FAIL: mergedAt leer"; exit 1; }
+  > ```
   Bei noch laufendem CI stattdessen `--auto` — GitHub mergt, sobald die Checks grün sind.
 
 * **Ticket schließen, sobald `mergedAt` gesetzt ist** (nur wenn `$TICKET_ID` gefunden;

--- a/.claude/skills/references/ticket-ops-procedures.md
+++ b/.claude/skills/references/ticket-ops-procedures.md
@@ -238,6 +238,13 @@ Edges come from two sources — merge both:
 > `agent-lock.sh check ticket <id>` ausgeführt. Bereits belegte Tickets (Status `held`) werden
 > vor dem Worktree-Setup gemeldet und zurückgestellt — teure Worktree-Erstellung für blockierte
 > Tickets entfällt. [T002424]
+>
+> **Lock-Scope-Vollständigkeit [T002498-M6]:** `check ticket <id>` allein greift strukturell
+> nicht: die dev-flow-*-Skills locken BRANCH-scoped (`agent-lock.sh claim branch <branch>`),
+> der ticket-Scope bleibt dabei leer (beobachtet bei T002497 — `check ticket` → `free`, der
+> zugehörige Branch-Lock `fix/vitest-main-red-T002497` → `held`). Ein dev-flow-verarbeitetes
+> Ticket meldet sich gegenüber ticket-ops also IMMER als frei. Der Pre-Check prüft deshalb
+> BEIDE Scopes und zusätzlich die Lock-Bestände:
 
 0. **Pre-Check:** For each wave-1 ticket, run `bash scripts/agent-lock.sh check ticket <ext-id>`.
    Collect all tickets that return `held` and report them:
@@ -246,6 +253,19 @@ Edges come from two sources — merge both:
    LOCK-KONFLIKT: T002YYY bereits gehalten von gemini (sid …, worktree …, …)
    ```
    Remove held tickets from the wave set. Proceed only with free tickets.
+
+   **[T002498-M6] Scope-übergreifende Prüfung** — `check ticket` ergänzen um:
+   ```bash
+   # 1) Branch-Scope des geplanten Arbeitstickets (dev-flow-*-Skills locken hier).
+   bash scripts/agent-lock.sh check branch "fix/<slug>-<ext-id>"   # "held" → LOCK-KONFLIKT
+   # 2) Jeden Lock-Bestand nach der Ticket-ID durchsuchen — Locks JEDES Scopes,
+   #    deren Branch- oder Worktree-Feld die ID trägt.
+   bash scripts/agent-lock.sh list | grep -E "<ext-id>"
+   # 3) Dirty Worktrees mit der ID im Verzeichnisnamen (der einzige verlässliche
+   #    Beleg für ungestaged Arbeit einer laufenden Session).
+   for wt in .worktrees/*"<ext-id>"*; do [ -d "$wt" ] && { git -C "$wt" status --porcelain | grep -q . \
+     && echo "DIRTY-WORKTREE: $wt"; }; done
+   ```
 
 ### Step 3.4: Route each ticket (plan vs. execute with subagent orchestration)
 

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -126,6 +126,14 @@ Routing (plan vs. execute), das Masterplan-Format und der Wave-1-Dispatch:
 > gehalten von ...`). Der Dispatch fährt nur mit den freien Tickets fort. Dadurch wird
 > verhindert, dass bereits belegte Tickets erst nach dem Aufbau des Worktrees (kostspielig)
 > als blockiert erkannt werden.
+>
+> **Beide Lock-Scopes prüfen [T002498-M6]:** `check ticket` allein greift nicht — die
+> dev-flow-*-Skills locken branch-scoped, das Feld `held` bleibt dann für das Ticket leer
+> (T002497). Zusätzlich `check branch <vorgesehener-branch>` sowie
+> `agent-lock.sh list | grep <ext-id>` (Locks jeden Scopes) und ein Porcelain-Check auf
+> Worktrees mit der ID im Namen ausführen — Details in
+> [`ticket-ops-procedures`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/ticket-ops-procedures.md)
+> §Step 3.3.
 
 **Merge = Abschluss:** Jedes Ticket schließt über seinen eigenen grünen Auto-Merge; der
 Masterplan verfolgt den Dispatch, nicht den Prod-Live-Stand.

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 699,
+      "file_count": 700,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -466,6 +466,7 @@
         "tests/spec/pr-refresh.bats",
         "tests/spec/pre-commit-freshness.bats",
         "tests/spec/projekttickets-cockpit.bats",
+        "tests/spec/public-symlinks-resolve-in-image.bats",
         "tests/spec/questionnaire-system.bats",
         "tests/spec/react-homepage-blocks.bats",
         "tests/spec/react-login-edit-homepage.bats",

--- a/scripts/plan-intel.sh
+++ b/scripts/plan-intel.sh
@@ -53,7 +53,14 @@ if [[ -f "$EXISTING_INTEL" ]]; then
   RISKS_EXTRA="$(jq -c '.risks // []' "$EXISTING_INTEL")"
 fi
 
-GIT_SHA="$(cd "$REPO_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+# [T002498-M2] Bezugspunkt ist origin/main, NICHT HEAD. Die intel.json behauptet
+# mit "generated_from: main@<sha>" einen main-Stand zu messen. Lief der Generator
+# im Hauptcheckout auf einem Feature-Branch, wurde dort HEAD als "main" verbucht
+# und das Artefakt eines fremden Changes trug einen Feature-Commit samt falscher
+# LOC-Zahlen (beobachtet bei T002493, Feature-Commit 364742268). origin/main ist
+# der einzige main, den das Feld ehrlich bezeugen darf. Fallback auf HEAD nur,
+# wenn kein origin/main existiert (z.B. detached, erster Push).
+GIT_SHA="$(cd "$REPO_ROOT" && { git rev-parse --short origin/main 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "unknown"; })"
 GENERATED_FROM="${GIT_SHA:+main@$GIT_SHA}"
 [[ "$GIT_SHA" == "unknown" ]] && GENERATED_FROM="unknown"
 

--- a/scripts/vda/ticket/_ticket-core.sh
+++ b/scripts/vda/ticket/_ticket-core.sh
@@ -121,13 +121,33 @@ _ticket_lock_guard() {
   # dupliziert sie und laeuft auseinander.
   out="$(CLAUDE_CODE_SESSION_ID="${CLAUDE_CODE_SESSION_ID:-}" CLAUDE_SESSION_ID="${CLAUDE_SESSION_ID:-}" bash "$lock_sh" check ticket "$id" 2>/dev/null)"; rc=$?
   if [[ $rc -eq 3 ]]; then
-    echo "ERROR: Ticket $id ist durch eine andere Session gesperrt (agent-lock) — Status-Schreibvorgang verweigert." >&2
-    echo "       Halter: $(printf '%s' "$out" | tr '\n' ' ')" >&2
+    # [T002498-M10] SID-Drift pro Aufrufkontext: der Claim lief über Bash, der
+    # Write über den MCP-Prozess — beide melden für DIESELBE Session verschiedene
+    # SIDs (beobachtet bei T002494-Dispatch). Der Lock-Guard blockierte daraufhin
+    # den eigenen Status-Write und bezeichnete die eigene Session als "ANDERE".
+    # Bei Gleichheit der Halter-SID mit der eigenen Session ist es kein fremder
+    # Lock → ohne Override durchlassen. Die Harness-UUID ist die einzige stabile
+    # Session-Kennung (Unix-SID wechselt pro Bash-Call, T002375-p1).
+    local my_sid holder_sid
+    my_sid="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+    holder_sid="$(printf '%s' "$out" | sed -n 's/.*"owner_sid": *"\([^"]*\)".*/\1/p' | head -1)"
+    if [[ -n "$my_sid" && -n "$holder_sid" && "$my_sid" == "$holder_sid" ]]; then
+      return 0
+    fi
+    # [T002498-M10] Meldung entschärft: der Halter ist nicht zwingend eine fremde
+    # Session (SID-Drift möglich) — das sagen statt einer falschen Behauptung, und
+    # Halter-Felder (tool/label/pid) zur Einordnung mitgeben. Der Halter-Block kam
+    # schon vorher; es fehlte nur die Einordnung, welchen Schutz das Override kostet.
+    local holder_label holder_tool
+    holder_label="$(printf '%s' "$out" | sed -n 's/.*"label": *"\([^"]*\)".*/\1/p' | head -1)"
+    holder_tool="$(printf '%s' "$out" | sed -n 's/.*"tool": *"\([^"]*\)".*/\1/p' | head -1)"
+    echo "ERROR: Ticket $id ist gesperrt (agent-lock) — Status-Schreibvorgang verweigert." >&2
+    echo "       Halter: tool=${holder_tool:-?}, label=${holder_label:-?}, sid=${holder_sid:-?} (siehe \"$(printf '%s' "$out" | tr '\n' ' ')\")" >&2
     # [T002424-M1] Diagnose: die eigene SID mit ausgeben. Ohne sie ist aus der
     # Meldung nicht ersichtlich, WARUM der Halter als fremd gilt — genau das
     # kostete bei T002424 eine Untersuchungsschleife.
-    echo "       Eigene SID: ${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-<nicht gesetzt>}} (Shell-PID $$)" >&2
-    echo "       Override nur bewusst: TICKET_LOCK_OVERRIDE=1" >&2
+    echo "       Eigene SID: ${my_sid:-<nicht gesetzt>} (Shell-PID $$)" >&2
+    echo "       Falls der Halter diese Session ist, gezielt durchlassen: TICKET_LOCK_OVERRIDE=1" >&2
     return 7
   fi
   return 0

--- a/scripts/vda/ticket/triage.sh
+++ b/scripts/vda/ticket/triage.sh
@@ -15,7 +15,7 @@ show_help() {
   vda_header "vda.sh ticket triage"
   echo "Usage: vda.sh ticket triage --id <ext-id> [flags]"
   echo ""
-  echo "Flags: --priority, --severity, --status, --component, --suggest, --apply, --no-comment, -h|--help"
+  echo "Flags: --priority, --severity, --status, --component, --type, --attention-mode, --suggest, --apply, --no-comment, -h|--help"
 }
 
 main() {
@@ -55,8 +55,10 @@ main() {
     # In non-interactive mode, only require fields that are explicitly being set.
     # If a field is not provided as a flag, skip the interactive prompt but don't error—
     # the database UPDATE will only set non-empty values.
-    [[ -n "$priority" || -n "$severity" || -n "$status" || -n "$type" || -n "$attention_mode" ]] || \
-      { vda_error "At least one field (--priority, --severity, --status, --type, --attention-mode) must be provided in non-interactive mode"; exit 2; }
+    # [T002498-M9] `component` zählt mit: es IST ein änderbares Feld des Tools,
+    # sein Fehlen in dieser Liste machte reine Komponenten-Nachtragungen unmöglich.
+    [[ -n "$priority" || -n "$severity" || -n "$status" || -n "$component" || -n "$type" || -n "$attention_mode" ]] || \
+      { vda_error "At least one field (--priority, --severity, --status, --component, --type, --attention-mode) must be provided in non-interactive mode"; exit 2; }
   fi
 
   local pod; pod=$(_pgpod)
@@ -67,10 +69,10 @@ SQL
 )
   [[ -z "$ticket" || "$ticket" == "null" ]] && { vda_error "Ticket $id not found"; exit 1; }
 
-  vda_header "Ticket $id"
-  for field in title type status priority severity component; do
-    vda_section "${field^}" "$(jq -r ".$field // \"—\"" <<<"$ticket" 2>/dev/null || echo "—")"
-  done; echo ""
+  # [T002498-M8] Der frühere Header-Block zeigte den Zustand VOR der Änderung —
+  # mit "—" für noch nicht gesetzte Felder. Zusammen mit der unvollständigen
+  # Bestätigungszeile unten suggerierte er einen Teilfehlschlag. Der VOR-Block
+  # wird nicht mehr ausgegeben; die Bestätigung am Ende listet den NACH-Zustand.
 
   if [[ "$suggest" == "true" ]]; then
     local r; r=$(curl -fsS -X POST "${TRIAGE_API_URL:-http://localhost:4321/api/admin/tickets}/${id}/triage" 2>/dev/null || true)
@@ -121,7 +123,21 @@ INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility) 
 SQL
   fi
 
-  vda_success "Ticket $id triaged: ${priority}/${severity} → ${status}"
+  # [T002498-M8] Die Bestätigung listet ALLE im Aufruf übergebenen (nicht-leeren)
+  # Felder — vorher zeigte das Template nur "<priority>/<severity> → <status>",
+  # ein Aufruf mit severity+component+attention_mode ergab "✓ /critical →" und
+  # suggerierte einen Teilfehlschlag, obwohl alle Felder korrekt geschrieben
+  # wurden. Der obenstehende VOR-Zustand-Block verstärkte den Eindruck (zeigte
+  # "—" für noch nicht gesetzte Felder) und wurde dafür entfernt.
+  local changed=() kv
+  for kv in "priority=$priority" "severity=$severity" "status=$status" "component=$component" "type=$type" "attention_mode=$attention_mode"; do
+    [[ -n "${kv#*=}" ]] && changed+=("$kv")
+  done
+  if [[ ${#changed[@]} -gt 0 ]]; then
+    vda_success "Ticket $id triaged: ${changed[*]}"
+  else
+    vda_success "Ticket $id triaged (keine Felder gesetzt)"
+  fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi

--- a/tests/spec/public-symlinks-resolve-in-image.bats
+++ b/tests/spec/public-symlinks-resolve-in-image.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+#
+# Prüfmodus: ERGEBNIS-Test (Test-Resultats-Konvention T002448-M4).
+#
+# Hintergrund [T002498-M4] (Verallgemeinerung von T002466): Jeder Symlink unter
+# einem `*/public/`-Verzeichnis, der AUS dem vom Dockerfile kopierten Teilbaum
+# HERAUSZEIGT, hat dieselbe Eigenschaft: lokal grün, im Image tot. `pnpm dev` und
+# ein lokaler Build servieren aus dem Checkout (Symlinks intakt), das Dockerfile
+# kopiert aber nur den App-Teilbaum — die relativen Ziele außerhalb davon
+# existieren im Image nicht. Genau diese Divergenz misst der Test: er baut die
+# COPY-Semantik des Dockerfiles nach und prüft die Auflösbarkeit am Ergebnis,
+# statt nach bestimmten COPY-Zeilen zu greppen.
+#
+# Die spezifischen Cockpit-Assets prüft tests/spec/sdlc-cockpit/kit-assets-in-image.bats;
+# dieser Test ist der generische Wächter über ALLE Apps mit Dockerfile+public/.
+# Konkrete Pfade werden hier wörtlich geführt (auch in Kommentaren), damit
+# find-changed-tests.sh per grep-Probe diesen Test bei Änderungen an
+# website/public/cockpit/, website/.lavish/ oder website/Dockerfile selektiert
+# (T002345).
+
+setup() {
+  REPO="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  cd "$REPO" || return 1
+}
+
+# Bildet `COPY <app>/ .` (WORKDIR /app) nach: der public/-Teilbaum landet im Ziel,
+# Symlinks werden als Symlinks übernommen. Nur public/, nicht die ganze App —
+# sonst zöge der Test in CI node_modules mit (T002499).
+_simulate_public_copy() {
+  local dest="$1" app="$2"
+  mkdir -p "$dest/public"
+  cp -r "$app/public/." "$dest/public/" 2>/dev/null || true
+}
+
+# Prüft, ob ein relativer Symlink-Pfad aus dem Teilbaum herauszeigt: zählt die
+# `..`-Segmente gegen die Verzeichnistiefe. Genau das bestimmt, ob ein `COPY`
+# des public/-Teilbaums das Ziel mitnimmt oder nicht.
+_escapes_root() {
+  local target="$1"
+  case "$target" in
+    /*) return 0 ;;        # absolutes Ziel → außerhalb des Teilbaums
+  esac
+  local up=0 dirs=0 seg
+  IFS='/' read -r -a segs <<<"$target"
+  for seg in "${segs[@]}"; do
+    if [ "$seg" = ".." ]; then up=$((up + 1)); elif [ -n "$seg" ]; then dirs=$((dirs + 1)); fi
+  done
+  [ "$up" -gt "$dirs" ]   # mehr .. als verbleibende Verzeichnisse → raus
+}
+
+@test "T002498-M4: public/-Symlinks bleiben im Docker-Image-Layout auflösbar" {
+  local apps=()
+  local app dockerfile
+  for dockerfile in */Dockerfile; do
+    [ -f "$dockerfile" ] || continue
+    app="${dockerfile%%/*}"
+    [ -d "$app/public" ] || continue
+    apps+=("$app")
+  done
+  [ ${#apps[@]} -gt 0 ] || { echo "keine App mit Dockerfile+public/ gefunden"; return 1; }
+
+  local failures=0
+  for app in "${apps[@]}"; do
+    dockerfile="$app/Dockerfile"
+    # Baukontext bestimmen: referenziert das Dockerfile `COPY <app>/`, baut es
+    # auf dem Repo-Root auf; sonst auf dem App-Root (z.B. brett: COPY src ...).
+    local context="$app"
+    if grep -qE "^COPY[[:space:]]+${app}/" "$dockerfile"; then context="."; fi
+
+    while IFS= read -r link; do
+      [ -n "$link" ] || continue
+      local target
+      target="$(readlink "$link")"
+      _escapes_root "$target" || continue
+
+      # Positiv-Anker (T002356-M1): im Checkout MÜSSEN die Symlinks auflösen —
+      # sonst wäre die Aussage vakuos (Symlink schlicht gelöscht).
+      [ -e "$link" ] || { echo "Vorbedingung verletzt: $link löst im Checkout nicht auf"; failures=$((failures + 1)); continue; }
+
+      local stage="$BATS_TEST_TMPDIR/${app}-app"
+      mkdir -p "$stage"
+      _simulate_public_copy "$stage" "$app"
+
+      # COPY-Zeilen (ohne --from, das ist eine spätere Build-Stage) nachfahren,
+      # um das Ergebnis zu messen statt es zu unterstellen. Format:
+      # COPY <src> <dest>, src relativ zum Baukontext, dest relativ zu WORKDIR.
+      local _prev line
+      while IFS= read -r line; do
+        case "$line" in
+          COPY[[:space:]]--from=*) continue ;;
+          COPY[[:space:]]*) ;;
+          *) continue ;;
+        esac
+        set -- $line; shift  # "COPY"
+        local src dest
+        src="$1"; dest="$2"
+        [ -n "$src" ] && [ -n "$dest" ] || continue
+        # src gegen den Baukontext auflösen
+        local src_path
+        if [ "$context" = "." ]; then src_path="$REPO/$src"; else src_path="$context/$src"; fi
+        [ -e "$src_path" ] || continue
+        # dest "." = der gesamte public/-Teilbaum wurde oben schon kopiert.
+        if [ "$dest" = "." ] || [ "$dest" = "./" ]; then continue; fi
+        local target_path="$stage/${dest#./}"
+        mkdir -p "$(dirname "$target_path")"
+        rm -rf "$target_path"
+        cp -rL "$src_path" "$target_path" 2>/dev/null || true
+      done < <(grep -E '^COPY[[:space:]]' "$dockerfile")
+
+      # Die eigentliche Aussage: nach der COPY-Simulation auflösbar.
+      local link_rel
+      link_rel="${link#"$app"/}"
+      if [ ! -e "$stage/$link_rel" ]; then
+        echo "FAIL: $link ($app) zeigt auf $target — im Image-Layout NICHT auflösbar (kopierter Teilbaum: $context)"
+        failures=$((failures + 1))
+      fi
+    done < <(find "$app/public" -type l 2>/dev/null)
+  done
+
+  [ "$failures" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2802,6 +2802,12 @@
     "kind": "shell"
   },
   {
+    "id": "public-symlinks-resolve-in-image",
+    "file": "tests/spec/public-symlinks-resolve-in-image.bats",
+    "category": "public-symlinks-resolve-in-image",
+    "kind": "shell"
+  },
+  {
     "id": "questionnaire-system",
     "file": "tests/spec/questionnaire-system.bats",
     "category": "questionnaire-system",


### PR DESCRIPTION
**Fixes aus T002498 (Mishap-Bundle 2)**

| Mishap | Fix |
|--------|-----|
| M2 | `plan-intel.sh`: GIT_SHA bezieht sich auf `origin/main` statt `HEAD` |
| M4 | Generischer Guard `tests/spec/public-symlinks-resolve-in-image.bats` — public/-Symlinks müssen im Image-Layout auflösbar sein (Verallgemeinerung von T002466) |
| M5 | `repo-hygiene-ops.md` §3: leere Antwort = KEIN Urteil |
| M6 | `ticket-ops-procedures.md` + SKILL.md: beide Lock-Scopes prüfen |
| M8 | `triage.sh`: Bestätigung zeigt nur übergebene Felder, kein VOR-Zustand |
| M9 | `triage.sh`: `component` ist Pflichtfeld bei nicht-interaktiver Validierung |
| M10 | `_ticket-core.sh`: eigene Session-ID wird beim Lock durchgelassen, Meldung entschärft |

**M7 (stale ticket-mcp-go Binary)**: Fix verifiziert — Binary wurde neu gebaut + installiert, enthält `Incident-Ticket angelegt`.
**M1** → separates Ticket T002522. **M3** → bereits gefixt via T002523.

**Verifikation**: bash -n für geänderte Skripte, betroffene BATS-Specs grün (ticket-system 70, dev-flow-plan 45, public-symlinks+kit-assets grün, test-inventory grün nach Regenerierung). Pre-commit (vorbestehend, Environment): `yaml`/`hono` fehlen in lokaler node_modules → ci-cd/daemon/FA-SF-57 scheitern auch auf main.