### PR TITLE
fix(agents): brain-ingest auf beliebigen OpenAI-kompatiblen Anbieter umstellen [T002533]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 700,
+      "file_count": 701,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -338,6 +338,7 @@
         "tests/spec/billing-pipeline.bats",
         "tests/spec/brain-auto-memory.bats",
         "tests/spec/brain-foundation.bats",
+        "tests/spec/brain-foundation/ingest-llm-endpoint.bats",
         "tests/spec/brain-foundation/k1-vector-db-doc.bats",
         "tests/spec/brain-gekko-inbox.bats",
         "tests/spec/brain-ingest.bats",

--- a/scripts/brain-ingest-transform.sh
+++ b/scripts/brain-ingest-transform.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 # brain-ingest-transform.sh — LLM-assisted transformation of source files
-# into brain wiki pages. Calls a local llama-server ingest-pool endpoint
-# (OpenAI-compatible; standalone llama-server.exe, not LM Studio's own
-# server — see start-qwen36-ingest-pool.ps1, -np 6 concurrent slots).
+# into brain wiki pages. Calls any OpenAI-compatible chat endpoint: a local
+# llama-server from scripts/llm/loadouts.json, or a hosted provider such as
+# DeepSeek when LM_API_KEY is set.
+#
+# Es gibt bewusst KEINE Vorgabe-Adresse mehr. Die frühere Vorgabe zeigte auf
+# einen Ingest-Pool (localhost:8093, qwen3.6-14b-a3b-fablevibes), der mit dem
+# Loadout-Umbau entfallen ist — samt des hier einmal genannten Startskripts
+# start-qwen36-ingest-pool.ps1. Weil das Skript trotzdem startete, meldete es
+# 92-mal einzeln "LLM failed" statt einmal zu sagen, dass es kein Ziel hat.
+# LM_STUDIO_URL und LM_MODEL sind deshalb Pflicht. [T002533]
 #
 # Usage: brain-ingest-transform.sh <source_file> <type> <slug> <slugs_json> <tag_defaults_json>
 #
@@ -14,9 +21,18 @@
 #   tag_defaults_json — JSON array of default tags for the group
 #
 # Env:
-#   LM_STUDIO_URL    — ingest-pool API URL (default: http://localhost:8093;
-#                      var name kept for backward compat, it's not LM Studio)
-#   LM_MODEL         — Model to use (default: qwen3.6-14b-a3b-fablevibes)
+#   LM_STUDIO_URL    — REQUIRED. OpenAI-compatible base URL, e.g.
+#                      http://127.0.0.1:8091 or https://api.deepseek.com
+#                      (var name kept for backward compat, it's not LM Studio)
+#   LM_MODEL         — REQUIRED. Model id, e.g. deepseek-chat
+#   LM_API_KEY       — Optional. Sent as `Authorization: Bearer`. Leer lassen
+#                      für lokale llama-server, die keine Auth erwarten.
+#   LM_DISABLE_THINKING — Optional (1). Schaltet die Denkphase ab. Pflicht bei
+#                      DeepSeek v4: sonst verbraucht das Modell das gesamte
+#                      Token-Budget in `reasoning_content` und liefert leeres
+#                      `content`. Mehr max_tokens hilft nicht — das Denken
+#                      waechst mit. Bei DeepSeek wirkt `thinking.type=disabled`;
+#                      `enable_thinking:false` wird dort ignoriert. [T002533]
 #   MAX_SOURCE_CHARS — Max source chars to send to LLM (default: 4000)
 #
 # Output: Transformed markdown with frontmatter to stdout
@@ -29,8 +45,12 @@ SLUG="${3:?page slug required}"
 SLUGS_JSON="${4:?slugs json required}"
 TAG_DEFAULTS="${5:?tag defaults json required}"
 
-LM_URL="${LM_STUDIO_URL:-http://localhost:8093}"
-LM_MODEL="${LM_MODEL:-qwen3.6-14b-a3b-fablevibes}"
+LM_URL="${LM_STUDIO_URL:?LM_STUDIO_URL required (OpenAI-compatible base URL, e.g. https://api.deepseek.com)}"
+LM_MODEL="${LM_MODEL:?LM_MODEL required (model id, e.g. deepseek-chat)}"
+LM_API_KEY="${LM_API_KEY:-}"
+# Gehostete Anbieter antworten spuerbar langsamer als ein lokaler llama-server;
+# 90 s reichen dort nicht zuverlaessig fuer 3072 Ausgabe-Tokens.
+LM_TIMEOUT="${LM_TIMEOUT:-180}"
 MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-4000}"
 
 # Validate source file exists
@@ -71,24 +91,44 @@ ${CONTENT}
 
 Gib NUR das fertige Markdown aus:"
 
-# Call LM Studio API with optimized settings, populating $OUTPUT.
+# Call the OpenAI-compatible chat endpoint, populating $OUTPUT.
+#
+# Der API-Schluessel geht ueber `curl --config -` (stdin), NICHT als -H-Argument:
+# alles in argv ist auf dem Host per `ps` fuer jeden anderen Prozess lesbar. Ohne
+# Schluessel bleibt die Konfiguration leer und das Verhalten unveraendert.
 call_llm() {
-  local prompt="$1" response
-  response="$(curl -sf --max-time 90 "${LM_URL}/v1/chat/completions" \
+  local prompt="$1" response curl_cfg="" think='{}'
+  [ -n "$LM_API_KEY" ] && curl_cfg="$(printf 'header = "Authorization: Bearer %s"' "$LM_API_KEY")"
+  [ "${LM_DISABLE_THINKING:-0}" = "1" ] && think='{"thinking":{"type":"disabled"}}'
+  response="$(printf '%s\n' "$curl_cfg" | curl -sf --config - --max-time "$LM_TIMEOUT" "${LM_URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d "$(jq -n \
       --arg model "$LM_MODEL" \
       --arg prompt "$prompt" \
-      '{model: $model, messages: [{role: "user", content: $prompt}], temperature: 0.2, max_tokens: 3072, top_p: 0.9}')" 2>&1)" || {
-    echo "error: LM Studio API call failed" >&2
+      --argjson think "$think" \
+      '{model: $model, messages: [{role: "user", content: $prompt}], temperature: 0.2, max_tokens: 3072, top_p: 0.9} + $think')" 2>&1)" || {
+    echo "error: chat completion request failed (${LM_URL}, model ${LM_MODEL})" >&2
     echo "$response" >&2
     exit 1
   }
 
   OUTPUT="$(echo "$response" | jq -r '.choices[0].message.content // empty')"
   if [ -z "$OUTPUT" ]; then
-    echo "error: empty response from LM Studio" >&2
-    echo "$response" >&2
+    # Leeres content bei gefuelltem reasoning_content ist kein Anbieterfehler,
+    # sondern ein Reasoning-Modell, das sein ganzes Budget verdacht hat. Diese
+    # Unterscheidung gehoert in die Meldung — ohne sie sieht der Fall aus wie
+    # ein toter Endpunkt und man sucht an der falschen Stelle. [T002533]
+    local reason_len finish
+    reason_len="$(echo "$response" | jq -r '(.choices[0].message.reasoning_content // "") | length' 2>/dev/null || echo 0)"
+    finish="$(echo "$response" | jq -r '.choices[0].finish_reason // "?"' 2>/dev/null || echo '?')"
+    if [ "${reason_len:-0}" -gt 0 ]; then
+      echo "error: leeres content, aber ${reason_len} Zeichen reasoning_content (finish_reason=${finish})." >&2
+      echo "       Das Modell hat sein Token-Budget im Denken verbraucht. Setze LM_DISABLE_THINKING=1." >&2
+      echo "       Mehr max_tokens hilft nicht — die Denkphase waechst mit." >&2
+    else
+      echo "error: empty response from ${LM_URL} (model ${LM_MODEL}, finish_reason=${finish})" >&2
+      echo "$response" >&2
+    fi
     exit 1
   fi
 

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -238,6 +238,29 @@ echo ""
 echo ""
 echo "Phase 2 complete: Processed=$PROCESSED, Skipped=$SKIPPED, Failed=$FAILED (parallel, MAX_PARALLEL=$MAX_PARALLEL)"
 
+# Fehlerschwelle (T002533). Ohne dieses Gate endete ein Lauf, der 0 von 92
+# Quellen verarbeitet und 67-mal "LLM failed" gemeldet hatte, mit Exit 0 — von
+# einem Erfolg nicht zu unterscheiden, wenn man nicht in den Log sieht. Genau so
+# blieb ein toter LLM-Endpunkt unbemerkt bestehen.
+#
+# Die Schwelle ist bewusst grob: ein einzelner Ausfall (Zeitueberschreitung an
+# einer grossen Datei) soll den Lauf nicht kippen, ein systematischer schon.
+# Attempted = alles ausser Uebersprungenem; nur DAS ist die sinnvolle Bezugsmenge,
+# denn idempotent uebersprungene Quellen sagen ueber die Anbieter-Gesundheit nichts.
+INGEST_MAX_FAIL_PCT="${INGEST_MAX_FAIL_PCT:-20}"
+_attempted=$((PROCESSED + FAILED))
+if [ "$_attempted" -gt 0 ]; then
+  _fail_pct=$((FAILED * 100 / _attempted))
+  if [ "$_fail_pct" -gt "$INGEST_MAX_FAIL_PCT" ]; then
+    echo "" >&2
+    echo "ERROR: ${FAILED} von ${_attempted} versuchten Quellen fehlgeschlagen (${_fail_pct}%, Schwelle ${INGEST_MAX_FAIL_PCT}%)." >&2
+    echo "       Das ist kein Einzelausfall — pruefe zuerst den LLM-Endpunkt:" >&2
+    echo "         LM_STUDIO_URL=${LM_STUDIO_URL:-<nicht gesetzt>}  LM_MODEL=${LM_MODEL:-<nicht gesetzt>}" >&2
+    echo "       Es wurde nichts ausgeliefert. Schwelle anpassbar via INGEST_MAX_FAIL_PCT." >&2
+    exit 1
+  fi
+fi
+
 # ============================================================
 # Phase 2b: MOC Generation
 # ============================================================

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -247,18 +247,43 @@ echo "Phase 2 complete: Processed=$PROCESSED, Skipped=$SKIPPED, Failed=$FAILED (
 # einer grossen Datei) soll den Lauf nicht kippen, ein systematischer schon.
 # Attempted = alles ausser Uebersprungenem; nur DAS ist die sinnvolle Bezugsmenge,
 # denn idempotent uebersprungene Quellen sagen ueber die Anbieter-Gesundheit nichts.
+# Zwei Regeln, weil eine allein jeweils den falschen Fall trifft:
+#
+#   a) Absolute Untergrenze. Viele Fehlschlaege heissen "der Endpunkt ist kaputt",
+#      unabhaengig von der Quote. Der Ausgangsfall waren 67 Fehlschlaege.
+#   b) Quote — aber erst ab einer Mindest-Stichprobe. Dank Idempotenz fasst ein
+#      Nachlauf oft nur eine Handvoll Quellen an; dort kippt ein einzelner
+#      transienter Fehlschlag (bei gehosteten Anbietern typisch:
+#      Ratenbegrenzung unter Parallelitaet) jede sinnvolle Quote.
+#
+# Ausdruecklich KEINE Regel ist "PROCESSED == 0 heisst Abbruch": ein Lauf, bei dem
+# alles idempotent uebersprungen wurde und genau eine hartnaeckige Quelle uebrig
+# bleibt, ist der Normalfall am Ende einer Ingest-Reihe, kein Stoerfall.
 INGEST_MAX_FAIL_PCT="${INGEST_MAX_FAIL_PCT:-20}"
+INGEST_MIN_SAMPLE="${INGEST_MIN_SAMPLE:-10}"
+INGEST_MAX_FAIL_ABS="${INGEST_MAX_FAIL_ABS:-10}"
 _attempted=$((PROCESSED + FAILED))
-if [ "$_attempted" -gt 0 ]; then
+_abort_reason=""
+if [ "$FAILED" -ge "$INGEST_MAX_FAIL_ABS" ]; then
+  _abort_reason="${FAILED} Quellen fehlgeschlagen (absolute Schwelle ${INGEST_MAX_FAIL_ABS})"
+elif [ "$_attempted" -ge "$INGEST_MIN_SAMPLE" ]; then
   _fail_pct=$((FAILED * 100 / _attempted))
   if [ "$_fail_pct" -gt "$INGEST_MAX_FAIL_PCT" ]; then
-    echo "" >&2
-    echo "ERROR: ${FAILED} von ${_attempted} versuchten Quellen fehlgeschlagen (${_fail_pct}%, Schwelle ${INGEST_MAX_FAIL_PCT}%)." >&2
-    echo "       Das ist kein Einzelausfall — pruefe zuerst den LLM-Endpunkt:" >&2
-    echo "         LM_STUDIO_URL=${LM_STUDIO_URL:-<nicht gesetzt>}  LM_MODEL=${LM_MODEL:-<nicht gesetzt>}" >&2
-    echo "       Es wurde nichts ausgeliefert. Schwelle anpassbar via INGEST_MAX_FAIL_PCT." >&2
-    exit 1
+    _abort_reason="${FAILED} von ${_attempted} versuchten Quellen fehlgeschlagen (${_fail_pct}%, Schwelle ${INGEST_MAX_FAIL_PCT}%)"
   fi
+fi
+if [ -n "$_abort_reason" ]; then
+  echo "" >&2
+  echo "ERROR: ${_abort_reason}." >&2
+  echo "       Das ist kein Einzelausfall — pruefe zuerst den LLM-Endpunkt:" >&2
+  echo "         LM_STUDIO_URL=${LM_STUDIO_URL:-<nicht gesetzt>}  LM_MODEL=${LM_MODEL:-<nicht gesetzt>}" >&2
+  echo "       Es wurde nichts ausgeliefert. Stellschrauben: INGEST_MAX_FAIL_ABS," >&2
+  echo "       INGEST_MAX_FAIL_PCT, INGEST_MIN_SAMPLE." >&2
+  exit 1
+fi
+if [ "$FAILED" -gt 0 ]; then
+  echo "WARN: ${FAILED} Quelle(n) fehlgeschlagen — unterhalb der Abbruchschwelle." >&2
+  echo "      Bei gehosteten Anbietern meist transient; ein Nachlauf holt sie idempotent nach." >&2
 fi
 
 # ============================================================

--- a/tests/spec/brain-foundation.bats
+++ b/tests/spec/brain-foundation.bats
@@ -259,7 +259,7 @@ stop_mock_llm() {
   SLUGS_JSON="$FIX/slugs.json"
   printf '["docs-kept"]\n' > "$SLUGS_JSON"
   start_mock_llm $'---\ntype: note\ntags: [x]\nstatus: active\n---\nkein rueckverweis'
-  LM_STUDIO_URL="http://127.0.0.1:$PORT" run bash "$REPO_ROOT/scripts/brain-ingest-transform.sh" "$FIX/repo/docs/kept.md" note docs-kept "$SLUGS_JSON" '["note"]'
+  LM_STUDIO_URL="http://127.0.0.1:$PORT" LM_MODEL=mock run bash "$REPO_ROOT/scripts/brain-ingest-transform.sh" "$FIX/repo/docs/kept.md" note docs-kept "$SLUGS_JSON" '["note"]'
   stop_mock_llm
   [ "$status" -ne 0 ]
   [[ "$output" == *"validation: missing source:: line"* ]]
@@ -271,7 +271,7 @@ stop_mock_llm() {
   SLUGS_JSON="$FIX/slugs.json"
   printf '["docs-kept"]\n' > "$SLUGS_JSON"
   start_mock_llm $'---\ntype: note\ntags: [x]\nstatus: active\n---\nsource:: Bachelorprojekt docs/kept.md\nbody [[docs-kept]]'
-  LM_STUDIO_URL="http://127.0.0.1:$PORT" run bash "$REPO_ROOT/scripts/brain-ingest-transform.sh" "$FIX/repo/docs/kept.md" note docs-kept "$SLUGS_JSON" '["note"]'
+  LM_STUDIO_URL="http://127.0.0.1:$PORT" LM_MODEL=mock run bash "$REPO_ROOT/scripts/brain-ingest-transform.sh" "$FIX/repo/docs/kept.md" note docs-kept "$SLUGS_JSON" '["note"]'
   stop_mock_llm
   [ "$status" -eq 0 ]
   [ "$(cat "$BATS_TEST_TMPDIR/hits")" -eq 1 ]

--- a/tests/spec/brain-foundation/ingest-llm-endpoint.bats
+++ b/tests/spec/brain-foundation/ingest-llm-endpoint.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# tests/spec/brain-foundation/ingest-llm-endpoint.bats
+# Ticket: T002533 — brain-ingest gegen beliebige OpenAI-kompatible Anbieter
+#
+# Pruefmodus (Test-Resultats-Konvention T002448-M4): ERGEBNIS-basiert. Jeder Test
+# FUEHRT scripts/brain-ingest-transform.sh aus und misst $status/$output. Wo ein
+# Gegenueber noetig ist, laeuft ein echter HTTP-Stub (python3 http.server) auf
+# einem freien Port — geprueft wird also der tatsaechliche Request/Response-Weg,
+# nicht der Quelltext des Skripts.
+
+TRANSFORM="$BATS_TEST_DIRNAME/../../../scripts/brain-ingest-transform.sh"
+
+setup() {
+  STUB_DIR="$BATS_TEST_TMPDIR/stub"
+  mkdir -p "$STUB_DIR"
+  SRC="$BATS_TEST_TMPDIR/quelle.md"
+  printf '# Titel\n\nEin Absatz.\n' > "$SRC"
+  # Gueltige Stub-Antwort: das Skript validiert Frontmatter, eine source::-Zeile
+  # und mindestens einen Wikilink und wiederholt sonst einmal. Eine unvollstaendige
+  # Antwort wuerde hier also zwei Requests ausloesen und die Header-Zaehlung
+  # verfaelschen.
+  VALID_PAGE='{"choices":[{"message":{"content":"---\ntype: note\nstatus: active\n---\n\n# X\n\nsource:: Bachelorprojekt quelle.md\n\nSiehe [[andere-seite]].\n"},"finish_reason":"stop"}]}'
+}
+
+teardown() {
+  [ -n "${STUB_PID:-}" ] && kill "$STUB_PID" 2>/dev/null
+  return 0
+}
+
+# Startet einen HTTP-Stub, der $1 als Antwortkoerper liefert, jeden eingehenden
+# Request-Header nach $STUB_DIR/headers.txt und jeden Request-BODY nach
+# $STUB_DIR/headers.txt.body schreibt.
+# Setzt STUB_PID und STUB_URL.
+#
+# Der Port wird ueber eine DATEI zurueckgegeben, nicht ueber einen freien
+# Dateideskriptor: BATS belegt FD 3 fuer seine eigene Ausgabe, und ein
+# `exec 3< <(...)` laesst den Testlauf blockieren statt zu scheitern.
+start_stub() {
+  local body="$1"
+  cat > "$STUB_DIR/server.py" <<PYEOF
+import http.server, socketserver, sys, json
+BODY = open(sys.argv[1], 'rb').read()
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        with open(sys.argv[2], 'a') as f:
+            for k, v in self.headers.items():
+                f.write(f"{k}: {v}\n")
+        body = self.rfile.read(int(self.headers.get('Content-Length', 0)))
+        with open(sys.argv[2] + '.body', 'ab') as f:
+            f.write(body + b"\n")
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(BODY)))
+        self.end_headers()
+        self.wfile.write(BODY)
+    def log_message(self, *a):
+        pass
+with socketserver.TCPServer(('127.0.0.1', 0), H) as s:
+    with open(sys.argv[3], 'w') as f:
+        f.write(str(s.server_address[1]))
+    s.serve_forever()
+PYEOF
+  printf '%s' "$body" > "$STUB_DIR/body.json"
+  : > "$STUB_DIR/headers.txt"
+  : > "$STUB_DIR/headers.txt.body"
+  rm -f "$STUB_DIR/port"
+  python3 "$STUB_DIR/server.py" "$STUB_DIR/body.json" "$STUB_DIR/headers.txt" "$STUB_DIR/port" &
+  STUB_PID=$!
+  local i
+  for i in $(seq 1 50); do
+    [ -s "$STUB_DIR/port" ] && break
+    sleep 0.1
+  done
+  [ -s "$STUB_DIR/port" ] || { echo "Stub-Server nicht gestartet" >&2; return 1; }
+  STUB_URL="http://127.0.0.1:$(cat "$STUB_DIR/port")"
+}
+
+@test "T002533 transform verlangt LM_STUDIO_URL statt still auf einen toten Pool zu zeigen" {
+  run env -u LM_STUDIO_URL -u LM_MODEL bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"LM_STUDIO_URL"* ]]
+}
+
+@test "T002533 transform verlangt LM_MODEL" {
+  run env -u LM_MODEL LM_STUDIO_URL=http://127.0.0.1:1 bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"LM_MODEL"* ]]
+}
+
+@test "T002533 LM_API_KEY wird als Authorization-Header gesendet" {
+  start_stub "$VALID_PAGE"
+
+  # Positiv-Anker: OHNE Schluessel laeuft derselbe Aufruf durch und sendet
+  # KEINEN Authorization-Header. Ohne diesen Anker koennte der Negativbefund
+  # unten auch bedeuten, dass der Aufruf gar nicht stattgefunden hat.
+  run env LM_STUDIO_URL="$STUB_URL" LM_MODEL=stub bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -eq 0 ]
+  run grep -c '^Authorization:' "$STUB_DIR/headers.txt"
+  [ "$output" -eq 0 ]
+
+  : > "$STUB_DIR/headers.txt"
+  run env LM_STUDIO_URL="$STUB_URL" LM_MODEL=stub LM_API_KEY=geheim-123 \
+      bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -eq 0 ]
+  run grep -c '^Authorization: Bearer geheim-123$' "$STUB_DIR/headers.txt"
+  [ "$output" -eq 1 ]
+}
+
+@test "T002533 der Schluessel steht nicht in argv (per ps lesbar)" {
+  start_stub "$VALID_PAGE"
+  # Der Schluessel wird EXPORTIERT, nicht per `env VAR=... cmd` uebergeben:
+  # sonst legt `env` ihn selbst in seine eigene Kommandozeile und der Test
+  # wuerde das Testgeruest messen statt das Skript.
+  export LM_STUDIO_URL="$STUB_URL" LM_MODEL=stub LM_API_KEY=streng-geheim-xyz
+  bash "$TRANSFORM" "$SRC" note slug '[]' '[]' >/dev/null &
+  local job=$! seen_running=0 hits=0 i
+  for i in $(seq 1 200); do
+    # Positiv-Anker: mindestens einmal muss der laufende Transform in ps
+    # sichtbar gewesen sein. Ohne ihn koennte "0 Treffer" auch bedeuten, dass
+    # nie gemessen wurde, weil der Job schon vorbei war.
+    # Klammer-Schreibweise: `grep 'streng-geheim-xyz'` traegt das Muster in die
+    # EIGENE Kommandozeile, und `ps` sieht diesen grep, weil beide in derselben
+    # Pipeline gleichzeitig starten — der Test wuerde sich selbst finden.
+    # `[s]treng-...` matcht denselben Text, aber nicht mehr sich selbst.
+    ps -eo args 2>/dev/null | grep -q '[b]rain-ingest-transform' && seen_running=1
+    ps -eo args 2>/dev/null | grep -q '[s]treng-geheim-xyz' && hits=$((hits + 1))
+    kill -0 "$job" 2>/dev/null || break
+  done
+  wait "$job"
+  local rc=$?
+  unset LM_STUDIO_URL LM_MODEL LM_API_KEY
+  [ "$rc" -eq 0 ]
+  [ "$seen_running" -eq 1 ]
+  [ "$hits" -eq 0 ]
+}
+
+@test "T002533 leeres content bei gefuelltem reasoning_content nennt LM_DISABLE_THINKING" {
+  # Genau der DeepSeek-v4-Fall: das Modell verbraucht sein Budget im Denken,
+  # content bleibt leer. Die alte Meldung war 'empty response' und schickte
+  # einen auf die Suche nach einem toten Endpunkt.
+  start_stub '{"choices":[{"message":{"content":"","reasoning_content":"lange denkphase"},"finish_reason":"length"}]}'
+  run env LM_STUDIO_URL="$STUB_URL" LM_MODEL=stub bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"LM_DISABLE_THINKING"* ]]
+}
+
+@test "T002533 LM_DISABLE_THINKING=1 setzt thinking.type=disabled im Request" {
+  start_stub "$VALID_PAGE"
+
+  # Positiv-Anker: OHNE den Schalter geht derselbe Request raus und enthaelt
+  # KEIN thinking-Feld. Ohne diesen Anker bestuende der Test auch dann, wenn
+  # der Schalter gar nichts bewirkt.
+  run env LM_STUDIO_URL="$STUB_URL" LM_MODEL=stub \
+      bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -eq 0 ]
+  run grep -c 'thinking' "$STUB_DIR/headers.txt.body"
+  [ "$output" -eq 0 ]
+
+  : > "$STUB_DIR/headers.txt.body"
+  run env LM_STUDIO_URL="$STUB_URL" LM_MODEL=stub LM_DISABLE_THINKING=1 \
+      bash "$TRANSFORM" "$SRC" note slug '[]' '[]'
+  [ "$status" -eq 0 ]
+  # jq -n gibt standardmaessig FORMATIERTES JSON aus — der Vergleich muss den
+  # Zeilenumbruch zwischen Schluessel und Wert vertragen, sonst prueft man das
+  # Ausgabeformat von jq statt den Inhalt des Requests.
+  run grep -c '"disabled"' "$STUB_DIR/headers.txt.body"
+  [ "$output" -ge 1 ]
+  run grep -c '"thinking"' "$STUB_DIR/headers.txt.body"
+  [ "$output" -ge 1 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2040,6 +2040,12 @@
     "kind": "shell"
   },
   {
+    "id": "brain-foundation/ingest-llm-endpoint",
+    "file": "tests/spec/brain-foundation/ingest-llm-endpoint.bats",
+    "category": "brain-foundation",
+    "kind": "shell"
+  },
+  {
     "id": "brain-foundation/k1-vector-db-doc",
     "file": "tests/spec/brain-foundation/k1-vector-db-doc.bats",
     "category": "brain-foundation",


### PR DESCRIPTION
Der Brain-Ingest war nicht lauffähig. Aufgefallen beim Versuch eines vollen Laufs am 2026-08-02.

## Drei zusammenhängende Ursachen

**1 — Tote Vorgabe-Adresse.** Voreingestellt war `localhost:8093` mit `qwen3.6-14b-a3b-fablevibes`. Dieser Ingest-Pool ist mit dem Loadout-Umbau entfallen; das im Skriptkopf genannte `start-qwen36-ingest-pool.ps1` existiert nicht in `scripts/llm/`. `LM_STUDIO_URL` und `LM_MODEL` sind jetzt **Pflicht** — ohne Ziel scheitert das Skript sofort, statt 92-mal einzeln `LLM failed` zu melden.

**2 — Kein Auth-Header.** `call_llm()` sendete nur `Content-Type`. Damit war **kein** authentifizierter Anbieter erreichbar — als der lokale Pool wegfiel, blieb kein Ausweichweg. Neu: `LM_API_KEY`, übergeben per `curl --config -` von stdin statt als `-H`-Argument, weil argv auf dem Host per `ps` für jeden Prozess lesbar ist.

**3 — Massenfehler meldete Erfolg.** Ein Lauf mit 0 verarbeiteten und 67 fehlgeschlagenen Quellen endete mit **Exit 0** — ohne Blick in den Log von einem Erfolg nicht zu unterscheiden. Genau deshalb konnte der tote Endpunkt unbemerkt bestehen.

## Dazu: LM_DISABLE_THINKING

DeepSeek v4 ist ein Reasoning-Modell und verbraucht sonst das gesamte Token-Budget in `reasoning_content`, während `content` leer bleibt und `// empty` es still verschluckt. Mehr `max_tokens` hilft nicht — die Denkphase wächst mit. Bei DeepSeek wirkt `thinking.type=disabled`; `enable_thinking:false` wird dort **ignoriert** (empirisch geprüft). Der Leerfall meldet jetzt, welcher der beiden Fälle vorliegt.

## Zur Fehlerschwelle

Die erste Fassung war eine reine Quote und hätte jeden inkrementellen Nachlauf blockiert: dank Idempotenz werden dort nur wenige Quellen angefasst, wo ein einzelner transienter Fehlschlag (Ratenbegrenzung unter Parallelität) die Quote sofort kippt. Jetzt zwei Regeln — eine **absolute** Untergrenze für „der Endpunkt ist kaputt" und die Quote erst ab einer Mindest-Stichprobe. „Nichts verarbeitet" allein ist ausdrücklich **kein** Abbruchgrund; das ist der Normalfall am Ende einer Ingest-Reihe.

## Verifikation

Der Ingest lief damit vollständig durch — 92 Quellen, 0 Fehlschläge, ausgeliefert als [Paddione/brain#11](https://github.com/Paddione/brain/pull/11) (474 Wiki-Seiten).

- 6 neue Ergebnis-Tests in `tests/spec/brain-foundation/ingest-llm-endpoint.bats` gegen einen echten HTTP-Stub: Pflichtvariablen, Authorization-Header, Abwesenheit des Schlüssels in `argv`, Reasoning-Diagnose, `thinking`-Feld im Request. Gegen die Vorgängerversion sind **5 der 6 rot**; der argv-Test ist ein reiner Regressionswächter.
- Zwei Bestandstests in `tests/spec/brain-foundation.bats` an die `LM_MODEL`-Pflicht angepasst — Vertragsänderung, Prüfabsicht unverändert.
- `task test:changed`: 815 grün, 0 Fehlschläge. `task freshness:check`: Exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)