### PR TITLE
chore(ops): Gemma 4 26B A4B als Factory-Loadout mit gemessenen fitt/KV-Werten [T002534]

### DIFF
--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -121,6 +121,24 @@
       "extraArgs": ["-kvu"],
       "exclusiveGroup": "chat-gpu",
       "notes": "Migriert aus scripts/llm/start-gemma-server.ps1 (-Slots-Profil, -np 5 -kvu). q8_0 wie gemma-factory und gptoss-context — siehe dortige Begruendung (T002501). Mit -kvu ist minCtx ein GEMEINSAMER Pool ueber alle Slots, kein Wert je Slot."
+    },
+    {
+      "slug": "gemma26-factory",
+      "label": "Gemma 4 26B A4B · Factory Single-Agent",
+      "model": "gemma4/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf",
+      "port": 8091,
+      "fit": { "enabled": true, "targetMarginMib": 256, "minCtx": 32768 },
+      "args": {
+        "ctx": null, "ngl": null, "parallel": 1,
+        "cacheTypeK": "q4_0", "cacheTypeV": "q4_0", "loadMode": "mmap",
+        "flashAttention": true, "jinja": true, "metrics": true,
+        "reasoning": "auto", "reasoningBudget": null
+      },
+      "speculative": { "draftModelPath": null, "draftNgl": null },
+      "mcp": { "serversConfig": null },
+      "extraArgs": [],
+      "exclusiveGroup": "chat-gpu",
+      "notes": "T002534, gemessen 2026-08-02 auf RTX 5070 Ti (16 GB, geteilt mit Windows-Desktop) unter llama.cpp b10223. targetMarginMib 256 und KV q4_0 sind BEIDE Messergebnisse, keine Uebernahme von den 12B-Loadouts. -fitt-Reihe bei KV q8_0: 512 -> 45824 ctx / 129 tok/s, 256 -> 62464 / 160, 128 -> 70912 / 121, 64 -> 75264 / 142. Eine kleinere Marge gewinnt Kontext UND Tempo, weil --fit dann mehr Layer auf der GPU behaelt statt sie auszulagern; ab ~128 verdraengt der grosse KV-Cache selbst wieder Layer. KV q4_0 bei fitt 256: 99328 ctx / 166 tok/s. Die T002501-Sorge (q4_0-KV degradiert woertliches Zurueckholen von Pfaden, Symbolnamen, Tool-Call-Argumenten) war hier NICHT reproduzierbar: Probe mit sechs exakten Zeichenketten bei temperature 0, fuenf von fuenf Durchlaeufen zeichengenau. ACHTUNG - diese Probe lief im KURZEN Kontext (~200 Tokens) und widerlegt T002501 damit nicht fuer den Langkontext-Fall; Fehlerakkumulation ueber 37k+ Tokens ist ungemessen. Deshalb bleiben die 12B-Loadouts bei q8_0. Kein Draft-Modell: der MTP-Drafter mtp-gemma-4-26B-A4B-it.gguf (Architektur gemma4-assistant) laesst sich unter b10223 nicht laden (vector::_M_range_check) und bricht den Serverstart komplett ab; MTP waere reine Beschleunigung, das Zielmodell verifiziert jeden gedrafteten Token. Kein mmproj: die vorhandene mmproj-F16.gguf gehoert zum 12B. -ncmoe verworfen: 6 von 30 Layern brachten 196864 ctx, kosteten aber Faktor 7 beim Decoding (21,5 tok/s)."
     }
   ]
 }

--- a/tests/spec/local-llm-proxy/gemma-kv-quant.bats
+++ b/tests/spec/local-llm-proxy/gemma-kv-quant.bats
@@ -67,16 +67,46 @@ _argv_facts() {
   echo "$output" | awk '$1 == "gemma-multiagent"' | grep -q .
 }
 
-@test "kein GPU-Chat-Loadout startet mit q4_0-KV" {
+# Loadouts, die bewusst von der q4_0-Sperre ausgenommen sind. Jeder Eintrag
+# braucht eine Begruendung im Block darunter — die Liste ist keine Sammelstelle.
+_KV_Q4_ALLOWED="gemma26-factory"
+
+@test "nur ausdruecklich ausgenommene GPU-Chat-Loadouts starten mit q4_0-KV" {
   run _argv_facts
   [ "$status" -eq 0 ]
 
   # Der eigentliche Gegenstand. q4_0 degradiert Tool-Call-Argumente; das
   # ueberwachte Profil faehrt q8_0.
+  #
+  # AUSNAHME gemma26-factory (T002534): Das 26B-A4B-Modell belegt 14,25 GB von
+  # 16 GB VRAM, die es sich mit dem Windows-Desktop teilt. Mit q8_0 bleiben
+  # 62464 Kontext, mit q4_0 sind es 99328 — bei gemessen gleichem Durchsatz
+  # (160 vs. 166 tok/s). Eine Woertlichkeits-Probe mit sechs exakten
+  # Zeichenketten (Kustomize-Pfad, Manifest-Dateiname, Funktionssignatur mit
+  # Klammern und Kommata, OCI-Referenz, absoluter Binaerpfad, Flag-Kombination)
+  # kam bei temperature 0 fuenfmal von fuenf zeichengenau zurueck.
+  #
+  # DIESE AUSNAHME RUHT AUF UNVOLLSTAENDIGER EVIDENZ. Die Probe lief im KURZEN
+  # Kontext (~200 Tokens). Die Sorge aus T002501 betrifft Fehlerakkumulation
+  # ueber LANGE Kontexte — also genau den 37k-Factory-Prompt, fuer den der
+  # Kontext hier vergroessert wird. Dieser Fall ist ungemessen: T002535.
+  # Treten Fehler in Tool-Call-Argumenten oder Pfaden auf, ist diese Ausnahme
+  # der erste Verdaechtige: gemma26-factory auf q8_0 zuruecksetzen und pruefen,
+  # ob sie verschwinden.
   local offenders
-  offenders=$(echo "$output" | awk '$2 == "q4_0" || $3 == "q4_0" { print $1 }')
-  echo "q4_0-Loadouts: ${offenders:-<keine>}"
+  offenders=$(echo "$output" | awk '$2 == "q4_0" || $3 == "q4_0" { print $1 }' \
+              | grep -vxF "$_KV_Q4_ALLOWED" || true)
+  echo "unerlaubte q4_0-Loadouts: ${offenders:-<keine>}"
   [ -z "$offenders" ]
+}
+
+@test "die q4_0-Ausnahme ist wirksam und nicht bloss deklariert" {
+  # Positiv-Anker: Waere gemma26-factory nicht mehr auf q4_0 (oder ganz weg),
+  # liefe der Test darueber vakuos durch — er verbietet dann nur noch etwas,
+  # das ohnehin niemand tut. Dieser Test faellt in dem Fall auf.
+  run _argv_facts
+  [ "$status" -eq 0 ]
+  echo "$output" | awk '$1 == "gemma26-factory" && ($2 == "q4_0" && $3 == "q4_0")' | grep -q .
 }
 
 @test "quantisierter KV-Cache zieht FlashAttention nach sich" {

--- a/tests/spec/local-llm-proxy/gemma-loadout-autorestart-queue.bats
+++ b/tests/spec/local-llm-proxy/gemma-loadout-autorestart-queue.bats
@@ -134,7 +134,7 @@ _start_proxy() {
 
 # --- 3) Szenario "Starting one Gemma profile blocks the other" --------------
 
-@test "die beiden 8091-Loadouts schliessen einander per exclusiveGroup aus" {
+@test "alle 8091-Loadouts schliessen einander per exclusiveGroup aus" {
   # Der 409-port_busy-Pfad in server.mjs greift genau dann, wenn zwei Loadouts
   # denselben Port teilen und eines aktiv ist. Ohne User-systemd ist "aktiv"
   # nicht herstellbar — pruefbar ist die Vorbedingung als Laufzeitergebnis.
@@ -152,7 +152,14 @@ _start_proxy() {
     assert.ok(solo.length > 0, 'kein Loadout mit exklusivem Port — Anker verloren');
 
     const on8091 = doc.loadouts.filter((l) => l.port === 8091);
-    assert.equal(on8091.length, 2, 'erwartet genau zwei Loadouts auf 8091');
+    // Nicht auf eine feste Anzahl pruefen: die Aussage ist 'wer sich 8091 teilt,
+    // muss sich gegenseitig ausschliessen', nicht 'es sind genau zwei'. Eine
+    // harte Zahl bricht bei jedem neuen 8091-Loadout, ohne dass die gepruefte
+    // Eigenschaft verletzt waere (T002534: gemma26-factory kam als drittes dazu).
+    // Untergrenze 2 haelt die Aussage nicht-vakuos — bei einem einzigen Loadout
+    // gaebe es nichts auszuschliessen.
+    assert.ok(on8091.length >= 2,
+      'erwartet mindestens zwei Loadouts auf 8091, sonst ist der Ausschluss gegenstandslos');
     for (const l of on8091) {
       assert.equal(l.exclusiveGroup, 'chat-gpu',
         l.slug + ': teilt 8091, muss also in der chat-gpu-Gruppe liegen');


### PR DESCRIPTION
## Was

Neues Loadout `gemma26-factory` in `scripts/llm/loadouts.json` — Port 8091, `exclusiveGroup: chat-gpu`, `targetMarginMib: 256`, KV `q4_0`, `parallel: 1`.

## Messgrundlage

Alle Werte gemessen am 2026-08-02 auf RTX 5070 Ti (16 GB, geteilt mit dem Windows-Desktop), llama.cpp b10223, identischer Prompt, 250 Tokens Ausgabe.

**`-fitt` (Sicherheitsmarge), KV q8_0:**

| `-fitt` | n_ctx | decode |
|---|---|---|
| 512 | 45.824 | 129,0 tok/s |
| **256** | 62.464 | **159,7 tok/s** |
| 128 | 70.912 | 120,9 tok/s |
| 64 | 75.264 | 142,1 tok/s |

Eine kleinere Marge gewinnt Kontext **und** Tempo: `--fit` behält dann mehr Layer auf der GPU statt sie auszulagern. Ab ~128 verdrängt der große KV-Cache selbst wieder Layer.

**KV-Quantisierung bei `-fitt 256`:**

| KV | n_ctx | decode | Wörtlichkeit |
|---|---|---|---|
| q8_0 | 62.464 | 159,7 tok/s | 3/3 |
| **q4_0** | **99.328** | **166,0 tok/s** | **5/5** |

**Verworfen:** `-ncmoe 6` (von 30) brachte 196.864 Kontext, kostete aber Faktor 7 beim Decoding (21,5 tok/s).

**Kein MTP-Drafter:** `mtp-gemma-4-26B-A4B-it.gguf` (Architektur `gemma4-assistant`) lädt unter b10223 nicht (`vector::_M_range_check`) und bricht den Serverstart komplett ab. MTP wäre reine Beschleunigung — das Zielmodell verifiziert jeden gedrafteten Token.

## Guard-Änderung: bitte hier genau hinsehen

Der Test `kein GPU-Chat-Loadout startet mit q4_0-KV` (T002501) wird für **dieses eine Loadout** geöffnet. Die Begründung steht im Test, samt ausdrücklichem Vorbehalt:

> Die Wörtlichkeits-Probe (sechs exakte Zeichenketten, temperature 0, 5/5 zeichengenau) lief im **kurzen** Kontext (~200 Tokens). Die Sorge aus T002501 betrifft Fehlerakkumulation über **lange** Kontexte — also genau den ~37k-Factory-Prompt. **Dieser Fall ist ungemessen.**

Folgeticket **T002535** misst ihn nach. Fällt er rot aus, ist der Rückweg im Test beschrieben (Loadout auf q8_0, Ausnahme entfernen — kostet 99.328 → 62.464 Kontext).

Ein neuer Positiv-Anker `die q4_0-Ausnahme ist wirksam und nicht bloss deklariert` verhindert, dass der Guard vakuos wird, falls das Loadout später doch auf q8_0 wandert. Wirksamkeit verifiziert: bei künstlich entfernter Ausnahme wird er rot, danach wieder grün.

## Nicht geändert

Die **12B-Loadouts bleiben bei `q8_0` / `fitt 2400`.** Die Messwerte gelten für den 26B, dessen VRAM-Enge sie begründet — eine Übertragung wäre genau die stille Qualitätsänderung, vor der `loadouts.json` an dieser Stelle selbst warnt.

## Nebenänderung

`alle 8091-Loadouts schliessen einander per exclusiveGroup aus` prüfte auf **genau zwei** Loadouts; jetzt sind es drei. Die geprüfte Eigenschaft ist der gegenseitige Ausschluss, nicht die Anzahl — die Assertion ist entsprechend auf „mindestens zwei" verallgemeinert (Untergrenze hält sie nicht-vakuos).

## Verifikation

`tests/spec/local-llm-proxy` + `local-llm-proxy.bats`: **42 ok, 0 not ok.**