### PR TITLE
fix(ops): Loadout-Start scheiterte an jedem GGUF über 2 GiB [T002536]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 701,
+      "file_count": 702,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -416,6 +416,7 @@
         "tests/spec/local-llm-proxy.bats",
         "tests/spec/local-llm-proxy/gemma-kv-quant.bats",
         "tests/spec/local-llm-proxy/gemma-loadout-autorestart-queue.bats",
+        "tests/spec/local-llm-proxy/model-path-large-file.bats",
         "tests/spec/lockfile-drift.bats",
         "tests/spec/mcp-gateway.bats",
         "tests/spec/mcp-gateway/authenticated-http-headers.bats",

--- a/scripts/llm-proxy/models.mjs
+++ b/scripts/llm-proxy/models.mjs
@@ -83,6 +83,30 @@ export function expandRoot(root) {
   return root.startsWith('~') ? join(homedir(), root.slice(1)) : root;
 }
 
+// Loest loadout.model gegen doc.modelRoots auf. Gibt den ersten Treffer als
+// absoluten Pfad zurueck, sonst null.
+//
+// statSync, NICHT readFileSync (T002536): readFileSync kennt keine Option
+// 'length' — die gehoert zu fs.read. Der fruehere Aufruf in server.mjs,
+//   readFileSync(candidate, { flag: 'r', encoding: null, length: 0 })
+// las deshalb die KOMPLETTE Datei in den Speicher, statt nur die Existenz zu
+// pruefen. Node wirft ab 2 GiB ERR_FS_FILE_TOO_LARGE; das leere catch
+// verschluckte den Fehler und der Start meldete 'model_missing' — also fuer
+// praktisch jedes Chat-Modell. Kleinere Dateien gingen durch, wurden aber
+// vollstaendig in den RAM gelesen.
+//
+// Steht hier statt in server.mjs, weil ein Import von server.mjs den
+// HTTP-Server startet und den Proxy-Port bindet; die Funktion war dort nicht
+// ohne Nebenwirkungen pruefbar.
+export function resolveModelPath(doc, loadout) {
+  for (const root of doc.modelRoots) {
+    const candidate = join(expandRoot(root), loadout.model);
+    try { if (statSync(candidate).isFile()) return candidate; }
+    catch { /* naechste Wurzel */ }
+  }
+  return null;
+}
+
 function walk(dir, out) {
   let entries;
   try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }

--- a/scripts/llm-proxy/server.mjs
+++ b/scripts/llm-proxy/server.mjs
@@ -7,15 +7,20 @@ import { applyFixups, sanitizeToolSchemaPatterns } from './fixups.mjs';
 import { readFileSync, existsSync } from 'node:fs';
 import { readLoadouts, writeLoadouts, findLoadout, DEFAULT_PATH, planAutoStart } from './loadouts.mjs';
 import os from 'node:os';
-import { scanModels, expandRoot } from './models.mjs';
+import { scanModels, resolveModelPath } from './models.mjs';
 import { unitName, startUnit, stopUnit, unitStatus, recentLogs } from './runner.mjs';
 import { join } from 'node:path';
 import { initBridge, handleMcp, stopBridge } from './mcp-bridge.mjs';
 
 const PORT = Number(process.env.LLM_PROXY_PORT || 18235);
 const POLL_MS = 30_000;
+// Versionsneutraler Symlink statt eines gepinnten Builds (T002536): der
+// fruehere Default 'opt/llama-b10155-cuda13.3' zwang bei jedem llama.cpp-Update
+// zu einer Code-Aenderung und verhinderte, dass der abgeloeste Build entfernt
+// werden kann. 'opt/llama-current' zeigt auf den jeweils aktuellen Build; ein
+// Versionswechsel ist damit ein Symlink-Umhaengen ohne Repo-Aenderung.
 const LLAMA_BIN = process.env.LLAMA_SERVER_BIN
-  || join(process.env.HOME, 'opt/llama-b10155-cuda13.3/bin/llama-server');
+  || join(process.env.HOME, 'opt/llama-current/bin/llama-server');
 const HEALTH_TIMEOUT_MS = 240_000;
 
 startRegistryPoll(POLL_MS);
@@ -199,14 +204,9 @@ async function proxyV1(req, res, subpath) {
 }
 
 // Loesst den Loadout-Modellpfad gegen die konfigurierten modelRoots auf.
-function resolveModelPath(doc, loadout) {
-  for (const root of doc.modelRoots) {
-    const candidate = join(expandRoot(root), loadout.model);
-    try { readFileSync(candidate, { flag: 'r', encoding: null, length: 0 }); return candidate; }
-    catch { /* naechste Wurzel */ }
-  }
-  return null;
-}
+// resolveModelPath liegt in models.mjs (T002536) — dort ist es ohne
+// Nebenwirkungen testbar. Ein Import von server.mjs startet den HTTP-Server
+// und bindet den Proxy-Port; die Funktion war hier also nicht pruefbar.
 
 async function waitHealthy(port, timeoutMs) {
   const deadline = Date.now() + timeoutMs;

--- a/tests/spec/local-llm-proxy/model-path-large-file.bats
+++ b/tests/spec/local-llm-proxy/model-path-large-file.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# tests/spec/local-llm-proxy/model-path-large-file.bats
+# SSOT: openspec/specs/local-llm-proxy.md
+# Ticket: T002536
+#
+# Pruefmodus (Test-Resultats-Konvention T002448-M4): ERGEBNIS-basiert. Geprueft
+# wird der Rueckgabewert von resolveModelPath() gegen echte Dateien im
+# Dateisystem — kein grep auf Script-Interna.
+#
+# Hintergrund: resolveModelPath() pruefte die Existenz der Modelldatei mit
+#   readFileSync(candidate, { flag: 'r', encoding: null, length: 0 })
+# readFileSync kennt keine Option 'length' (die gehoert zu fs.read), las also
+# die komplette Datei. Node wirft ab 2 GiB ERR_FS_FILE_TOO_LARGE, das leere
+# catch verschluckte es, der Loadout-Start meldete 'model_missing'. Damit war
+# der Start fuer JEDES Chat-Modell kaputt — die sind praktisch alle groesser.
+#
+# Die Testdatei wird spaerlich angelegt (truncate), belegt also keinen realen
+# Plattenplatz. Ihre Groesse liegt bewusst UEBER 2 GiB, weil genau dort die
+# alte Implementierung umkippte; eine kleinere Datei wuerde den Fehler nicht
+# reproduzieren und der Test liefe vakuos gruen.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  TMPROOT="$(mktemp -d)"
+  mkdir -p "$TMPROOT/sub"
+  truncate -s 3G "$TMPROOT/sub/gross.gguf"
+  truncate -s 1M "$TMPROOT/sub/klein.gguf"
+}
+
+teardown() {
+  [ -n "$TMPROOT" ] && rm -rf "$TMPROOT"
+}
+
+# Ruft resolveModelPath fuer <relPath> auf und gibt den Rueckgabewert aus
+# ('null' wenn nicht gefunden).
+_resolve() {
+  node --input-type=module -e "
+    const { resolveModelPath } = await import('file://$REPO/scripts/llm-proxy/models.mjs');
+    const doc = { modelRoots: ['$TMPROOT'] };
+    console.log(String(resolveModelPath(doc, { model: '$1' })));
+  "
+}
+
+@test "resolveModelPath findet ein Modell ueber 2 GiB" {
+  # Der eigentliche Gegenstand: mit readFileSync warf Node hier
+  # ERR_FS_FILE_TOO_LARGE und die Funktion gab null zurueck.
+  run _resolve "sub/gross.gguf"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TMPROOT/sub/gross.gguf" ]
+}
+
+@test "resolveModelPath findet auch kleine Dateien weiterhin" {
+  # Positiv-Anker (T002356-M1): Waere die Aufloesung generell kaputt, wuerde
+  # der Test darueber nichts ueber die Dateigroesse aussagen. Dieser belegt,
+  # dass der Pfad ueberhaupt funktioniert.
+  run _resolve "sub/klein.gguf"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TMPROOT/sub/klein.gguf" ]
+}
+
+@test "resolveModelPath gibt null fuer eine fehlende Datei" {
+  # Gegenprobe: die Funktion darf nicht einfach immer einen Pfad melden.
+  run _resolve "sub/gibtsnicht.gguf"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "null" ]
+}
+
+@test "resolveModelPath gibt null fuer ein Verzeichnis gleichen Namens" {
+  # statSync wirft bei einem Verzeichnis nicht — ohne isFile()-Pruefung wuerde
+  # ein Verzeichnis als Modell durchgehen und llama-server erst beim Start
+  # scheitern.
+  mkdir -p "$TMPROOT/sub/verzeichnis.gguf"
+  run _resolve "sub/verzeichnis.gguf"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "null" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2502,6 +2502,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/model-path-large-file",
+    "file": "tests/spec/local-llm-proxy/model-path-large-file.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "lockfile-drift",
     "file": "tests/spec/lockfile-drift.bats",
     "category": "lockfile-drift",


### PR DESCRIPTION
## Fehler

`resolveModelPath()` prüfte die Existenz der Modelldatei so:

```js
readFileSync(candidate, { flag: 'r', encoding: null, length: 0 })
```

**`readFileSync` kennt keine Option `length`** — die gehört zu `fs.read`. Der Aufruf las deshalb die **komplette Datei** in den Speicher, statt nur die Existenz zu prüfen. Node wirft ab 2 GiB `ERR_FS_FILE_TOO_LARGE`; das leere `catch` verschluckte den Fehler und der Start meldete `model_missing`.

Wirkung: `POST /admin/loadouts/<slug>/start` war für **praktisch jedes Chat-Modell** kaputt. Kleinere Dateien gingen durch, wurden aber vollständig in den RAM gelesen — bei bge-m3 immerhin 635 MB pro Startversuch.

Reproduziert am 2026-08-02, Node v22.23.1:

| Datei | Größe | Ergebnis |
|---|---|---|
| `gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf` | 14,25 GB | `ERR_FS_FILE_TOO_LARGE` |
| `bge-m3-Q8_0.gguf` | 635 MB | OK |

Der Fehler erklärt, warum der Loadout-Startweg aus T002459 auf dem Host nie erfolgreich benutzt wurde.

## Fix

`statSync(...).isFile()` statt `readFileSync`.

**Die Funktion wandert nach `models.mjs`.** In `server.mjs` war sie nicht prüfbar: ein Import dieser Datei startet den HTTP-Server und bindet den Proxy-Port (`server.listen` auf Modulebene, plus ein Top-Level-`await`). `models.mjs` ist nebenwirkungsfrei.

## Zweite Änderung

Der `LLAMA_BIN`-Default zeigt nicht mehr auf den gepinnten Build `opt/llama-b10155-cuda13.3`, sondern auf den versionsneutralen Symlink `opt/llama-current`. Der gepinnte Pfad zwang bei jedem llama.cpp-Update zu einer Code-Änderung und verhinderte, dass der abgelöste Build entfernt werden kann. Der `LLAMA_SERVER_BIN`-Override bleibt unverändert vorrangig.

## Test

`tests/spec/local-llm-proxy/model-path-large-file.bats` legt eine **spärliche 3-GiB-Datei** an (`truncate`, kein realer Plattenplatz) und prüft den Rückgabewert von `resolveModelPath()`.

Die Größe liegt bewusst über 2 GiB — darunter reproduziert der Test den Fehler nicht und liefe vakuos grün.

**Gegen die alte Implementierung verifiziert:** Test 1 (`findet ein Modell ueber 2 GiB`) wird rot, Tests 2–4 bleiben grün. Damit ist belegt, dass der Test genau die Dateigröße prüft und nicht etwas anderes.

Vier Fälle: >2 GiB, kleine Datei (Positiv-Anker), fehlende Datei, und ein *Verzeichnis* mit `.gguf`-Namen — ohne `isFile()` würde `statSync` dort nicht werfen und das Verzeichnis als Modell durchgehen.

## Verifikation

- `tests/spec/local-llm-proxy` + `local-llm-proxy.bats`: **46 ok, 0 not ok**
- `node --test scripts/llm-proxy/`: loadouts 12/12, models 7/7, runner 12/12, server 11/11

**Vorbestehend rot, nicht von diesem PR:** `scripts/llm-proxy/mcp-bridge.test.mjs` importiert `vitest`, das im Repo-Root nicht installiert ist (Root nutzt npm, vitest hängt an `website/`). Schlägt auf `main` identisch fehl.