### PR TITLE
feat(ops): bge-Embed/Rerank als versionierte WSL-Loadouts, env-Feld im Schema [T002538]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 703,
+      "file_count": 704,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -417,6 +417,7 @@
         "tests/spec/local-llm-proxy.bats",
         "tests/spec/local-llm-proxy/gemma-kv-quant.bats",
         "tests/spec/local-llm-proxy/gemma-loadout-autorestart-queue.bats",
+        "tests/spec/local-llm-proxy/loadout-env-property.bats",
         "tests/spec/local-llm-proxy/model-path-large-file.bats",
         "tests/spec/lockfile-drift.bats",
         "tests/spec/mcp-gateway.bats",

--- a/scripts/llm-proxy/loadouts.mjs
+++ b/scripts/llm-proxy/loadouts.mjs
@@ -9,6 +9,11 @@ export const DEFAULT_PATH = 'scripts/llm/loadouts.json';
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
 const LOADOUT_KEYS = new Set([
   'slug', 'label', 'model', 'port', 'fit', 'args', 'speculative', 'mcp', 'extraArgs', 'notes', 'exclusiveGroup',
+  // T002538: Umgebungsvariablen fuer die systemd-Unit. Gebraucht fuer
+  // CUDA_VISIBLE_DEVICES='' bei den CPU-gebundenen bge-Servern — '-ngl 0'
+  // verhindert nur das Auslagern der Layer, NICHT die Allokation eines
+  // CUDA-Kontexts (gemessen rund 600 MB je Prozess).
+  'env',
 ]);
 const ARG_KEYS = new Set([
   'ctx', 'ngl', 'parallel', 'cacheTypeK', 'cacheTypeV', 'loadMode',
@@ -64,6 +69,20 @@ function validateLoadout(l, index, seen) {
   }
 
   if (l.extraArgs != null && !Array.isArray(l.extraArgs)) fail(`${l.slug}: extraArgs muss ein Array sein`);
+
+  // env: flaches Objekt String -> String. Der Wert DARF leer sein — genau das
+  // ist der Anwendungsfall (CUDA_VISIBLE_DEVICES=''). Der Name muss dem
+  // POSIX-Muster folgen; ein '=' darin wuerde die systemd-Property zerlegen.
+  if (l.env != null) {
+    if (typeof l.env !== 'object' || Array.isArray(l.env)) {
+      fail(`${l.slug}: env muss ein Objekt sein`);
+    }
+    for (const [k, v] of Object.entries(l.env)) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) fail(`${l.slug}: env-Name '${k}' ist kein gueltiger Variablenname`);
+      if (typeof v !== 'string') fail(`${l.slug}: env['${k}'] muss ein String sein`);
+      if (v.includes('\n')) fail(`${l.slug}: env['${k}'] darf keinen Zeilenumbruch enthalten`);
+    }
+  }
   return l;
 }
 

--- a/scripts/llm-proxy/runner.mjs
+++ b/scripts/llm-proxy/runner.mjs
@@ -76,6 +76,10 @@ export function buildStartCommand(loadout, modelPath, defaults, binPath, resolve
     // D3: systemd restart properties. MUST be before '--' separator.
     '--property=Restart=on-failure',
     '--property=RestartSec=5',
+    // T002538: Umgebungsvariablen der Unit. Ebenfalls VOR dem '--' — danach
+    // gaeben sie systemd-run als Argumente an das Binary weiter, das sie nicht
+    // kennt und mit unbekannter Option abbricht.
+    ...Object.entries(loadout.env ?? {}).map(([k, v]) => `--property=Environment=${k}=${v}`),
     `--description=llama.cpp loadout ${loadout.slug}`,
     '--',
     binPath,

--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -79,6 +79,44 @@
       "notes": "T002426 Paar A: bewusst CPU-gebunden (-ngl 0). Eigener Prozess neben bge-embed-batch, weil llama.cpp CLS- und RANK-Pooling nicht in einem Server bedienen kann."
     },
     {
+      "slug": "bge-embed",
+      "label": "bge-m3 · Embedding (WSL, CPU)",
+      "model": "gpustack/bge-m3-GGUF/bge-m3-Q8_0.gguf",
+      "port": 8095,
+      "fit": { "enabled": false, "targetMarginMib": null, "minCtx": null },
+      "args": {
+        "ctx": 8192, "ngl": 0, "parallel": 4,
+        "cacheTypeK": null, "cacheTypeV": null, "loadMode": "mmap",
+        "flashAttention": false, "jinja": false, "metrics": true,
+        "reasoning": null, "reasoningBudget": null,
+        "uiMcpProxy": false
+      },
+      "speculative": { "draftHfRepo": null, "draftNgl": null },
+      "mcp": { "serversConfig": null },
+      "env": { "CUDA_VISIBLE_DEVICES": "" },
+      "extraArgs": ["--embedding", "--pooling", "cls", "--embd-normalize", "2", "-b", "8192", "-ub", "8192"],
+      "notes": "T002538. Der kanonische Embedding-Endpunkt: :8095 steht in Taskfile.yml, Taskfile.llm.yml, environments/dev.yaml, tests/local/NFA-11.sh und ~/.config/bge-mcp/server.env. Laeuft in WSL unter dem b10223-Build, nicht mehr als llama-server.exe auf Windows. CUDA_VISIBLE_DEVICES='' ist NICHT redundant zu -ngl 0: letzteres verhindert nur das Auslagern der Layer, llama.cpp allokiert trotzdem einen CUDA-Kontext. Gemessen 2026-08-02: die vier Windows-bge-Server hielten so zusammen 2,65 GB VRAM; deren Freigabe hob den Gemma-26B-Kontext von 12032 auf 45824. Kein fit: bei -ngl 0 waere es wirkungslos und wuerde Teilnahme am VRAM-Wettbewerb vortaeuschen. parallel 4 uebernimmt den Batch-Durchsatz des stillgelegten Paars auf :8085."
+    },
+    {
+      "slug": "bge-rerank",
+      "label": "bge-reranker-v2-m3 · Rerank (WSL, CPU)",
+      "model": "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q8_0.gguf",
+      "port": 8096,
+      "fit": { "enabled": false, "targetMarginMib": null, "minCtx": null },
+      "args": {
+        "ctx": 8192, "ngl": 0, "parallel": 4,
+        "cacheTypeK": null, "cacheTypeV": null, "loadMode": "mmap",
+        "flashAttention": false, "jinja": false, "metrics": true,
+        "reasoning": null, "reasoningBudget": null,
+        "uiMcpProxy": false
+      },
+      "speculative": { "draftHfRepo": null, "draftNgl": null },
+      "mcp": { "serversConfig": null },
+      "env": { "CUDA_VISIBLE_DEVICES": "" },
+      "extraArgs": ["--reranking", "-b", "8192", "-ub", "8192"],
+      "notes": "T002538. Der kanonische Rerank-Endpunkt :8096, Gegenstueck zu bge-embed. Eigener Prozess, weil llama.cpp CLS- und RANK-Pooling nicht in einem Server bedienen kann — dieselbe Begruendung wie beim Batch-Paar. CUDA_VISIBLE_DEVICES='' siehe bge-embed. Der OpenAI-kompatible /v1/rerank-Pfad liefert dieselben Werte wie der native /rerank; verglichen wird die Reihenfolge der relevance_score, nicht deren Absolutwert (die sind rohe Logits, typisch um -11 fuer irrelevante Dokumente)."
+    },
+    {
       "slug": "gemma-factory",
       "label": "Gemma 4 12B · Factory Single-Agent",
       "model": "unsloth/gemma-4-12B-it-qat-UD-Q4_K_XL/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",

--- a/tests/spec/local-llm-proxy/loadout-env-property.bats
+++ b/tests/spec/local-llm-proxy/loadout-env-property.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# tests/spec/local-llm-proxy/loadout-env-property.bats
+# SSOT: openspec/specs/local-llm-proxy.md
+# Ticket: T002538
+#
+# Pruefmodus (Test-Resultats-Konvention T002448-M4): ERGEBNIS-basiert. Geprueft
+# wird die von buildStartCommand() erzeugte Kommandozeile und der Rueckgabewert
+# von parseLoadouts() — kein grep auf Script-Interna.
+#
+# Hintergrund: Die bge-Server sind CPU-gebunden (-ngl 0), allokieren aber
+# trotzdem je Prozess rund 600 MB CUDA-Kontext. Nur CUDA_VISIBLE_DEVICES=''
+# verhindert das. Ohne env-Unterstuetzung im Loadout-Schema waere ein
+# Registry-Eintrag nicht aequivalent zu den handangelegten Units, sondern
+# still schlechter — der VRAM-Gewinn (2,65 GB, entspricht rund 34.000 Tokens
+# Kontext beim Gemma 26B) ginge verloren, ohne dass irgendetwas rot wird.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  LOADOUTS="$REPO/scripts/llm/loadouts.json"
+}
+
+# Gibt die Kommandozeile fuer <slug> aus der echten loadouts.json aus.
+_start_cmd() {
+  node --input-type=module -e "
+    import { readFileSync } from 'node:fs';
+    const { buildStartCommand } = await import('file://$REPO/scripts/llm-proxy/runner.mjs');
+    const d = JSON.parse(readFileSync('$LOADOUTS', 'utf8'));
+    const l = d.loadouts.find((x) => x.slug === '$1');
+    if (!l) { console.error('slug nicht gefunden'); process.exit(1); }
+    console.log(buildStartCommand(l, '/m.gguf', d.defaults, '/bin/llama-server').join('\n'));
+  "
+}
+
+# Validiert ein Loadout-Dokument und gibt 'OK' oder die Fehlermeldung aus.
+_validate() {
+  node --input-type=module -e "
+    const { parseLoadouts } = await import('file://$REPO/scripts/llm-proxy/loadouts.mjs');
+    try { parseLoadouts(process.argv[1]); console.log('OK'); }
+    catch (e) { console.log(e.message); }
+  " "$1"
+}
+
+_doc_with_env() {
+  cat <<EOF
+{"version":1,"modelRoots":["~/m"],"defaults":{"host":"127.0.0.1"},"loadouts":[
+ {"slug":"t","label":"t","model":"a.gguf","port":9999,
+  "fit":{"enabled":false},"args":{"ctx":8192,"ngl":0},"env":$1}]}
+EOF
+}
+
+# ── Schema ───────────────────────────────────────────────────────────────────
+
+@test "T002538: env mit leerem Wert wird akzeptiert" {
+  # Der eigentliche Anwendungsfall. Ein Schema, das leere Werte ablehnt, waere
+  # fuer CUDA_VISIBLE_DEVICES unbrauchbar.
+  run _validate "$(_doc_with_env '{"CUDA_VISIBLE_DEVICES":""}')"
+  echo "$output"
+  [ "$output" = "OK" ]
+}
+
+@test "T002538: env mit ungueltigem Variablennamen wird abgelehnt" {
+  # Positiv-Anker zuerst (T002356-M1): ein gueltiger Name muss durchgehen,
+  # sonst waere die Ablehnung auch bei kaputtem Schema 'richtig'.
+  run _validate "$(_doc_with_env '{"GUELTIG_1":"x"}')"
+  [ "$output" = "OK" ]
+
+  run _validate "$(_doc_with_env '{"NICHT GUELTIG":"x"}')"
+  echo "$output"
+  [ "$output" != "OK" ]
+  [[ "$output" == *"env-Name"* ]]
+}
+
+@test "T002538: env mit Nicht-String-Wert wird abgelehnt" {
+  run _validate "$(_doc_with_env '{"A":"ok"}')"
+  [ "$output" = "OK" ]
+
+  run _validate "$(_doc_with_env '{"A":1}')"
+  echo "$output"
+  [ "$output" != "OK" ]
+}
+
+@test "T002538: env als Array wird abgelehnt" {
+  run _validate "$(_doc_with_env '["A=1"]')"
+  echo "$output"
+  [ "$output" != "OK" ]
+}
+
+# ── Kommandozeile ────────────────────────────────────────────────────────────
+
+@test "T002538: bge-embed setzt CUDA_VISIBLE_DEVICES als systemd-Property" {
+  run _start_cmd bge-embed
+  [ "$status" -eq 0 ]
+  echo "$output"
+  echo "$output" | grep -Fxq -- '--property=Environment=CUDA_VISIBLE_DEVICES='
+}
+
+@test "T002538: bge-rerank setzt CUDA_VISIBLE_DEVICES als systemd-Property" {
+  run _start_cmd bge-rerank
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -Fxq -- '--property=Environment=CUDA_VISIBLE_DEVICES='
+}
+
+@test "T002538: die Environment-Property steht VOR dem '--'-Trenner" {
+  # Danach gaebe systemd-run sie als Argument an llama-server weiter, das die
+  # Option nicht kennt und mit Fehler abbricht. Die Reihenfolge ist der
+  # eigentliche Gegenstand — dass die Zeile ueberhaupt vorkommt, sagt nichts.
+  run _start_cmd bge-embed
+  [ "$status" -eq 0 ]
+  local i_env i_sep
+  i_env=$(echo "$output" | grep -nFx -- '--property=Environment=CUDA_VISIBLE_DEVICES=' | cut -d: -f1)
+  i_sep=$(echo "$output" | grep -nFx -- '--' | head -1 | cut -d: -f1)
+  echo "env at $i_env, separator at $i_sep"
+  [ -n "$i_env" ] && [ -n "$i_sep" ]
+  [ "$i_env" -lt "$i_sep" ]
+}
+
+@test "T002538: ein Loadout ohne env erzeugt keine Environment-Property" {
+  # Gegenprobe: die Erweiterung darf bestehende Loadouts nicht veraendern.
+  # Positiv-Anker zuerst — ohne ihn waere die Negativ-Aussage auch dann wahr,
+  # wenn _start_cmd gar nichts ausgibt.
+  run _start_cmd gemma26-factory
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -Fxq -- '--property=Restart=on-failure'
+
+  local n
+  n=$(echo "$output" | grep -cF -- '--property=Environment=' || true)
+  echo "Environment-Properties: $n"
+  [ "$n" -eq 0 ]
+}
+
+@test "T002538: bge-embed und bge-rerank halten -ngl 0 und eigene Ports" {
+  # Belegt, dass die Registry-Eintraege den laufenden Units entsprechen:
+  # CPU-gebunden, und die kanonischen Ports 8095/8096 statt der stillgelegten
+  # Batch-Ports 8085/8086.
+  run _start_cmd bge-embed
+  echo "$output" | grep -Fxq -- '8095'
+  echo "$output" | grep -Fxq -- '0'
+
+  run _start_cmd bge-rerank
+  echo "$output" | grep -Fxq -- '8096'
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2508,6 +2508,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/loadout-env-property",
+    "file": "tests/spec/local-llm-proxy/loadout-env-property.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/model-path-large-file",
     "file": "tests/spec/local-llm-proxy/model-path-large-file.bats",
     "category": "local-llm-proxy",


### PR DESCRIPTION
## Was

Die bge-Server liefen als **handangelegte systemd-Units außerhalb der Registry**. Sie stehen jetzt als Loadouts `bge-embed` (`:8095`) und `bge-rerank` (`:8096`) in `scripts/llm/loadouts.json` und sind über `POST /admin/loadouts/<slug>/start` startbar.

## Warum ein neues Schemafeld nötig war

`buildStartCommand()` konnte bisher nur `Restart`, `RestartSec` und `--description` an `systemd-run` übergeben — **keine Umgebungsvariablen**.

Die bge-Units brauchen `CUDA_VISIBLE_DEVICES=''`. Das ist **nicht redundant** zu `-ngl 0`: letzteres verhindert nur das Auslagern der Layer, llama.cpp allokiert trotzdem einen CUDA-Kontext. Gemessen am 2026-08-02 hielten die vier Windows-bge-Server so zusammen **2,65 GB VRAM**; deren Freigabe hob den Gemma-26B-Kontext von 12.032 auf 45.824.

Ein Registry-Eintrag ohne `env` wäre also **nicht äquivalent** zu den laufenden Units gewesen, sondern still schlechter — ohne dass irgendein Test rot wird. Genau die Sorte Regression, die man erst Wochen später am Kontextbudget bemerkt.

## Die Reihenfolge ist der Kern

Die Environment-Properties stehen **vor** dem `--`-Trenner. Danach gäbe `systemd-run` sie als Argumente an `llama-server` weiter, das die Option nicht kennt und abbricht.

## Validierung

`env` ist ein flaches Objekt String → String:
- **Leere Werte sind ausdrücklich erlaubt** — das ist der Anwendungsfall.
- Variablennamen müssen `^[A-Za-z_][A-Za-z0-9_]*$` folgen, weil ein `=` im Namen die systemd-Property zerlegen würde.
- Zeilenumbrüche im Wert werden abgelehnt.

## Tests gegen die Implementierung verifiziert

Nicht nur „läuft grün", sondern geprüft, dass sie den Fehler *fangen*:

| Manipulation | Erwartung | Ergebnis |
|---|---|---|
| env-Emission entfernt | 5–7 rot, 8+9 grün | ✓ |
| Property **nach** `--` verschoben | nur 7 rot, 5+6 grün | ✓ |

Der zweite Fall ist der wichtigere: Die beiden Vorhandenseins-Tests hätten die Fehlplatzierung **übersehen**. Erst der Reihenfolge-Test fängt sie.

## Nicht in diesem Vorgang

Die Einträge `bge-embed-batch`/`bge-rerank-batch` auf `:8085`/`:8086` und die **T002426-Suite** (`tests/spec/llm-pipeline/dual-pair-failover.bats`) bleiben unangetastet. Die Suite ist 20/20 grün und prüft *Dateiinhalte* der `.ps1`-Skripte, keine laufenden Dienste — sie wird durch das stillgelegte Batch-Paar also nicht falsch. Das Stilllegen ist ein eigener Vorgang mit eigener Prüfung; die `.ps1`-Skripte bleiben vorerst als Rückfallweg liegen, wie schon `start-gemma-server.ps1`.

## Verifikation

- `tests/spec/local-llm-proxy` + `local-llm-proxy.bats` + `tests/spec/llm-pipeline`: **85 ok, 0 not ok**
- `node --test`: loadouts 12/12, models 7/7, runner 12/12, server 11/11
- **Vorbestehend rot, nicht von diesem PR:** `mcp-bridge.test.mjs` importiert `vitest` (im Repo-Root nicht installiert); schlägt auf `main` identisch fehl.