### PR TITLE
chore(ops): dauerhaft deaktivierte stdio-Server aus mcp-bridge.json entfernen [T002542]

### DIFF
--- a/scripts/llm/mcp-bridge.json
+++ b/scripts/llm/mcp-bridge.json
@@ -25,48 +25,6 @@
       "cwd": "/home/patrick/Bachelorprojekt",
       "enabled": true,
       "bearerTokenEnv": null
-    },
-    "github-mcp": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
-      "env": {
-        "GITHUB_TOKEN": "{env:GITHUB_TOKEN}"
-      },
-      "cwd": "/home/patrick/Bachelorprojekt",
-      "enabled": false,
-      "bearerTokenEnv": null
-    },
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"],
-      "env": {},
-      "cwd": "/home/patrick/Bachelorprojekt",
-      "enabled": false,
-      "bearerTokenEnv": null
-    },
-    "docfork": {
-      "command": "npx",
-      "args": ["-y", "docfork"],
-      "env": {},
-      "cwd": "/home/patrick/Bachelorprojekt",
-      "enabled": false,
-      "bearerTokenEnv": null
-    },
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
-      "env": {},
-      "cwd": "/home/patrick/Bachelorprojekt",
-      "enabled": false,
-      "bearerTokenEnv": null
-    },
-    "webresearch": {
-      "command": "npx",
-      "args": ["-y", "@mzxrai/mcp-webresearch@latest"],
-      "env": {},
-      "cwd": "/home/patrick/Bachelorprojekt",
-      "enabled": false,
-      "bearerTokenEnv": null
     }
   }
 }


### PR DESCRIPTION
## Was

Entfernt die fünf dauerhaft deaktivierten stdio-Server aus `scripts/llm/mcp-bridge.json`:
`github-mcp`, `playwright`, `docfork`, `sequential-thinking`, `webresearch`.

Verbleibend aktiv: `ticket-mcp`, `mcp-task-runner`, `codebase-memory-mcp`.

## Warum

Alle fünf standen seit T002429 unverändert auf `enabled: false`. Das damalige Proposal nannte
`playwright` und `webresearch` selbst „fragwürdige Kandidaten". Als Karteileichen verschleiern
sie, welche Server die Brücke tatsächlich bedient.

## Keine Verhaltensänderung — belegt

Command-Output gegen die **laufende** Brücke (noch mit der alten 8-Einträge-Config):

| Server | `POST :18235/mcp/<name>` |
|---|---|
| `ticket-mcp` | `200` |
| `mcp-task-runner` | `200` |
| `codebase-memory-mcp` | `200` |
| `playwright` | `404 server_not_found` |
| `webresearch` | `404 server_not_found` |
| `github-mcp` | `404 server_not_found` |

„disabled" und „nicht vorhanden" sind für `initBridge` identisch — sie überspringt disabled-Einträge
schon beim Start (`if (!srvCfg.enabled) continue;`, `scripts/llm-proxy/mcp-bridge.mjs`).

Weiter geprüft:
- `mcp-bridge.test.mjs` nutzt eigene Fixtures statt dieser Config → **17/17 grün**
- SSOT-Spec `openspec/specs/local-llm-proxy.md` nennt keinen der fünf Namen → kein Spec-Drift
- `task test:all` grün, `task freshness:check` grün

## Nebenbefund (nicht Teil dieses PRs)

`openspec/changes/t2429-stdio-mcps-bridge/` liegt trotz Ticket-Status `done` noch unarchiviert
in `openspec/changes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFCEbTiSiHgVrwrbKEq2DW