### PR TITLE
chore(ops): github-mcp über die stdio-Brücke anbinden [T002547]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3042,7 +3042,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 605,
+      "file_count": 606,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3457,6 +3457,7 @@
         "scripts/llm-proxy/server.test.mjs",
         "scripts/llm-proxy/ui/index.html",
         "scripts/llm-pull-models.sh",
+        "scripts/llm/github-mcp-wrapper.sh",
         "scripts/llm/harden-gpu-firewall.ps1",
         "scripts/llm/install-startup-autostart.ps1",
         "scripts/llm/loadouts.json",

--- a/scripts/llm/github-mcp-wrapper.sh
+++ b/scripts/llm/github-mcp-wrapper.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# scripts/llm/github-mcp-wrapper.sh
+#
+# Startet den offiziellen GitHub-MCP-Server (github/github-mcp-server) als
+# stdio-Kindprozess der Bruecke (scripts/llm-proxy/mcp-bridge.mjs), erreichbar
+# unter http://127.0.0.1:18235/mcp/github-mcp.
+#
+# Warum ein Wrapper und kein direkter command-Eintrag in mcp-bridge.json:
+#
+#   1. TOKEN: Der Server braucht GITHUB_PERSONAL_ACCESS_TOKEN. Statt den Wert in
+#      eine Datei zu schreiben, holt der Wrapper ihn zur LAUFZEIT aus dem
+#      gh-CLI-Keyring. Damit liegt das Credential weder getrackt noch ungetrackt
+#      auf Platte — es existiert nur in der Umgebung dieses Prozesses.
+#
+#   2. PATH: Die llm-proxy-Unit setzt PATH=/usr/local/bin:/usr/bin:/bin.
+#      ~/.local/bin ist NICHT enthalten, das Binary dort waere fuer den
+#      Kindprozess unauffindbar. Deshalb der absolute Pfad unten.
+#      (gh liegt unter /usr/bin/gh und waere auffindbar, wird der Symmetrie und
+#      der Robustheit gegen PATH-Aenderungen halber aber ebenso absolut genannt.)
+#
+# Installation des Servers (Release v1.8.0, SHA256 gegen checksums.txt geprueft):
+#   curl -fL -o gh-mcp.tar.gz \
+#     https://github.com/github/github-mcp-server/releases/download/v1.8.0/github-mcp-server_Linux_x86_64.tar.gz
+#   tar -xzf gh-mcp.tar.gz github-mcp-server
+#   install -m 0755 github-mcp-server ~/.local/bin/github-mcp-server
+#
+# Argumente dieses Wrappers werden an `github-mcp-server stdio` durchgereicht,
+# etwa --read-only oder --toolsets=repos,issues. Aktuell laeuft er bewusst ohne
+# Einschraenkung (voller Toolset, 44 Tools) — Betreiber-Entscheidung T002547.
+set -euo pipefail
+
+GH_BIN="${GH_BIN:-/usr/bin/gh}"
+MCP_BIN="${GITHUB_MCP_BIN:-$HOME/.local/bin/github-mcp-server}"
+
+if [[ ! -x "$MCP_BIN" ]]; then
+  echo "github-mcp-wrapper: $MCP_BIN fehlt oder ist nicht ausfuehrbar." >&2
+  echo "  Installation siehe Kopfkommentar dieser Datei." >&2
+  exit 127
+fi
+
+if [[ ! -x "$GH_BIN" ]]; then
+  echo "github-mcp-wrapper: $GH_BIN fehlt — ohne gh-CLI gibt es keinen Token." >&2
+  exit 127
+fi
+
+# Fail-closed: ein leerer Token wuerde den Server starten lassen und erst beim
+# ersten API-Aufruf scheitern. Die Bruecke expandiert {env:VAR} ihrerseits mit
+# `|| ''` (mcp-bridge.mjs), still-leere Credentials sind hier also eine reale
+# Fehlerklasse — nicht bloss Theorie.
+if ! TOKEN="$("$GH_BIN" auth token 2>/dev/null)" || [[ -z "$TOKEN" ]]; then
+  echo "github-mcp-wrapper: 'gh auth token' lieferte nichts." >&2
+  echo "  Anmelden mit: gh auth login" >&2
+  exit 1
+fi
+
+export GITHUB_PERSONAL_ACCESS_TOKEN="$TOKEN"
+unset TOKEN
+
+exec "$MCP_BIN" stdio "$@"

--- a/scripts/llm/mcp-bridge.json
+++ b/scripts/llm/mcp-bridge.json
@@ -25,6 +25,14 @@
       "cwd": "/home/patrick/Bachelorprojekt",
       "enabled": true,
       "bearerTokenEnv": null
+    },
+    "github-mcp": {
+      "command": "/home/patrick/Bachelorprojekt/scripts/llm/github-mcp-wrapper.sh",
+      "args": [],
+      "env": {},
+      "cwd": "/home/patrick/Bachelorprojekt",
+      "enabled": true,
+      "bearerTokenEnv": null
     }
   }
 }


### PR DESCRIPTION
## Was

GitHub als MCP für das lokale Modell, erreichbar unter `http://127.0.0.1:18235/mcp/github-mcp`.

- `scripts/llm/github-mcp-wrapper.sh` (neu, `100755`)
- `scripts/llm/mcp-bridge.json` — vierter Brücken-Eintrag

## Warum nicht der gehostete Dienst

`https://api.githubcopilot.com/mcp` wurde geprüft und verworfen: Anfragen verlassen den Rechner
(`x-github-edge-region: iad`), was der On-Premises-Ausrichtung der Plattform widerspricht.

## Warum nicht der alte Eintrag

Bis T002542 stand in `mcp-bridge.json` ein `github-mcp` auf `npx @modelcontextprotocol/server-github`.
Dieses Paket ist bei npm **deprecated** („Package no longer supported", letzte Version 2025.4.8) —
vermutlich der Grund für sein `enabled: false`. Ersatz ist der offizielle Go-Server
`github/github-mcp-server` **v1.8.0**, per Release-Tarball installiert, SHA256 gegen die
mitgelieferte `checksums.txt` geprüft.

## Token

**Kein Token auf Platte.** Der Wrapper holt ihn zur Laufzeit per `gh auth token` und übergibt ihn
als `GITHUB_PERSONAL_ACCESS_TOKEN` an den Kindprozess — weder in einer getrackten noch in einer
ungetrackten Datei. Fail-closed bei leerem Wert: die Brücke expandiert `{env:VAR}` sonst still zu
`''` (`mcp-bridge.mjs`), und der Server schlüge erst beim ersten API-Aufruf fehl.

## Verifikation (Command-Output)

Zweite llm-proxy-Instanz aus dem Worktree, `LLM_PROXY_PORT=18999`:

| Route | `initialize` |
|---|---|
| `ticket-mcp` | `200` |
| `mcp-task-runner` | `200` |
| `codebase-memory-mcp` | `200` |
| `github-mcp` | `200` — Capabilities + Server-Instructions, `tools/list` → **44 Tools** |

`mcp-bridge.test.mjs` 17/17, `task test:all` grün, `task freshness:check` grün.

> Der Eintrag trägt bewusst den **Hauptcheckout-Pfad** und greift daher erst nach dem Merge —
> `mcp-bridge.mjs` löst `configPath()` über `__dirname` auf. Ein absoluter Pfad zum Binary ist
> ebenfalls notwendig: die llm-proxy-Unit setzt `PATH=/usr/local/bin:/usr/bin:/bin`, `~/.local/bin`
> ist darin nicht enthalten.

## Rechteumfang

Bewusste Betreiber-Entscheidung: **voller Toolset** inklusive `delete_file`, `create_repository`,
`fork_repository`, `create_pull_request` — mit dem `gh`-CLI-Token (`gist, read:org, repo`) über alle
Repositories des Accounts. `--read-only` und `--toolsets` wurden angeboten und nicht gewählt; der
Wrapper reicht beide Flags durch, falls das später eingegrenzt werden soll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFCEbTiSiHgVrwrbKEq2DW