### PR TITLE
fix(ops): Handshake der stdio-Brücke einmal führen statt durchreichen [T002548]

### DIFF
--- a/scripts/llm-proxy/mcp-bridge.mjs
+++ b/scripts/llm-proxy/mcp-bridge.mjs
@@ -106,6 +106,17 @@ function createServerEntry(name, srvCfg) {
 
   const sessions = new Set();
 
+  // T002548 — Handshake-Zustand des Kindes.
+  //
+  // Die Bruecke teilt EINEN Kindprozess ueber alle HTTP-Sessions (T002429 §3.1),
+  // waehrend MCP `initialize` einmal pro Session vorsieht. Ein spec-treuer Server
+  // lehnt jedes weitere mit "duplicate 'initialize' received" ab. Deshalb fuehrt
+  // die Bruecke den Handshake genau einmal und beantwortet spaetere Anfragen aus
+  // `initResult` selbst. Der Zustand haengt am Kindprozess, nicht an der Route:
+  // beim Neustart (proc.on('exit') -> createServerEntry) entsteht er frisch, was
+  // korrekt ist — der neue Prozess hat noch keinen Handshake gesehen.
+  const handshake = { initResult: null, pendingInitId: null, notified: false };
+
   // Read stdout line by line – each line is a JSON-RPC message
   const rl = createInterface({ input: proc.stdout });
   rl.on('line', (line) => {
@@ -123,6 +134,16 @@ function createServerEntry(name, srvCfg) {
     }
     if (msg && msg.id !== undefined) {
       const key = String(msg.id);
+
+      // Antwort auf den einen Handshake, den wir durchgereicht haben → merken.
+      // Nur `result` wird gecacht: ein Fehler darf nicht als gueltiger Handshake
+      // konserviert werden, sonst bekaeme jede spaetere Session denselben Fehler
+      // ohne Chance auf einen neuen Versuch.
+      if (handshake.pendingInitId !== null && key === handshake.pendingInitId) {
+        handshake.pendingInitId = null;
+        if (msg.result !== undefined) handshake.initResult = msg.result;
+      }
+
       const p = pending.get(key);
       if (p) {
         clearTimeout(p.timer);
@@ -161,7 +182,7 @@ function createServerEntry(name, srvCfg) {
     console.error(`[mcp-bridge] ${name}: spawn error`, err.message);
   });
 
-  return { proc, sessions, rl, keepAliveTimer: null };
+  return { proc, sessions, rl, keepAliveTimer: null, handshake };
 }
 
 function broadcastToSessions(sessions, line) {
@@ -300,6 +321,36 @@ function handleMcp(req, res, serverName, method) {
         res.writeHead(400, withCors({ 'content-type': 'application/json' }));
         res.end(JSON.stringify({ error: { code: 'invalid_rpc', message: 'missing jsonrpc or method field' } }));
         return;
+      }
+
+      // T002548 — Handshake nicht durchreichen, wenn er schon gefuehrt wurde.
+      //
+      // MCP sieht `initialize` einmal pro Session vor, die Bruecke teilt aber
+      // einen Kindprozess. Ohne diesen Abfang antwortet ein spec-treuer Server
+      // (github-mcp-server v1.8.0) jeder zweiten Session mit
+      // "duplicate 'initialize' received". Die Antwort traegt die id des
+      // ANFRAGENDEN Clients, nicht die des ersten — sonst ordnet sein
+      // JSON-RPC-Layer sie keiner Anfrage zu.
+      const hs = entry.handshake;
+      if (hs) {
+        if (message.method === 'initialize') {
+          if (hs.initResult !== null) {
+            res.writeHead(200, withCors({ 'content-type': 'application/json' }));
+            res.end(JSON.stringify({ jsonrpc: '2.0', id: message.id, result: hs.initResult }));
+            return;
+          }
+          hs.pendingInitId = String(message.id);
+        } else if (message.method === 'notifications/initialized') {
+          // Auch diese Notification gehoert einmal pro Session — der geteilte
+          // Prozess hat sie nach dem ersten Mal gesehen. 202 wie bei jeder
+          // Notification, nur ohne Schreibvorgang.
+          if (hs.notified) {
+            res.writeHead(202, withCors());
+            res.end();
+            return;
+          }
+          hs.notified = true;
+        }
       }
 
       try {

--- a/scripts/llm-proxy/mcp-bridge.test.mjs
+++ b/scripts/llm-proxy/mcp-bridge.test.mjs
@@ -435,4 +435,106 @@ describe('mcp-bridge', () => {
 
     expect(res.writeHead).toHaveBeenCalledWith(405, expect.any(Object));
   });
+
+  // ── initialize: einmal zum Kind, danach aus dem Cache (T002548) ────────────
+  //
+  // Die Bruecke teilt EINEN Kindprozess ueber alle HTTP-Sessions (T002429 §3.1),
+  // waehrend MCP `initialize` einmal pro Session vorsieht. Ein spec-treuer Server
+  // (github-mcp-server v1.8.0) lehnt das zweite mit "duplicate 'initialize'
+  // received" ab; die nachsichtigen stdio-Server verdeckten die Luecke bisher.
+
+  it('reicht das erste initialize an das Kind durch und merkt sich das Ergebnis', async () => {
+    useSingleConfig();
+    const proc = spawnOne();
+    await initBridge();
+
+    const body = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'a', version: '1' } },
+    });
+    const res = mockRes();
+    handleMcp(mockReq({}, body), res, 'ticket-mcp', 'POST');
+
+    await vi.waitFor(() => {
+      expect(proc.stdin.write).toHaveBeenCalledWith(body + '\n');
+    });
+
+    const childReply = JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      result: { protocolVersion: '2025-06-18', capabilities: { tools: {} }, serverInfo: { name: 'ticket-mcp', version: '1.0.0' } },
+    });
+    lineHandlerFrom(mockState.getRlInstances()[0])(childReply);
+
+    await vi.waitFor(() => {
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
+    });
+  });
+
+  it('beantwortet ein zweites initialize selbst, ohne es an das Kind zu schicken', async () => {
+    useSingleConfig();
+    const proc = spawnOne();
+    await initBridge();
+
+    // Erste Session: Handshake vollstaendig durchfuehren.
+    const first = JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'a', version: '1' } },
+    });
+    handleMcp(mockReq({}, first), mockRes(), 'ticket-mcp', 'POST');
+    await vi.waitFor(() => {
+      expect(proc.stdin.write).toHaveBeenCalledWith(first + '\n');
+    });
+    lineHandlerFrom(mockState.getRlInstances()[0])(JSON.stringify({
+      jsonrpc: '2.0', id: 1,
+      result: { protocolVersion: '2025-06-18', capabilities: { tools: {} }, serverInfo: { name: 'ticket-mcp', version: '1.0.0' } },
+    }));
+
+    // Positiv-Anker (T002356-M1): der Durchreich-Pfad funktioniert ueberhaupt.
+    // Ohne ihn waere die Negativ-Aussage unten bei einer toten Bruecke trivial erfuellt.
+    const writesAfterFirst = proc.stdin.write.mock.calls.length;
+    expect(writesAfterFirst).toBeGreaterThan(0);
+
+    // Zweite Session: eigene id, eigener Client.
+    const second = JSON.stringify({
+      jsonrpc: '2.0', id: 99, method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'b', version: '1' } },
+    });
+    const res2 = mockRes();
+    handleMcp(mockReq({}, second), res2, 'ticket-mcp', 'POST');
+
+    // Muss ohne Zutun des Kindes beantwortet werden.
+    await vi.waitFor(() => {
+      expect(res2.writeHead).toHaveBeenCalledWith(200, expect.any(Object));
+    });
+
+    // Kern der Regression: kein weiterer initialize-Schreibvorgang zum Kind.
+    expect(proc.stdin.write.mock.calls.length).toBe(writesAfterFirst);
+
+    // Und die Antwort traegt die id des ZWEITEN Aufrufers, nicht die des ersten.
+    const payload = JSON.parse(res2.end.mock.calls[0][0]);
+    expect(payload.id).toBe(99);
+    expect(payload.error).toBeUndefined();
+    expect(payload.result.serverInfo.name).toBe('ticket-mcp');
+  });
+
+  it('schickt notifications/initialized nur einmal an das Kind', async () => {
+    useSingleConfig();
+    const proc = spawnOne();
+    await initBridge();
+
+    const note = JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+    handleMcp(mockReq({}, note), mockRes(), 'ticket-mcp', 'POST');
+    await vi.waitFor(() => {
+      expect(proc.stdin.write).toHaveBeenCalledWith(note + '\n');
+    });
+    const after = proc.stdin.write.mock.calls.length;
+
+    const res2 = mockRes();
+    handleMcp(mockReq({}, note), res2, 'ticket-mcp', 'POST');
+    await vi.waitFor(() => {
+      expect(res2.writeHead).toHaveBeenCalledWith(202, expect.any(Object));
+    });
+    expect(proc.stdin.write.mock.calls.length).toBe(after);
+  });
 });


### PR DESCRIPTION
Closes T002548

## Fehler

`github-mcp` war über die Brücke funktional tot: **jedes** `initialize` scheiterte mit
`duplicate 'initialize' received` — auch das erste über HTTP, weil der eine erlaubte Handshake
beim Prozessstart bereits verbraucht war.

## Ursache

`mcp-bridge.mjs` verzweigte nur nach HTTP-Verb (`OPTIONS`/`GET`/`POST`) und reichte jede
JSON-RPC-Nachricht unverändert an den Kindprozess weiter. Die Brücke teilt aber **einen**
Kindprozess über alle HTTP-Sessions (T002429 §3.1), während MCP `initialize` **einmal pro Session**
vorsieht.

**Nicht github-spezifisch:** `ticket-mcp`, `mcp-task-runner` und `codebase-memory-mcp` akzeptieren
wiederholte `initialize` stillschweigend und haben die Lücke verdeckt. Jeder künftige spec-treue
Server wäre gebrochen — `github-mcp-server` v1.8.0 war nur der erste, der sich an die Spec hält.

## Behebung

Die Brücke führt den Handshake genau einmal mit dem Kind und beantwortet spätere Anfragen aus dem
gemerkten `result` selbst.

Drei Details, die nicht beliebig sind:

- Die Antwort trägt die id des **anfragenden** Clients, nicht die des ersten — sonst ordnet dessen
  JSON-RPC-Layer sie keiner Anfrage zu.
- Gecacht wird **nur** ein `result`. Ein konservierter Fehler ließe jede spätere Session ohne neuen
  Versuch scheitern.
- Der Zustand hängt am Kindprozess, nicht an der Route — beim Auto-Restart entsteht er korrekt neu.

`notifications/initialized` wird ebenso nur einmal durchgereicht.

## Rot-Grün

| | Tests |
|---|---|
| vor der Änderung | **2 failed** \| 18 passed |
| nach der Änderung | **20 passed** |

Zusätzlich am laufenden System gegen eine zweite llm-proxy-Instanz (`LLM_PROXY_PORT=18999`) —
drei aufeinanderfolgende `initialize` je Route:

| Route | 1. | 2. | 3. |
|---|---|---|---|
| `github-mcp` | `result` (id=1) | `result` (id=2) | `result` (id=3) |
| `ticket-mcp` | `result` (id=1) | `result` (id=2) | `result` (id=3) |
| `codebase-memory-mcp` | `result` (id=1) | `result` (id=2) | `result` (id=3) |

Vorher lieferte `github-mcp` bei **jedem** Aufruf `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFCEbTiSiHgVrwrbKEq2DW