### PR TITLE
fix(ops): WebUI-Seed beim Loadout-Start tatsächlich rendern [T002549]

### DIFF
--- a/docs/agent-guide/registry/mcp.yaml
+++ b/docs/agent-guide/registry/mcp.yaml
@@ -232,12 +232,16 @@ clients:
 
   github-mcp:
     transport: stdio
-    command: npx
-    args:
-      - -y
-      - "@modelcontextprotocol/server-github"
-    env:
-      GITHUB_TOKEN: "{env:GITHUB_TOKEN}"
+    browser_endpoint: http://127.0.0.1:18235/mcp/github-mcp
+    # T002547: offizieller Go-Server github/github-mcp-server statt
+    # @modelcontextprotocol/server-github — letzteres ist bei npm als
+    # deprecated markiert ("Package no longer supported").
+    #
+    # Der Wrapper existiert aus zwei Gruenden, die beide nicht kosmetisch sind:
+    # er holt den Token zur LAUFZEIT per 'gh auth token' (kein Credential auf
+    # Platte), und er adressiert das Binary absolut, weil die llm-proxy-Unit
+    # PATH=/usr/local/bin:/usr/bin:/bin setzt und ~/.local/bin darin fehlt.
+    command: /home/patrick/Bachelorprojekt/scripts/llm/github-mcp-wrapper.sh
     bridge:
       url: http://127.0.0.1:18235/mcp/github-mcp
       bind: 127.0.0.1:18235

--- a/scripts/llm-proxy/runner.mjs
+++ b/scripts/llm-proxy/runner.mjs
@@ -9,6 +9,7 @@
 //   30,9 tok/s decode; ungesetzt mit -fitt 2400 waren es 158-166 tok/s bei
 //   105.472 statt 65.536 Kontext.
 import { execFileSync } from 'node:child_process';
+import { generateUiConfigSeed } from '../llm/ui-config-seed.mjs';
 
 export function unitName(slug) { return `llama-${slug}.service`; }
 
@@ -88,7 +89,36 @@ export function buildStartCommand(loadout, modelPath, defaults, binPath, resolve
   ];
 }
 
+/**
+ * T002549 — Erzeugt die Datei, auf die `--ui-config-file` zeigt.
+ *
+ * T002544 lieferte das Flag (buildServerArgv) und den Generator, aber keinen
+ * Aufruf: `--ui-config-file` zeigte auf einen Pfad, den niemand schrieb. Der
+ * Aufruf gehoert hierher und nicht in eine handgepflegte systemd-Unit — so
+ * wirkt er automatisch fuer jedes kuenftige Loadout mit dem Feld, und die
+ * Logik bleibt im Repo statt auf dem Host.
+ *
+ * Best-effort mit Absicht: schlaegt das Rendern fehl (z.B. weil BGE_MCP_TOKEN
+ * fehlt), soll der Modellstart trotzdem laufen. Ein Server ohne vorbelegte
+ * MCP-Liste ist brauchbar, ein nicht startender Server nicht. Der Fehler wird
+ * laut protokolliert, nicht verschluckt.
+ *
+ * @param {{slug?: string, uiConfigFile?: string|null}} loadout
+ */
+export function ensureUiConfigRendered(loadout) {
+  if (!loadout || !loadout.uiConfigFile) return;
+  try {
+    generateUiConfigSeed({ outputPath: loadout.uiConfigFile });
+  } catch (err) {
+    console.error(
+      `[runner] ui-config seed for '${loadout.slug}' not written: ${err.message}\n` +
+      `  Der Server startet ohne vorbelegte MCP-Liste; die WebUI faellt auf den Browser-Storage zurueck.`,
+    );
+  }
+}
+
 export function startUnit(loadout, modelPath, defaults, binPath, resolved = {}) {
+  ensureUiConfigRendered(loadout);
   const [cmd, ...args] = buildStartCommand(loadout, modelPath, defaults, binPath, resolved);
   execFileSync(cmd, args, { encoding: 'utf8', stdio: 'pipe' });
 }

--- a/scripts/llm-proxy/runner.test.mjs
+++ b/scripts/llm-proxy/runner.test.mjs
@@ -123,3 +123,45 @@ test('buildStartCommand kapselt systemd-run mit --user und --collect', () => {
   const sep = cmd.indexOf('--')
   assert.equal(cmd[sep + 1], '/opt/llama/bin/llama-server')
 })
+
+// ── T002549: uiConfigFile muss vor dem Start auch ERZEUGT werden ─────────────
+//
+// T002544 lieferte das Flag (buildServerArgv) und den Generator, aber keinen
+// Aufruf: --ui-config-file zeigte auf eine Datei, die niemand schrieb. Geprueft
+// wird hier das Resultat auf der Platte, nicht ob irgendwo ein Funktionsname
+// im Quelltext steht (T002448-M4).
+
+test('ensureUiConfigRendered schreibt die Seed-Datei fuer ein Loadout mit uiConfigFile', async () => {
+  const { ensureUiConfigRendered } = await import('./runner.mjs')
+  const fs = await import('node:fs')
+  const os = await import('node:os')
+  const path = await import('node:path')
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'uicfg-'))
+  const out = path.join(tmp, 'nested', 'ui-config.json')
+  const prev = process.env.BGE_MCP_TOKEN
+  process.env.BGE_MCP_TOKEN = 'test-token'
+
+  try {
+    ensureUiConfigRendered({ slug: 'gemma26-factory', uiConfigFile: out })
+
+    assert.ok(fs.existsSync(out), 'Seed-Datei wurde nicht geschrieben')
+    const doc = JSON.parse(fs.readFileSync(out, 'utf8'))
+    assert.equal(typeof doc.mcpServers, 'string',
+      'mcpServers muss ein String sein — ein blankes Array verwirft die WebUI still')
+    const arr = JSON.parse(doc.mcpServers)
+    assert.ok(Array.isArray(arr) && arr.length > 0)
+  } finally {
+    if (prev === undefined) delete process.env.BGE_MCP_TOKEN
+    else process.env.BGE_MCP_TOKEN = prev
+    fs.rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('ensureUiConfigRendered ist ein No-op ohne uiConfigFile', async () => {
+  const { ensureUiConfigRendered } = await import('./runner.mjs')
+  // Darf nicht werfen und nichts schreiben — Loadouts ohne das Feld bleiben
+  // unveraendert, ihre argv traegt kein --ui-config-file.
+  assert.doesNotThrow(() => ensureUiConfigRendered({ slug: 'bge-embed' }))
+  assert.doesNotThrow(() => ensureUiConfigRendered({ slug: 'x', uiConfigFile: null }))
+})

--- a/scripts/llm/ui-config-seed.mjs
+++ b/scripts/llm/ui-config-seed.mjs
@@ -16,15 +16,16 @@ export function generateUiConfigSeed(options = {}) {
   const registry = yaml.load(registryContent);
   const clients = registry.clients || {};
 
-  const targetServerKeys = [
-    'mcp-kubernetes',
-    'mcp-postgres',
-    'factory-mcp',
-    'bge-mcp',
-    'ticket-mcp',
-    'mcp-task-runner',
-    'codebase-memory-mcp'
-  ];
+  // T002549 — Die Serverauswahl wird aus der Registry ABGELEITET, nicht in einer
+  // Codeliste gefuehrt. Eine hartkodierte Liste erzwingt eine Code-Aenderung fuer
+  // jeden neuen Server; genau daran fiel github-mcp (T002547) heraus, obwohl die
+  // Bruecke ihn bedient. Kriterium ist ausschliesslich die Erreichbarkeit:
+  // browser_endpoint (bevorzugt) oder endpoint. stdio-Eintraege ohne beides
+  // bedient die Bruecke nicht und gehoeren deshalb nicht in den Seed.
+  //
+  // Anzeigenamen entsprechen dem Registry-Schluessel — einzige Ausnahme ist
+  // mcp-kubernetes, das in der UI seit jeher als "k8s" gefuehrt wird.
+  const DISPLAY_NAME_OVERRIDES = { 'mcp-kubernetes': 'k8s' };
 
   let templateContent = {};
   let templateRaw = '';
@@ -42,18 +43,13 @@ export function generateUiConfigSeed(options = {}) {
 
   const token = process.env.BGE_MCP_TOKEN || '';
 
-  const clientKeys = Object.keys(clients);
-  const keysToProcess = targetServerKeys.filter(k => clientKeys.includes(k)).length > 0
-    ? targetServerKeys
-    : clientKeys;
-
   const servers = [];
 
-  for (const key of keysToProcess) {
+  for (const key of Object.keys(clients)) {
     const entry = clients[key];
     if (!entry) continue;
 
-    const name = key === 'mcp-kubernetes' ? 'k8s' : key;
+    const name = DISPLAY_NAME_OVERRIDES[key] || key;
     const url = entry.browser_endpoint || entry.endpoint;
 
     if (!url) continue;

--- a/scripts/llm/ui-config-seed.test.mjs
+++ b/scripts/llm/ui-config-seed.test.mjs
@@ -82,4 +82,41 @@ clients:
       });
     }).toThrow(/BGE_MCP_TOKEN/);
   });
+
+  // ── T002549: Serverauswahl aus der Registry statt aus einer Codeliste ──────
+  //
+  // T002544 fuehrte eine hartkodierte targetServerKeys-Liste. Damit braucht
+  // jeder neue Server eine Code-Aenderung, und github-mcp (T002547) fiel
+  // heraus, obwohl die Bruecke ihn bedient.
+
+  it('nimmt jeden Registry-Eintrag mit erreichbarer Adresse auf, auch neu hinzugekommene', () => {
+    const templatePath = path.join(tmpDir, 'tpl.json');
+    const registryPath = path.join(tmpDir, 'reg.yaml');
+    const outputPath = path.join(tmpDir, 'out.json');
+
+    fs.writeFileSync(templatePath, JSON.stringify({}));
+    fs.writeFileSync(registryPath, `
+clients:
+  factory-mcp:
+    transport: http
+    endpoint: "http://127.0.0.1:13003/mcp"
+  github-mcp:
+    transport: stdio
+    browser_endpoint: "http://127.0.0.1:18235/mcp/github-mcp"
+  playwright:
+    transport: stdio
+`);
+    process.env.BGE_MCP_TOKEN = 'test-token';
+    generateUiConfigSeed({ templatePath, outputPath, registryPath });
+
+    const names = JSON.parse(JSON.parse(fs.readFileSync(outputPath, 'utf8')).mcpServers)
+      .map((s) => s.name);
+
+    // Positiv-Anker zuerst (T002356-M1): ohne ihn waere die Negativ-Aussage
+    // bei einer leeren Liste trivial erfuellt.
+    expect(names).toContain('factory-mcp');
+    expect(names).toContain('github-mcp');
+    // stdio ohne jede Adresse bleibt draussen — die Bruecke bedient ihn nicht.
+    expect(names).not.toContain('playwright');
+  });
 });


### PR DESCRIPTION
Closes T002549

## Fehler

`--ui-config-file` zeigte auf `~/.config/llama-cpp/ui-config.json` — **eine Datei, die niemand
erzeugt.** Ein `grep` über das Repo fand `ui-config-seed.mjs` nur in seinen eigenen Tests: kein
Taskfile-Eintrag, kein `ExecStartPre`, kein Aufruf in `runner.mjs`. `/props` lieferte kein
`ui_settings`, die Serverliste blieb im Browser-`localStorage` — genau der Zustand, den T002544
beseitigen sollte.

Der zugehörige Plan-Task war als **systemd-Unit-Änderung** formuliert. Ein Repo-PR kann keine Unit
auf dem Host anfassen; der Task war für den ausführenden Agenten strukturell unerfüllbar und fiel
stumm heraus, während alles andere durchlief.

## Behebung

**1 — Rendern in `startUnit()`.** Nicht in einer handgepflegten Unit: so wirkt es automatisch für
jedes künftige Loadout mit dem Feld, und die Logik bleibt im Repo. Bewusst **best-effort** —
schlägt das Rendern fehl (etwa ohne `BGE_MCP_TOKEN`), startet das Modell trotzdem und fällt auf den
Browser-Storage zurück. Ein Server ohne vorbelegte Liste ist brauchbar, ein nicht startender nicht.

**2 — Serverauswahl aus der Registry ableiten** statt aus einer hartkodierten `targetServerKeys`.
Kriterium ist allein die Erreichbarkeit (`browser_endpoint`, sonst `endpoint`). An der Codeliste
fiel `github-mcp` heraus, obwohl die Brücke ihn seit T002547 bedient — jeder weitere Server hätte
dieselbe Code-Änderung erzwungen.

**3 — Registry-Nachzug aus T002547.** `github-mcp` bekommt `browser_endpoint`, und sein `command`
zeigt nicht mehr auf das bei npm **deprecated** `@modelcontextprotocol/server-github`, sondern auf
den Wrapper. Die Registry ist SSOT; `mcp-bridge.json` war ihr voraus.

## Rot-Grün

| | vorher | nachher |
|---|---|---|
| `ui-config-seed.test.mjs` (vitest) | 1 failed \| 2 passed | **3 passed** |
| `runner.test.mjs` (node:test) | 2 failed \| 12 passed | **14 passed** |

End-to-End über `runner.mjs` gerendert — **8 Server** statt vorher 7:

```
k8s, mcp-postgres, factory-mcp, bge-mcp,
mcp-task-runner, ticket-mcp, codebase-memory-mcp, github-mcp
```

`mcpServers` ist ein **String**, nicht ein Array — ein blankes Array verwirft die WebUI still
(`console.warn("[MCP] Failed to parse mcpServers JSON, ignoring value")`). Token expandiert, keine
Platzhalter-Reste. `task mcp:check` ohne Drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFCEbTiSiHgVrwrbKEq2DW