### PR TITLE
chore(ops): loadouts.json gegen Formatierungs-Drift absichern [T002553]

### DIFF
--- a/Taskfile.llm.yml
+++ b/Taskfile.llm.yml
@@ -231,6 +231,16 @@ tasks:
     cmds:
       - bash scripts/llm/routing-check.sh
 
+  loadouts:check:
+    desc: "Prueft loadouts.json auf die kanonische writeLoadouts()-Form (fail-closed, CI) [T002553]"
+    cmds:
+      - node scripts/llm/loadouts-format.mjs --check
+
+  loadouts:format:
+    desc: "Normalisiert loadouts.json auf die kanonische Form — Reparatur fuer loadouts:check [T002553]"
+    cmds:
+      - node scripts/llm/loadouts-format.mjs --write
+
   measure-equivalence:
     desc: "Measure embedding equivalence between TEI and new llama.cpp endpoint"
     cmds:

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 708,
+      "file_count": 709,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -420,6 +420,7 @@
         "tests/spec/local-llm-proxy/gemma-kv-quant.bats",
         "tests/spec/local-llm-proxy/gemma-loadout-autorestart-queue.bats",
         "tests/spec/local-llm-proxy/loadout-env-property.bats",
+        "tests/spec/local-llm-proxy/loadouts-format.bats",
         "tests/spec/local-llm-proxy/model-path-large-file.bats",
         "tests/spec/local-llm-proxy/ui-config-seed.bats",
         "tests/spec/lockfile-drift.bats",
@@ -3044,7 +3045,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 610,
+      "file_count": 611,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3463,6 +3464,7 @@
         "scripts/llm/harden-gpu-firewall.ps1",
         "scripts/llm/install-startup-autostart.ps1",
         "scripts/llm/kv-budget.sh",
+        "scripts/llm/loadouts-format.mjs",
         "scripts/llm/loadouts.json",
         "scripts/llm/mcp-bridge.json",
         "scripts/llm/mcp-servers.json",

--- a/scripts/llm-proxy/loadouts.mjs
+++ b/scripts/llm-proxy/loadouts.mjs
@@ -1,5 +1,9 @@
 // scripts/llm-proxy/loadouts.mjs
-// Einziger Ort, der scripts/llm/loadouts.json liest und schreibt.
+// Der einzige Ort, der scripts/llm/loadouts.json schreiben SOLL — nicht der
+// einzige, der es faktisch tut: die Datei wurde wiederholt mit fremden
+// JSON-Werkzeugen umgeschrieben (#3640, #3617, #3613, #3569). Weil ein
+// Kommentar das nicht verhindert, prueft `task llm:loadouts:check` die
+// kanonische Form (serializeLoadouts) fail-closed in CI [T002553].
 // Bewusst fail-closed bei der Validierung: eine kaputte Datei darf nicht als
 // halbgueltiges Dokument durchrutschen und spaeter beim argv-Bau explodieren.
 import { readFileSync, writeFileSync, statSync } from 'node:fs';
@@ -140,6 +144,28 @@ export function readLoadouts(path = DEFAULT_PATH) {
   return { doc: parseLoadouts(text), mtimeMs: statSync(path).mtimeMs };
 }
 
+/**
+ * T002553 — Die EINE kanonische Serialisierung von loadouts.json.
+ *
+ * Sowohl writeLoadouts() als auch der Format-Guard (scripts/llm/loadouts-format.mjs)
+ * gehen durch diese Funktion. Zwei getrennte Definitionen — eine im Schreiber, eine
+ * im Pruefer — koennten auseinanderlaufen und der Guard wuerde eine Form verlangen,
+ * die das Werkzeug gar nicht erzeugt.
+ *
+ * Verbindlich sind drei Eigenschaften, an denen fremde JSON-Werkzeuge scheitern:
+ *   - zwei Leerzeichen Einrueckung
+ *   - Nicht-ASCII UNESCAPED ('·', nicht '·'). Pythons json.dumps hat
+ *     ensure_ascii=True als Default und escaped stillschweigend.
+ *   - abschliessender Zeilenumbruch (json.dump schreibt keinen)
+ *
+ * Jede dieser Abweichungen normalisiert beim naechsten regulaeren Schreibvorgang
+ * die GANZE Datei zurueck und erzeugt einen Vollzeilen-Diff — in PR #3640 waren es
+ * ~360 statt ~15 Zeilen, die inhaltliche Aenderung war darin nicht mehr erkennbar.
+ */
+export function serializeLoadouts(doc) {
+  return `${JSON.stringify(doc, null, 2)}\n`;
+}
+
 /** Schreibt nur, wenn die Datei seit dem Lesen unveraendert ist (verhindert,
  *  dass das UI eine Handbearbeitung ueberschreibt). */
 export function writeLoadouts(doc, path = DEFAULT_PATH, expectedMtimeMs = null) {
@@ -150,7 +176,7 @@ export function writeLoadouts(doc, path = DEFAULT_PATH, expectedMtimeMs = null) 
       throw new Error(`loadouts.json: extern geaendert (conflict) — erneut laden und Aenderung wiederholen`);
     }
   }
-  writeFileSync(path, `${JSON.stringify(doc, null, 2)}\n`, 'utf8');
+  writeFileSync(path, serializeLoadouts(doc), 'utf8');
 }
 
 export function findLoadout(doc, slug) {

--- a/scripts/llm/loadouts-format.mjs
+++ b/scripts/llm/loadouts-format.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// scripts/llm/loadouts-format.mjs
+//
+// T002553 — Haelt scripts/llm/loadouts.json in der kanonischen Form, die
+// writeLoadouts() erzeugt. Beide gehen durch serializeLoadouts(); der Guard
+// kann daher keine Form verlangen, die das Werkzeug nicht schreibt.
+//
+//   --check [pfad]   Exit 1 bei Abweichung, nennt die Reparaturanweisung (CI)
+//   --write [pfad]   Schreibt die kanonische Form (lokale Reparatur)
+//
+// Der Pfad ist optional und existiert, damit der Guard gegen manipulierte
+// Kopien testbar ist statt nur gegen die ausgelieferte Datei — ein Guard, der
+// nur den Gutfall belegen kann, belegt nichts.
+//
+// Warum ueberhaupt: loadouts.json wird gelegentlich mit fremden JSON-Werkzeugen
+// umgeschrieben. Pythons json.dumps escaped Nicht-ASCII (ensure_ascii=True ist
+// Default) und schreibt keinen abschliessenden Zeilenumbruch. Beim naechsten
+// regulaeren Schreibvorgang normalisiert das die GANZE Datei zurueck — der
+// Diff umfasst dann jede Zeile statt der geaenderten. In PR #3640 waren es
+// ~360 statt ~15; die inhaltliche Aenderung war darin nicht mehr auffindbar.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseLoadouts, serializeLoadouts, DEFAULT_PATH } from '../llm-proxy/loadouts.mjs';
+
+const REPAIR = 'task llm:loadouts:format';
+
+/**
+ * @returns {{ok: boolean, canonical: string, actual: string, findings: string[]}}
+ */
+export function inspect(path = DEFAULT_PATH) {
+  const actual = readFileSync(path, 'utf8');
+  const canonical = serializeLoadouts(parseLoadouts(actual));
+  const findings = [];
+
+  // Benannte Befunde statt eines blossen "weicht ab". Wer nur liest, dass die
+  // Datei nicht kanonisch ist, weiss nicht, welches Werkzeug sie angefasst hat;
+  // "escaped Nicht-ASCII" zeigt direkt auf ensure_ascii.
+  const escapes = actual.match(/\\u[0-9a-fA-F]{4}/g);
+  if (escapes) {
+    const uniq = [...new Set(escapes)].sort();
+    findings.push(
+      `${escapes.length} escapte Nicht-ASCII-Zeichen (${uniq.slice(0, 5).join(' ')}${uniq.length > 5 ? ' …' : ''})` +
+      ` — ein JSON-Werkzeug mit ensure_ascii=True hat die Datei geschrieben`,
+    );
+  }
+  if (!actual.endsWith('\n')) {
+    findings.push("kein abschliessender Zeilenumbruch — json.dump schreibt keinen, writeLoadouts() schon");
+  }
+  if (actual !== canonical && findings.length === 0) {
+    findings.push('Einrueckung oder Schluesselreihenfolge weicht ab');
+  }
+
+  return { ok: actual === canonical, canonical, actual, findings };
+}
+
+function main(argv) {
+  const write = argv.includes('--write');
+  const check = argv.includes('--check');
+  if (write === check) {
+    console.error('Usage: loadouts-format.mjs (--check | --write) [pfad]');
+    return 2;
+  }
+
+  const path = argv.find((a) => !a.startsWith('--')) ?? DEFAULT_PATH;
+  let r;
+  try {
+    r = inspect(path);
+  } catch (err) {
+    // Ein kaputtes Dokument ist kein Formatproblem — die Meldung darf nicht auf
+    // `--write` verweisen, das hier gar nichts reparieren koennte.
+    console.error(`loadouts-format: ${path} ist nicht lesbar: ${err.message}`);
+    return 2;
+  }
+
+  if (r.ok) {
+    console.log(`loadouts-format: ${path} ist kanonisch`);
+    return 0;
+  }
+
+  if (write) {
+    writeFileSync(path, r.canonical, 'utf8');
+    console.log(`loadouts-format: ${path} normalisiert`);
+    for (const f of r.findings) console.log(`  - ${f}`);
+    return 0;
+  }
+
+  console.error(`loadouts-format: ${path} weicht von der kanonischen Form ab`);
+  for (const f of r.findings) console.error(`  - ${f}`);
+  console.error('');
+  console.error(`  Reparatur:  ${REPAIR}   (dann committen)`);
+  console.error('  Hintergrund: die Datei gehoert scripts/llm-proxy/loadouts.mjs.');
+  console.error('  Sie mit einem anderen JSON-Werkzeug umzuschreiben normalisiert');
+  console.error('  beim naechsten regulaeren Schreibvorgang jede Zeile.');
+  return 1;
+}
+
+if (import.meta.filename === process.argv[1]) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -10,7 +10,7 @@
   "loadouts": [
     {
       "slug": "gptoss-context",
-      "label": "gpt-oss-20b \u00b7 maximaler Kontext",
+      "label": "gpt-oss-20b · maximaler Kontext",
       "model": "gptoss20/gpt-oss-20b-Q8_0.gguf",
       "port": 8098,
       "fit": {
@@ -44,7 +44,7 @@
     },
     {
       "slug": "devstral-quality",
-      "label": "Devstral-Small-2 24B \u00b7 Code-Qualitaet",
+      "label": "Devstral-Small-2 24B · Code-Qualitaet",
       "model": "devstral24/Devstral-Small-2-24B-Instruct-2512-IQ4_XS.gguf",
       "port": 8099,
       "fit": {
@@ -78,7 +78,7 @@
     },
     {
       "slug": "bge-embed-batch",
-      "label": "bge-m3 \u00b7 Batch-Embedding (CPU)",
+      "label": "bge-m3 · Batch-Embedding (CPU)",
       "model": "F:/Embedding/bge-m3-Q8_0.gguf",
       "port": 8085,
       "fit": {
@@ -122,7 +122,7 @@
     },
     {
       "slug": "bge-rerank-batch",
-      "label": "bge-reranker-v2-m3 \u00b7 Batch-Rerank (CPU)",
+      "label": "bge-reranker-v2-m3 · Batch-Rerank (CPU)",
       "model": "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q8_0.gguf",
       "port": 8086,
       "fit": {
@@ -162,7 +162,7 @@
     },
     {
       "slug": "bge-embed",
-      "label": "bge-m3 \u00b7 Embedding (WSL, CPU)",
+      "label": "bge-m3 · Embedding (WSL, CPU)",
       "model": "gpustack/bge-m3-GGUF/bge-m3-Q8_0.gguf",
       "port": 8095,
       "fit": {
@@ -209,7 +209,7 @@
     },
     {
       "slug": "bge-rerank",
-      "label": "bge-reranker-v2-m3 \u00b7 Rerank (WSL, CPU)",
+      "label": "bge-reranker-v2-m3 · Rerank (WSL, CPU)",
       "model": "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q8_0.gguf",
       "port": 8096,
       "fit": {
@@ -248,11 +248,11 @@
         "-ub",
         "8192"
       ],
-      "notes": "T002538. Der kanonische Rerank-Endpunkt :8096, Gegenstueck zu bge-embed. Eigener Prozess, weil llama.cpp CLS- und RANK-Pooling nicht in einem Server bedienen kann \u2014 dieselbe Begruendung wie beim Batch-Paar. CUDA_VISIBLE_DEVICES='' siehe bge-embed. Der OpenAI-kompatible /v1/rerank-Pfad liefert dieselben Werte wie der native /rerank; verglichen wird die Reihenfolge der relevance_score, nicht deren Absolutwert (die sind rohe Logits, typisch um -11 fuer irrelevante Dokumente)."
+      "notes": "T002538. Der kanonische Rerank-Endpunkt :8096, Gegenstueck zu bge-embed. Eigener Prozess, weil llama.cpp CLS- und RANK-Pooling nicht in einem Server bedienen kann — dieselbe Begruendung wie beim Batch-Paar. CUDA_VISIBLE_DEVICES='' siehe bge-embed. Der OpenAI-kompatible /v1/rerank-Pfad liefert dieselben Werte wie der native /rerank; verglichen wird die Reihenfolge der relevance_score, nicht deren Absolutwert (die sind rohe Logits, typisch um -11 fuer irrelevante Dokumente)."
     },
     {
       "slug": "gemma-factory",
-      "label": "Gemma 4 12B \u00b7 Factory Single-Agent",
+      "label": "Gemma 4 12B · Factory Single-Agent",
       "model": "unsloth/gemma-4-12B-it-qat-UD-Q4_K_XL/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "port": 8091,
       "fit": {
@@ -283,11 +283,11 @@
       },
       "extraArgs": [],
       "exclusiveGroup": "chat-gpu",
-      "notes": "Migriert aus scripts/llm/start-gemma-server.ps1 \u2014 aus dem UEBERWACHTEN Profil (-Ctx 262144 -Slots 1 -KvType q8_0, so starten watchdog-llm-servers.ps1 und install-startup-autostart.ps1), NICHT aus den param()-Defaults des Skripts (65536/q4_0). Die Defaults weichen vom laufenden Server ab; wer sie migriert, senkt still die Qualitaet. q8_0 ist Absicht: q4_0-KV degradiert das woertliche Zurueckholen von Pfaden, Symbolnamen und Tool-Call-Argumenten (T002501). -fit ersetzt das harte -c; minCtx haelt die Untergrenze."
+      "notes": "Migriert aus scripts/llm/start-gemma-server.ps1 — aus dem UEBERWACHTEN Profil (-Ctx 262144 -Slots 1 -KvType q8_0, so starten watchdog-llm-servers.ps1 und install-startup-autostart.ps1), NICHT aus den param()-Defaults des Skripts (65536/q4_0). Die Defaults weichen vom laufenden Server ab; wer sie migriert, senkt still die Qualitaet. q8_0 ist Absicht: q4_0-KV degradiert das woertliche Zurueckholen von Pfaden, Symbolnamen und Tool-Call-Argumenten (T002501). -fit ersetzt das harte -c; minCtx haelt die Untergrenze."
     },
     {
       "slug": "gemma-multiagent",
-      "label": "Gemma 4 12B \u00b7 Factory Multi-Agent",
+      "label": "Gemma 4 12B · Factory Multi-Agent",
       "model": "unsloth/gemma-4-12B-it-qat-UD-Q4_K_XL/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf",
       "port": 8091,
       "fit": {
@@ -320,11 +320,11 @@
         "-kvu"
       ],
       "exclusiveGroup": "chat-gpu",
-      "notes": "Migriert aus scripts/llm/start-gemma-server.ps1 (-Slots-Profil, -np 5 -kvu). q8_0 wie gemma-factory und gptoss-context \u2014 siehe dortige Begruendung (T002501). Mit -kvu ist minCtx ein GEMEINSAMER Pool ueber alle Slots, kein Wert je Slot."
+      "notes": "Migriert aus scripts/llm/start-gemma-server.ps1 (-Slots-Profil, -np 5 -kvu). q8_0 wie gemma-factory und gptoss-context — siehe dortige Begruendung (T002501). Mit -kvu ist minCtx ein GEMEINSAMER Pool ueber alle Slots, kein Wert je Slot."
     },
     {
       "slug": "gemma26-factory",
-      "label": "Gemma 4 26B A4B \u00b7 Factory Single-Agent",
+      "label": "Gemma 4 26B A4B · Factory Single-Agent",
       "model": "gemma4/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf",
       "port": 8091,
       "fit": {

--- a/tests/spec/local-llm-proxy/loadouts-format.bats
+++ b/tests/spec/local-llm-proxy/loadouts-format.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# T002553 — Format-Guard fuer scripts/llm/loadouts.json.
+#
+# Pruefmodus: command output verification [T002448-M4]. Jeder Test FUEHRT
+# scripts/llm/loadouts-format.mjs aus und prueft $status und $output — kein
+# grep auf die Quelldatei. Ein Guard, dessen Existenz nur im Quelltext belegt
+# ist, sagt nichts darueber, ob er den Drift auch findet.
+#
+# Auswahl in CI: scripts/find-changed-tests.sh greppt geaenderte Dateipfade in
+# den .bats-Dateien — ein Test wird dadurch relevant, dass er den Pfad ERWAEHNT.
+# Deshalb stehen hier beide bewusst woertlich: scripts/llm/loadouts.json (die
+# geschuetzte Datei) und scripts/llm-proxy/loadouts.mjs (wo serializeLoadouts
+# die kanonische Form definiert). Ohne die zweite Erwaehnung liefe der Guard
+# nicht, wenn jemand genau diese Definition aendert.
+#
+# Hintergrund: loadouts.json wurde wiederholt mit fremden JSON-Werkzeugen
+# umgeschrieben (#3640, #3617, #3613, #3569). Pythons json.dumps escaped
+# Nicht-ASCII (ensure_ascii=True ist Default) und schreibt keinen abschliessenden
+# Zeilenumbruch; beide Abweichungen normalisieren beim naechsten regulaeren
+# Schreibvorgang die ganze Datei zurueck und erzeugen einen Vollzeilen-Diff.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  GUARD="${REPO_ROOT}/scripts/llm/loadouts-format.mjs"
+  TMP="$(mktemp -d)"
+  COPY="${TMP}/loadouts.json"
+  cp "${REPO_ROOT}/scripts/llm/loadouts.json" "${COPY}"
+}
+
+teardown() {
+  rm -rf "${TMP}"
+}
+
+@test "T002553: die ausgelieferte loadouts.json ist kanonisch" {
+  cd "${REPO_ROOT}"
+  run node "${GUARD}" --check
+  [ "${status}" -eq 0 ]
+  [[ "${output}" == *"ist kanonisch"* ]]
+}
+
+@test "T002553: escapte Nicht-ASCII-Zeichen werden erkannt und benannt" {
+  # Positiv-Anker zuerst [T002356-M1]: die unveraenderte Kopie laeuft durch.
+  # Ohne ihn koennte der Test auch bei einem Guard bestehen, der immer meckert.
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 0 ]
+
+  # Genau der Effekt von json.dumps(ensure_ascii=True).
+  python3 -c "
+import json, sys
+p = sys.argv[1]
+with open(p) as f: doc = json.load(f)
+with open(p, 'w') as f: json.dump(doc, f, indent=2)
+" "${COPY}"
+
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"ensure_ascii"* ]]
+}
+
+@test "T002553: fehlender abschliessender Zeilenumbruch wird erkannt" {
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 0 ]
+
+  printf '%s' "$(cat "${COPY}")" > "${COPY}.tmp" && mv "${COPY}.tmp" "${COPY}"
+
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"Zeilenumbruch"* ]]
+}
+
+@test "T002553: der Guard nennt die Reparaturanweisung, nicht nur den Befund" {
+  printf '%s' "$(cat "${COPY}")" > "${COPY}.tmp" && mv "${COPY}.tmp" "${COPY}"
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 1 ]
+  # Ein Guard ohne Handlungsanweisung verlagert die Suche auf den Leser.
+  [[ "${output}" == *"task llm:loadouts:format"* ]]
+}
+
+@test "T002553: --write stellt die kanonische Form her" {
+  python3 -c "
+import json, sys
+p = sys.argv[1]
+with open(p) as f: doc = json.load(f)
+with open(p, 'w') as f: json.dump(doc, f, indent=2)
+" "${COPY}"
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 1 ]
+
+  run node "${GUARD}" --write "${COPY}"
+  [ "${status}" -eq 0 ]
+
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "T002553: --write erhaelt den Inhalt, es normalisiert nur die Form" {
+  local before after
+  before="$(node -e 'console.log(JSON.stringify(JSON.parse(require("node:fs").readFileSync(process.argv[1],"utf8"))))' "${COPY}")"
+  python3 -c "
+import json, sys
+p = sys.argv[1]
+with open(p) as f: doc = json.load(f)
+with open(p, 'w') as f: json.dump(doc, f, indent=2)
+" "${COPY}"
+  run node "${GUARD}" --write "${COPY}"
+  [ "${status}" -eq 0 ]
+  after="$(node -e 'console.log(JSON.stringify(JSON.parse(require("node:fs").readFileSync(process.argv[1],"utf8"))))' "${COPY}")"
+  [ "${before}" = "${after}" ]
+}
+
+@test "T002553: ein kaputtes Dokument meldet Lesefehler statt Formatfehler" {
+  # Die Unterscheidung ist nicht kosmetisch: --write koennte hier nichts
+  # reparieren, also darf die Meldung auch nicht dorthin verweisen.
+  echo '{ kaputt' > "${COPY}"
+  run node "${GUARD}" --check "${COPY}"
+  [ "${status}" -eq 2 ]
+  [[ "${output}" != *"task llm:loadouts:format"* ]]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2526,6 +2526,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/loadouts-format",
+    "file": "tests/spec/local-llm-proxy/loadouts-format.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/model-path-large-file",
     "file": "tests/spec/local-llm-proxy/model-path-large-file.bats",
     "category": "local-llm-proxy",


### PR DESCRIPTION
## Problem

`scripts/llm/loadouts.json` wich von der Form ab, die `writeLoadouts()` erzeugt — **12 escapte Nicht-ASCII-Zeichen** (9× `·`, 3× `—`) und **kein abschließender Zeilenumbruch**. Beides sind die Signaturen von Pythons `json.dumps`: `ensure_ascii=True` ist dort Default, und `json.dump` schreibt kein trailing `\n`.

Belegt statt vermutet:

```
$ node -e 'console.log(JSON.stringify({a:"Gemma · Factory"}))'
{"a":"Gemma · Factory"}
$ python3 -c 'import json; print(json.dumps({"a":"Gemma · Factory"}))'
{"a": "Gemma · Factory"}
```

**Warum das mehr als Kosmetik ist:** beim nächsten regulären Schreibvorgang normalisiert `writeLoadouts()` die Datei zurück — der Diff umfasst dann *jede* Zeile statt der geänderten. In #3640 waren es ~360 statt ~15; die inhaltliche Änderung war darin nicht mehr auffindbar. Dieselbe Signatur findet sich in #3617, #3613, #3569 — kein Einzelfall.

## Änderungen

**`serializeLoadouts()`** als die *eine* kanonische Serialisierung. `writeLoadouts()` und der Guard gehen beide hindurch — zwei getrennte Definitionen könnten auseinanderlaufen und der Guard würde eine Form verlangen, die das Werkzeug gar nicht schreibt.

**`scripts/llm/loadouts-format.mjs`** mit `--check` / `--write`. Der Check *benennt* den Befund statt nur „weicht ab" zu melden:

```
loadouts-format: scripts/llm/loadouts.json weicht von der kanonischen Form ab
  - 12 escapte Nicht-ASCII-Zeichen (· —) — ein JSON-Werkzeug mit ensure_ascii=True hat die Datei geschrieben
  - kein abschliessender Zeilenumbruch — json.dump schreibt keinen, writeLoadouts() schon

  Reparatur:  task llm:loadouts:format   (dann committen)
```

Ein kaputtes Dokument gibt Exit 2 und verweist **nicht** auf `--write`, das dort nichts reparieren könnte.

**`task llm:loadouts:check`** (fail-closed) und **`task llm:loadouts:format`** (Reparatur).

**`loadouts.json` einmalig normalisiert** — 13 Zeilen Diff, Inhalt beweisbar identisch (`JSON.stringify` vorher == nachher, im Test verankert).

**Der Kommentar in `loadouts.mjs:2`** behauptete, dies sei der einzige Schreiber der Datei. Die Datei widerlegte ihn. Er nennt jetzt die Belege und verweist auf den Guard — ein Kommentar allein hat es vier PRs lang nicht verhindert.

## CI-Verdrahtung

`scripts/find-changed-tests.sh` wählt Specs per **Rückwärts-Grep** des geänderten Pfads — ein Test wird dadurch relevant, dass er den Pfad *erwähnt*. Die `.bats` erwähnt deshalb bewusst wörtlich **beide** Pfade: `scripts/llm/loadouts.json` (die geschützte Datei) und `scripts/llm-proxy/loadouts.mjs` (wo `serializeLoadouts` die Form definiert). Ohne die zweite Erwähnung liefe der Guard nicht, wenn jemand genau diese Definition ändert.

Verifiziert über die Test-Naht `FIND_CHANGED_TESTS_FILES` für alle drei Pfade — nicht angenommen.

## Verifikation

- `bats tests/spec/local-llm-proxy/` → **34/34** (7 davon neu)
- `node --test` loadouts/runner/server/models → 17/16/11/7
- `task quality:check` → „no new or worsened violations"
- `task -n` auf beide neuen Ziele → auflösbar
- Guard gegen den echten Drift getestet: fand exakt 12 Escapes + fehlendes `\n`, Exit 1

Die Tests prüfen command output (`$status`/`$output`) gegen manipulierte Kopien, nicht die Implementierungsquelle [T002448-M4]; jeder Negativtest trägt einen Positiv-Anker [T002356-M1].

**Kein Verhaltenswechsel** — die Registry-Inhalte sind identisch, nur ihre Serialisierung ist jetzt festgeschrieben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoVw6vutoS45LcF8C1DSHZ