### PR TITLE
fix(security): gitleaks-Allowlist um nicht versionierbare Pfade ergaenzen [T002554]

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -35,8 +35,30 @@
     "(?i)openspec/changes/archive/.*",
     # Skill references with YAML examples containing fake private keys
     "(?i)\\.claude/skills/gitops-knowledge/references/.*",
+    # [T002554] Nicht versionierbare Pfade. Der pre-commit-Hook und der CI-Step
+    # rufen gitleaks mit --no-git auf, scannen also den ARBEITSBAUM statt der
+    # Versionierung — damit auch alles, was gitignored ist.
+    #
+    # In CI fiel das nie auf: der Job `security-scan` fuehrt kein npm ci aus, dort
+    # gibt es weder node_modules noch tmp/. Lokal lieferten dieselbe Config und
+    # dasselbe Kommando 85 Funde und blockierten jeden Commit — der lokale Hook
+    # war strenger als das Gate, das er simulieren soll.
+    #
+    # Sicherheitlich unbedenklich, weil beide Pfade gitignored sind und damit gar
+    # nicht in einen Commit gelangen koennen (verifiziert per git check-ignore).
+    # Die Funde stammten aus Drittanbieter-Testfixturen (dotenv, zod, prettier)
+    # und aus Scratch-Dateien.
+    "(?i)(^|.*/)node_modules/.*",
+    "(?i)^tmp/.*",
     ".gitattributes",
     ".gitignore",
+    # [T002554] Diese Datei selbst. Eine Config, die Secret-MUSTER beschreibt,
+    # matcht sie zwangslaeufig: der Kommentar oben nennt "sk-Automatisierungstool"
+    # als Beispiel und loest damit die openai-api-key-Regel aus. Der Fund bestand
+    # schon vorher, war aber unter den 85 node_modules-Fehlalarmen unsichtbar —
+    # ein Guard, der staendig falsch anschlaegt, verbirgt genau das, was er
+    # zeigen soll.
+    ".gitleaks.toml",
   ]
 
 # ── Standard rules ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Mit lokal installiertem gitleaks **8.18.2** (der Version, die CI per curl holt) schlug der pre-commit-Hook fail-closed fehl: **85 Funde, Exit 1, jeder Commit blockiert.**

Kein einziger Fund war ein echtes Secret:

| Anzahl | Pfad | Regel |
|---:|---|---|
| 34 | `tmp/claude-scratch/vector-backup` | `jwt-token` |
| 33 | `node_modules/**` | `private-key` (dotenv/zod/prettier-Fixturen) |
| 18 | `node_modules/**` | `openai-api-key`, `aws-access-key`, `slack-token`, `github-token` |

## Warum es in CI nie auffiel

Hook und CI-Step rufen gitleaks mit `--no-git` auf — gescannt wird der **Arbeitsbaum**, nicht die Versionierung, also auch alles Gitignorierte.

Der CI-Job `security-scan` führt **kein `npm ci`** aus; dort existieren weder `node_modules` noch `tmp/`. Dieselbe Config und dasselbe Kommando liefern lokal und in CI verschiedene Ergebnisse — und der lokale Hook war **strenger** als das Gate, das er simulieren soll.

Die praktische Folge vor diesem Fix: gitleaks zu *installieren* machte den Commit-Pfad kaputt. Brauchbar war der Hook nur, solange das Binary fehlte und er fail-open übersprang — also genau dann, wenn er nichts prüft.

## Zweiter Fund, erst nach dem Wegfall des Rauschens sichtbar

`.gitleaks.toml` löst **selbst** die `openai-api-key`-Regel aus: der Kommentar zu `docs/bereitstellungsdetails.md` nennt `"sk-Automatisierungstool"` als Beispiel für ein deutsches Kompositum, das dem Muster gleicht — und matcht es damit. Eine Config, die Secret-Muster beschreibt, kann ihnen nicht ausweichen; `.gitattributes` und `.gitignore` stehen aus verwandtem Grund längst in der Allowlist.

Bemerkenswert ist der Weg dorthin: der Befund war die ganze Zeit da, nur unter den 85 Fehlalarmen unsichtbar. **Ein Guard, der ständig falsch anschlägt, verbirgt genau das, was er zeigen soll.**

## Sicherheit

`node_modules/` und `tmp/` sind gitignored (verifiziert per `git check-ignore`) und können nicht in einen Commit gelangen.

Gegenprobe, dass die Allowlist nicht blind macht:

```
unveränderter Arbeitsbaum (Worktree)        → Exit 0
unveränderter Arbeitsbaum (Hauptcheckout)   → Exit 0
mit AWS-Key-Datei im Repo-Root              → Exit 1   ← weiterhin erkannt
```

## Kein Test — bewusst

Der Effekt ist rein lokal. In CI gibt es die betroffenen Pfade nicht; ein dortiger Test könnte den Unterschied gar nicht messen und wäre grün, ohne etwas zu belegen. Der bestehende `security-scan`-Step bleibt das fail-closed Gate.

## Nebenbefund, kein Handlungsbedarf

Der Scan über die Git-**Historie** (ohne `--no-git`) meldet 2 Funde in `openspec/changes/brain-auto-memory/tasks.md` — ein BATS-Testfixture (`"scan skips a page containing a secret pattern"`), das das Muster absichtlich enthält. Die heutige Testdatei steht bereits in der Allowlist; die Plan-Kopie liegt inzwischen unter `openspec/changes/archive/` und ist damit ebenfalls abgedeckt.

**git-crypt ist davon unberührt und korrekt konfiguriert:** 23 Dateien managed, `git-crypt-guard.sh check-tracked` Exit 0, keine gitleaks-Funde unterhalb `environments/.secrets/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoVw6vutoS45LcF8C1DSHZ