### PR TITLE
fix(ops): opencode durch den llm-proxy routen statt direkt auf :8091 [T002558]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -7,7 +7,12 @@
       // synct sie nach ~/.config/opencode/opencode.jsonc; .opencode/opencode.jsonc darf sie
       // NICHT erneut definieren, sonst driftet der Wert projekt-lokal ab (T002159).
       "options": {
-        "baseURL": "http://127.0.0.1:8091/v1",
+        // T002558: ueber den llm-proxy, NICHT direkt auf :8091. Damit gilt
+        // max_inflight=1 auch fuer die opencode-Agenten (sie serialisieren,
+        // statt gleichzeitig auf den Server zu gehen), und die Fallback-Kette
+        // gemma -> deepseek -> opencode-zen greift auch lokal. Vorher standen
+        // die Agenten bei totem Gemma schlicht ohne Modell da.
+        "baseURL": "http://127.0.0.1:18235/v1",
         "timeout": 600000,
         "chunkTimeout": 120000
       },
@@ -28,7 +33,7 @@
           // aber nicht gleichzeitig ausschoepfen - sie konkurrieren um
           // denselben Speicher.
           "limit": {
-            "context": 99840,
+            "context": 88832,
             "output": 8192
           }
         }

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 712,
+      "file_count": 713,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -422,6 +422,7 @@
         "tests/spec/local-llm-proxy/loadouts-format.bats",
         "tests/spec/local-llm-proxy/model-path-large-file.bats",
         "tests/spec/local-llm-proxy/opencode-agent-model-drift.bats",
+        "tests/spec/local-llm-proxy/opencode-routes-via-proxy.bats",
         "tests/spec/local-llm-proxy/proxy-env-token-guard.bats",
         "tests/spec/local-llm-proxy/ui-config-seed.bats",
         "tests/spec/lockfile-drift.bats",

--- a/tests/spec/llm-local-dev.bats
+++ b/tests/spec/llm-local-dev.bats
@@ -110,18 +110,40 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-@test "agent-models.jsonc points llamacpp-gemma26 at the Gemma port 8091" {
-  run grep -qE '"baseURL": *"http://127\.0\.0\.1:8091/v1"' "$REPO/.opencode/agent-models.jsonc"
+@test "agent-models.jsonc points llamacpp-gemma26 at the llm-proxy, not at :8091 (T002558)" {
+  # T002558: opencode geht durch den Proxy. Damit gilt max_inflight=1 auch fuer
+  # die Agenten (sie serialisieren statt gleichzeitig auf den Server zu gehen),
+  # und die Fallback-Kette gemma -> deepseek -> opencode-zen greift auch lokal.
+  # Vorher stand hier :8091 — direkt am Proxy vorbei.
+  run grep -qE '"baseURL": *"http://127\.0\.0\.1:18235/v1"' "$REPO/.opencode/agent-models.jsonc"
   [ "$status" -eq 0 ]
+
+  # Negativ-Aussage nach dem Anker: kein llamacpp-Provider zeigt mehr direkt
+  # auf den Server.
+  run bash -c "python3 - <<'EOF'
+import re
+s = open('$REPO/.opencode/agent-models.jsonc').read()
+bad = re.findall(r'\"(llamacpp[^\"]*)\"\s*:\s*\{.*?\"baseURL\"\s*:\s*\"[^\"]*:8091[^\"]*\"', s, re.S)
+print(len(bad))
+EOF"
+  [ "$output" = "0" ]
 }
 
-@test "agent-models.jsonc declares ~99840 context for Gemma4 (T002545)" {
-  # T002545: gemma26-factory mit --fit 256 MiB, KV q4_0 → gemessen 99840 ctx.
-  # Der Puffer ist geteilt (-kvu), die Zahl gilt je Agent — drei Agenten
-  # koennen sie nicht gleichzeitig voll ausschoepfen.
+@test "agent-models.jsonc declares a MEASURED context for Gemma4, not n_ctx_train (T002545/T002558)" {
+  # Keine harte Konstante mehr. --fit entscheidet den Wert zur Laufzeit, und er
+  # aendert sich mit der Slot-Zahl: bei einem Slot wurden 99840 gemessen, bei
+  # drei (T002545) nur noch 88832, weil der geteilte -kvu-Puffer fuer drei
+  # Sequenzen reichen muss. Eine gepflegte Zahl driftet damit bei jeder
+  # Loadout-Aenderung — genau die Klasse, die dieses Ticket schliesst.
+  #
+  # Geprueft wird deshalb die EIGENSCHAFT: plausibel und nicht der alte
+  # 12B-Wert 262144 (= n_ctx_train, das 2,6-fache des real Verfuegbaren).
   ctx="$(awk '/"gemma26-factory": *\{/,/"context"/' \
     "$REPO/.opencode/agent-models.jsonc" | grep -oE '"context": *[0-9]+' | head -1 | grep -oE '[0-9]+')"
-  [ "$ctx" = "99840" ]
+  [ -n "$ctx" ]
+  [ "$ctx" != "262144" ]
+  [ "$ctx" -gt 50000 ]
+  [ "$ctx" -lt 200000 ]
 }
 
 @test "agent-models.jsonc defines three gemma subagents (T002545)" {
@@ -152,8 +174,11 @@ setup() {
     const model = prim[0][1].model;
     const [prov, mid] = model.split('/');
     const ctx = o.provider[prov].models[mid].limit.context;
-    if (![99840, 99328, 98304].includes(ctx)) {
-      console.error('primary gemma ctx ' + ctx + ' not in expected range [99840,99328,98304]');
+    // Keine Liste gemessener Werte pflegen — sie driftet mit jeder
+    // --fit-/Slot-Aenderung (99840 bei 1 Slot, 88832 bei 3). Geprueft wird die
+    // Eigenschaft: plausibel und nicht der alte 12B-Wert 262144.
+    if (!Number.isInteger(ctx) || ctx === 262144 || ctx <= 50000 || ctx >= 200000) {
+      console.error('primary gemma ctx ' + ctx + ' implausible (expected a measured value, not n_ctx_train)');
       process.exit(1);
     }
     process.exit(0);

--- a/tests/spec/local-llm-proxy/opencode-routes-via-proxy.bats
+++ b/tests/spec/local-llm-proxy/opencode-routes-via-proxy.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# T002558 — opencode muss durch den llm-proxy gehen, nicht direkt auf :8091.
+#
+# Pruefmodus: Querschnitts-Konsistenz zwischen Konfigurationsdateien und einer
+# Live-Messung. Die Config-Assertions greppen den Quelltext (dort manifestiert
+# sich das Ergebnis, dokumentierte Ausnahme in [T002448-M4]); der Kontextwert
+# wird gegen den LAUFENDEN Server geprueft und uebersprungen, wenn keiner da
+# ist — in CI laeuft kein llama-server.
+#
+# Warum ueberhaupt: bis T002558 zeigte agent-models.jsonc auf
+# http://127.0.0.1:8091/v1, also am Proxy vorbei. Folgen:
+#   - max_inflight=1 galt fuer die opencode-Agenten NICHT, sie gingen
+#     gleichzeitig auf den Server statt zu serialisieren.
+#   - Die Fallback-Kette (gemma -> deepseek -> opencode-zen) griff nicht: bei
+#     totem Gemma standen die lokalen Agenten ohne Modell da. Genau das trat
+#     am 2026-08-02 fuer rund zehn Minuten ein.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  AGENTS="${REPO_ROOT}/.opencode/agent-models.jsonc"
+  PROXY_PORT=18235
+  LLAMA_PORT=8091
+}
+
+@test "T002558: die llamacpp-Provider zeigen auf den Proxy, nicht auf den Server" {
+  # Positiv-Anker zuerst [T002356-M1]: es gibt ueberhaupt einen baseURL-Eintrag.
+  [ -f "${AGENTS}" ]
+  run bash -c "grep -c '\"baseURL\"' '${AGENTS}'"
+  [ "${status}" -eq 0 ]
+  [ "${output}" -gt 0 ]
+
+  # Kein llamacpp-Provider darf direkt auf den llama-server zeigen.
+  run bash -c "python3 - <<'EOF'
+import re
+s = open('${AGENTS}').read()
+bad = [m.group(1) for m in re.finditer(r'\"(llamacpp[^\"]*)\"\s*:\s*\{.*?\"baseURL\"\s*:\s*\"[^\"]*:${LLAMA_PORT}[^\"]*\"', s, re.S)]
+print(len(bad))
+EOF"
+  [ "${output}" = "0" ]
+}
+
+@test "T002558: mindestens ein Provider zeigt auf den Proxy-Port" {
+  run bash -c "grep -c ':${PROXY_PORT}/v1' '${AGENTS}'"
+  [ "${status}" -eq 0 ]
+  [ "${output}" -gt 0 ]
+}
+
+@test "T002558: die deklarierte Kontextzahl stimmt mit dem laufenden Server ueberein" {
+  # Live-Messung statt gepflegter Zahl. Ohne laufenden Server (CI) uebersprungen
+  # — ein skip ist hier ehrlicher als eine Annahme.
+  curl -s -m 3 "http://127.0.0.1:${LLAMA_PORT}/props" >/dev/null 2>&1 \
+    || skip "kein llama-server auf :${LLAMA_PORT}"
+
+  local live
+  live="$(curl -s -m 5 "http://127.0.0.1:${LLAMA_PORT}/props" | jq -r '.default_generation_settings.n_ctx')"
+  [ -n "${live}" ]
+  [ "${live}" != "null" ]
+
+  # Der Wert im gemma26-Modelleintrag muss dem entsprechen. --fit entscheidet
+  # ihn zur Laufzeit; bei drei Slots fiel er von 99840 auf 88832, weil der
+  # geteilte Puffer fuer drei Sequenzen reichen muss.
+  local declared
+  declared="$(python3 -c "
+import re,sys
+s=open('${AGENTS}').read()
+m=re.search(r'\"gemma26-factory\"\s*:\s*\{.*?\"context\"\s*:\s*(\d+)', s, re.S)
+print(m.group(1) if m else 'NONE')
+")"
+  [ "${declared}" = "${live}" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2544,6 +2544,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/opencode-routes-via-proxy",
+    "file": "tests/spec/local-llm-proxy/opencode-routes-via-proxy.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/proxy-env-token-guard",
     "file": "tests/spec/local-llm-proxy/proxy-env-token-guard.bats",
     "category": "local-llm-proxy",


### PR DESCRIPTION
## Problem

`.opencode/agent-models.jsonc` zeigte auf `http://127.0.0.1:8091/v1` — **am Proxy vorbei**. Zwei Folgen:

1. **`max_inflight=1` galt für die opencode-Agenten nicht.** Sie gingen gleichzeitig auf den Server. Mit den drei Slots aus #3653 wäre daraus echte Nebenläufigkeit geworden — gewollt ist aber *ein* paralleler Lauf bei drei Slots, damit jeder Agent seinen Prefix-Cache behält.
2. **Die Fallback-Kette griff nicht.** `gemma → deepseek → opencode-zen` existiert nur im Proxy; bei totem Gemma standen die lokalen Agenten ohne Modell da. Genau das trat heute für rund zehn Minuten ein.

## Zweite Änderung: Kontextzahl aus der Live-Messung

`limit.context` 99840 → **88832**, gemessen an `:8091/props` nach dem Merge von #3653.

`--fit` regelt bei drei Slots herunter, weil der geteilte Puffer für drei Sequenzen reichen muss. Die im Plan vorhergesagten 99840 lagen um **7 % daneben** — genau dafür stand „messen statt rechnen" dort.

## Verifikation am laufenden System

```
/props    total_slots: 3, n_ctx: 88832
/slots    drei Einträge, je n_ctx=88832        ← nicht ein Drittel
Log       n_slots = 3, n_ctx_slot = 88832, kv_unified = 'true'
Aufruf    POST :18235/v1/chat/completions {"model":"gemma26-factory"}
          → served: gemma26-factory, max_inflight=1 greift
```

Der `-kvu`-Befund ist damit am Produktivsystem bestätigt: **jeder** Slot sieht den vollen Kontext.

`bats tests/spec/local-llm-proxy/` → **47/47** grün. Der neue Test misst die Kontextzahl gegen den laufenden Server und *skippt* ohne ihn — in CI läuft kein llama-server, und ein Skip ist dort ehrlicher als eine gepflegte Annahme.

## Bewusst nicht getan

**Der Fallback-Test.** Gemma zu stoppen, um zu prüfen ob DeepSeek übernimmt, würde das Modell erneut herunterreißen — heute bereits einmal passiert, und die Factory arbeitet damit. Er gehört in ein Fenster, in dem niemand darauf angewiesen ist.

**Der Model-Alias in der DB.** Er ist *wirkungslos*, nicht defekt: `resolveModel()` Stufe 2 greift nie, weil sein Ziel auf keinem Backend existiert — die Anfragen laufen über den Blind-Fallback in Stufe 3. Ihn zu „reparieren" hätte an etwas gedreht, das nichts tut. Begründung als Kommentar am Ticket.

## Nebenbefund

Der Proxy-Log belegt jetzt die Ursache von **T002556** im Klartext:

```
[loadout] Failed to generate uiConfigFile seed: Required environment variable BGE_MCP_TOKEN is not set
```

`llm-proxy.service` hat die Variable nicht in seiner Umgebung. Das Rendern scheitert still, `--ui-config-file` kommt trotzdem in die argv, und `llama-server` bricht bei fehlender Datei hart ab. Am Ticket dokumentiert, nicht Teil dieses PRs.

Closes T002558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoVw6vutoS45LcF8C1DSHZ