### PR TITLE
fix(ops): BGE_MCP_TOKEN fuer den llm-proxy bereitstellen und sein Fehlen sichtbar machen [T002556]

### DIFF
--- a/Taskfile.llm.yml
+++ b/Taskfile.llm.yml
@@ -203,6 +203,24 @@ tasks:
           exit 1
         fi
         echo "llm-proxy installed as systemd --user service (active/running, autostart + Restart=always)."
+        # [T002556] BGE_MCP_TOKEN ist fuer diese Unit nicht optional: ohne die
+        # Variable scheitert ensureUiConfigRendered() still, --ui-config-file
+        # zeigt danach auf eine fehlende Datei, und llama-server bricht beim
+        # naechsten Loadout-Start HART ab (Exit 1). Der Fehler faellt dann nicht
+        # hier auf, sondern erst Minuten spaeter beim Modellstart — deshalb hier
+        # pruefen, wo der Zusammenhang noch sichtbar ist.
+        PROXY_ENV="${HOME}/.config/llm-proxy/proxy.env"
+        if ! grep -q "^BGE_MCP_TOKEN=" "$PROXY_ENV" 2>/dev/null; then
+          echo "" >&2
+          echo "WARNUNG: BGE_MCP_TOKEN fehlt in $PROXY_ENV [T002556]" >&2
+          echo "  Folge: der naechste Loadout-Start mit uiConfigFile scheitert mit" >&2
+          echo "  'failed to open file ... ui-config.json' und crashloopt." >&2
+          echo "  Beheben (Wert aus der vorhandenen Quelle uebernehmen, nicht abtippen):" >&2
+          echo "    mkdir -p ~/.config/llm-proxy && touch $PROXY_ENV" >&2
+          echo "    chmod 0600 $PROXY_ENV" >&2
+          echo "    grep '^BGE_MCP_TOKEN=' ~/.config/bge-mcp/server.env >> $PROXY_ENV" >&2
+          echo "    systemctl --user restart llm-proxy.service" >&2
+        fi
 
   proxy:uninstall-service:
     desc: "Stop + disable the llm-proxy systemd service and remove the symlinked unit."

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 711,
+      "file_count": 712,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -422,6 +422,7 @@
         "tests/spec/local-llm-proxy/loadouts-format.bats",
         "tests/spec/local-llm-proxy/model-path-large-file.bats",
         "tests/spec/local-llm-proxy/opencode-agent-model-drift.bats",
+        "tests/spec/local-llm-proxy/proxy-env-token-guard.bats",
         "tests/spec/local-llm-proxy/ui-config-seed.bats",
         "tests/spec/lockfile-drift.bats",
         "tests/spec/mcp-gateway.bats",

--- a/scripts/llm-proxy/llm-proxy.service
+++ b/scripts/llm-proxy/llm-proxy.service
@@ -48,6 +48,21 @@ Restart=always
 RestartSec=5
 # Optionale Overrides (LLM_PROXY_PORT, DEEPSEEK_API_KEY, ...) - fehlt die Datei,
 # startet die Unit trotzdem (fuehrendes Minus).
+#
+# BGE_MCP_TOKEN gehoert hier hinein und ist NICHT optional [T002556]:
+# ensureUiConfigRendered() in runner.mjs braucht es, um die ui-config-file zu
+# erzeugen, auf die --ui-config-file zeigt. Fehlt es, scheitert das Rendern
+# still (best-effort, nur eine Logzeile) — aber llama-server bricht bei einem
+# --ui-config-file, das auf eine fehlende Datei zeigt, HART ab (Exit 1). Aus
+# "Komfortfunktion fehlt" wird dann "Modell startet nicht"; am 2026-08-02 stand
+# gemma26-factory deshalb rund zehn Minuten still.
+#
+# Den Wert nicht abtippen, sondern aus der bereits vorhandenen Quelle uebernehmen:
+#   mkdir -p ~/.config/llm-proxy && touch ~/.config/llm-proxy/proxy.env
+#   chmod 0600 ~/.config/llm-proxy/proxy.env
+#   grep '^BGE_MCP_TOKEN=' ~/.config/bge-mcp/server.env >> ~/.config/llm-proxy/proxy.env
+#
+# `task llm:proxy:install-service` warnt, wenn die Variable fehlt.
 EnvironmentFile=-%h/.config/llm-proxy/proxy.env
 
 [Install]

--- a/tests/spec/local-llm-proxy/proxy-env-token-guard.bats
+++ b/tests/spec/local-llm-proxy/proxy-env-token-guard.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+# T002556 — BGE_MCP_TOKEN muss in der Umgebung des llm-proxy stehen, und sein
+# Fehlen muss AUFFALLEN, statt still zu bleiben.
+#
+# Pruefmodus: gemischt und im Test benannt.
+#   - Die Warnlogik wird AUSGEFUEHRT (extrahiertes Fragment gegen eine
+#     praeparierte Datei), nicht gegrept — sonst belegte der Test nur, dass
+#     Text existiert [T002448-M4].
+#   - Der Verweis in der Unit-Datei ist Dokumentation; dort ist grep das
+#     angemessene Mittel (dokumentierte Ausnahme).
+#
+# Hintergrund: ensureUiConfigRendered() braucht die Variable, um die Datei zu
+# erzeugen, auf die --ui-config-file zeigt. Fehlt sie, scheitert das Rendern
+# still (best-effort, eine Logzeile), aber llama-server bricht bei einem
+# --ui-config-file auf eine fehlende Datei HART ab. Am 2026-08-02 stand
+# gemma26-factory deshalb rund zehn Minuten still — der Stop gelang, der Start
+# nicht.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  UNIT="${REPO_ROOT}/scripts/llm-proxy/llm-proxy.service"
+  TASKFILE="${REPO_ROOT}/Taskfile.llm.yml"
+  TMP="$(mktemp -d)"
+}
+
+teardown() { rm -rf "${TMP}"; }
+
+# Die Pruefung aus dem Taskfile als ausfuehrbares Fragment — dieselbe Bedingung,
+# damit der Test das Verhalten misst und nicht die Formulierung.
+_guard() {  # $1 = Pfad der proxy.env
+  if ! grep -q "^BGE_MCP_TOKEN=" "$1" 2>/dev/null; then
+    echo "WARNUNG: BGE_MCP_TOKEN fehlt in $1 [T002556]"
+    return 1
+  fi
+  return 0
+}
+
+@test "T002556: fehlende proxy.env loest die Warnung aus" {
+  run _guard "${TMP}/nicht-vorhanden.env"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"BGE_MCP_TOKEN fehlt"* ]]
+}
+
+@test "T002556: vorhandene Datei OHNE das Token loest die Warnung aus" {
+  # Der haeufigere Fall: die Datei existiert wegen anderer Overrides
+  # (LLM_PROXY_PORT, DEEPSEEK_API_KEY), nur das Token fehlt.
+  printf 'LLM_PROXY_PORT=18235\n' > "${TMP}/proxy.env"
+  run _guard "${TMP}/proxy.env"
+  [ "${status}" -ne 0 ]
+  [[ "${output}" == *"BGE_MCP_TOKEN fehlt"* ]]
+}
+
+@test "T002556: mit gesetztem Token schweigt der Guard" {
+  # Positiv-Anker [T002356-M1]: ohne ihn bestuende der Test auch bei einem
+  # Guard, der immer warnt.
+  printf 'BGE_MCP_TOKEN=irrelevant-fuer-den-test\n' > "${TMP}/proxy.env"
+  run _guard "${TMP}/proxy.env"
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}
+
+@test "T002556: ein auskommentierter Eintrag zaehlt nicht als gesetzt" {
+  printf '# BGE_MCP_TOKEN=frueher-mal\n' > "${TMP}/proxy.env"
+  run _guard "${TMP}/proxy.env"
+  [ "${status}" -ne 0 ]
+}
+
+@test "T002556: install-service fuehrt die Pruefung tatsaechlich aus" {
+  # Querschnitt: dass der Guard im Taskfile verdrahtet ist, manifestiert sich
+  # nur im Quelltext — hier ist grep richtig. Der Test oben misst das Verhalten.
+  run grep -c 'BGE_MCP_TOKEN=' "${TASKFILE}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" -gt 0 ]
+}
+
+@test "T002556: die Unit-Datei nennt Herkunft und Folge des fehlenden Tokens" {
+  # Wer die Unit liest, muss erfahren, warum die Variable nicht optional ist —
+  # der EnvironmentFile-Eintrag traegt ein fuehrendes Minus und sieht deshalb
+  # nach 'kann fehlen' aus.
+  run grep -c 'BGE_MCP_TOKEN' "${UNIT}"
+  [ "${status}" -eq 0 ]
+  [ "${output}" -gt 0 ]
+  run grep -c 'bge-mcp/server.env' "${UNIT}"
+  [ "${output}" -gt 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2544,6 +2544,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/proxy-env-token-guard",
+    "file": "tests/spec/local-llm-proxy/proxy-env-token-guard.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/ui-config-seed",
     "file": "tests/spec/local-llm-proxy/ui-config-seed.bats",
     "category": "local-llm-proxy",


### PR DESCRIPTION
## Was auf dem Host behoben ist

`~/.config/llm-proxy/proxy.env` angelegt (`0600`), Wert aus `~/.config/bge-mcp/server.env` übernommen. Die Unit las diese Datei **schon vorher** (`EnvironmentFile=-%h/.config/llm-proxy/proxy.env`) — sie existierte nur nicht.

**Belegt statt behauptet:** `ui-config.json` gelöscht, Loadout über den Proxy neu gestartet — die Datei wurde selbstständig neu erzeugt (2051 Bytes), die Unit kam hoch, und `Required environment variable BGE_MCP_TOKEN is not set` erscheint nicht mehr im Journal.

## Was dieser PR ändert

Der Host-Fix darf nicht Host-Wissen bleiben — beim nächsten Setup wäre der Fehler zurück.

**`llm-proxy.service`**: Der `EnvironmentFile`-Eintrag trägt ein führendes Minus und liest sich deshalb wie „kann fehlen". Für `BGE_MCP_TOKEN` stimmt das nicht. Der Kommentar nennt jetzt die Folgekette und den Weg, den Wert aus der vorhandenen Quelle zu übernehmen statt ihn abzutippen.

**`task llm:proxy:install-service`** warnt, wenn die Variable fehlt. Ohne die Warnung fällt der Fehler nicht bei der Installation auf, sondern erst Minuten später beim nächsten Loadout-Start — und dort sieht er wie ein llama.cpp-Problem aus, nicht wie eine fehlende Env-Variable.

## Die Folgekette, die den Fehler so schwer lesbar macht

```
BGE_MCP_TOKEN fehlt
  → generateUiConfigSeed() wirft
    → ensureUiConfigRendered() fängt ab, loggt nur          ← best-effort, T002549
      → buildServerArgv() setzt --ui-config-file trotzdem
        → llama-server: "failed to open file …"  Exit 1     ← HARTER Abbruch
          → Unit crashloopt, Modell steht still
```

Schritt 3 und 4 zusammen sind der Defekt: die Best-Effort-Absicht wird eine Zeile später zunichtegemacht. Am 2026-08-02 stand `gemma26-factory` deshalb rund zehn Minuten still — der *Stop* gelang, der *Start* nicht.

## Tests

Sie **führen die Warnlogik aus** (extrahiertes Fragment gegen präparierte Dateien) statt sie zu greppen, inklusive der zwei Fälle, die ein naives `grep` verwechselt:

- Datei existiert, enthält andere Overrides, nur das Token fehlt
- Eintrag ist auskommentiert

Plus Positiv-Anker: mit gesetztem Token schweigt der Guard. `bats tests/spec/local-llm-proxy/` → **50/50** grün.

## Ausdrücklich NICHT behoben

**Die Klasse.** `ensureUiConfigRendered()` bleibt best-effort und setzt `--ui-config-file` auch bei gescheitertem Rendern. Scheitert es aus einem *anderen* Grund als dem fehlenden Token, bricht der Start erneut ab.

Die saubere Lösung ist, das Flag bei fehlgeschlagenem Rendern gar nicht erst zu setzen — dann gilt die ursprüngliche Absicht aus T002549 wieder („Server startet ohne vorbelegte Liste"). Das ist ein eigener Schritt und bleibt in T002556 offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoVw6vutoS45LcF8C1DSHZ