### PR TITLE
chore: remove duplicate spec_too_short pre-gate in scout-quality-check

### DIFF
--- a/.worktrees/fix-plan-intel-merge-T002540/openspec/changes/fix-plan-intel-merge/tasks.d/p1-fix-line46.md
+++ b/.worktrees/fix-plan-intel-merge-T002540/openspec/changes/fix-plan-intel-merge/tasks.d/p1-fix-line46.md
@@ -1,0 +1,16 @@
+# Partial p1 — Zeile 46: EXISTING_INTEL aus --out lesen
+
+## Scope
+Fix in `scripts/plan-intel.sh` Zeile 46: `EXISTING_INTEL` aus `$OUT_PATH` ableiten statt aus `$CHANGE_DIR`.
+
+## Task List
+
+- [ ] **1.1** Zeile 46 ändern: wenn `--out` vom Default (`$CHANGE_DIR/intel.json`) abweicht, `$OUT_PATH` als `EXISTING_INTEL` verwenden; sonst Fallback `$CHANGE_DIR/intel.json`
+- [ ] **1.2** Manuell testen: `plan-intel.sh test-slug --out /tmp/merge-out/intel.json` — mit und ohne existierende `intel.json` im `--out`-Verzeichnis
+
+## Verification
+```bash
+bash -n scripts/plan-intel.sh   # Syntax-Check
+bash scripts/plan-intel.sh test-slug --target-files scripts/plan-intel.sh --out /tmp/test-out.json
+# Prüft: intel.json wird aus /tmp gelesen, nicht aus openspec/changes/test-slug/
+```

--- a/.worktrees/fix-plan-intel-merge-T002540/openspec/changes/fix-plan-intel-merge/tasks.d/p2-fix-line183-bats.md
+++ b/.worktrees/fix-plan-intel-merge-T002540/openspec/changes/fix-plan-intel-merge/tasks.d/p2-fix-line183-bats.md
@@ -1,0 +1,16 @@
+# Partial p2 — Zeile 183: .ticket aus --out lesen + BATS-Test
+
+## Scope
+Fix in `scripts/plan-intel.sh` Zeile 183 + BATS-Test in `tests/spec/dev-flow-plan/plan-intel-risks-dedupe.bats`.
+
+## Task List
+
+- [ ] **2.1** Zeile 183 ändern: `.ticket` aus `$(dirname "$OUT_PATH")/.ticket` lesen wenn `--out` gesetzt und vom Default abweicht; Fallback `$CHANGE_DIR/.ticket`
+- [ ] **2.2** BATS-Test: `--out`-Merge-Integration — legt `intel.json` mit bekanntem `api_contracts`-Wert im `--out`-Verzeichnis an, führt `plan-intel.sh` mit `--out` aus, prüft Übernahme
+- [ ] **2.3** BATS-Test: `--out` mit `.ticket` — legt `.ticket` im `--out`-Verzeichnis an, prüft korrekte Ticket-ID
+
+## Verification
+```bash
+task test:changed
+bash tests/spec/dev-flow-plan/plan-intel-risks-dedupe.bats
+```

--- a/.worktrees/fix-plan-intel-merge-T002540/openspec/changes/fix-plan-intel-merge/tasks.md
+++ b/.worktrees/fix-plan-intel-merge-T002540/openspec/changes/fix-plan-intel-merge/tasks.md
@@ -1,0 +1,29 @@
+---
+title: "plan-intel --out Merge-Fix"
+ticket_id: T002540
+domains: [scripts]
+status: plan_staged
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# plan-intel.sh --out Merge-Fix
+
+_Ticket: T002540_
+
+## File Structure
+
+| Datei | Ist | Budget |
+| --- | --- | --- |
+| `scripts/plan-intel.sh` | 215 | — |
+| `tests/spec/dev-flow-plan/plan-intel-risks-dedupe.bats` | — | neu |
+
+## Partials
+
+| id | file | role | target_files | depends_on |
+|----|------|------|-------------|------------|
+| 1 | tasks.d/p1-fix-line46.md | fix | scripts/plan-intel.sh | — |
+| 2 | tasks.d/p2-fix-line183-bats.md | fix | scripts/plan-intel.sh, tests/spec/dev-flow-plan/plan-intel-risks-dedupe.bats | 1 |

--- a/scripts/factory/scout-quality-check.cjs
+++ b/scripts/factory/scout-quality-check.cjs
@@ -2,8 +2,9 @@
  * scripts/factory/scout-quality-check.cjs
  * Pure quality evaluator for Software-Factory Scout output.
  * No external dependencies. Loadable via require() from pipeline.js (Workflow script).
+ * Note: spec_too_short is handled by evaluateSpecPreGate (pre-gate), not here.
  *
- * @param {{touched_files?: unknown, spec_content?: unknown, plan_path?: unknown}} scoutResult
+ * @param {{touched_files?: unknown, plan_path?: unknown}} scoutResult
  * @returns {{weak: boolean, reasons: string[]}}
  */
 function evaluateScoutQuality(scoutResult) {
@@ -12,9 +13,6 @@ function evaluateScoutQuality(scoutResult) {
 
   const touched = Array.isArray(r.touched_files) ? r.touched_files : []
   if (touched.length === 0) reasons.push('touched_files_empty')
-
-  const spec = typeof r.spec_content === 'string' ? r.spec_content : ''
-  if (spec.length < 300) reasons.push('spec_too_short')
 
   if (!r.plan_path) reasons.push('no_plan_path')
 
@@ -68,7 +66,6 @@ function evaluateSpecPreGate(specContent, options) {
 function runScoutGate(scout, ticketId, repo, cp, log, phaseEvent) {
   const sq = evaluateScoutQuality({
     touched_files: scout.touched_files,
-    spec_content: `${scout.title ?? ''}\n${scout.description ?? ''}`,
     plan_path: 'pending',
   })
   if (!sq.weak) return null

--- a/tests/unit/factory-scout-quality.bats
+++ b/tests/unit/factory-scout-quality.bats
@@ -20,11 +20,10 @@ setup() { export PROJECT_DIR MOD; }
   [[ "$output" == *'touched_files_empty'* ]]
 }
 
-@test "scout-quality: spec under 300 chars -> weak with spec_too_short" {
+@test "scout-quality: short spec with files and plan_path passes post-gate" {
   run node -e "const {evaluateScoutQuality}=require('$MOD'); const r=evaluateScoutQuality({touched_files:['a.ts'],spec_content:'short',plan_path:'p.md'}); process.stdout.write(JSON.stringify(r))"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'"weak":true'* ]]
-  [[ "$output" == *'spec_too_short'* ]]
+  [[ "$output" == *'"weak":false'* ]]
 }
 
 @test "scout-quality: missing plan_path -> weak with no_plan_path" {


### PR DESCRIPTION
## Summary
- Recovered work that was sitting uncommitted directly on the `main` checkout (never on a branch/PR) — an accidental-mutation case per the repo-hygiene runbook.
- Removes the `spec_too_short` check from `evaluateScoutQuality` in `scripts/factory/scout-quality-check.cjs`; that check already lives in `evaluateSpecPreGate` (the actual pre-gate), so this was a duplicate.
- Updates the matching BATS test in `tests/unit/factory-scout-quality.bats` to reflect that a short spec no longer makes the post-gate weak on its own.

## Test plan
- [ ] CI: BATS unit tests green