### PR TITLE
chore(plans): ergaenze fehlende Scenario-Bloecke in brain-k8-gesamtbild [T002567]

### DIFF
--- a/openspec/specs/brain-k8-gesamtbild.md
+++ b/openspec/specs/brain-k8-gesamtbild.md
@@ -8,6 +8,8 @@ _Purpose fehlt — beim nächsten inhaltlichen Delta zu brain-k8-gesamtbild erg�
 
 ### Requirement: Gesamtdiagramm mit beschrifteten Kanten (REQ-k8-01)
 
+#### Scenario: Gesamtdiagramm-Erstellung
+
 **GIVEN** die Komponenten K1–K7 sind dokumentiert
 **WHEN** K8 erstellt wird
 **THEN** existiert ein Gesamtdiagramm, das alle sieben Komponenten und ihre Kanten beschriftet darstellt
@@ -15,12 +17,16 @@ _Purpose fehlt — beim nächsten inhaltlichen Delta zu brain-k8-gesamtbild erg�
 
 ### Requirement: Vollständige Defektliste (REQ-k8-02)
 
+#### Scenario: Defekt-Konsolidierung
+
 **GIVEN** T002430 definiert D1–D9 und die Einzelkinder haben weitere Defekte gefunden
 **WHEN** K8 konsolidiert die Defekte
 **THEN** existiert eine vollständige Liste aller Defekte mit betroffener Kante, Auswirkung und Typ
 **AND** jeder Defekt ist einer der Kategorien Fehlfunktion, Inkompatibilität oder falsche Richtung zugeordnet
 
 ### Requirement: Fehlende Kanten (REQ-k8-03)
+
+#### Scenario: Luecken-Analyse
 
 **GIVEN** die Architektur hat strukturelle Lücken
 **WHEN** K8 analysiert die Schnittstellen


### PR DESCRIPTION
## Problem

`main` ist rot. `tests/spec/openspec-workflow.bats` Tests **29** und **32** fallen beide über `openspec/specs/brain-k8-gesamtbild.md`: die drei Requirements REQ-k8-01 bis REQ-k8-03 tragen ihren GIVEN/WHEN/THEN-Inhalt, aber keine `#### Scenario:`-Überschrift.

Das blockiert aktuell vier offene PRs (#3676, #3678, #3680, #3681), deren Auto-Merge auf grüne Checks wartet.

## Fix

Rein strukturell: je Requirement eine `#### Scenario:`-Überschrift, benannt analog zu den Schwester-Specs `brain-k2-bge.md` und `brain-k3-code-graph.md`. Inhalte unverändert.

## Wiederholungsmuster — kein Einzelfall

Dieselbe Lücke trat innerhalb weniger Stunden **dreimal** auf: `brain-k2-bge.md`, `brain-k3-code-graph.md` und jetzt `brain-k8-gesamtbild.md`. Alle drei entstanden beim Archivieren eines `brain-K*`-Changes, dessen Delta-Spec keine Scenario-Header trug — der Merge übernimmt sie unverändert in die SSOT.

Die Ursache liegt damit in der **Delta-Erzeugung**, nicht im Merge. Verschärfend: mehrere dieser Archivierungen liefen als Direkt-Commit auf `main` ohne PR, wodurch keine CI lief und der Guard erst nachträglich zuschlug. Beides ist in **T002567** als offener Punkt festgehalten.

## Verifikation

```
validateTree('openspec')  →  ok: true, errors: 0
ok 29 T001452: validator ignores specs under openspec/specs/archive/
ok 32 T002004: every SSOT requirement in openspec/specs/ declares a scenario
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwdLpdgySPtJ6rt93fAt1A