### PR TITLE
chore(plans): ergaenze Scenario-Bloecke im brain-k5-openspec Delta [T002567]

### DIFF
--- a/openspec/changes/brain-k5-openspec/specs/brain-k5-openspec.md
+++ b/openspec/changes/brain-k5-openspec/specs/brain-k5-openspec.md
@@ -4,11 +4,15 @@
 
 ### Requirement: Diagramm mit beschrifteten Kanten (REQ-k5-01)
 
+#### Scenario: Diagramm-Erstellung
+
 **GIVEN** die Brain-Architektur wird dokumentiert
 **WHEN** K5 erstellt wird
 **THEN** existiert ein Diagramm, das den Lebenszyklus propose→apply→archive sowie die Kanten K5→K1 (Embedding) und K5→K4 (Brain-Ingest) beschriftet darstellt
 
 ### Requirement: Lebenszyklus und Auslöser (REQ-k5-02)
+
+#### Scenario: Lebenszyklus-Erhebung
 
 **GIVEN** ein Change durchläuft propose→apply→archive
 **WHEN** K5 wird dokumentiert
@@ -16,11 +20,15 @@
 
 ### Requirement: Rückstau-Erhebung (REQ-k5-03)
 
+#### Scenario: Rückstau-Messung
+
 **GIVEN** unarchivierte Changes können hinter bereits gemergter Realität zurückbleiben
 **WHEN** K5 wird dokumentiert
 **THEN** ist die aktuelle Anzahl unarchivierter Verzeichnisse unter `openspec/changes/` gemessen (nicht abgeleitet) und im Dokument beziffert
 
 ### Requirement: Defekt-Referenz (REQ-k5-04)
+
+#### Scenario: Defekt-Zuordnung
 
 **GIVEN** T002430 definiert die Defekte D1-D9
 **WHEN** K5 wird dokumentiert


### PR DESCRIPTION
## Präventiv, nicht reaktiv

`openspec/changes/brain-k5-openspec/specs/brain-k5-openspec.md` liegt unarchiviert auf `main` mit **4 Requirements und 0 `#### Scenario:`-Blöcken**. Beim Archivieren übernimmt `scripts/openspec-merge.mjs` das Delta unverändert in die SSOT — der Guard T002004 hätte `main` dann zum **vierten Mal** in dieser Serie rot gemacht (nach K2, K3 und K8, alle heute).

Rein strukturell: je Requirement eine Scenario-Überschrift. Inhalte unverändert.

## Verifikation

```
Delta:  R=4  S=4
validateTree('openspec')  →  ok: true, errors: 0
```

## Kontext (T002567)

Die Ursache liegt in der **Delta-Erzeugung**, nicht im Merge — belegt: es existiert kein Fall, in dem ein Delta Scenarios trug und die SSOT sie verlor. Der Guard prüft heute nur `openspec/specs/`, nicht `openspec/changes/*/specs/`, wodurch der Fehler erst Tage später im Archivierungs-PR eines *anderen* Vorgangs sichtbar wird.

**Der Befund ist größer als diese Serie:** ein Scan über alle unarchivierten Deltas findet **18 weitere** mit derselben Lücke. Details und Liste in T002567; für den geplanten Archiv-Rückstau-Abbau (T002569) ist das ein Vorbedingung, kein Randfall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwdLpdgySPtJ6rt93fAt1A