### PR TITLE
fix(scripts): agent-lock Heartbeat-TTL mit -ge vergleichen — behebt 50%-Flake [T002571]

### DIFF
--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -5,6 +5,10 @@
 # AGENT_LOCK_FETCH_TTL.
 set -uo pipefail
 
+# [T002571] Der Heartbeat-Vergleich unten ist `-ge`, nicht `-gt`: die Zeitbasis ist
+# sekundengenau, also hiesse `-gt 0` faktisch "TTL 1s" statt "keine Toleranz".
+# Genau daran war T002448-M8 zu ~50% flaky — fielen claim und reap in dieselbe
+# Sekunde, ueberlebte der Lock. Bei Default 1800 ist der Unterschied wirkungslos.
 AGENT_LOCK_TTL="${AGENT_LOCK_TTL:-1800}"
 AGENT_LOCK_GRACE="${AGENT_LOCK_GRACE:-120}"
 # [T002502] cmd_reap-Fetch (pre-claim reap bei JEDEM claim) max 1x pro TTL-Fenster:
@@ -122,7 +126,7 @@ _reapable() {
   if [ -n "$sid" ] && _sid_alive "$sid"; then
     # [T002392-M3] Heartbeat-TTL-Check auch bei lebendiger SID: non-numeric UUIDs
     # gelten immer als "alive" — ein alter Heartbeat zeigt aber einen toten Halter.
-    if [ -n "$hb" ] && [ "$(( now - hb ))" -gt "$AGENT_LOCK_TTL" ]; then
+    if [ -n "$hb" ] && [ "$(( now - hb ))" -ge "$AGENT_LOCK_TTL" ]; then
       _reap_log "$f" heartbeat-ttl; return 0
     fi
     return 1
@@ -139,7 +143,7 @@ _reapable() {
     local wt_branch
     wt_branch="$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)"
     if [ -n "$wt_branch" ] && [ "$wt_branch" = "$br" ]; then
-      if [ -n "$hb" ] && [ "$(( now - hb ))" -gt "$AGENT_LOCK_TTL" ]; then
+      if [ -n "$hb" ] && [ "$(( now - hb ))" -ge "$AGENT_LOCK_TTL" ]; then
         _reap_log "$f" heartbeat-ttl; return 0
       fi
       return 1
@@ -167,7 +171,7 @@ _reapable() {
       _reap_log "$f" sid-dead; return 0
     fi
   fi
-  if [ -n "$hb" ] && [ "$(( now - hb ))" -gt "$AGENT_LOCK_TTL" ]; then _reap_log "$f" heartbeat-ttl; return 0; fi
+  if [ -n "$hb" ] && [ "$(( now - hb ))" -ge "$AGENT_LOCK_TTL" ]; then _reap_log "$f" heartbeat-ttl; return 0; fi
   return 1
 }
 


### PR DESCRIPTION
## Problem

Der BATS-Test `T002448-M8: agent-lock reap removes lock with dead PID once the heartbeat is stale` ist zu **rund 50 % rot** und blockiert damit zufällig beliebige PRs — beobachtet am 2026-08-02 an #3687, #3681 und #3678, jeweils ohne inhaltlichen Bezug zu deren Änderungen.

## Ursache

Die drei Heartbeat-Prüfungen in `scripts/agent-lock.sh` verglichen mit `-gt "$AGENT_LOCK_TTL"`. Der Test setzt `AGENT_LOCK_TTL=0` und erwartet „sofort reapbar" — aber bei sekundengenauer Zeitbasis verlangt `-gt 0` eine **volle Sekunde** Differenz. Fallen `claim` und `reap` in dieselbe Sekunde, überlebt der Lock und `[ ! -f "$LF" ]` schlägt fehl. Daher lastabhängig.

Die Grace-Prüfung unmittelbar darüber nutzt bereits `-ge` — die Inkonsistenz innerhalb derselben Funktion war der eigentliche Defekt.

## Änderung

Alle drei Vergleiche auf `-ge` vereinheitlicht, plus ein Kommentar an der TTL-Definition, der die Sekundengranularität festhält.

- `TTL=0` bedeutet jetzt „keine Toleranz" statt „eine Sekunde Toleranz".
- Bei Default `1800` ist die Änderung wirkungslos.
- `AGENT_LOCK_TTL=0` wird repo-weit **ausschließlich** in diesem einen Test gesetzt (geprüft).

## Verifikation

- Test 8× wiederholt → **8× grün** (vorher: 3 Läufe ergaben rot/grün/rot).
- `AGENT-LOCK-01-core`, `-02-reap`, `-03-precommit`, `active-sessions-hub`: unverändert.
- `AGENT-LOCK-03f` ist im Worktree rot, aber **auch ohne diese Änderung** (per `git stash` gegengeprüft) und auf `main` grün — ein worktree-abhängiger Setup-Defekt, kein Regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ7aFE3kDsuZdy3owarnnf