### PR TITLE
fix(plans): openspec archive atomar machen — Guards vor den Delta-Merge [T002581]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 730,
+      "file_count": 731,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -467,6 +467,7 @@
         "tests/spec/openspec-pgvector.bats",
         "tests/spec/openspec-upstream-cli.bats",
         "tests/spec/openspec-workflow.bats",
+        "tests/spec/openspec-workflow/archive-atomic-guards.bats",
         "tests/spec/openspec-workflow/archive-terminal-ticket-status.bats",
         "tests/spec/openspec-workflow/delta-scenario-guard.bats",
         "tests/spec/openspec-workflow/half-archive-guard.bats",

--- a/scripts/openspec-merge.mjs
+++ b/scripts/openspec-merge.mjs
@@ -70,7 +70,10 @@ function endOfRequirements(lines) {
   return i
 }
 
-export function applyDelta(deltaPath, ssotPath, today = new Date().toISOString().slice(0, 10), createNew = false, forceNewComponent = false) {
+// dryRun führt jeden Guard aus, schreibt aber nichts — weder die --create-new-
+// Skeleton-SSOT noch das Merge-Ergebnis. [T002581] Nur so kann cmd_archive alle
+// Deltas eines Change vorab prüfen, bevor der erste Schreibvorgang stattfindet.
+export function applyDelta(deltaPath, ssotPath, today = new Date().toISOString().slice(0, 10), createNew = false, forceNewComponent = false, dryRun = false) {
   const deltaName = basename(deltaPath)
   const delta = readFileSync(deltaPath, 'utf-8')
 
@@ -78,6 +81,13 @@ export function applyDelta(deltaPath, ssotPath, today = new Date().toISOString()
     if (re.test(delta)) fail(`${deltaName}: contains unedited skeleton stub (${STUB_MARKER} / 'The system SHALL …') — edit before archiving`)
   }
 
+  // Die --create-new-Skeleton-SSOT wird zunächst nur IM SPEICHER aufgebaut.
+  // [T002581] Bis Zeile 90 landete sie direkt auf der Platte — scheiterte danach
+  // ein Guard (MODIFIED-Ziel nicht gefunden, --create-new ohne Requirement-Block),
+  // blieb eine verwaiste Skeleton-Datei zurück, während das Change-Verzeichnis
+  // unverschoben liegen blieb. Beobachtet in T002569 Charge 6 (auto-close-guard.md).
+  let content
+  let creating = false
   if (!existsSync(ssotPath)) {
     if (!createNew) {
       fail(`Target '${ssotPath}' does not exist. Point the delta at an existing spec, or pass --create-new for a genuinely new component (e.g. a cross-cutting mishap bundle with no parent SSOT spec).`)
@@ -86,10 +96,11 @@ export function applyDelta(deltaPath, ssotPath, today = new Date().toISOString()
     if (/^(t[0-9]{6}|g-[a-z0-9]+[0-9]{2})/.test(newSlug) && !forceNewComponent) {
       fail(`Refusing to create one-off spec '${newSlug}.md' (ticket/gate slug pattern). Use --target-spec <parent> to fold it into an existing component, or --force-new-component to override.`)
     }
-    mkdirSync(dirname(ssotPath), { recursive: true })
-    writeFileSync(ssotPath, `# ${newSlug}\n\n## Purpose\n\n_Purpose fehlt — beim nächsten inhaltlichen Delta zu ${newSlug} ergänzen._\n\n## Requirements\n`)
+    creating = true
+    content = `# ${newSlug}\n\n## Purpose\n\n_Purpose fehlt — beim nächsten inhaltlichen Delta zu ${newSlug} ergänzen._\n\n## Requirements\n`
+  } else {
+    content = readFileSync(ssotPath, 'utf-8')
   }
-  let content = readFileSync(ssotPath, 'utf-8')
   const deltaHash = createHash('sha1').update(delta).digest('hex').slice(0, 12)
   const marker = `<!-- merged from change delta ${deltaName} (${deltaHash}) -->`
   if (content.includes(marker)) {
@@ -131,6 +142,10 @@ export function applyDelta(deltaPath, ssotPath, today = new Date().toISOString()
     fail(`--create-new but no ### Requirement: block merged into ${basename(ssotPath)} — check that the delta has '## ADDED Requirements' with at least one '### Requirement: …' child.`)
   }
 
+  // Ab hier ist jeder Guard durch. Erst jetzt wird geschrieben — im check-Modus
+  // gar nicht. [T002581]
+  if (dryRun) return 0
+  if (creating) mkdirSync(dirname(ssotPath), { recursive: true })
   writeFileSync(ssotPath, merged)
   return 0
 }
@@ -139,13 +154,14 @@ function main(argv) {
   const positional = argv.filter(a => !a.startsWith('--'))
   const flags = argv.filter(a => a.startsWith('--'))
   const [verb, deltaPath, ssotPath] = positional
-  if (verb !== 'apply' || !deltaPath || !ssotPath) {
-    process.stderr.write('Usage: openspec-merge.mjs apply <deltaPath> <ssotPath> [--create-new] [--force-new-component]\n')
+  // 'check' ist 'apply' ohne Schreibvorgang — identische Guards. [T002581]
+  if ((verb !== 'apply' && verb !== 'check') || !deltaPath || !ssotPath) {
+    process.stderr.write('Usage: openspec-merge.mjs <apply|check> <deltaPath> <ssotPath> [--create-new] [--force-new-component]\n')
     process.exit(2)
   }
   const createNew = flags.includes('--create-new')
   const forceNewComponent = flags.includes('--force-new-component')
-  return applyDelta(deltaPath, ssotPath, new Date().toISOString().slice(0, 10), createNew, forceNewComponent)
+  return applyDelta(deltaPath, ssotPath, new Date().toISOString().slice(0, 10), createNew, forceNewComponent, verb === 'check')
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/openspec.sh
+++ b/scripts/openspec.sh
@@ -240,7 +240,19 @@ cmd_archive() {
   Pruefe, ob der Change schon (teilweise) archiviert ist:
     bash scripts/openspec-half-archive-check.sh"
   fi
+  # [T002581] Zwei-Pass: erst ALLE Deltas pruefen, dann ALLE anwenden. Vorher lief
+  # der Merge pro Datei in einer Schleife — brach Datei 2 an einem Guard ab, war die
+  # SSOT von Datei 1 bereits mutiert, das Change-Verzeichnis aber unverschoben. Ein
+  # solcher Lauf war weder vollzogen noch folgenlos und nur von Hand zu reparieren.
+  # Der Vorab-Check ist vollstaendig, nicht heuristisch: die Delta-Dateinamen in
+  # changes/<slug>/specs/ sind eindeutig, jedes Delta zielt also auf eine eigene SSOT.
+  # Kein Pass kann das Ergebnis eines anderen im selben Lauf beeinflussen.
   if [[ -d "$dir/specs" ]]; then
+    for capfile in "$dir/specs"/*.md; do
+      [[ -e "$capfile" ]] || continue
+      local cap; cap="$(basename "$capfile")"
+      _check_delta "$capfile" "$OPENSPEC_ROOT/specs/$cap" "$create_new" "$force_new"
+    done
     for capfile in "$dir/specs"/*.md; do
       [[ -e "$capfile" ]] || continue
       local cap; cap="$(basename "$capfile")"
@@ -263,6 +275,13 @@ _merge_delta() {
   # target, a RENAMED without **Renamed-to:**, or a skeleton stub exits non-zero
   # and aborts the archive (set -e) before the SSOT can be corrupted.
   node "$REPO/scripts/openspec-merge.mjs" apply "$delta" "$ssot" $create_new $force_new
+}
+
+_check_delta() {
+  local delta="$1" ssot="$2" create_new="${3:-}" force_new="${4:-}"
+  # Trockenlauf mit denselben Guards wie _merge_delta, ohne jeden Schreibvorgang.
+  # Fail-closed via set -e: bricht hier etwas ab, hat noch keine SSOT sich geaendert.
+  node "$REPO/scripts/openspec-merge.mjs" check "$delta" "$ssot" $create_new $force_new
 }
 
 cmd_validate() {

--- a/tests/spec/openspec-workflow/archive-atomic-guards.bats
+++ b/tests/spec/openspec-workflow/archive-atomic-guards.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# T002581 — archive muss atomar sein: kein Schreibvorgang, bevor alle Guards durch sind.
+#
+# Hintergrund (T002569 Charge 6): openspec-merge.mjs legt bei --create-new die
+# Skeleton-SSOT an, BEVOR die Merge-Schleife an einem spaeteren Guard scheitern
+# kann. Zurueck blieb openspec/specs/auto-close-guard.md als verwaiste Datei.
+# Zweite Ebene: cmd_archive merged pro Delta-Datei in einer Schleife — bricht
+# Datei 2 ab, ist die SSOT von Datei 1 bereits mutiert, das Change-Verzeichnis
+# aber nicht verschoben. Ein solcher Lauf ist weder vollzogen noch folgenlos.
+#
+# Pruefmodus (T002448-M4): command output verification. Alle Tests FUEHREN
+# openspec-merge.mjs bzw. openspec.sh aus und pruefen $status sowie den
+# Zustand des Dateisystems danach; keiner greppt Quelltext.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  MERGE="$REPO_ROOT/scripts/openspec-merge.mjs"
+  ROOT="$BATS_TEST_TMPDIR/openspec"
+  mkdir -p "$ROOT/specs" "$ROOT/changes"
+}
+
+# Legt einen Change mit beliebig vielen Delta-Dateien an.
+# Aufruf: _mk_change <slug> <delta-dateiname> <inhalt> [<dateiname> <inhalt> ...]
+_mk_change() {
+  local slug="$1"; shift
+  mkdir -p "$ROOT/changes/$slug/specs"
+  while [ $# -gt 0 ]; do
+    printf '%s\n' "$2" > "$ROOT/changes/$slug/specs/$1"
+    shift 2
+  done
+}
+
+_valid_added() {
+  cat <<'EOF'
+## ADDED Requirements
+
+### Requirement: Beispielanforderung
+
+The system SHALL etwas Nachpruefbares tun.
+
+#### Scenario: Normalfall
+
+- **GIVEN** ein Zustand
+- **WHEN** etwas geschieht
+- **THEN** ein Ergebnis
+EOF
+}
+
+# ── Positiv-Anker (Pflicht nach T002356-M1) ──────────────────────────────────
+# Ohne ihn waeren die Negativtests unten auch dann gruen, wenn 'check' gar
+# nichts pruefte oder 'apply' generell nicht mehr schriebe.
+
+@test "T002581: check laesst ein gueltiges Delta durch und schreibt dabei NICHT" {
+  _mk_change c1 ziel.md "$(_valid_added)"
+  printf '# ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/ziel.md"
+  local before; before="$(cat "$ROOT/specs/ziel.md")"
+
+  run node "$MERGE" check "$ROOT/changes/c1/specs/ziel.md" "$ROOT/specs/ziel.md"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$ROOT/specs/ziel.md")" = "$before" ]
+}
+
+@test "T002581: apply schreibt das gueltige Delta danach weiterhin in die SSOT" {
+  _mk_change c2 ziel.md "$(_valid_added)"
+  printf '# ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/ziel.md"
+
+  run node "$MERGE" apply "$ROOT/changes/c2/specs/ziel.md" "$ROOT/specs/ziel.md"
+  [ "$status" -eq 0 ]
+  grep -q '### Requirement: Beispielanforderung' "$ROOT/specs/ziel.md"
+}
+
+# ── Ebene 1: keine verwaiste SSOT bei --create-new ───────────────────────────
+
+@test "T002581: check auf ein Delta mit nicht auffindbarem MODIFIED-Ziel schlaegt fehl" {
+  _mk_change c3 ziel.md "$(printf '## MODIFIED Requirements\n\n### Requirement: Gibt es nicht\n\nThe system SHALL x.\n')"
+  printf '# ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/ziel.md"
+
+  run node "$MERGE" check "$ROOT/changes/c3/specs/ziel.md" "$ROOT/specs/ziel.md"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"MODIFIED target 'Gibt es nicht' not found"* ]]
+}
+
+@test "T002581: gescheitertes --create-new hinterlaesst KEINE verwaiste SSOT-Datei" {
+  # Delta ohne '### Requirement:'-Block: der --create-new-Nachweis am Ende von
+  # applyDelta schlaegt fehl — vor dem Fix war die Skeleton-Datei da bereits
+  # geschrieben. Das ist der Fall aus T002569 Charge 6 (auto-close-guard.md).
+  _mk_change c4 neuespec.md "$(printf '## ADDED Requirements\n\nKein Requirement-Block, nur Fliesstext.\n')"
+
+  run node "$MERGE" apply "$ROOT/changes/c4/specs/neuespec.md" "$ROOT/specs/neuespec.md" --create-new
+  [ "$status" -ne 0 ]
+  [ ! -e "$ROOT/specs/neuespec.md" ]
+}
+
+# ── Ebene 2: kein Teil-Merge ueber mehrere Delta-Dateien ─────────────────────
+
+@test "T002581: archive laesst SSOT des ersten Deltas unveraendert, wenn ein zweites bricht" {
+  _mk_change c5 \
+    a-ziel.md "$(_valid_added)" \
+    b-ziel.md "$(printf '## MODIFIED Requirements\n\n### Requirement: Gibt es nicht\n\nThe system SHALL x.\n')"
+  printf '# a-ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/a-ziel.md"
+  printf '# b-ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/b-ziel.md"
+  local before_a; before_a="$(cat "$ROOT/specs/a-ziel.md")"
+
+  run env OPENSPEC_ROOT="$ROOT" TICKET_OFFLINE=1 bash "$REPO_ROOT/scripts/openspec.sh" archive c5
+  [ "$status" -ne 0 ]
+  # a-ziel.md darf NICHT mutiert sein, obwohl sein Delta fuer sich gueltig ist
+  [ "$(cat "$ROOT/specs/a-ziel.md")" = "$before_a" ]
+  # und der Change bleibt an Ort und Stelle
+  [ -d "$ROOT/changes/c5" ]
+}
+
+@test "T002581: archive vollzieht einen Change mit zwei gueltigen Deltas vollstaendig" {
+  # Positiv-Anker zum Test darueber: der Zwei-Pass darf den Normalfall nicht
+  # blockieren. Ohne ihn waere obiger Test auch gruen, wenn archive gar nichts
+  # mehr merged.
+  _mk_change c6 a2-ziel.md "$(_valid_added)" b2-ziel.md "$(_valid_added)"
+  printf '# a2-ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/a2-ziel.md"
+  printf '# b2-ziel\n\n## Purpose\n\nx\n\n## Requirements\n' > "$ROOT/specs/b2-ziel.md"
+
+  run env OPENSPEC_ROOT="$ROOT" TICKET_OFFLINE=1 bash "$REPO_ROOT/scripts/openspec.sh" archive c6
+  [ "$status" -eq 0 ]
+  grep -q '### Requirement: Beispielanforderung' "$ROOT/specs/a2-ziel.md"
+  grep -q '### Requirement: Beispielanforderung' "$ROOT/specs/b2-ziel.md"
+  [ ! -d "$ROOT/changes/c6" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2814,6 +2814,12 @@
     "kind": "shell"
   },
   {
+    "id": "openspec-workflow/archive-atomic-guards",
+    "file": "tests/spec/openspec-workflow/archive-atomic-guards.bats",
+    "category": "openspec-workflow",
+    "kind": "shell"
+  },
+  {
     "id": "openspec-workflow/archive-terminal-ticket-status",
     "file": "tests/spec/openspec-workflow/archive-terminal-ticket-status.bats",
     "category": "openspec-workflow",


### PR DESCRIPTION
Behebt M5 aus T002578. Beobachtet in T002569 Charge 6.

## Befund

Ein gescheiterter `openspec.sh archive`-Lauf hinterliess mutierte SSOT-Dateien, obwohl das Change-Verzeichnis nie verschoben wurde — weder vollzogen noch folgenlos, und nur von Hand zu reparieren. Zwei Ebenen:

1. **Innerhalb einer Delta-Datei:** `openspec-merge.mjs` schrieb bei `--create-new` die Skeleton-SSOT, *bevor* die Merge-Schleife an einem `MODIFIED target not found` oder am `--create-new`-Nachweis scheitern konnte. In Charge 6 blieb so `openspec/specs/auto-close-guard.md` verwaist zurueck.
2. **Ueber mehrere Delta-Dateien:** `cmd_archive` merged pro Datei in einer Schleife. Datei 1 schreibt, Datei 2 bricht ab.

## Fix

1. Die Skeleton-SSOT wird im Speicher aufgebaut; `writeFileSync`/`mkdirSync` laufen erst, wenn jeder Guard durch ist.
2. Zwei-Pass in `cmd_archive`: erst alle Deltas per neuem `check`-Verb pruefen (identische Guards, kein Schreibvorgang), dann alle anwenden.

Der Vorab-Check ist **vollstaendig, nicht heuristisch**: die Delta-Dateinamen in `changes/<slug>/specs/` sind eindeutig, jedes Delta zielt also auf eine eigene SSOT — kein Pass kann das Ergebnis eines anderen im selben Lauf beeinflussen.

## Nachweis

`tests/spec/openspec-workflow/archive-atomic-guards.bats` — 6 Tests, Output-Verifikation, davon 2 Positiv-Anker (T002356-M1). Vor dem Fix: 4 rot, 2 gruen. Danach: 6 gruen.

Zusaetzlich am echten Fall gegengeprueft: `archive t002105-mishap-bundle --create-new` bricht weiterhin am MODIFIED-Guard ab, laesst den Arbeitsbaum aber unveraendert und legt keine verwaiste SSOT mehr an.

Regression: `tests/spec/openspec-workflow.bats` + `archive.bats` + `openspec-upstream-cli.bats` (58) und `tests/spec/openspec-workflow/` (20) ohne Fehlschlag; `task test:changed` 52 pass / 0 fail.