### PR TITLE
chore(plans): mcp-gateway-Spec nennt behobene Defekte als bestehend — behebt roten main [T002589]

### DIFF
--- a/openspec/specs/mcp-gateway.md
+++ b/openspec/specs/mcp-gateway.md
@@ -479,13 +479,13 @@ server registration, rather than from a new test file.
 ### Requirement: The registry must record known defects of the cluster layer rather than repair them
 
 The `cluster` section MUST record, for each container of the monolith, whether it is functional,
-and reference the ticket for any that is not. Two are known at the time of writing: the
-`keycloak` container targets a service that no longer exists because Pocket ID replaced Keycloak
-(T002311), and the SSOT description of this component claims the monolith was decommissioned
-while it is running (T002312).
+and reference the ticket for any that is not. Two such defects existed when this requirement was
+written — a `keycloak` container targeting a service that Pocket ID had already replaced
+(T002311), and a stale claim about this component's deployment status (T002312). Both have since
+been resolved; the requirement stands for any future defect.
 
-Repairing either requires changing a production manifest and is out of scope for a change whose
-subject is configuration generation.
+Repairing such a defect requires changing a production manifest and is out of scope for a change
+whose subject is configuration generation.
 
 #### Scenario: a container is known to be broken
 


### PR DESCRIPTION
Behebt den roten `main`.

## Befund

Das Requirement *"The registry must record known defects of the cluster layer rather than repair them"* in `openspec/specs/mcp-gateway.md` führte in normativer Prosa zwei Defekte als aktuell auf. Beide sind längst behoben:

| Ticket | Titel | Status |
|---|---|---|
| T002311 | keycloak-Sidecar läuft gegen nicht existierenden Service | `done · fixed` |
| T002312 | Spec behauptet fälschlich, der MCP-Monolith sei dekommissioniert | `done · fixed` |

Der Satz zu T002312 enthielt dabei das Wort `decommissioned`. Der Guard aus T002321 (`tests/spec/mcp-gateway.bats`, Test 39) nimmt `#### Scenario:`-Blöcke bewusst aus, prüft die normative Prosa aber streng — und schlug zu, seit der Absatz mit dem Archivieren von **Charge 3 (PR #3697, T002569)** in die SSOT gemergt wurde.

## Warum das dringend war

Seither ist `main` rot. Der Fehlschlag ist nicht PR-spezifisch — **fremde PRs scheitern an genau demselben Job**:

```
PR #3712  [T002443]  CI: failure   Factory spec shard 4, Test 202
PR #3708  [T002582]  CI: failure   derselbe Job, derselbe Test
```

Das blockierte die gesamte Merge-Pipeline.

## Der Fix

Kein Umgehen des Guards, sondern Beseitigung seines Anlasses: die Aufzählung wird als historisch gekennzeichnet und der Verweis auf den Deployment-Status neutral formuliert.

Das Requirement selbst bleibt **unverändert gültig** — es beschreibt eine Regel ("record known defects"), keinen Zustand. Nur die Beispielliste war veraltet. Der `#### Scenario:`-Block darunter, der `keycloak` als Prüfbedingung nennt, bleibt ebenfalls unangetastet.

Direkt in der SSOT editiert, nicht im Delta: der zugehörige Change ist bereits archiviert, ein offener Delta-Pfad existiert nicht.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `tests/spec/mcp-gateway.bats` Test 39 (der zuvor rote) | ok |
| `task test:all` | exit 0, **0** `not ok` |
| `task freshness:check` | exit 0 |
| `bash scripts/openspec.sh validate` | OK |

## Danach

`#3712` und `#3708` brauchen je einen Rebase auf `origin/main`, damit ihr stale Check neu läuft; deren Auto-Merge feuert dann selbstständig.
