### PR TITLE
chore(plans): mcp-gateway.md Defektbeschreibung entschaerfen [T002589]

### DIFF
--- a/openspec/specs/mcp-gateway.md
+++ b/openspec/specs/mcp-gateway.md
@@ -484,6 +484,15 @@ written — a `keycloak` container targeting a service that Pocket ID had alread
 (T002311), and a stale claim about this component's deployment status (T002312). Both have since
 been resolved; the requirement stands for any future defect.
 
+<!-- [T002589] Der Absatz oben umschreibt den Defekt aus T002312 bewusst, statt ihn beim Namen
+     zu nennen. Der Guard in tests/spec/mcp-gateway.bats greppt normative Prosa auf das
+     Abschaltungs-Signalwort (deutsche und englische Form, siehe den Regex dort) und nimmt nur
+     Scenario-Bloecke aus — er kann Beschreibung und Behauptung nicht unterscheiden. Beim
+     Archivieren von Charge 3 (T002569, PR #3697) wanderte eine Formulierung mit dem Signalwort
+     in die SSOT und faerbte main rot. Dieser Kommentar darf es deshalb selbst nicht
+     ausschreiben; der erste Anlauf tat es und blieb prompt rot. Den Guard aufzuweichen waere
+     falsch — er existiert, weil genau diese Behauptung monatelang unwidersprochen hier stand. -->
+
 Repairing such a defect requires changing a production manifest and is out of scope for a change
 whose subject is configuration generation.
 


### PR DESCRIPTION
**Behebt rotes `main`** (zweite Nachwirkung der OpenSpec-Archivierung aus T002569).

## Ursache

`tests/spec/mcp-gateway.bats` prueft, dass ausserhalb von Scenario-Bloecken kein Abschaltungs-Signalwort in `openspec/specs/mcp-gateway.md` steht — der Guard aus T002312 gegen die Behauptung, der MCP-Monolith sei abgeschaltet, waehrend sein Manifest weiter ausgeliefert wird.

Beim Archivieren von **Charge 3 (PR #3697)** wurde ein Delta gemerged, dessen Requirement *"The registry must record known defects of the cluster layer rather than repair them"* den Defekt aus T002312 in normativer Prosa **beschreibt**. Der Satz behauptet die Abschaltung nicht — aber der Guard greppt Prosa und nimmt nur Scenario-Bloecke aus; er kann Beschreibung und Behauptung nicht unterscheiden.

## Fix

Umformuliert, sodass die Aussage erhalten bleibt, ohne das Signalwort in normativer Prosa zu fuehren. **Den Guard aufzuweichen waere der falsche Weg** — er existiert, weil genau diese Behauptung monatelang unwidersprochen in der SSOT stand.

Ein Kommentar an der Stelle haelt fest, warum der Absatz so formuliert ist. Er darf das Signalwort selbst nicht ausschreiben: der erste Anlauf tat es und blieb prompt rot — der Guard sieht HTML-Kommentare wie jede andere Prosa.

## Nachweis

`tests/spec/mcp-gateway.bats` → **40/40 ok** (vorher Test 39 rot). `task openspec:validate` gruen (11/11).

Scope `chore(plans)` statt `fix()`: der Diff enthaelt ausschliesslich ein SSOT-Dokument, keinen Produktionscode — `check-commit-vs-diff` weist `fix()` hier zu Recht ab (T001434-Muster).