### PR TITLE
chore(plans): Warn-Level G2 bei Task-Anzahl ausserhalb 3-7 [T002593]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 743,
+      "file_count": 744,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -384,6 +384,7 @@
         "tests/spec/dev-flow-plan-ticket-sh-mishaps.bats",
         "tests/spec/dev-flow-plan.bats",
         "tests/spec/dev-flow-plan/plan-intel-risks-dedupe.bats",
+        "tests/spec/dev-flow-plan/plan-lint-task-count.bats",
         "tests/spec/dev-flow-plan/task-context.bats",
         "tests/spec/devflow-selection-archive-hardening.bats",
         "tests/spec/divergence-guard.bats",

--- a/scripts/plan-lint.sh
+++ b/scripts/plan-lint.sh
@@ -442,6 +442,46 @@ while IFS= read -r g; do warn "${g/G1:/G1: }"; done < <(awk '
   END{ if (started && n>3) print "G1:" task " touches " n " files" }
 ' "$PLAN")
 
+# === G2: task-count corridor — warn outside 3..7 tasks (warn only, T002593) ===
+# Rationale: the task count is a SYMPTOM, not a target. Below 3 the work is a chore
+# with no plan-worthy structure; above 7 the ticket carries more than one core and
+# belongs to an epic with children. Deliberately NOT a hard fail — a gate on a number
+# produces plans cut to hit the number instead of the invariant (one task = one
+# verifiable claim ending in a green, committable state).
+#
+# TWO heading conventions coexist in openspec/changes and both must count, or the
+# warning fires on plans that are perfectly well structured and is learned-ignored —
+# taking the neighbouring W3/W4/G1 warnings down with it:
+#   a) "## Task 1 ", "## Task 1:", "## Task 1.", "### Task: x"
+#   b) "## 1. <title>" — the OpenSpec skeleton default (17 of 95 plans on 2026-08-03)
+#   c) "## T1 — <title>"
+#   d) "- [ ] **Task 1: <title>**" — tasks as checklist items, not headings
+# `## Tasks` and `## Task List` are section headers, not tasks — hence the required
+# digit-or-colon after `Task` in (a).
+G2_TASK_RE='(^#+[[:space:]]+([0-9]+\.[[:space:]]|T[0-9]+[[:space:]]|Task([[:space:]]+[0-9]|:)))|(^-[[:space:]]+\[[[:space:]x]\][[:space:]]+\*{0,2}Task[[:space:]]+[0-9])'
+# Partial mode (T002074): tasks.md is only an index — the real tasks live in tasks.d/.
+# Counting the index alone would flag EVERY partial plan as "too few tasks".
+g2_count=$(grep -cE "$G2_TASK_RE" "$PLAN" || true)
+if [[ $PARTIAL_MODE -eq 1 ]]; then
+  for pf in "${PARTIAL_FILES[@]:-}"; do
+    [[ -f "$PLAN_DIR/$pf" ]] || continue
+    g2_count=$(( g2_count + $(grep -cE "$G2_TASK_RE" "$PLAN_DIR/$pf" || true) ))
+  done
+fi
+if [[ $g2_count -eq 0 ]]; then
+  # SILENT BY DESIGN: zero recognised tasks means "heading format not recognised",
+  # not "the plan has no tasks" — the repo carries at least four task conventions and
+  # a fifth would silently re-break the regex. Warning here produced 38 of 46 hits on
+  # 2026-08-03 (83% noise), and noise is not free: readers learn to skim the whole ⚠
+  # block and lose W3/W4/G1 with it. Structureless plans are already caught HARD by
+  # STRUCT2/STRUCT3, so nothing goes unnoticed.
+  :
+elif [[ $g2_count -lt 3 ]]; then
+  warn "G2: only $g2_count task(s) — below the 3..7 corridor; if there is no plan-worthy structure this is a chore (dev-flow-chore)"
+elif [[ $g2_count -gt 7 ]]; then
+  warn "G2: $g2_count tasks — above the 3..7 corridor; consider splitting the ticket into an epic with children instead of lengthening the plan"
+fi
+
 # === verdict ===
 # Pure-bash JSON string escaper (no python3 fork). Escapes \ and " and the few
 # control chars that can appear; valid UTF-8 (e.g. ≤) passes through unchanged.

--- a/tests/spec/dev-flow-plan/plan-lint-task-count.bats
+++ b/tests/spec/dev-flow-plan/plan-lint-task-count.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+# G2 (T002593): plan-lint warnt — nicht blockierend — wenn ein Plan weniger als 3
+# oder mehr als 7 "## Task"-Bloecke hat. Die Zahl ist ein Signal an den Planner,
+# kein Gate: ein Hard-Fail auf eine Task-Anzahl wuerde Plaene erzeugen, die die
+# Schwelle treffen statt die Invariante (ein Task = eine pruefbare Aussage).
+#
+# Pruefmodus: command output verification [T002448-M4]. Jeder Test ruft
+# scripts/plan-lint.sh AUS und prueft $status/$output — kein Source-Grep.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  LINT="$REPO/scripts/plan-lint.sh"
+}
+
+# mkplan <n-tasks> <ziel-datei> — erzeugt einen ansonsten lint-konformen Plan
+# (F1/F2-Frontmatter, STRUCT1-3, keine P1-Platzhalter) mit genau n "## Task"-Bloecken.
+# Task 1 traegt den failing-test-Schritt, Task n den Verify-Block.
+mkplan() {
+  local n="$1" out="$2" i
+  {
+    echo '---'
+    echo 'title: Task Count Fixture'
+    echo 'ticket_id: T002593'
+    echo 'domains: [test]'
+    echo 'status: active'
+    echo '---'
+    echo
+    echo '# Task Count Fixture Implementation Plan'
+    echo
+    echo '## File Structure'
+    echo
+    echo '- Modify: `scripts/example.sh`'
+    echo
+    echo '## Task 1: RED'
+    echo
+    echo '- [ ] **Step 1: Write the failing test**'
+    echo
+    echo 'Run: `bats tests/unit/example.bats`'
+    echo 'Expected: FAIL'
+    for ((i = 2; i < n; i++)); do
+      echo
+      echo "## Task $i: GREEN step $i"
+      echo
+      echo '- [ ] **Step 1: Implement**'
+    done
+    echo
+    echo "## Task $n: Verify"
+    echo
+    echo '```bash'
+    echo 'task test:changed'
+    echo 'task freshness:regenerate'
+    echo 'task freshness:check'
+    echo '```'
+  } > "$out"
+}
+
+@test "G2: 5 Tasks liegen im Korridor und loesen keine Warnung aus" {
+  # Positiv-Anker [T002356-M1]: erst belegen, dass G2 ueberhaupt feuert. Ohne ihn
+  # waere "kein G2 im Output" auch dann gruen, wenn der Check gar nicht existiert.
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/zwei.md"
+  echo "$output" | grep -q 'G2' || { echo "Anker: G2 feuert nicht bei 2 Tasks"; return 1; }
+
+  mkplan 5 "$BATS_TEST_TMPDIR/fuenf.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/fuenf.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'PLAN-LINT: PASS'
+  ! echo "$output" | grep -q 'G2'
+}
+
+@test "G2: unter 3 Tasks warnt, ohne den Exit-Code zu aendern (warn-only)" {
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/zwei.md"
+  # Kernaussage der Chore: warn, kein Gate.
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'PLAN-LINT: PASS'
+  echo "$output" | grep '^⚠' | grep -q 'G2'
+  echo "$output" | grep 'G2' | grep -q '2'
+}
+
+@test "G2: ueber 7 Tasks warnt, ohne den Exit-Code zu aendern (warn-only)" {
+  mkplan 8 "$BATS_TEST_TMPDIR/acht.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/acht.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q 'PLAN-LINT: PASS'
+  echo "$output" | grep '^⚠' | grep -q 'G2'
+  echo "$output" | grep 'G2' | grep -q '8'
+}
+
+@test "G2: Schwellenwerte 3 und 7 selbst sind noch im Korridor" {
+  # Positiv-Anker [T002356-M1]: ohne ihn waeren beide Negativ-Aussagen unten auch
+  # dann gruen, wenn G2 gar nicht existiert.
+  mkplan 8 "$BATS_TEST_TMPDIR/acht.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/acht.md"
+  echo "$output" | grep -q 'G2' || { echo "Anker: G2 feuert nicht bei 8 Tasks"; return 1; }
+
+  mkplan 3 "$BATS_TEST_TMPDIR/drei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/drei.md"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q 'G2'
+
+  mkplan 7 "$BATS_TEST_TMPDIR/sieben.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/sieben.md"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q 'G2'
+}
+
+@test "G2 partial-mode: Tasks werden ueber tasks.d/ summiert, nicht nur im Index gezaehlt" {
+  # Das ok-Fixture hat 1 Task im Index + je 1 in p1-impl/p2-tests = 3 gesamt.
+  # Naive Zaehlung (nur tasks.md) saehe 1 und wuerde jeden Partial-Plan
+  # faelschlich als "zu wenige Tasks" melden.
+  bash "$REPO/tests/spec/fixtures/make-partial-plan.sh" "$BATS_TEST_TMPDIR/chg" ok
+
+  # Positiv-Anker [T002356-M1], zwei Teile:
+  # (a) G2 existiert und feuert ueberhaupt,
+  # (b) der Index allein liegt unter der Schwelle — nur dann ist das Ausbleiben
+  #     der Warnung unten ein Beleg fuer die Summierung statt ein Zufall.
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/zwei.md"
+  echo "$output" | grep -q 'G2' || { echo "Anker: G2 feuert nicht bei 2 Tasks"; return 1; }
+  [ "$(grep -c '^#\+[[:space:]]\+Task' "$BATS_TEST_TMPDIR/chg/tasks.md")" -lt 3 ]
+
+  run bash "$LINT" "$BATS_TEST_TMPDIR/chg/tasks.md"
+  [ "$status" -eq 0 ]
+  ! echo "$output" | grep -q 'G2'
+}
+
+@test "G2 zaehlt auch das OpenSpec-Format '## N. Titel', nicht nur '## Task N'" {
+  # 17 von 95 Plaenen nutzten am 2026-08-03 das nummerierte Skeleton-Format. Zaehlt
+  # G2 es nicht, warnt es dort "0 Tasks" — eine Warnung, die man ignorieren lernt.
+  local p="$BATS_TEST_TMPDIR/numeriert.md"
+  {
+    printf -- '---\ntitle: Numeriert\nticket_id: T002593\ndomains: [test]\nstatus: active\n---\n\n'
+    printf '# Numeriert Implementation Plan\n\n## File Structure\n\n- Modify: `scripts/example.sh`\n\n'
+    printf '## 1. RED\n\nRun: `bats tests/unit/example.bats`\nExpected: FAIL\n\n'
+    printf '## 2. GREEN\n\n- [ ] implement\n\n'
+    printf '## 3. Verify\n\n```bash\ntask test:changed\ntask freshness:regenerate\ntask freshness:check\n```\n'
+  } > "$p"
+
+  # Positiv-Anker [T002356-M1]: G2 muss ueberhaupt feuern koennen.
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/zwei.md"
+  echo "$output" | grep -q 'G2' || { echo "Anker: G2 feuert nicht bei 2 Tasks"; return 1; }
+
+  run bash "$LINT" "$p"
+  ! echo "$output" | grep -q 'G2'
+}
+
+@test "G2 zaehlt '## Tasks' und '## Task List' nicht als Task" {
+  # Sammelueberschriften duerfen die Zaehlung nicht aufblaehen: ein 2-Task-Plan mit
+  # einer '## Tasks'-Ueberschrift muss weiterhin als 2 gelten und warnen.
+  local p="$BATS_TEST_TMPDIR/sammel.md"
+  mkplan 2 "$p"
+  printf '\n## Tasks\n\n## Task List\n' >> "$p"
+  run bash "$LINT" "$p"
+  echo "$output" | grep 'G2' | grep -q '2'
+}
+
+@test "G2 schweigt bei 0 erkannten Tasks (Format-Unsicherheit, kein Befund)" {
+  # 0 heisst "Format nicht erkannt", nicht "keine Tasks". Das Repo fuehrt mindestens
+  # vier Task-Konventionen; eine fuenfte wuerde den Regex still brechen und den Plan
+  # faelschlich anklagen. Strukturlose Plaene fangen STRUCT2/STRUCT3 hart ab.
+  local p="$BATS_TEST_TMPDIR/kein-format.md"
+  {
+    printf -- '---\ntitle: Ohne\nticket_id: T002593\ndomains: [test]\nstatus: active\n---\n\n'
+    printf '# Ohne Implementation Plan\n\n## File Structure\n\n- Modify: `scripts/example.sh`\n\n'
+    printf '## Vorgehen\n\nRun: `bats tests/unit/example.bats`\nExpected: FAIL\n\n'
+    printf '## Abschluss\n\n```bash\ntask test:changed\ntask freshness:regenerate\ntask freshness:check\n```\n'
+  } > "$p"
+
+  # Positiv-Anker [T002356-M1]: G2 muss ueberhaupt feuern koennen.
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/zwei.md"
+  echo "$output" | grep -q 'G2' || { echo "Anker: G2 feuert nicht bei 2 Tasks"; return 1; }
+
+  run bash "$LINT" "$p"
+  ! echo "$output" | grep -q 'G2'
+}
+
+@test "G2 erkennt die Formate '## T1 —' und '- [ ] **Task 1:**'" {
+  local p="$BATS_TEST_TMPDIR/t-form.md"
+  {
+    printf -- '---\ntitle: T-Form\nticket_id: T002593\ndomains: [test]\nstatus: active\n---\n\n'
+    printf '# T-Form Implementation Plan\n\n## File Structure\n\n- Modify: `scripts/example.sh`\n\n'
+    printf '## T1 — RED\n\nRun: `bats tests/unit/example.bats`\nExpected: FAIL\n\n'
+    printf '## T2 — GREEN\n\n- [ ] **Task 3: extra step**\n\n'
+    printf '## T4 — Verify\n\n```bash\ntask test:changed\ntask freshness:regenerate\ntask freshness:check\n```\n'
+  } > "$p"
+
+  # 4 erkannte Tasks (T1, T2, Checklisten-Task 3, T4) => im Korridor, keine Warnung.
+  # Ohne die Formate (c)/(d) waeren es 0 und der Plan liefe in den Schweige-Zweig —
+  # deshalb prueft der Anker unten, dass ueberhaupt gezaehlt wurde.
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" "$BATS_TEST_TMPDIR/zwei.md"
+  echo "$output" | grep -q 'G2' || { echo "Anker: G2 feuert nicht bei 2 Tasks"; return 1; }
+
+  # Scharfer Nachweis der Erkennung: nur EINEN der vier Tasks stehen lassen -> 1 Task,
+  # das ist unter der Schwelle und MUSS warnen (im Schweige-Zweig waere es still).
+  local q="$BATS_TEST_TMPDIR/t-form-eins.md"
+  sed '/^## T2 /,/^- \[ \] \*\*Task 3/d; /^## T4 /d' "$p" > "$q"
+  run bash "$LINT" "$q"
+  echo "$output" | grep 'G2' | grep -q '1'
+
+  run bash "$LINT" "$p"
+  ! echo "$output" | grep -q 'G2'
+}
+
+@test "G2 erscheint im JSON-Modus unter warn, niemals unter hard" {
+  mkplan 2 "$BATS_TEST_TMPDIR/zwei.md"
+  run bash "$LINT" --json "$BATS_TEST_TMPDIR/zwei.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | python3 -c '
+import json,sys
+d = json.load(sys.stdin)
+assert d["verdict"] == "PASS", d["verdict"]
+assert any("G2" in w for w in d["warn"]), d["warn"]
+assert not any("G2" in h for h in d["hard"]), d["hard"]
+'
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2274,6 +2274,12 @@
     "kind": "shell"
   },
   {
+    "id": "dev-flow-plan/plan-lint-task-count",
+    "file": "tests/spec/dev-flow-plan/plan-lint-task-count.bats",
+    "category": "dev-flow-plan",
+    "kind": "shell"
+  },
+  {
     "id": "dev-flow-plan/task-context",
     "file": "tests/spec/dev-flow-plan/task-context.bats",
     "category": "dev-flow-plan",


### PR DESCRIPTION
## Was

`scripts/plan-lint.sh` bekommt **G2**: eine Warnung (kein Gate), wenn ein Plan weniger als 3 oder mehr als 7 Tasks hat.

| Task-Anzahl | Bedeutung |
|---|---|
| 1-2 | Kein Plan noetig -> `dev-flow-chore` |
| 3-7 | Gesunder Feature/Fix-Plan |
| > 7 | Ticket zu gross -> Epic mit Kindern |

## Warum warn-only

Die Task-Anzahl ist ein **Symptom**, kein Ziel. Ein Hard-Fail auf eine Zahl erzeugt Plaene, die die Schwelle treffen statt die Invariante: ein Task = eine pruefbare Aussage, die gruen und committbar endet. Exit-Code und CI-Semantik bleiben unveraendert.

## Zwei Haertungen gegen Rauschen

Eine Warnung, die falsch feuert, wird ignoriert - und nimmt die benachbarten W3/W4/G1 mit.

1. **Partial-Mode (`tasks.d/`)**: Tasks werden ueber die Partials summiert. Ohne das meldet *jeder* Partial-Plan faelschlich zu wenige Tasks (der Index allein hat 1).
2. **0 erkannte Tasks -> G2 schweigt**: Null heisst "Format nicht erkannt", nicht "keine Tasks". Das Repo fuehrt vier Task-Konventionen (`## Task N`, `## N. Titel`, `## T1 —`, `- [ ] **Task N:**`); eine fuenfte wuerde den Regex still brechen. Dieser Fall trug **38 von 46** Treffern (83 % Rauschen). Strukturlose Plaene fallen ohnehin hart durch STRUCT2/STRUCT3.

## Messung gegen die 95 aktiven Plaene

Vor Haertung 46 Warnungen, danach **8** (3x unter, 5x ueber dem Korridor) - 8,4 %.

## Tests

10 neue Tests in `tests/spec/dev-flow-plan/plan-lint-task-count.bats` (T002416-Konvention: eigenes Verzeichnis, eigene Datei). Alle Negativtests tragen einen Positiv-Anker (T002356-M1) - der RED-Lauf zeigte, dass zwei davon ohne Anker vakuos gruen waren. Mutationstest gegen die Partial-Summierung bestanden.

Bestandssuite `tests/unit/plan-lint.bats`: 28/28 gruen. `task test:spec:changed`: 110/110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCqNfpXbx3s2gyMXNXuUBN