### PR TITLE
fix(scripts): plan-qa-check.sh Review-Fixes (Newlines, -sf Health, Payload-Fehlerpfad) [T002595]

### DIFF
--- a/openspec/changes/plan-qa-check-quoting/tasks.md
+++ b/openspec/changes/plan-qa-check-quoting/tasks.md
@@ -18,7 +18,7 @@ _Ticket: T002595 · Design: `openspec/changes/plan-qa-check-quoting/design.md`_
 
 | File | Ist | Budget |
 |------|-----|--------|
-| `scripts/plan-qa-check.sh` | 215 | 585 |
+| `scripts/plan-qa-check.sh` | 227 | 573 |
 
 ```
 GEAENDERT:
@@ -29,7 +29,7 @@ NEU (liegt bereits als RED-Test im Branch):
   tests/spec/dev-flow-plan/plan-qa-payload.bats   ungated (.bats), kein S1-Budget
 ```
 
-Die geänderte Datei liegt mit 192 Zeilen weit unter ihrer wirksamen Schwelle (Restbudget 608);
+Die geänderte Datei liegt mit 227 Zeilen weit unter ihrer wirksamen Schwelle (Restbudget 573);
 ein Verkleinerungs- oder Split-Schritt ist nicht nötig.
 
 ## Ausgangslage

--- a/scripts/plan-qa-check.sh
+++ b/scripts/plan-qa-check.sh
@@ -83,15 +83,25 @@ USER_PROMPT_PREFIX="Prüfe den folgenden Implementierungsplan gegen die 6 Kriter
 build_payload() {
   local plan_content
   plan_content=$(cat "$PLAN_FILE")
+  # Echte Newlines (nicht die Literale "\n"): bash expandiert \n in
+  # Doppelquotes nicht, jq --arg würde die 2-Zeichen-Sequenz sonst 1:1
+  # übernehmen. Die Trennzeile zwischen Prefix und Plan soll ankommen.
+  local usr_content
+  usr_content="$(printf '%s\n\n%s' "$USER_PROMPT_PREFIX" "$plan_content")"
   jq -n \
     --arg model "$MODEL" \
     --arg sys "$SYSTEM_PROMPT" \
-    --arg usr "${USER_PROMPT_PREFIX}\n\n${plan_content}" \
+    --arg usr "$usr_content" \
     --argjson et false \
     '{model: $model, max_tokens: 2048, enable_thinking: $et, chat_template_kwargs: {enable_thinking: $et}, messages: [{role: "system", content: $sys}, {role: "user", content: $usr}]}'
 }
 
-PAYLOAD=$(build_payload)
+# Payload ungültig (z.B. jq nicht installiert) → deutliche stderr-Warnung,
+# weiterhin exit 0 (advisory Charakter, siehe T002595 Task 4).
+PAYLOAD=$(build_payload) || {
+  err "Failed to build JSON payload — skipping QA (advisory)."
+  exit 0
+}
 
 # === --emit-payload mode: print payload and exit (no gateway/network) ===
 if [[ "$EMIT_PAYLOAD" -eq 1 ]]; then
@@ -100,7 +110,9 @@ if [[ "$EMIT_PAYLOAD" -eq 1 ]]; then
 fi
 
 # === Gateway reachability ===
-if ! curl -s --max-time 3 -o /dev/null "${GATEWAY_BASE_URL}/health"; then
+# -f: degraded (503) gilt als nicht erreichbar — sonst würde curl einen 503
+# als Erfolg werten und erst der POST-Call fiele in den Skip-Pfad (T002595).
+if ! curl -sf --max-time 3 -o /dev/null "${GATEWAY_BASE_URL}/health"; then
   warn "Gateway ${GATEWAY_BASE_URL} not reachable — skipping QA (advisory)."
   info "Manual check: review the plan against .claude/skills/references/plan-quality-gates.md"
   exit 0


### PR DESCRIPTION
## Kontext

Follow-up zu #3722 (T002595): Die 4 Review-Befunde aus der PR-Review werden hier nachgereicht. Kern des Tickets (D1+D2+Gateway-Umstellung) ist bereits gemergt und verifiziert.

## Änderungen

- **Echte Newlines im User-Prompt**: Prefix und Plan werden mit `printf '%s\n\n%s'` getrennt statt Literal-`\\n` im jq-`--arg` (die 2-Zeichen-Sequenz wäre 1:1 übernommen worden).
- **Health-Check mit `-sf`**: `curl -sf` — degraded (503) gilt jetzt als nicht erreichbar; vorher fiel erst der POST-Call in den Skip-Pfad.
- **Payload-Fehlerpfad**: Scheitert `build_payload` (z.B. jq nicht installiert), wird eine stderr-Warnung ausgegeben + exit 0 (advisory).
- **tasks.md-Budget**: 215/585 → 227/573 nach Zeilenwachstum.

## Verifikation

- `bash -n` Syntax OK
- bats 5/5 grün (`plan-qa-payload.bats`)
- `plan-lint --json` → PASS

## Deploy

Nicht deploy-pflichtig (nur `scripts/`). Kein Auto-Merge — erst CI grün abwarten.