### PR TITLE
feat: health goals entschlackung T002598

### DIFF
--- a/.claude/lib/goals.md
+++ b/.claude/lib/goals.md
@@ -3,7 +3,16 @@
 Quantifizierbare Ziele für die strukturelle Gesundheit des Repos.
 Ein Ziel ohne reproduzierbaren Mess-Befehl ist kein Ziel, sondern ein Wunsch.
 
-**Baseline-Stichtag:** `2026-07-01` · **Dashboard:** Homepage-Section `#health`
+**Baseline-Stichtag:** `2026-07-01` · **Zuletzt gemessen:** `2026-07-27` · **Dashboard:** Homepage-Section `#health`
+
+> **`Zuletzt gemessen` ist das Messdatum des Dashboards** und wird von
+> `scripts/health-goals-update.sh` bei jedem Lauf gestempelt. Vor T002598 leitete
+> `scripts/gen-goals-data.mjs` dieses Datum aus dem jüngsten `Baseline-Update`-Marker der
+> Chronik-Prosa ab. Seit die Chronik in [`docs/health-goals-history.md`](../../docs/health-goals-history.md)
+> liegt, gäbe es dort nichts mehr zu finden — der Parser wäre still auf den statischen
+> `Baseline-Stichtag` zurückgefallen und hätte ein Monat altes Datum als frisch ausgewiesen,
+> ohne dass irgendetwas rot wird. Dieses Feld von Hand zu ändern ist sinnlos: der nächste
+> Messlauf überschreibt es.
 
 > **Format.** Jedes Ziel trägt eine Meta-Zeile:
 > `Priorität · Baseline · Target · Aufwand · Messzyklus · Reproduzierbar`
@@ -46,50 +55,6 @@ gh run list --workflow e2e.yml --limit 14 --json conclusion \
 
 > **A · Baseline:** 0 (0/14 grün, 2026-07-22) · **Target:** ≥ 90 · **Aufwand:** mittel · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002063 (Aufnahme; Suite-Fix läuft separat über `fix/e2e-auth-token-and-cron-secret`) — **Root-Cause 2026-07-25:** DNS-Auflösung `EAI_AGAIN web.korczewski.de` in CI-Runnern (globalSetup/globalTeardown `fetch` schlägt fehl); zweitens 401 auf Ingest-Endpoint (`INGEST_TOKEN`-Secret prüfen) — **Fix 2026-07-25:** PR #3207 gefixt (global-db-cleanup.ts fängt Network-Errors ab; ingest-e2e.ts akzeptiert E2E_INGEST_TOKEN)
 
----
-
-## G-AGENTIC09 — Projekteigene SKILL.md > 400 Zeilen: 0 (Gate)
-
-**Was:** Zählt **projekteigene** `SKILL.md`-Dateien mit mehr als **400** Zeilen. Der
-projekteigene Satz wird aus der Vendor-Sektion in `.claude/skills/OVERVIEW.md` abgeleitet
-(getrackt minus Marker-Block); upstream-gepflegte Skills sind ausgenommen, weil eine Änderung
-dort beim nächsten Sync kollidiert.
-
-**Warum verschärft (T002303):** Die frühere Fassung maß alle Skills gegen 500 Zeilen und war ein
-`target`, kein `gate` — sie konnte eine Regression nur protokollieren, nicht stoppen. 500 lag
-zudem weit über der Progressive-Disclosure-Grenze, die sie schützen sollte. Erschwerend:
-`SKILL.md` ist **nicht** vom S1-Zeilen-Ratchet erfasst (`docs/code-quality/baseline.json` führt
-nur `.astro/.svelte/.ts/.mjs/.py`), Skill-Bodies wuchsen also gegen keinerlei Widerstand — sechs
-lagen bei der Umstellung zwischen 283 und 486 Zeilen.
-
-**Warum von 250 auf 400 gelockert (T002452):** Die Verschärfung war richtig, die Zahl zu knapp.
-Nach der Kompression standen `dev-flow-plan/SKILL.md` auf **exakt 250** und `dev-flow-execute`
-auf 247 — Reserve 0 bzw. 3. Das Gate blockierte damit nicht mehr Wachstum, sondern **jede**
-inhaltliche Änderung an genau den Skills, die am häufigsten angefasst werden: wer eine Zeile
-Erklärung ergänzte, bekam einen roten Guard, unabhängig von der Qualität der Änderung. Das ist
-keine Progressive Disclosure, das ist ein Schreibverbot. 400 hält den Abstand zur alten,
-wirkungslosen 500 und gibt ~150 Zeilen Reserve. **Die 500 bleibt verworfen** — der Guard
-`G-AGENTIC09 measures 400 lines, not the legacy 500` in
-`tests/spec/agentic-tooling-quality-goals.bats` hält beide Richtungen fest.
-
-> **Die Schwelle steht nur hier und in `scripts/health-goals-check.sh`.** Die beiden BATS-Guards
-> (`agent-skills.bats`, `agentic-tooling-quality-goals.bats`) **lesen** sie von dort. Vor T002452
-> führten vier Stellen unabhängig die Zahl 250 — bei jeder Anhebung wäre eine liegengeblieben.
-> Wer die Schwelle ändert, ändert `health-goals-check.sh` und diesen Abschnitt, sonst nichts.
-
-```bash
-c=0; for d in $(project_owned_skills); do
-  [ "$(wc -l < ".claude/skills/$d/SKILL.md")" -gt 400 ] && c=$((c+1)); done; echo $c
-```
-
-Die Hilfsfunktion `project_owned_skills` liegt im Kopf von `scripts/health-goals-check.sh` und
-wird auch von G-AGENTIC08 genutzt. Fehlt der Marker-Block in `OVERVIEW.md`, ist die Vendor-Liste
-leer und alle Skills gelten als projekteigen — das Gate wird dann strenger, nie schwächer.
-
-> **C · Baseline:** 2 → 0 (2026-07-27, T002303) · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002303 · **Klasse:** Gate (fail-closed)
-
----
-
 ## G-DB09 — Slow Queries in pg_stat_statements (COPY+DDL-bereinigt): 1 → 0
 
 **Was:** Zählt Abfragen in `pg_stat_statements` mit `mean_exec_time > 1s`. T001926 hatte
@@ -131,9 +96,7 @@ JOIN information_schema.tables t ON t.table_schema=c.table_schema AND t.table_na
 WHERE c.column_name='is_test_data' AND t.table_type='BASE TABLE';
 ```
 
-> **B · Baseline:** 24 (21 mentolder + 3 korczewski, 2026-07-25) · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002063
-
-**Baseline-Update 2026-07-25 (T002063):** G-E2E02 Baseline 2→24 (21× mentolder: 18× coaching.sessions + 3× public.inbox_items; 3× korczewski: public.inbox_items). Root cause: abgebrochene Nightly-E2E-Läufe (DNS-Fehler EAI_AGAIN web.korczewski.de) verhinderten den globalTeardown-Purge. Fix: `global-db-cleanup.ts` fängt Network-Errors ab (PR #3207).
+> **B · Baseline:** 24 (21 mentolder + 3 korczewski, 2026-07-25) · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** T002063 · **Historie:** [T002063](../../docs/health-goals-history.md)
 
 ## G-OPS01 — Pods nicht Running/Ready (fleet, beide Brand-Namespaces): 3 → 0
 
@@ -364,20 +327,6 @@ print(todo)"
 ```
 
 > **C · Baseline:** 17 → 0 ✅ · **Target:** 0 · **Aufwand:** gering (manueller Ingest-Lauf via `scripts/brain-ingest.sh`, GPU-Host-gebunden) · **Messzyklus:** monatlich · **Reproduzierbar:** eingeschränkt (lokales State-File + GPU-Host) · **Ticket:** T001912 (**done ohne Messwert-Fix**) → **T001951 gefixt** (2026-07-19, PR Paddione/brain#8: 15 verbleibende Backlog-Seiten via LM Studio :1234 (Qwen3.6-14B-A3B-FableVibes) ingested + gemerged; Target 0 erreicht)
-
-## G-IMG01 — Fremd-Image-Versions-Drift: 1 → 0
-
-**Was:** Zählt unique Container-Images im Deployment, deren Tag nicht dem gepinnten Stand
-in den Kustomize-Manifesten entspricht. Ein Drift bedeutet, dass ein Image nach einem
-Deploy manuell geändert wurde (z.B. via `kubectl set image`) oder ein Helm-Chart-Digest
-nicht nachgezogen wurde. T001766 hatte 2 Drifts (Loki/Promtail-Helm-Digests) gefixt —
-seitdem ist ein neuer Drift aufgetreten.
-
-```bash
-grep -rhE 'image:' k3d/ prod*/ | grep -v '#' | sed 's/.*image:\s*//' | sort -u | awk -F'\t' '{c[$1]++} END{for(k in c) if(c[k]>1) print k}'
-```
-
-> **B · Baseline:** 2 → 0 (T001766 gefixt) → 1 (Regressions-Check 2026-07-25) → 0 (2026-07-25, `alpine/k8s:1.28.2` in `health-goals-cronjob.yaml` auf `1.36.2@sha256:...` gepinnt) · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja · **Ticket:** TBD (**gefixt**)
 
 ## G-IF01 — MCP-Endpunkte ohne Listener: n/a → 0
 
@@ -688,7 +637,6 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-RH01** | Gate-Violations (baseline.json) | 8 ✓ | ≤ 30 | `python3 -c "import json,sys; print(len(json.load(sys.stdin)))" < docs/code-quality/baseline.json` |
 | **G-RH02** | TypeScript-Suppressionen | 0 ✓ | 0 | `grep -r '@ts-ignore\|@ts-expect-error' website/src --include='*.ts' \| grep -v goals-data.ts \| wc -l` |
 | **G-RH04** | Stale Remote Branches | 0 ✓ | 0 | `git for-each-ref ... refs/remotes/origin \| while IFS='|' read b ts; do [[ $ts -lt $CUTOFF ]] && echo $b; done \| wc -l` |
-| **G-RH05** | Plan-Staged idle >14d | 0 ✓ | 0 | `bash scripts/vda.sh oracle 'list plan_staged tickets'` |
 | **G-RH06** | Sentinel-Issues >48h | 0 ✓ | 0 | `gh-axi issue list --label sentinel --state open --json createdAt` |
 | **G-RH07** | Freshness-Check grün | Exit 0 ✓ | Exit 0 | `task freshness:check` |
 | **G-TEST01** | BATS Debt-Skips | 0 ✓ | 0 | `grep -rniE "skip [\"']" tests --include=*.bats \| grep -ciE "pending\|todo\|WP-\|disabled"` |
@@ -720,20 +668,16 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-SEC02** | git-crypt Guard | Exit 0 ✓ | Exit 0 | `bash scripts/git-crypt-guard.sh check-tracked` |
 | **G-SEC03** | SealedSecret-Rotation | 6 Tage ✓ | ≤ 90 Tage | `git log -1 --format='%at' -- environments/sealed-secrets/*.yaml \| ...` |
 | **G-SEC04** | Sealing-Cert Restlaufzeit | ~3587 Tage ✓ | ≥ 30 Tage | `openssl x509 -enddate -noout -in environments/certs/*.pem` |
-| **G-SEC05** | Unsignierte Commits (adj.) | 0/50 adj. ✓ (Mess-Bug fix: Skript filtert beide github-actions[bot] Mail-Varianten) | ≤ 5 % | `git log -50 --pretty='%G? %ae' main \| grep -v freshness-bot \| grep -ciE 'github-actions\[bot\]|41898282\+github-actions\[bot\]'` — **fix:** beide Bot-Mail-Varianten (`github-actions[bot]@...` und `41898282+github-actions[bot]@...`) werden nun korrekt gefiltert; alle 25 vorherigen "unsignierten" Commits waren GitHub-Bots, kein echtes Signing-Problem.
+| **G-SEC05** | Unsignierte Commits (adj.) | 0/50 adj. ✓ (Mess-Bug fix: Skript filtert beide github-actions[bot] Mail-Varianten) | ≤ 5 % | `git log -50 --pretty='%G? %ae' main \| grep -v freshness-bot \| grep -ciE 'github-actions\[bot\]|41898282\+github-actions\[bot\]'` — **fix:** beide Bot-Mail-Varianten (`github-actions[bot]@...` und `41898282+github-actions[bot]@...`) werden nun korrekt gefiltert; alle 25 vorherigen "unsignierten" Commits waren GitHub-Bots, kein echtes Signing-Problem. |
 | **G-SPEC01** | openspec:validate grün | Exit 0 ✓ | Exit 0 | `bash scripts/openspec.sh validate` |
 | **G-SPEC02** | Changes >30 Tage | 0 ✓ | 0 | `for d in openspec/changes/*/; do ... done` |
 | **G-SPEC03** | Proposals ohne .ticket-Verknüpfung | 0 ✓ | 0 | `for d in openspec/changes/*/; do [ -f "$d/.ticket" ] \|\| m=$((m+1)); done` |
 | **G-DB06** | Orphan-Rows (3 FK-Paare) | 0 ✓ | 0 | `db_scalar NOT-EXISTS-Summe (ticket_plans/comments/links → tickets)` |
-| **G-DOC01** | Defekte interne Doc-Links | 0 ✓ | 0 | `python3 scripts/check-links.py` |
 | **G-DOC02** | Root-CLAUDE.md Zeilen | 209 ⚠ | ≤ 200 | `wc -l < CLAUDE.md` |
 | **G-DOC03** | README-Index in Hauptverzeichnissen | 5/5 ✓ | 5/5 | `for d in website brett scripts tests k3d; do ls "$d"/README* ... done` |
-| **G-DOC04** | Architektur-ADRs | 5 ✓ | ≥ 5 | `find docs -ipath '*adr*' -name '*.md' \| wc -l` |
-| **G-DOC06** | Agent Guide Index | 30 ✓ | ≥ 30 | `find .claude/skills docs/agent-guide -name SKILL.md -o -name README.md \| wc -l` |
 | **G-CI01** | main CI-Erfolgsrate (letzte 20) | 95 % ✓ | ≥ 95 % | `gh-axi run list --workflow ci.yml --branch main --limit 20 \| grep -oE 'completed,(success\|failure\|cancelled)' \| sort \| uniq -c` (19/20, 1 cancelled) |
 | **G-CI02** | Rote main-HEAD-Läufe | 0 ✓ | 0 | `gh-axi run list --workflow ci.yml --branch main --limit 5 \| grep -c failure` |
 | **G-CI03** | CI Pipeline p95 Duration (min) | 5 ✓ | ≤ 12 | `gh run list --workflow ci.yml --branch main --limit 20 --json createdAt,updatedAt \| python3 -c "..p95.."` (T001910: Messscript-Bug in `gh-axi run list --json` behoben, jetzt `gh` direkt) |
-| **G-RH03** | OpenSpec-BATS-Abdeckung | 82 % ✓ | ≥ 60 % | `SPECS=$(ls openspec/specs/*.md \| wc -l); BATS=$(ls tests/spec/*.bats \| wc -l); echo "$BATS/$SPECS"` |
 | **G-CD02** | post-merge.yml-Rate | 100 % ✓ | ≥ 95 % | `gh-axi run list --workflow post-merge.yml --branch main --limit 15 \| ...` |
 | **G-DORA01** | Deployment Frequency | Elite ✓ | ≥ 5/Wo | `git log --since="4 weeks ago" --first-parent --oneline main \| wc -l` |
 | **G-DORA02** | Lead Time (PR→merge) | Median 0.03h ✓ | ≤ 1h | `gh-axi api repos/{owner}/{repo}/pulls?...` |
@@ -749,8 +693,7 @@ Auf Target, nur halten. `bash scripts/health-goals-check.sh` prüft die ✅-repr
 | **G-AGENTIC06** | OVERVIEW.md Skill-Zähler vs real | 0 ✓ | 0 | `claimed - real (Betrag)` via grep claim + `git ls-files -- .claude/skills \| grep -c '/SKILL\.md$'` (nur getrackte — market-cli-Installationen zählen nicht, T001783) |
 | **G-AGENTIC07** | Verwaiste aktive Skills | 0 ✓ | 0 | `for SKILL.md in git ls-files; if description exist && zero refs in CLAUDE.md/AGENTS.md/OVERVIEW.md/other SKILL.md → count` (nur getrackte) |
 | **G-AGENTIC08** | Tote Script-Pfade in projekteigenen Skill-`.md` | 0 ✓ | 0 | `grep -rhoP '(?<![A-Za-z0-9_./-])scripts/...\.(sh\|mjs\|py)' $(project_owned_skills) + references --include='*.md' \| sort -u \| test -f || count` (Lookbehind gegen Substring-False-Positives; Scope seit T002303 auf alle `.md` statt nur `SKILL.md`, damit ausgelagerte `references/` nicht ungeprüft bleiben) |
-| **G-AGENTIC09** | Projekteigene `SKILL.md` >400 Zeilen | 0 ✓ | 0 | `for d in $(project_owned_skills); wc -l > 400 → count`; projekteigen = getrackt minus Vendor-Sektion in `OVERVIEW.md` (T002303; vorher `target` mit Schwelle 500 über alle Skills — Schwelle 250→400 in T002452, weil zwei Skills auf 0 bzw. 3 Zeilen Reserve standen) |
-
+| **G-AGENTIC09** | Projekteigene `SKILL.md` >400 Zeilen | 0 ✓ | 0 | `for d in $(project_owned_skills); wc -l > 400 → count`; projekteigen = getrackt minus Vendor-Sektion in `OVERVIEW.md`. **Die Schwelle 400 steht nur hier und in `scripts/health-goals-check.sh`** — die BATS-Guards (`agent-skills.bats`, `agentic-tooling-quality-goals.bats`) lesen sie von dort. Wer sie ändert, ändert genau diese zwei Stellen, sonst nichts; vor T002452 führten vier Stellen die Zahl unabhängig. Fehlt der Vendor-Marker-Block in `OVERVIEW.md`, gilt jeder Skill als projekteigen — das Gate wird dann strenger, nie schwächer. Historie: [T002303, T002452](../../docs/health-goals-history.md) |
 | **G-AGENTIC11** | CLAUDE.md opencode-Liste vs opencode.jsonc | 0 ✓ | 0 | `comm -3 <(grep opencode-Liste \| extract backtick-names) <(mcp_servers opencode.jsonc)` |
 | **G-AGENTIC12** | .mcp.json-Server undokumentiert | 0 ✓ | 0 | `for s in $(mcp_servers .mcp.json); grep -q -- "$s" mcp-tool-guide.md || count` |
 | **G-AGENTIC13** | Tote MCP-Server-Refs in SKILL.md | 0 ✓ | 0 | `grep -rhoE 'mcp__...__\|mcp-..._browser_' .claude/skills \| gegen registrierte Server` |
@@ -790,198 +733,43 @@ bash scripts/health-goals-llm-fill.sh --apply      # schreibt Prio-C-Aktuell mit
 - **Monatlich/Quartal:** G-DEP02, G-SEC03/04, G-DOC02, G-FE01/02, G-BRAIN14, G-AGENTIC09, G-DB11
 - **Nur lokal (nicht in CI):** G-WT01–G-WT06. Diese Familie misst lokalen Maschinenzustand — Worktrees, Hauptcheckout-Branch, agent-locks, `main`-Divergenz. Ein CI-Runner hat davon nichts; die Ziele wären dort strukturell immer grün und damit wertlos. Messort ist `task health:wt` (Ziel-IDs aus der Taskfile-Variable `HG_LOCAL_ONLY_GOALS`) sowie ein **nicht failender** Warn-Block in `task freshness:check`, der in CI mit sichtbarer Notiz übersprungen wird. [T002443]
 
-**Sprint-Highlights 2026-07-01:** G-CI01 erreicht Target (85 %→95 %, 19/20 grün) und wechselt von Prio A nach Prio C. G-RH03 (OpenSpec-BATS-Abdeckung 50 %→82 %) und G-DEP02 (Major-Deps 9→2) erreichen ihr Target und wechseln von Prio B nach Prio C. G-CQ01 erstmals gemessen: 0 astro-check-Fehler. G-CQ02 (explizite `any`) fällt weiter von 154 auf 8. G-GIT03 (Dateien >1MB) erreicht Target 7→6 per Policy-Ausschluss von `.codebase-memory/` (T001348) und wechselt von Prio A nach Prio C. G-SEC05-Messfehler dokumentiert: das Skript filtert nur eine von zwei GitHub-Actions-Bot-Mail-Varianten heraus, wodurch 4 Bot-Commits fälschlich als unsigniert zählen — echter Wert 0/50, Skript-Fix noch offen.
 
-**Sprint-Highlights 2026-07-03:** G-FE03 (console.error/warn) von 10 auf 1 reduziert — deutliche Verbesserung. G-CQ02 (explizite `any`) weiter von 11 auf 10 gesunken. G-SIZE03 (God-File website-db.ts) von 2106 auf 1957 Zeilen geschrumpft. G-TEST05 (Vitest Coverage) steigt von 82 %→85 %. **Regressionen:** G-CFG01 (env:validate:all) von Exit 0 auf 201 Schema-Verstöße gesprungen; G-GIT02 (non-conventional Commits) von 0 auf 1; G-AGENTIC06/07 jeweils von 0 auf 3 — vier Gates von Prio C nach Prio A zurückgestuft.
+---
 
-**Baseline-Update 2026-07-02:** G-SIZE04 +324.494→+325.521 (weiterhin im Spike-Fenster, aber Top-Diffs sind wieder normale Feature-Arbeit); G-GIT03 7→6 (graph.db.zst per Policy-Entscheidung T001348 aus Gate-Scope ausgeschlossen, keine LFS-Migration); G-CD01 unverändert bei 100 % (15/15); G-CQ02 154→8; G-CQ01 ?→0; G-RH03 50 %→82 %; G-DEP02 9→2 Major; G-CI01 85 %→95 %; **G-SEC05** 25→0 (Mess-Bug fix: beide github-actions[bot] Mail-Varianten werden korrekt gefiltert, alle vorherigen "unsignierten" Commits waren GitHub-Bots); **G-AGENTIC01** 3→0 (tools:-Feld zu security/infra/db Agenten hinzugefügt); **G-AGENTIC10** 3→0 (dispatchende Skills website-specialist/database-specialist/security-specialist erstellt).
+# Chronik {#chronik}
 
-**Baseline-Update 2026-07-03:** G-CQ02 11→10; G-SIZE03 2106→1957; G-FE03 10→1; G-TEST05 82 %→85 %; **G-CFG01** Exit 0→201 (Schema-Drift nach GITHUB_CONTENT_TOKEN-Add); **G-GIT02** 0→1 (non-conventional Commit); **G-AGENTIC06** 0→3 (OVERVIEW.md Skill-Zähler); **G-AGENTIC07** 0→3 (verwaiste Skills) — vier Gates von Prio C nach Prio A zurückgestuft.
+Die vollständige Änderungshistorie ab dem Baseline-Stichtag steht in
+[`docs/health-goals-history.md`](../../docs/health-goals-history.md).
 
-**Baseline-Update 2026-07-03 (Fix):** G-CFG01 201→0 — PRIMARY_FRONTEND + TURN_OVERLAY_IP in fleet-*/staging ergänzt, RUSTDESK-Keys auf `required: false` gesetzt (mentolder-only). Wechselt von Prio A → Prio C.
+> **Kappungsregel [T002598].** Hier stehen höchstens **5** `Baseline-Update`-Einträge — die
+> jüngsten. Ältere werden in die Chronik-Datei verschoben. Erzwungen von
+> `tests/spec/health-goals/id-parity.bats`.
+>
+> Warum die Trennung: Dieses Dokument ist das **Register** — es sagt, was gilt. Solange es auch
+> die Chronik führte, wuchs es monoton: jeder Fix hängte einen Absatz an, keiner räumte einen ab.
+> Bei der Auslagerung waren es 195 Zeilen Chronik auf 987 Zeilen Datei.
 
-**Baseline-Update 2026-07-03 (Fix 2):** G-GIT02 1→0 — `--no-merges` im Gate (Merge-Commit war falsch positiv). G-AGENTIC06 3→0 — OVERVIEW.md Zähler 27→30. G-AGENTIC07 3→0 — specialist Skills in OVERVIEW.md registriert. Drei Gates von Prio A → Prio C.
+**Baseline-Update 2026-08-03 (T002598 — Entschlackung und Paritäts-Guard):**
+105 → 101 Ziele, alle gemessen oder ehrlich als SKIP ausgewiesen. Vier Ziele gestrichen, weil ihr
+Wert sich nicht verschlechtern kann oder die falsche Menge misst: **G-DOC04** (≥ 5 ADRs — kann nur
+steigen), **G-DOC06** (≥ 30 Skill-Dateien — dito), **G-RH03** (BATS/Spec-Quote zählte
+`tests/spec/*.bats` flach und verfehlte seit T002416 die Unterverzeichnisse; Target 23 % lag zudem
+weit unter dem Ist), **G-RH05** (plan_staged-idle ist ein Ticket-Ops-Signal, kein Repo-Gesundheitswert).
+31 zuvor nur dokumentierte Ziele in `health-goals-check.sh` verdrahtet — nicht messbare Fälle
+liefern jetzt SKIP statt eines eingefrorenen grünen Werts. Neu: `**Zuletzt gemessen:**` im Kopf
+(vorher riet `gen-goals-data.mjs` das Datum aus der Chronik-Prosa) und der bidirektionale
+Paritäts-Guard, der Register und Messung deckungsgleich hält.
 
-**Baseline-Update 2026-07-04 (morning):** G-CQ01 (T001553) → done (Bereits grün, gate aktiv). G-CQ03 (T001554) → done (Bereits grün, ESLint-Gate aktiv). G-CQ08 (T001555) → done (knip-Baseline: ~120 unused exports, 7 unused files, 5 unused deps entfernt). G-FE01 (T001557) → done (axe 4.12.1, Baseline: 7 violations). G-FE02 (T001558) → done (Bundle-Budget: 747 KB, 99 JS files). G-SIZE02 (T001556) → backlog (17 files >600 Zeilen, ~2-3 Wochen). G-AGENTIC09 (T001559) → done (3 SKILL.md via Whitespace-Kompression auf <500 Zeilen).
+**Baseline-Update 2026-07-27 (T002303 — Skill-Qualitäts-Pass):** G-AGENTIC09 von `target` auf
+`gate` hochgestuft, Schwelle 500 → 250, Scope auf projekteigene Skills eingeengt (Baseline 2 → 0).
+G-AGENTIC08 Scope von `SKILL.md` auf alle `.md` der projekteigenen Skills plus `references/`
+erweitert. Neue Hilfsfunktion `project_owned_skills()` in `health-goals-check.sh`.
 
-**Baseline-Update 2026-07-04 (Fix):** G-AGENTIC06 0→0 (OVERVIEW.md 30→31 — brain-ingest nachgezogen). G-AGENTIC08 1→0 (toter Script-Pfad `scripts/brain-ingest.mjs` aus brain-ingest/SKILL.md entfernt). G-GIT02 0→1 (Commit `f9dc1ae4e` durch Mishap-Bundle-Routine — kann nicht aus History entfernt werden, löst sich nach ~17 weiteren main-Commits).
-
-**Baseline-Update 2026-07-04:** G-CQ07 S2 Import-Zyklen 0 (baseline.json); G-CQ09 S3 Hostnames 0; G-CQ10 S4 Orphaned Scripts 0 — alle grün, Gates neu eingefügt.
-
-**Baseline-Update 2026-07-10:** G-CFG01 Exit 0→201→0 (fehlendes `TERMINAL_OVERLAY_IP` in `environments/staging.yaml` ergänzt). G-AGENTIC06 6→0 (OVERVIEW.md Skill-Zähler 31→37 korrigiert — brain-ingest/infra-ops/lavish/references/vitest waren nicht mitgezählt). G-AGENTIC07 1→0 (Verweis auf `superpowers-executing-plans`-Stub in dev-flow-execute/SKILL.md ergänzt). G-FE03 2→0 (Mess-Scope-Fix: `logger.ts`/`error-log-store.ts`-Selbstschutz-Fallbacks ausgeschlossen, analog `browser-logger.ts`). G-FE04 3→0 (`website/src/db/migrate.ts`: drei `console.log` auf den bereits importierten pino-`logger` umgestellt). G-DB04 163h→1h (Backup-Alter unter Target — Root-Cause-Status T001738 nicht verifiziert, Messzyklus bleibt täglich als Regressionswache). **Neue Regression:** G-IMG01 0→2 (`promtail-rendered.yaml`/`loki-rendered.yaml`, Helm-Chart-Digests nach T001703-Upgrade nicht nachgezogen) — von Prio C nach Prio B verschoben, Ticket T001766. Nebenbei zwei doppelt vorhandene G-CQ09/G-CQ10-Tabellenzeilen (Copy-Paste-Duplikat) aus der Prio-C-Tabelle entfernt.
-
-**Baseline-Update 2026-07-14 (T001804):** G-AGENTIC06 1→0 (OVERVIEW.md Zähler 37→36 + Mess-Umstellung auf getrackte SKILL.md via `git ls-files` — lokal via market-cli installierte Skills kippen das Gate nicht mehr, Präzedenz T001783). G-AGENTIC07 6→0 (2 untrackte lokale Skills aus dem Mess-Scope entfernt; 4 getrackte Drittanbieter-/ML-Skills — ui-ux-pro-max, unsloth, gguf-quantization, speculative-decoding — in neuer OVERVIEW.md-Sektion registriert). G-AGENTIC08 1→0 (Mess-Bug: Regex ohne Anker matchte `scripts/search.py` als Substring des existierenden Pfads `.claude/skills/ui-ux-pro-max/scripts/search.py` — Lookbehind ergänzt). G-AGENTIC11 5→0 (CLAUDE.md-opencode-Liste um `github-mcp`, `playwright`, `sequential-thinking`, `webresearch`, `docfork` ergänzt). G-DOC02 216→190 (CLAUDE.md kondensiert: Merge=Abschluss- und Bug-Triage-Blöcke entwrappt, leere `### Brett`-Überschrift und redundantes Oracle-Beispiel entfernt). G-AGENTIC09 1→0 (dev-flow-plan/SKILL.md 513→495 Zeilen, Prosa-Entwrapping ohne Inhaltsverlust). G-GIT03 bleibt 7 (>Target 6): Kandidaten `assets/grilling-brett-admin-panel/Brett Admin Panel.html` und `environments/korczewski/KERN Logo Design.html` sind Nutzer-Assets — Löschen/LFS braucht manuelle Entscheidung.
-
-**Baseline-Update 2026-07-17 (T001902):** G-GIT03 7→6 — Target erreicht, wechselt von Prio A nach Prio C. Entfernt: `.claude/skills/unsloth/references/llms-full.md` (1.03 MB, redundanter GitBook-Volldump, von der Skill selbst nicht referenziert — SKILL.md listet nur `llms-txt.md`). Die 2 verbleibenden Nutzer-Assets (`assets/grilling-brett-admin-panel/Brett Admin Panel.html`, `environments/korczewski/KERN Logo Design.html`) bleiben bewusst unangetastet: Löschen ohne Nutzerfreigabe riskant, LFS repo-weit als defekt dokumentiert (T001348); da das Target auch ohne sie erreicht ist, ist keine Gate-Scope-Ausnahme nötig.
-
-**Baseline-Update 2026-07-17 (T001903):** G-SIZE02 Messmethode gefixt — die naive `wc -l`-Zählung folgte den Symlinks `.opencode/plugins/background-agents.ts` und `.opencode/plugins/worktree.ts` (git-tracked Symlinks auf `.opencode/skills/dev-flow/*.ts`) und zählte deren Zeilen doppelt (19 statt 17). Messkommando um `[ -L "$f" ]`-Filter ergänzt. Echter, verifizierter Bestand bleibt bei 17 (3× .opencode/, bereits sanktioniert via S1-Gate-Ignore; 14× VideoVault/, echter Produktionscode, keine Duplikate/generierte Artefakte). T001556 hatte den Wert nie wirklich gefixt — der archivierte Plan referenzierte nicht-existente Pfade (`VideoVault/src/lib/upload.ts` statt der realen `VideoVault/client/src/...` / `VideoVault/server/...`-Struktur), daher blieben alle abgehakten Tasks wirkungslos. Zielwert ≤8 erfordert echtes, getestetes Code-Splitting über ~9 Dateien (~2-3 Wochen) — kein Chore-Scope (kein `node_modules` installiert, kein Testlauf als Regressionsnetz in dieser Session verfügbar) → Nachfolger-Ticket T001920 mit konkreten Split-Vorschlägen je realer Datei, zur Umsetzung über `dev-flow-plan`.
-
-**Offene Tickets (2026-07-17):** G-AGENTIC09 (T001904), G-DB01 (T001905), G-SEC06 (T001909), G-FE05 (T001911), G-BRAIN14 (T001912), G-SIZE02 (T001920, Nachfolger von T001903 — echtes VideoVault-Refactoring), G-DB03 (T001925, Nachfolger von T001906 — echte 41-Tabellen-Migration in 3 Gruppen), G-DB09 (T001926, Nachfolger von T001907 — Messmethoden-Korrektur Backup-COPY-Ausschluss), G-DB10 (T001928, Nachfolger von T001908 — 92 restliche Unused-Index-Kandidaten klassifizieren)
-
-| Ziel | Ticket | Status |
-|------|--------|--------|
-| G-GIT03 | T001902 | done (7→6, Target erreicht — `llms-full.md` entfernt, 2 Nutzer-Assets bewusst unangetastet) |
-| G-SIZE02 | T001903 | **gefixt** (Messmethode korrigiert — Symlink-Doppelzählung behoben; echter Bestand 17 verifiziert, davon 3 bereits sanktioniert. Zielwert ≤8 nicht erreichbar ohne echtes Code-Splitting → Nachfolger T001920) |
-| G-AGENTIC09 | T001904 | **gefixt** (dev-flow-plan/SKILL.md 508→479 Zeilen, Whitespace-Kompression ohne Inhaltsverlust — Nachfolger von T001559) |
-| G-DB01 | T001905 | Migration erstellt, Anwendung ausstehend (nächster Deploy) — Nachfolger von T001739 |
-| G-DB03 | T001906 | **gefixt** (Messmethode korrigiert — 3 VIEWs ausgeschlossen, echter Bestand 41 Basistabellen; kein einheitlicher Wertebereich [Wildcard `'*'` + NULL-Ausnahmen] → Nachfolger T001925) |
-| G-DB09 | T001907 | offen (Slow Queries, erster Scan + Optimierung — Nachfolger von T001838) |
-| G-DB10 | T001908 | **gefixt** (Baseline 93 gemessen, 1 zweifelsfreier Drop [`idx_customers_email`] via Migration umgesetzt — Nachfolger T001928 für die restlichen 92 Kandidaten, Nachfolger von T001839) |
-| G-SEC06 | T001909 | **gefixt** (Image-Pin-Refresh 39→8 CRITICAL, Rest Upstream-blockiert [gosu/grpc-go] — Nachfolger von T001840) → Nachfolger **T001949** |
-| G-CI03 | T001910 | **gefixt** (CI p95 = 7 min ✅ ≤12, Messscript-Bug behoben — Nachfolger von T001841) |
-| G-FE05 | T001911 | **gefixt** (90/100 ✅ Target erreicht 2026-07-19 via T001950 — sidekick-panels.css async + PortalSidekick dynamic-import) |
-| G-BRAIN14 | T001912 | **gefixt** (Nachfolger T001951, 2026-07-19: 15 Backlog-Seiten ingested, Backlog 17→0, PR Paddione/brain#8 gemergt — zurück nach Prio C) |
-| G-DB04 | T001739 | gruen (1h, Target ≤26h — Root-Cause-Fix nicht verifiziert, Regressionswache bleibt täglich) |
-| G-DB06 | T001739 | gruen (Gate, halten) |
-| G-IMG01 | T001766 | **gefixt** (Regression 0→2→0, Helm-Digest-Drift Loki/Promtail behoben — zurück nach Prio C) |
-| G-SIZE04 | T001280 | geschlossen (`done`), Messwert weiterhin rot → Nachfolger T001347 |
-| G-SIZE04 | T001347 | offen |
-| G-GIT03 | T001275 | **gefixt** (gitignore search-index.json [T001305]) |
-| G-GIT03 | T001320 | geschlossen (`done`), graph.db.zst nicht migriert → Nachfolger T001348 |
-| G-GIT03 | T001348 | **gefixt** (Policy-Ausschluss `.codebase-memory/` aus Gate-Scope, keine LFS-Migration) |
-| G-CD01 | T001276 | geschlossen (`done`), Erfolgsrate unverändert → Nachfolger T001349 |
-| G-CD01 | T001349 | **gefixt** (Root Cause: Messbefehl zeigte auf geloeschten Workflow build-website-korczewski.yml; jetzt Job-Level gh api gegen build-website.yml) |
-| G-CQ01 | T001277 | **gefixt** (PR #2225) |
-| G-DEP01 | T001278 | **gefixt** (0 vulnerabilities) |
-| G-CI01 | T001279 | **gefixt** (95 % letzte 20 Läufe) |
-| G-CFG01 | T001548 | **gefixt** (Commit 97f04f031) |
-| G-GIT02 | T001552 | **gefixt** (Commit 1d4ba261b — `--no-merges` im Gate) |
-| G-AGENTIC06 | T001550 | **gefixt** (OVERVIEW.md count 27→30, am 2026-07-04 erneut 30→31 für brain-ingest) |
-| G-AGENTIC07 | T001551 | **gefixt** (OVERVIEW.md: specialist skills registriert) |
-| G-CQ01 | T001553 | **gefixt** (0 astro-check errors, gate aktiv seit PR #2225) |
-| G-CQ03 | T001554 | **gefixt** (ESLint-Gate aktiv, 2 legitime inline-disables) |
-| G-CQ08 | T001555 | **gefixt** (knip-Baseline: ~120 unused exports, −5 unused deps) |
-| G-SIZE02 | T001556 | Prio B — backlog (17 files >600 Zeilen) |
-| G-FE01 | T001557 | **gefixt** (axe 4.12.1, Baseline: 7 violations) |
-| G-FE02 | T001558 | **gefixt** (Bundle-Budget: 747 KB, 99 JS files) |
-| G-AGENTIC09 | T001559 | **gefixt** (Whitespace-Kompression → alle <500 Zeilen) |
-| G-AGENTIC08 | — | **gefixt** (2026-07-04: toter script-path `scripts/brain-ingest.mjs` aus SKILL.md entfernt) |
-| G-GIT02 | T001552 | **regressed** (Commit f9dc1ae4e — `mishap-bundle-fix:` non-conventional) |
-
-**Baseline-Update 2026-07-15:** G-SEC06 n/a→0 (Trivy-Integration in CI + scripts/trivy-scan.sh erstellt, erster Scan ausstehend); G-CI03 n/a→0 (Implementierung in health-goals-check.sh abgeschlossen, erster Scan ausstehend); G-FE05 n/a→0 (Lighthouse CI in ci.yml + health-goals-check.sh integriert, lighthouse-budget.json erstellt, erster Scan ausstehend)
-
-**Baseline-Update 2026-07-17 (T001904):** G-AGENTIC09 1→0 — `dev-flow-plan/SKILL.md` 508→479 Zeilen. Whitespace-Kompression analog T001559/T001804 (redundante Leerzeilen vor Headern/Listen/Codefences entfernt, Codefence-interne Leerzeilen unangetastet gelassen) — reine Deletion-Diffs, kein Inhaltsverlust.
-
-**Baseline-Update 2026-07-17 (T001901 — Struktur-Refresh + Brain-Ziele):** Strukturbereinigung:
-G-IMG01 2→0 (Helm-Digest-Drift behoben, T001766 gefixt) — von Prio B zurück nach Prio C; die
-Duplikat-Zeile G-IMG02 (identisches Ziel/Messung) und die doppelte G-DORA04-Zeile aus der
-Prio-C-Tabelle entfernt; G-GIT03-Duplikatzeile aus Prio C entfernt (lebt nur noch in Prio A).
-Fünf gemessene, aber undokumentierte Ziele als Prio-C-Zeilen nachgetragen: G-AGENTIC01, G-AGENTIC10,
-G-DB04, G-DB08, G-TEST05. **Neu: Brain-Dokumentations-Ziele** (Namespace ab G-BRAIN12; G-BRAIN01–11
-leben im brain-Repo): G-BRAIN12 Manifest-Drift 0 (Gate), G-BRAIN13 Merge-Hook-Pfad-Parität 0 (Gate),
-G-BRAIN15 Seed-Template-Lint Exit 0 (Gate) — alle drei in health-goals-check.sh verdrahtet;
-G-BRAIN14 Ingest-Backlog 17→0 (Prio B, T001912). Messwerte: G-CQ02 9→8, G-CQ05 1→0.
-
-**Baseline-Update 2026-07-17 (T001909 — G-SEC06 erster Trivy-Scan):** G-SEC06 n/a→39 (CRITICAL;
-706 HIGH). Vollständige CVE-Triage in [`docs/audits/2026-07-17-trivy-cve-baseline.md`](../../docs/audits/2026-07-17-trivy-cve-baseline.md).
-Alle CRITICAL-Funde fixable, keine False-Positives; Konzentration auf `alpine/k8s:1.34.0`
-(23/39). Bugfix im gleichen Zug: `scripts/trivy-scan.sh` fehlte der `ghcr.io/`-Prefix beim
-pocket-id-Image (Scan schlug für dieses Image still fehl statt zu warnen). Fix der CRITICAL-CVEs
-(Image-Pin-Refresh, 6 betroffene Images) ist bewusst nicht Teil dieses Baseline-Chores —
-Folgeticket empfohlen.
-Alle Alt-Tickets der offenen Ziele waren done/archived ohne Messwert-Fix — elf Nachfolge-Tickets
-T001902–T001912 angelegt und in den Meta-Zeilen referenziert.
-
-**Baseline-Update 2026-07-17 (T001911 — erster Lighthouse-Lauf):** G-FE05 n/a→60 (3× `npx @lhci/cli
-autorun` gegen `https://web.mentolder.de`, Performance-Score konstant 60/100; FCP 6.0s, LCP 7.5s,
-TTI 7.5s, TBT 0ms, CLS 0 — größte Opportunity: fehlende Text-Compression, ~622 KiB Einsparpotenzial,
-gefolgt von unused-javascript ~278 KiB und responsive Images ~146 KiB). Score liegt deutlich unter
-Target 90 — echte Optimierung ist bewusst nicht Teil dieses Chores; Follow-up-Ticket T001922 angelegt.
-
-**Baseline-Update 2026-07-17 (T001910 — G-CI03 erster Messlauf):** G-CI03 n/a→7 min p95 ✅ (Ziel ≤12 min; Messscript-Bug behoben — `gh-axi run list` unterstützt kein `--json` (nur `--fields`), Python-Auswertung parste ISO-Timestamps nicht als datetime — beide Stellen auf `gh` direkt + `datetime.fromisoformat` korrigiert).
-
-**Baseline-Update 2026-07-19 (T001952 — Prio-B Ticket-Backfill):** Alle Tracking-Tickets der 10 Prio-B-Ziele waren via Merge=Abschluss-Konvention bereits `done`, ohne dass die zugrundeliegenden Health-Goals ihr Target erreicht hätten (T001280→T001347-Stil-Churn). Für die 7 Ziele mit weiterhin verfehltem Target wurden neue Nachfolge-Tickets angelegt: G-SIZE02 → T001945, G-DB01 → T001946, G-DB03 → T001947, G-DB10 → T001948, G-SEC06 → T001949, G-FE05 → T001950, G-BRAIN14 → T001951. Die 3 Ziele, deren Wert bereits am oder über dem Target liegt (G-AGENTIC09 0≤0, G-DB09 0=0, G-CI03 7≤12), wurden redaktionell von Prio B in die Prio-C Green-Gates-Tabelle verschoben — kein neues Ticket, da kein offener Arbeitsbedarf besteht.
-
-**Baseline-Update 2026-07-19 (T001949 — G-SEC06 Image-Pin-Refresh):** G-SEC06 39→8 CRITICAL (−79%). alpine/k8s 1.34.0→1.36.2, pgvector 0.8.0-pg16→0.8.5-pg16, nats 2.10-alpine→2.12-alpine, [livekit/egress — removed T002184] — je mit `trivy image --severity CRITICAL` vor Merge verifiziert. Wichtiger Messfehler in der Baseline korrigiert: `alpine/k8s` im Manifest ist ein Docker-Hub-Image (nicht `registry.gitlab.com/alpine/k8s`, das für anonyme Pulls gesperrt ist) — Docker Hub führt aktiv gepflegte Tags bis 1.36.x. Verbleibende CRITICAL nach LiveKit-Entfernung (T002184) reduziert.
-
-**Baseline-Update 2026-07-19 (T001950 — Lighthouse Stufe 3):** G-FE05 Live-Baseline neu vermessen (3× `npx @lhci/cli autorun --collect.numberOfRuns=3` gegen `https://web.mentolder.de`, `CHROME_PATH=/usr/bin/google-chrome` gesetzt): aktueller Prod-Stand (vor diesem Fix) misst konstant **89/100** (FCP 2.0s, LCP 3.1s, SI 4.5s über alle 3 Läufe) — höher als der am 2026-07-17 dokumentierte Wert von 74, vermutlich durch zwischenzeitliche CDN-/Cache-Warmup-Effekte, aber weiterhin unter Target 90. Root-Cause-Analyse via `pnpm build` + manuellem Dist-Vergleich: `sidekick-panels.css` (~180 KB) wurde von Vite mit `global.css` in einen gemeinsamen Chunk gebündelt und war in `Layout.astro` (der öffentlichen Homepage-Layout-Datei, für beide Brands) ein render-blockendes `<link rel="stylesheet">`, obwohl es nur Styles für `PortalSidekick`-Drawer-Subviews liefert, die erst nach FAB-Klick sichtbar werden. `PortalSidekick.svelte` selbst importierte alle 9 Subviews (SupportView, QuestionnaireView, HelpView, AgentGuideView, MediaviewerPanel, TerminalSessionIframe, CockpitSidekickView, AiQualitySidekickView, LogsSidekickView) statisch, wodurch der über `client:idle` geladene Chunk auf 246 KB anwuchs (Lighthouse: 117 KB "unused JavaScript" allein hier). Fix: (1) `sidekick-panels.css` per `?url`-Import + `<link rel="preload" as="style" onload="this.rel='stylesheet'">`+`<noscript>`-Fallback asynchron nachgeladen (bleibt in `PortalLayout.astro`/`AdminLayout.astro` weiterhin eager, dort ist der Sidekick primäre UI); (2) die 9 Subviews in `PortalSidekick.svelte` auf `{#await import(...)}`-Dynamic-Imports umgestellt → PortalSidekick-Chunk 246 KB→84 KB, 9 neue On-Demand-Chunks (5–36 KB je View). Lokale Vorher/Nachher-Messung (`pnpm build` + `pnpm preview`-Server, `npx lighthouse`, gleiche unkomprimierte Dev-Umgebung ohne Traefik-Kompression, daher nicht direkt mit der Prod-Zahl vergleichbar, aber intern konsistent): Performance-Score **68→77** (+9), FCP 4.1s→2.8s, LCP 6.2s→5.0s. Live-Bestätigung gegen `https://web.mentolder.de` ist erst nach Merge + Deploy von `build-website.yml`/`build-website-korczewski.yml` möglich — Folge-Messung dort ausstehend (kein neues Ticket nötig, Messung ist Teil des Post-Merge-Verify-Schritts).
-
-**Baseline-Update 2026-07-19 (T001951 — G-BRAIN14 Ingest-Backlog gefixt):** Backlog 17→0. `bash scripts/brain-ingest-worklist.sh` gegen `~/.brain-ingest-state.json` zeigte real noch 15 offene Seiten (2 der ursprünglichen 17 waren zwischenzeitlich bereits ingested). Ingest-Pool-Blocker gefunden und umschifft: der dokumentierte Default `LM_STUDIO_URL=http://localhost:8095` (`start-qwen36-ingest-pool.ps1`) war nicht aktiv — stattdessen lief unter einem Zufallsport (`127.0.0.1:52875`) eine von LM Studio selbst verwaltete Backend-Instanz mit `--api-key` (401 Invalid API Key, da `brain-ingest-transform.sh` keinen Authorization-Header sendet). Fix: `LM_STUDIO_URL=http://127.0.0.1:1234` (LM Studios öffentlicher Endpunkt, kein API-Key, Modell `qwen3.6-14b-a3b-fablevibes` bereits geladen) statt des dedizierten Standalone-Pools verwendet — funktioniert, aber nur `--parallel 1` (LM Studios eigene Server-Instanz), daher `MAX_PARALLEL=2` statt 6 für den Lauf gewählt. Alle 15 Seiten erfolgreich transformiert (0 Failed), Wikilink-Lint-Autofix lief durch, PR [Paddione/brain#8](https://github.com/Paddione/brain/pull/8) erstellt und gemergt. Re-Messung bestätigt Backlog 0. G-BRAIN14 damit von Prio B nach Prio C (Green Gates) verschoben — kein Code-Fix in `Bachelorprojekt` nötig (reiner Ops-Ingest-Lauf), daher kein PR gegen dieses Repo.
-
-**Baseline-Update 2026-07-19 (T001950 — Live-Bestätigung nach Deploy):** G-FE05 **89→90 ✅ Target erreicht.** Nach Merge von PR #2948 (Auto-Deploy via `build-website.yml`, beide Brand-Jobs `Deploy Website (mentolder)`/`Deploy Website (korczewski)` grün) erneut 3× `npx @lhci/cli autorun --collect.numberOfRuns=3` gegen `https://web.mentolder.de` gemessen: Performance-Score konstant **90/100** über alle 3 Läufe (FCP 2.0s, LCP 3.0–3.1s). Live-HTML bestätigt den Fix: `sidekick-panels.css` wird per `<link rel="preload" as="style" onload="this.rel='stylesheet'">` + `<noscript>`-Fallback geladen, keine blockierende `<link rel="stylesheet">`-Variante mehr im `<head>`. G-FE05 wechselt von Prio B/A nach Prio C (Green Gate).
-
-**Baseline-Update 2026-07-21:** G-AGENTIC08 1→0 (toter Script-Pfad `scripts/openspec-validate.sh` in `openspec-propose/SKILL.md` zu `scripts/openspec.sh validate` korrigiert); G-DB04 1h→13h (Backup-Alter 13h, weiterhin im Target ≤26h); G-DEP04 2→0 (package.json engines korrigiert, Gate grün); G-CQ06 1→0 (@deprecated stripeServiceKey entfernt); G-CQ02 8→0 (any-Typen und comment-false-positives behoben); alle Prio-C-Gates grün via `scripts/health-goals-check.sh` verifiziert.
-
-**Baseline-Update 2026-07-22 (T002063 — neue Scopes E2E/OPS/Restore):** Drei neue Goal-Scopes
-aufgenommen, die die Laufzeit-Perspektive abdecken (bisher maßen nur die G-DB-Goals gegen
-Live-Systeme): **G-E2E01** Nightly-E2E-Erfolgsrate `e2e.yml` — Baseline **0 % (0/14 grün)**,
-direkte Prio A (aktive Verletzung; Fix läuft über `fix/e2e-auth-token-and-cron-secret`).
-**G-E2E02** E2E-Testdaten-Leak (is_test_data-Rows in Prod) — Baseline 2 (je 1×
-`public.inbox_items` in beiden Brand-DBs), Prio B. **G-OPS01** Pods nicht Running/Ready —
-Baseline 3 (`[livekit-egress — removed T002184]` Pending, `test-pod` Failed/Debris, `oauth2-proxy-terminal`
-Pending), Prio B. **G-OPS02** Container-Restarts <24h — 1 ≤ 3 ✓ (Green Gate). **G-OPS03**
-Live-TLS-Cert-Restlaufzeit — 37 Tage ≥ 14 ✓ (Green Gate; erste Messung gegen
-`web.korczewski.de` schlug transient fehl → Messung mit Retry). **G-DB11** Tage seit letztem
-Restore-Verify — n/a (Marker-ConfigMap `recovery-verify-status` wird ab jetzt von
-`backup-restore-lib.sh cmd_recovery_verify` bei Erfolg gestempelt; erster `verify`-Lauf
-ausstehend), Prio B. Alle sechs in `scripts/health-goals-check.sh` verdrahtet
-(kubectl/gh/openssl-Checks SKIPpen bei `--fast` oder fehlender Erreichbarkeit).
-Der erste G-DB11-Verify-Lauf schlug direkt fehl (shared-db `/dev/shm` 64M zu klein für den
-HNSW-Index-Build — website-Backup aktuell nicht vollständig restaurierbar, Bug **T002064**);
-Nebenbefund Wegwerf-DB-Leiche bei Job-Abbruch via cleanup-`trap` gefixt.
-
-**Baseline-Update 2026-07-22 (T002064 — G-DB11 Verify-Blocker gefixt):** G-DB11 n/a → **0 ✅**.
-shared-db bekam via PR #3089 ein Memory-backed `/dev/shm` (512Mi, nur postgres-Container);
-nach Deploy lief der Restore-Verify des Backups `20260722-000016` (website) vollständig durch
-(93 Tabellen, inkl. `chunks_embedding_hnsw`-HNSW-Build) und stempelte `recovery-verify-status`.
-Das website-Backup ist damit nachweislich wieder restaurierbar. Nebenbei entdeckt + gefixt
-(T002066, PR #3091): `RECOVER_DOMAIN` war im Schema required, fehlte aber in allen vier
-Brand-Env-Dateien — blockierte jeden `workspace:deploy`. OpenSpec-Change
-`fix-t002064-shared-db-dev-shm` archiviert (Delta in `backup-pipeline`-SSOT gemergt).
-
-**Baseline-Update 2026-07-22:** Prio-C-Tabellenwerte mit `health-goals-check.sh` synchronisiert:
-G-DB04 8→22 (Backup-Alter steigt, weiterhin im Target ≤26h); G-OPS03 37→36 (TLS-Restlaufzeit
-sinkt mit der Zeit korrekt); G-DB08 n/a→1 (Seq-Scan-Quote erstmals gemessen, 1 Tabelle >5 %
-Seq-Scan-Anteil, 1 ≤3 ✓); G-OPS01 3→2 (Baseline-Korrektur: `test-pod` debris zwischenzeitlich
-gelöscht, nur noch `[livekit-egress — removed T002184]` + `oauth2-proxy-terminal` Pending). **Regressionen:**
-G-AGENTIC09 0→2 (Prio C → Prio A: zwei SKILL.md >500 Zeilen, Target=0) — Nachfolger TBD.
-G-DB09 0→1 (Prio C → Prio A: eine Slow Query in pg_stat_statements, Target=0) — Nachfolger TBD.
-`website/src/lib/goals-data.generated.json` via `node scripts/gen-goals-data.mjs` neu generiert.
-
-**Baseline-Update 2026-07-26 (T002162 — erste automatisierte Messung):** Ab heute schreibt
-`.github/workflows/health-goals.yml` (cron `0 1 * * *`) die Prio-C-Werte nächtlich fort. Bis
-hierher lief die Messung ausschließlich manuell: `gen-goals-data.mjs` misst nichts, es parst
-diese Datei — änderte sie niemand, erzeugte der nächtliche `freshness-regen`-Lauf bitgleiche
-Ausgabe, sah keinen Diff und committete nichts. Die Pipeline war durchgehend grün und lieferte
-trotzdem eingefrorene Zahlen. T002158 (PR #3206) hatte zuvor die *Publish*-Kette repariert
-(`build-website.yml` triggert auf `.claude/lib/goals.md`, bedingtes `[skip ci]`); dieses Ticket
-schließt die verbleibende Lücke davor — die Messung selbst.
-
-Werte aus dem ersten vollständigen Lauf (`health-goals-update.sh --full`, gegen `fleet`):
-**G-SIZE03 1939→311** — der auffälligste Posten. `website/src/lib/website-db.ts` wurde in
-T002149/T002150 (PRs #3182, #3194) zweistufig zerlegt; das Dashboard zeigte tagelang weiter
-1939. Ein ungemessenes Ziel verdeckt nicht nur Regressionen, sondern auch erreichte Ziele.
-G-DOC02 190→200 (CLAUDE.md exakt am Target ≤200 — nächste Ergänzung kippt das Gate);
-G-CI03 7→5 min p95; G-TEST05 85→86 %; G-OPS03 36→33 Tage TLS-Restlaufzeit.
-**Regression:** G-DB04 22→35 h — das letzte erfolgreiche `db-backup`-Job liegt 35 h zurück und
-verletzt damit Target ≤26 h. Erster Befund dieses Laufs, der ohne die Automatisierung
-unentdeckt geblieben wäre; Ursachenklärung als eigenes Ticket, nicht in diesem Change.
-
-Ebenfalls in T002162 behoben: `gen-goals-data.mjs` las `measured_at` aus dem **letzten**
-`Baseline-Update`-Marker in Dokument-Reihenfolge. Die Marker stehen hier aber thematisch
-sortiert (Prio-A-Abschnitt oben, Prio-B/C-Historie unten), nicht chronologisch — der
-2026-07-25-Eintrag auf Zeile 108 verlor deshalb gegen die 2026-07-22-Einträge weiter unten,
-und alle 95 Ziele trugen einen vier Tage alten Mess-Stichtag. Jetzt gewinnt das jüngste Datum.
-
-**Baseline-Update 2026-07-27 (T002302 — Skill-Inventar-Bereinigung):**
-- 11 getrackte Skills entfernt (6 STUBs, 1 Grabstein `llm-ops`, 4 ML-Vendor-Skills)
-- G-AGENTIC06 Zähler in OVERVIEW.md von 39 auf 28 korrigiert (Soll: `git ls-files | grep -c SKILL.md`)
-- Drei ML-Skill-Registrierungen (unsloth, gguf-quantization, speculative-decoding) aus OVERVIEW.md entfernt
-- `skills-lock.json`: llama-cpp-Eintrag entfernt (nur lavish, vitest verbleiben)
-- Skill-Deny-Liste in `.opencode/opencode.jsonc` um 12 Einträge bereinigt
-
-**Baseline-Update 2026-07-27 (T002303 — Skill-Qualitäts-Pass):**
-- **G-AGENTIC09 verschärft und von `target` auf `gate` hochgestuft:** Schwelle 500 → 250, Scope
-  von „alle Skills" auf „projekteigene" (abgeleitet aus der Vendor-Sektion in `OVERVIEW.md`).
-  Baseline 2 → 0. Die sechs Übergrößen wurden per Progressive Disclosure gekürzt, ohne einen
-  Schritt zu verlieren: `dev-flow-execute` 486→248, `infra-ops` 476→176, `dev-flow-plan` 460→209,
-  `ticket-ops` 334→131, `openspec-explore` 298→206, `git-workflow` 283→230.
-- **G-AGENTIC08 Scope erweitert:** von `--include=SKILL.md` auf alle `.md` der projekteigenen
-  Skills plus `references/`. Vorher blieben ausgelagerte Referenzdateien ungeprüft — genau die
-  Lücke, die dieser Change sonst vergrößert hätte. Vendor-Skills bleiben ausgenommen, weil ihre
-  relativen `scripts/`-Pfade skill-lokal korrekt sind und repo-relativ falsch gelesen würden.
-- Neue gemeinsame Hilfsfunktion `project_owned_skills()` im Kopf von `health-goals-check.sh`.
-- Nebenbefund, nicht gemessen: **sieben `description`-Frontmatter waren kein gültiges YAML**
-  (unquotierter `: ` im Plain-Scalar), davon fünf Vorbestand. Alle projekteigenen descriptions
-  sind jetzt gequotet; `brain-ingest` hatte überhaupt kein Frontmatter und war damit nie über
-  Intent-Matching erreichbar.
+**Baseline-Update 2026-07-26 (T002162 — erste automatisierte Messung):** Ab hier schreibt
+`.github/workflows/health-goals.yml` (cron `0 1 * * *`) die Prio-C-Werte nächtlich fort. Davor lief
+die Messung ausschließlich manuell — `gen-goals-data.mjs` misst nichts, es parst diese Datei.
+Änderte sie niemand, erzeugte der nächtliche Lauf bitgleiche Ausgabe, sah keinen Diff und
+committete nichts: eine durchgehend grüne Pipeline, die eingefrorene Zahlen auslieferte.
+Auffälligster Posten des ersten echten Laufs: **G-SIZE03 1939 → 311** — das Ziel war längst
+erreicht, das Dashboard zeigte tagelang weiter den alten Wert. Ein ungemessenes Ziel verdeckt nicht
+nur Regressionen, sondern auch Erfolge.

--- a/.github/workflows/health-goals.yml
+++ b/.github/workflows/health-goals.yml
@@ -46,7 +46,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          # Volle History, sonst sind die DORA-Ziele hier strukturell nicht messbar.
+          # G-DORA01/03/04 leiten Deployment Frequency, Change Failure Rate und den
+          # MTTR-Proxy aus `git log --since=…` über main ab. Mit fetch-depth: 1 gibt
+          # es genau einen Commit — die Auswertung liefert dann nicht "wenig
+          # Deployments", sondern eine falsche Zahl. Bis T002598 standen diese drei
+          # Ziele mit "Elite ✓" in goals.md, während der einzige automatisierte
+          # Messlauf sie gar nicht ermitteln konnte. health-goals-check.sh skippt sie
+          # jetzt bei einem Shallow Clone; damit sie nicht dauerhaft skippen, holt
+          # dieser Job die History. [T002598]
+          fetch-depth: 0
           fetch-tags: false
           token: ${{ secrets.GH_PAT }}
 

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 748,
+      "file_count": 750,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -419,6 +419,8 @@
         "tests/spec/health-goal-latest-image-exclusions.bats",
         "tests/spec/health-goals-erden.bats",
         "tests/spec/health-goals.bats",
+        "tests/spec/health-goals/id-parity.bats",
+        "tests/spec/health-goals/measured-at-field.bats",
         "tests/spec/health-goals/worktree-hygiene-goals.bats",
         "tests/spec/helpers/agent-tools.py",
         "tests/spec/hermes-mcp-access.bats",

--- a/docs/health-goals-history.md
+++ b/docs/health-goals-history.md
@@ -1,0 +1,218 @@
+# Health Goals — Chronik
+
+Vollständige Änderungshistorie der Health Goals ab dem Baseline-Stichtag `2026-07-01`.
+
+> **Warum diese Datei existiert.** `.claude/lib/goals.md` ist das Ziel-**Register**: es sagt,
+> was gilt. Diese Datei sagt, was war. Bis T002598 standen beide im selben Dokument, wodurch
+> das Register monoton wuchs — jeder Fix hängte einen Absatz an, keiner räumte einen ab.
+>
+> **Kappungsregel:** `goals.md` behält höchstens **5** `Baseline-Update`-Einträge; alles Ältere
+> wird hierher verschoben. Erzwungen von `tests/spec/health-goals/id-parity.bats`.
+>
+> **Reihenfolge:** Die Einträge stehen in der Reihenfolge, in der sie im ursprünglichen
+> Dokument standen — **thematisch**, nicht chronologisch. Sie wurden bewusst nicht umsortiert,
+> um den Textbestand unverändert zu übernehmen. Wer nach einem Datum sucht, greppt danach.
+
+---
+
+**Baseline-Update 2026-07-25 (T002063):** G-E2E02 Baseline 2→24 (21× mentolder: 18× coaching.sessions + 3× public.inbox_items; 3× korczewski: public.inbox_items). Root cause: abgebrochene Nightly-E2E-Läufe (DNS-Fehler EAI_AGAIN web.korczewski.de) verhinderten den globalTeardown-Purge. Fix: `global-db-cleanup.ts` fängt Network-Errors ab (PR #3207).
+
+> Dieser Eintrag stand bis T002598 im Fließtext des Ziels G-E2E02 in `goals.md` statt im
+> Chronik-Abschnitt — er war damit der letzte verbliebene `Baseline-Update`-Marker im Register
+> und hätte nach der Auslagerung zufällig das Messdatum des gesamten Dashboards bestimmt.
+
+**Sprint-Highlights 2026-07-01:** G-CI01 erreicht Target (85 %→95 %, 19/20 grün) und wechselt von Prio A nach Prio C. G-RH03 (OpenSpec-BATS-Abdeckung 50 %→82 %) und G-DEP02 (Major-Deps 9→2) erreichen ihr Target und wechseln von Prio B nach Prio C. G-CQ01 erstmals gemessen: 0 astro-check-Fehler. G-CQ02 (explizite `any`) fällt weiter von 154 auf 8. G-GIT03 (Dateien >1MB) erreicht Target 7→6 per Policy-Ausschluss von `.codebase-memory/` (T001348) und wechselt von Prio A nach Prio C. G-SEC05-Messfehler dokumentiert: das Skript filtert nur eine von zwei GitHub-Actions-Bot-Mail-Varianten heraus, wodurch 4 Bot-Commits fälschlich als unsigniert zählen — echter Wert 0/50, Skript-Fix noch offen.
+
+**Sprint-Highlights 2026-07-03:** G-FE03 (console.error/warn) von 10 auf 1 reduziert — deutliche Verbesserung. G-CQ02 (explizite `any`) weiter von 11 auf 10 gesunken. G-SIZE03 (God-File website-db.ts) von 2106 auf 1957 Zeilen geschrumpft. G-TEST05 (Vitest Coverage) steigt von 82 %→85 %. **Regressionen:** G-CFG01 (env:validate:all) von Exit 0 auf 201 Schema-Verstöße gesprungen; G-GIT02 (non-conventional Commits) von 0 auf 1; G-AGENTIC06/07 jeweils von 0 auf 3 — vier Gates von Prio C nach Prio A zurückgestuft.
+
+**Baseline-Update 2026-07-02:** G-SIZE04 +324.494→+325.521 (weiterhin im Spike-Fenster, aber Top-Diffs sind wieder normale Feature-Arbeit); G-GIT03 7→6 (graph.db.zst per Policy-Entscheidung T001348 aus Gate-Scope ausgeschlossen, keine LFS-Migration); G-CD01 unverändert bei 100 % (15/15); G-CQ02 154→8; G-CQ01 ?→0; G-RH03 50 %→82 %; G-DEP02 9→2 Major; G-CI01 85 %→95 %; **G-SEC05** 25→0 (Mess-Bug fix: beide github-actions[bot] Mail-Varianten werden korrekt gefiltert, alle vorherigen "unsignierten" Commits waren GitHub-Bots); **G-AGENTIC01** 3→0 (tools:-Feld zu security/infra/db Agenten hinzugefügt); **G-AGENTIC10** 3→0 (dispatchende Skills website-specialist/database-specialist/security-specialist erstellt).
+
+**Baseline-Update 2026-07-03:** G-CQ02 11→10; G-SIZE03 2106→1957; G-FE03 10→1; G-TEST05 82 %→85 %; **G-CFG01** Exit 0→201 (Schema-Drift nach GITHUB_CONTENT_TOKEN-Add); **G-GIT02** 0→1 (non-conventional Commit); **G-AGENTIC06** 0→3 (OVERVIEW.md Skill-Zähler); **G-AGENTIC07** 0→3 (verwaiste Skills) — vier Gates von Prio C nach Prio A zurückgestuft.
+
+**Baseline-Update 2026-07-03 (Fix):** G-CFG01 201→0 — PRIMARY_FRONTEND + TURN_OVERLAY_IP in fleet-*/staging ergänzt, RUSTDESK-Keys auf `required: false` gesetzt (mentolder-only). Wechselt von Prio A → Prio C.
+
+**Baseline-Update 2026-07-03 (Fix 2):** G-GIT02 1→0 — `--no-merges` im Gate (Merge-Commit war falsch positiv). G-AGENTIC06 3→0 — OVERVIEW.md Zähler 27→30. G-AGENTIC07 3→0 — specialist Skills in OVERVIEW.md registriert. Drei Gates von Prio A → Prio C.
+
+**Baseline-Update 2026-07-04 (morning):** G-CQ01 (T001553) → done (Bereits grün, gate aktiv). G-CQ03 (T001554) → done (Bereits grün, ESLint-Gate aktiv). G-CQ08 (T001555) → done (knip-Baseline: ~120 unused exports, 7 unused files, 5 unused deps entfernt). G-FE01 (T001557) → done (axe 4.12.1, Baseline: 7 violations). G-FE02 (T001558) → done (Bundle-Budget: 747 KB, 99 JS files). G-SIZE02 (T001556) → backlog (17 files >600 Zeilen, ~2-3 Wochen). G-AGENTIC09 (T001559) → done (3 SKILL.md via Whitespace-Kompression auf <500 Zeilen).
+
+**Baseline-Update 2026-07-04 (Fix):** G-AGENTIC06 0→0 (OVERVIEW.md 30→31 — brain-ingest nachgezogen). G-AGENTIC08 1→0 (toter Script-Pfad `scripts/brain-ingest.mjs` aus brain-ingest/SKILL.md entfernt). G-GIT02 0→1 (Commit `f9dc1ae4e` durch Mishap-Bundle-Routine — kann nicht aus History entfernt werden, löst sich nach ~17 weiteren main-Commits).
+
+**Baseline-Update 2026-07-04:** G-CQ07 S2 Import-Zyklen 0 (baseline.json); G-CQ09 S3 Hostnames 0; G-CQ10 S4 Orphaned Scripts 0 — alle grün, Gates neu eingefügt.
+
+**Baseline-Update 2026-07-10:** G-CFG01 Exit 0→201→0 (fehlendes `TERMINAL_OVERLAY_IP` in `environments/staging.yaml` ergänzt). G-AGENTIC06 6→0 (OVERVIEW.md Skill-Zähler 31→37 korrigiert — brain-ingest/infra-ops/lavish/references/vitest waren nicht mitgezählt). G-AGENTIC07 1→0 (Verweis auf `superpowers-executing-plans`-Stub in dev-flow-execute/SKILL.md ergänzt). G-FE03 2→0 (Mess-Scope-Fix: `logger.ts`/`error-log-store.ts`-Selbstschutz-Fallbacks ausgeschlossen, analog `browser-logger.ts`). G-FE04 3→0 (`website/src/db/migrate.ts`: drei `console.log` auf den bereits importierten pino-`logger` umgestellt). G-DB04 163h→1h (Backup-Alter unter Target — Root-Cause-Status T001738 nicht verifiziert, Messzyklus bleibt täglich als Regressionswache). **Neue Regression:** G-IMG01 0→2 (`promtail-rendered.yaml`/`loki-rendered.yaml`, Helm-Chart-Digests nach T001703-Upgrade nicht nachgezogen) — von Prio C nach Prio B verschoben, Ticket T001766. Nebenbei zwei doppelt vorhandene G-CQ09/G-CQ10-Tabellenzeilen (Copy-Paste-Duplikat) aus der Prio-C-Tabelle entfernt.
+
+**Baseline-Update 2026-07-14 (T001804):** G-AGENTIC06 1→0 (OVERVIEW.md Zähler 37→36 + Mess-Umstellung auf getrackte SKILL.md via `git ls-files` — lokal via market-cli installierte Skills kippen das Gate nicht mehr, Präzedenz T001783). G-AGENTIC07 6→0 (2 untrackte lokale Skills aus dem Mess-Scope entfernt; 4 getrackte Drittanbieter-/ML-Skills — ui-ux-pro-max, unsloth, gguf-quantization, speculative-decoding — in neuer OVERVIEW.md-Sektion registriert). G-AGENTIC08 1→0 (Mess-Bug: Regex ohne Anker matchte `scripts/search.py` als Substring des existierenden Pfads `.claude/skills/ui-ux-pro-max/scripts/search.py` — Lookbehind ergänzt). G-AGENTIC11 5→0 (CLAUDE.md-opencode-Liste um `github-mcp`, `playwright`, `sequential-thinking`, `webresearch`, `docfork` ergänzt). G-DOC02 216→190 (CLAUDE.md kondensiert: Merge=Abschluss- und Bug-Triage-Blöcke entwrappt, leere `### Brett`-Überschrift und redundantes Oracle-Beispiel entfernt). G-AGENTIC09 1→0 (dev-flow-plan/SKILL.md 513→495 Zeilen, Prosa-Entwrapping ohne Inhaltsverlust). G-GIT03 bleibt 7 (>Target 6): Kandidaten `assets/grilling-brett-admin-panel/Brett Admin Panel.html` und `environments/korczewski/KERN Logo Design.html` sind Nutzer-Assets — Löschen/LFS braucht manuelle Entscheidung.
+
+**Baseline-Update 2026-07-17 (T001902):** G-GIT03 7→6 — Target erreicht, wechselt von Prio A nach Prio C. Entfernt: `.claude/skills/unsloth/references/llms-full.md` (1.03 MB, redundanter GitBook-Volldump, von der Skill selbst nicht referenziert — SKILL.md listet nur `llms-txt.md`). Die 2 verbleibenden Nutzer-Assets (`assets/grilling-brett-admin-panel/Brett Admin Panel.html`, `environments/korczewski/KERN Logo Design.html`) bleiben bewusst unangetastet: Löschen ohne Nutzerfreigabe riskant, LFS repo-weit als defekt dokumentiert (T001348); da das Target auch ohne sie erreicht ist, ist keine Gate-Scope-Ausnahme nötig.
+
+**Baseline-Update 2026-07-17 (T001903):** G-SIZE02 Messmethode gefixt — die naive `wc -l`-Zählung folgte den Symlinks `.opencode/plugins/background-agents.ts` und `.opencode/plugins/worktree.ts` (git-tracked Symlinks auf `.opencode/skills/dev-flow/*.ts`) und zählte deren Zeilen doppelt (19 statt 17). Messkommando um `[ -L "$f" ]`-Filter ergänzt. Echter, verifizierter Bestand bleibt bei 17 (3× .opencode/, bereits sanktioniert via S1-Gate-Ignore; 14× VideoVault/, echter Produktionscode, keine Duplikate/generierte Artefakte). T001556 hatte den Wert nie wirklich gefixt — der archivierte Plan referenzierte nicht-existente Pfade (`VideoVault/src/lib/upload.ts` statt der realen `VideoVault/client/src/...` / `VideoVault/server/...`-Struktur), daher blieben alle abgehakten Tasks wirkungslos. Zielwert ≤8 erfordert echtes, getestetes Code-Splitting über ~9 Dateien (~2-3 Wochen) — kein Chore-Scope (kein `node_modules` installiert, kein Testlauf als Regressionsnetz in dieser Session verfügbar) → Nachfolger-Ticket T001920 mit konkreten Split-Vorschlägen je realer Datei, zur Umsetzung über `dev-flow-plan`.
+
+**Offene Tickets (2026-07-17):** G-AGENTIC09 (T001904), G-DB01 (T001905), G-SEC06 (T001909), G-FE05 (T001911), G-BRAIN14 (T001912), G-SIZE02 (T001920, Nachfolger von T001903 — echtes VideoVault-Refactoring), G-DB03 (T001925, Nachfolger von T001906 — echte 41-Tabellen-Migration in 3 Gruppen), G-DB09 (T001926, Nachfolger von T001907 — Messmethoden-Korrektur Backup-COPY-Ausschluss), G-DB10 (T001928, Nachfolger von T001908 — 92 restliche Unused-Index-Kandidaten klassifizieren)
+
+| Ziel | Ticket | Status |
+|------|--------|--------|
+| G-GIT03 | T001902 | done (7→6, Target erreicht — `llms-full.md` entfernt, 2 Nutzer-Assets bewusst unangetastet) |
+| G-SIZE02 | T001903 | **gefixt** (Messmethode korrigiert — Symlink-Doppelzählung behoben; echter Bestand 17 verifiziert, davon 3 bereits sanktioniert. Zielwert ≤8 nicht erreichbar ohne echtes Code-Splitting → Nachfolger T001920) |
+| G-AGENTIC09 | T001904 | **gefixt** (dev-flow-plan/SKILL.md 508→479 Zeilen, Whitespace-Kompression ohne Inhaltsverlust — Nachfolger von T001559) |
+| G-DB01 | T001905 | Migration erstellt, Anwendung ausstehend (nächster Deploy) — Nachfolger von T001739 |
+| G-DB03 | T001906 | **gefixt** (Messmethode korrigiert — 3 VIEWs ausgeschlossen, echter Bestand 41 Basistabellen; kein einheitlicher Wertebereich [Wildcard `'*'` + NULL-Ausnahmen] → Nachfolger T001925) |
+| G-DB09 | T001907 | offen (Slow Queries, erster Scan + Optimierung — Nachfolger von T001838) |
+| G-DB10 | T001908 | **gefixt** (Baseline 93 gemessen, 1 zweifelsfreier Drop [`idx_customers_email`] via Migration umgesetzt — Nachfolger T001928 für die restlichen 92 Kandidaten, Nachfolger von T001839) |
+| G-SEC06 | T001909 | **gefixt** (Image-Pin-Refresh 39→8 CRITICAL, Rest Upstream-blockiert [gosu/grpc-go] — Nachfolger von T001840) → Nachfolger **T001949** |
+| G-CI03 | T001910 | **gefixt** (CI p95 = 7 min ✅ ≤12, Messscript-Bug behoben — Nachfolger von T001841) |
+| G-FE05 | T001911 | **gefixt** (90/100 ✅ Target erreicht 2026-07-19 via T001950 — sidekick-panels.css async + PortalSidekick dynamic-import) |
+| G-BRAIN14 | T001912 | **gefixt** (Nachfolger T001951, 2026-07-19: 15 Backlog-Seiten ingested, Backlog 17→0, PR Paddione/brain#8 gemergt — zurück nach Prio C) |
+| G-DB04 | T001739 | gruen (1h, Target ≤26h — Root-Cause-Fix nicht verifiziert, Regressionswache bleibt täglich) |
+| G-DB06 | T001739 | gruen (Gate, halten) |
+| G-IMG01 | T001766 | **gefixt** (Regression 0→2→0, Helm-Digest-Drift Loki/Promtail behoben — zurück nach Prio C) |
+| G-SIZE04 | T001280 | geschlossen (`done`), Messwert weiterhin rot → Nachfolger T001347 |
+| G-SIZE04 | T001347 | offen |
+| G-GIT03 | T001275 | **gefixt** (gitignore search-index.json [T001305]) |
+| G-GIT03 | T001320 | geschlossen (`done`), graph.db.zst nicht migriert → Nachfolger T001348 |
+| G-GIT03 | T001348 | **gefixt** (Policy-Ausschluss `.codebase-memory/` aus Gate-Scope, keine LFS-Migration) |
+| G-CD01 | T001276 | geschlossen (`done`), Erfolgsrate unverändert → Nachfolger T001349 |
+| G-CD01 | T001349 | **gefixt** (Root Cause: Messbefehl zeigte auf geloeschten Workflow build-website-korczewski.yml; jetzt Job-Level gh api gegen build-website.yml) |
+| G-CQ01 | T001277 | **gefixt** (PR #2225) |
+| G-DEP01 | T001278 | **gefixt** (0 vulnerabilities) |
+| G-CI01 | T001279 | **gefixt** (95 % letzte 20 Läufe) |
+| G-CFG01 | T001548 | **gefixt** (Commit 97f04f031) |
+| G-GIT02 | T001552 | **gefixt** (Commit 1d4ba261b — `--no-merges` im Gate) |
+| G-AGENTIC06 | T001550 | **gefixt** (OVERVIEW.md count 27→30, am 2026-07-04 erneut 30→31 für brain-ingest) |
+| G-AGENTIC07 | T001551 | **gefixt** (OVERVIEW.md: specialist skills registriert) |
+| G-CQ01 | T001553 | **gefixt** (0 astro-check errors, gate aktiv seit PR #2225) |
+| G-CQ03 | T001554 | **gefixt** (ESLint-Gate aktiv, 2 legitime inline-disables) |
+| G-CQ08 | T001555 | **gefixt** (knip-Baseline: ~120 unused exports, −5 unused deps) |
+| G-SIZE02 | T001556 | Prio B — backlog (17 files >600 Zeilen) |
+| G-FE01 | T001557 | **gefixt** (axe 4.12.1, Baseline: 7 violations) |
+| G-FE02 | T001558 | **gefixt** (Bundle-Budget: 747 KB, 99 JS files) |
+| G-AGENTIC09 | T001559 | **gefixt** (Whitespace-Kompression → alle <500 Zeilen) |
+| G-AGENTIC08 | — | **gefixt** (2026-07-04: toter script-path `scripts/brain-ingest.mjs` aus SKILL.md entfernt) |
+| G-GIT02 | T001552 | **regressed** (Commit f9dc1ae4e — `mishap-bundle-fix:` non-conventional) |
+
+**Baseline-Update 2026-07-15:** G-SEC06 n/a→0 (Trivy-Integration in CI + scripts/trivy-scan.sh erstellt, erster Scan ausstehend); G-CI03 n/a→0 (Implementierung in health-goals-check.sh abgeschlossen, erster Scan ausstehend); G-FE05 n/a→0 (Lighthouse CI in ci.yml + health-goals-check.sh integriert, lighthouse-budget.json erstellt, erster Scan ausstehend)
+
+**Baseline-Update 2026-07-17 (T001904):** G-AGENTIC09 1→0 — `dev-flow-plan/SKILL.md` 508→479 Zeilen. Whitespace-Kompression analog T001559/T001804 (redundante Leerzeilen vor Headern/Listen/Codefences entfernt, Codefence-interne Leerzeilen unangetastet gelassen) — reine Deletion-Diffs, kein Inhaltsverlust.
+
+**Baseline-Update 2026-07-17 (T001901 — Struktur-Refresh + Brain-Ziele):** Strukturbereinigung:
+G-IMG01 2→0 (Helm-Digest-Drift behoben, T001766 gefixt) — von Prio B zurück nach Prio C; die
+Duplikat-Zeile G-IMG02 (identisches Ziel/Messung) und die doppelte G-DORA04-Zeile aus der
+Prio-C-Tabelle entfernt; G-GIT03-Duplikatzeile aus Prio C entfernt (lebt nur noch in Prio A).
+Fünf gemessene, aber undokumentierte Ziele als Prio-C-Zeilen nachgetragen: G-AGENTIC01, G-AGENTIC10,
+G-DB04, G-DB08, G-TEST05. **Neu: Brain-Dokumentations-Ziele** (Namespace ab G-BRAIN12; G-BRAIN01–11
+leben im brain-Repo): G-BRAIN12 Manifest-Drift 0 (Gate), G-BRAIN13 Merge-Hook-Pfad-Parität 0 (Gate),
+G-BRAIN15 Seed-Template-Lint Exit 0 (Gate) — alle drei in health-goals-check.sh verdrahtet;
+G-BRAIN14 Ingest-Backlog 17→0 (Prio B, T001912). Messwerte: G-CQ02 9→8, G-CQ05 1→0.
+
+**Baseline-Update 2026-07-17 (T001909 — G-SEC06 erster Trivy-Scan):** G-SEC06 n/a→39 (CRITICAL;
+706 HIGH). Vollständige CVE-Triage in [`docs/audits/2026-07-17-trivy-cve-baseline.md`](../../docs/audits/2026-07-17-trivy-cve-baseline.md).
+Alle CRITICAL-Funde fixable, keine False-Positives; Konzentration auf `alpine/k8s:1.34.0`
+(23/39). Bugfix im gleichen Zug: `scripts/trivy-scan.sh` fehlte der `ghcr.io/`-Prefix beim
+pocket-id-Image (Scan schlug für dieses Image still fehl statt zu warnen). Fix der CRITICAL-CVEs
+(Image-Pin-Refresh, 6 betroffene Images) ist bewusst nicht Teil dieses Baseline-Chores —
+Folgeticket empfohlen.
+Alle Alt-Tickets der offenen Ziele waren done/archived ohne Messwert-Fix — elf Nachfolge-Tickets
+T001902–T001912 angelegt und in den Meta-Zeilen referenziert.
+
+**Baseline-Update 2026-07-17 (T001911 — erster Lighthouse-Lauf):** G-FE05 n/a→60 (3× `npx @lhci/cli
+autorun` gegen `https://web.mentolder.de`, Performance-Score konstant 60/100; FCP 6.0s, LCP 7.5s,
+TTI 7.5s, TBT 0ms, CLS 0 — größte Opportunity: fehlende Text-Compression, ~622 KiB Einsparpotenzial,
+gefolgt von unused-javascript ~278 KiB und responsive Images ~146 KiB). Score liegt deutlich unter
+Target 90 — echte Optimierung ist bewusst nicht Teil dieses Chores; Follow-up-Ticket T001922 angelegt.
+
+**Baseline-Update 2026-07-17 (T001910 — G-CI03 erster Messlauf):** G-CI03 n/a→7 min p95 ✅ (Ziel ≤12 min; Messscript-Bug behoben — `gh-axi run list` unterstützt kein `--json` (nur `--fields`), Python-Auswertung parste ISO-Timestamps nicht als datetime — beide Stellen auf `gh` direkt + `datetime.fromisoformat` korrigiert).
+
+**Baseline-Update 2026-07-19 (T001952 — Prio-B Ticket-Backfill):** Alle Tracking-Tickets der 10 Prio-B-Ziele waren via Merge=Abschluss-Konvention bereits `done`, ohne dass die zugrundeliegenden Health-Goals ihr Target erreicht hätten (T001280→T001347-Stil-Churn). Für die 7 Ziele mit weiterhin verfehltem Target wurden neue Nachfolge-Tickets angelegt: G-SIZE02 → T001945, G-DB01 → T001946, G-DB03 → T001947, G-DB10 → T001948, G-SEC06 → T001949, G-FE05 → T001950, G-BRAIN14 → T001951. Die 3 Ziele, deren Wert bereits am oder über dem Target liegt (G-AGENTIC09 0≤0, G-DB09 0=0, G-CI03 7≤12), wurden redaktionell von Prio B in die Prio-C Green-Gates-Tabelle verschoben — kein neues Ticket, da kein offener Arbeitsbedarf besteht.
+
+**Baseline-Update 2026-07-19 (T001949 — G-SEC06 Image-Pin-Refresh):** G-SEC06 39→8 CRITICAL (−79%). alpine/k8s 1.34.0→1.36.2, pgvector 0.8.0-pg16→0.8.5-pg16, nats 2.10-alpine→2.12-alpine, [livekit/egress — removed T002184] — je mit `trivy image --severity CRITICAL` vor Merge verifiziert. Wichtiger Messfehler in der Baseline korrigiert: `alpine/k8s` im Manifest ist ein Docker-Hub-Image (nicht `registry.gitlab.com/alpine/k8s`, das für anonyme Pulls gesperrt ist) — Docker Hub führt aktiv gepflegte Tags bis 1.36.x. Verbleibende CRITICAL nach LiveKit-Entfernung (T002184) reduziert.
+
+**Baseline-Update 2026-07-19 (T001950 — Lighthouse Stufe 3):** G-FE05 Live-Baseline neu vermessen (3× `npx @lhci/cli autorun --collect.numberOfRuns=3` gegen `https://web.mentolder.de`, `CHROME_PATH=/usr/bin/google-chrome` gesetzt): aktueller Prod-Stand (vor diesem Fix) misst konstant **89/100** (FCP 2.0s, LCP 3.1s, SI 4.5s über alle 3 Läufe) — höher als der am 2026-07-17 dokumentierte Wert von 74, vermutlich durch zwischenzeitliche CDN-/Cache-Warmup-Effekte, aber weiterhin unter Target 90. Root-Cause-Analyse via `pnpm build` + manuellem Dist-Vergleich: `sidekick-panels.css` (~180 KB) wurde von Vite mit `global.css` in einen gemeinsamen Chunk gebündelt und war in `Layout.astro` (der öffentlichen Homepage-Layout-Datei, für beide Brands) ein render-blockendes `<link rel="stylesheet">`, obwohl es nur Styles für `PortalSidekick`-Drawer-Subviews liefert, die erst nach FAB-Klick sichtbar werden. `PortalSidekick.svelte` selbst importierte alle 9 Subviews (SupportView, QuestionnaireView, HelpView, AgentGuideView, MediaviewerPanel, TerminalSessionIframe, CockpitSidekickView, AiQualitySidekickView, LogsSidekickView) statisch, wodurch der über `client:idle` geladene Chunk auf 246 KB anwuchs (Lighthouse: 117 KB "unused JavaScript" allein hier). Fix: (1) `sidekick-panels.css` per `?url`-Import + `<link rel="preload" as="style" onload="this.rel='stylesheet'">`+`<noscript>`-Fallback asynchron nachgeladen (bleibt in `PortalLayout.astro`/`AdminLayout.astro` weiterhin eager, dort ist der Sidekick primäre UI); (2) die 9 Subviews in `PortalSidekick.svelte` auf `{#await import(...)}`-Dynamic-Imports umgestellt → PortalSidekick-Chunk 246 KB→84 KB, 9 neue On-Demand-Chunks (5–36 KB je View). Lokale Vorher/Nachher-Messung (`pnpm build` + `pnpm preview`-Server, `npx lighthouse`, gleiche unkomprimierte Dev-Umgebung ohne Traefik-Kompression, daher nicht direkt mit der Prod-Zahl vergleichbar, aber intern konsistent): Performance-Score **68→77** (+9), FCP 4.1s→2.8s, LCP 6.2s→5.0s. Live-Bestätigung gegen `https://web.mentolder.de` ist erst nach Merge + Deploy von `build-website.yml`/`build-website-korczewski.yml` möglich — Folge-Messung dort ausstehend (kein neues Ticket nötig, Messung ist Teil des Post-Merge-Verify-Schritts).
+
+**Baseline-Update 2026-07-19 (T001951 — G-BRAIN14 Ingest-Backlog gefixt):** Backlog 17→0. `bash scripts/brain-ingest-worklist.sh` gegen `~/.brain-ingest-state.json` zeigte real noch 15 offene Seiten (2 der ursprünglichen 17 waren zwischenzeitlich bereits ingested). Ingest-Pool-Blocker gefunden und umschifft: der dokumentierte Default `LM_STUDIO_URL=http://localhost:8095` (`start-qwen36-ingest-pool.ps1`) war nicht aktiv — stattdessen lief unter einem Zufallsport (`127.0.0.1:52875`) eine von LM Studio selbst verwaltete Backend-Instanz mit `--api-key` (401 Invalid API Key, da `brain-ingest-transform.sh` keinen Authorization-Header sendet). Fix: `LM_STUDIO_URL=http://127.0.0.1:1234` (LM Studios öffentlicher Endpunkt, kein API-Key, Modell `qwen3.6-14b-a3b-fablevibes` bereits geladen) statt des dedizierten Standalone-Pools verwendet — funktioniert, aber nur `--parallel 1` (LM Studios eigene Server-Instanz), daher `MAX_PARALLEL=2` statt 6 für den Lauf gewählt. Alle 15 Seiten erfolgreich transformiert (0 Failed), Wikilink-Lint-Autofix lief durch, PR [Paddione/brain#8](https://github.com/Paddione/brain/pull/8) erstellt und gemergt. Re-Messung bestätigt Backlog 0. G-BRAIN14 damit von Prio B nach Prio C (Green Gates) verschoben — kein Code-Fix in `Bachelorprojekt` nötig (reiner Ops-Ingest-Lauf), daher kein PR gegen dieses Repo.
+
+**Baseline-Update 2026-07-19 (T001950 — Live-Bestätigung nach Deploy):** G-FE05 **89→90 ✅ Target erreicht.** Nach Merge von PR #2948 (Auto-Deploy via `build-website.yml`, beide Brand-Jobs `Deploy Website (mentolder)`/`Deploy Website (korczewski)` grün) erneut 3× `npx @lhci/cli autorun --collect.numberOfRuns=3` gegen `https://web.mentolder.de` gemessen: Performance-Score konstant **90/100** über alle 3 Läufe (FCP 2.0s, LCP 3.0–3.1s). Live-HTML bestätigt den Fix: `sidekick-panels.css` wird per `<link rel="preload" as="style" onload="this.rel='stylesheet'">` + `<noscript>`-Fallback geladen, keine blockierende `<link rel="stylesheet">`-Variante mehr im `<head>`. G-FE05 wechselt von Prio B/A nach Prio C (Green Gate).
+
+**Baseline-Update 2026-07-21:** G-AGENTIC08 1→0 (toter Script-Pfad `scripts/openspec-validate.sh` in `openspec-propose/SKILL.md` zu `scripts/openspec.sh validate` korrigiert); G-DB04 1h→13h (Backup-Alter 13h, weiterhin im Target ≤26h); G-DEP04 2→0 (package.json engines korrigiert, Gate grün); G-CQ06 1→0 (@deprecated stripeServiceKey entfernt); G-CQ02 8→0 (any-Typen und comment-false-positives behoben); alle Prio-C-Gates grün via `scripts/health-goals-check.sh` verifiziert.
+
+**Baseline-Update 2026-07-22 (T002063 — neue Scopes E2E/OPS/Restore):** Drei neue Goal-Scopes
+aufgenommen, die die Laufzeit-Perspektive abdecken (bisher maßen nur die G-DB-Goals gegen
+Live-Systeme): **G-E2E01** Nightly-E2E-Erfolgsrate `e2e.yml` — Baseline **0 % (0/14 grün)**,
+direkte Prio A (aktive Verletzung; Fix läuft über `fix/e2e-auth-token-and-cron-secret`).
+**G-E2E02** E2E-Testdaten-Leak (is_test_data-Rows in Prod) — Baseline 2 (je 1×
+`public.inbox_items` in beiden Brand-DBs), Prio B. **G-OPS01** Pods nicht Running/Ready —
+Baseline 3 (`[livekit-egress — removed T002184]` Pending, `test-pod` Failed/Debris, `oauth2-proxy-terminal`
+Pending), Prio B. **G-OPS02** Container-Restarts <24h — 1 ≤ 3 ✓ (Green Gate). **G-OPS03**
+Live-TLS-Cert-Restlaufzeit — 37 Tage ≥ 14 ✓ (Green Gate; erste Messung gegen
+`web.korczewski.de` schlug transient fehl → Messung mit Retry). **G-DB11** Tage seit letztem
+Restore-Verify — n/a (Marker-ConfigMap `recovery-verify-status` wird ab jetzt von
+`backup-restore-lib.sh cmd_recovery_verify` bei Erfolg gestempelt; erster `verify`-Lauf
+ausstehend), Prio B. Alle sechs in `scripts/health-goals-check.sh` verdrahtet
+(kubectl/gh/openssl-Checks SKIPpen bei `--fast` oder fehlender Erreichbarkeit).
+Der erste G-DB11-Verify-Lauf schlug direkt fehl (shared-db `/dev/shm` 64M zu klein für den
+HNSW-Index-Build — website-Backup aktuell nicht vollständig restaurierbar, Bug **T002064**);
+Nebenbefund Wegwerf-DB-Leiche bei Job-Abbruch via cleanup-`trap` gefixt.
+
+**Baseline-Update 2026-07-22 (T002064 — G-DB11 Verify-Blocker gefixt):** G-DB11 n/a → **0 ✅**.
+shared-db bekam via PR #3089 ein Memory-backed `/dev/shm` (512Mi, nur postgres-Container);
+nach Deploy lief der Restore-Verify des Backups `20260722-000016` (website) vollständig durch
+(93 Tabellen, inkl. `chunks_embedding_hnsw`-HNSW-Build) und stempelte `recovery-verify-status`.
+Das website-Backup ist damit nachweislich wieder restaurierbar. Nebenbei entdeckt + gefixt
+(T002066, PR #3091): `RECOVER_DOMAIN` war im Schema required, fehlte aber in allen vier
+Brand-Env-Dateien — blockierte jeden `workspace:deploy`. OpenSpec-Change
+`fix-t002064-shared-db-dev-shm` archiviert (Delta in `backup-pipeline`-SSOT gemergt).
+
+**Baseline-Update 2026-07-22:** Prio-C-Tabellenwerte mit `health-goals-check.sh` synchronisiert:
+G-DB04 8→22 (Backup-Alter steigt, weiterhin im Target ≤26h); G-OPS03 37→36 (TLS-Restlaufzeit
+sinkt mit der Zeit korrekt); G-DB08 n/a→1 (Seq-Scan-Quote erstmals gemessen, 1 Tabelle >5 %
+Seq-Scan-Anteil, 1 ≤3 ✓); G-OPS01 3→2 (Baseline-Korrektur: `test-pod` debris zwischenzeitlich
+gelöscht, nur noch `[livekit-egress — removed T002184]` + `oauth2-proxy-terminal` Pending). **Regressionen:**
+G-AGENTIC09 0→2 (Prio C → Prio A: zwei SKILL.md >500 Zeilen, Target=0) — Nachfolger TBD.
+G-DB09 0→1 (Prio C → Prio A: eine Slow Query in pg_stat_statements, Target=0) — Nachfolger TBD.
+`website/src/lib/goals-data.generated.json` via `node scripts/gen-goals-data.mjs` neu generiert.
+
+**Baseline-Update 2026-07-26 (T002162 — erste automatisierte Messung):** Ab heute schreibt
+`.github/workflows/health-goals.yml` (cron `0 1 * * *`) die Prio-C-Werte nächtlich fort. Bis
+hierher lief die Messung ausschließlich manuell: `gen-goals-data.mjs` misst nichts, es parst
+diese Datei — änderte sie niemand, erzeugte der nächtliche `freshness-regen`-Lauf bitgleiche
+Ausgabe, sah keinen Diff und committete nichts. Die Pipeline war durchgehend grün und lieferte
+trotzdem eingefrorene Zahlen. T002158 (PR #3206) hatte zuvor die *Publish*-Kette repariert
+(`build-website.yml` triggert auf `.claude/lib/goals.md`, bedingtes `[skip ci]`); dieses Ticket
+schließt die verbleibende Lücke davor — die Messung selbst.
+
+Werte aus dem ersten vollständigen Lauf (`health-goals-update.sh --full`, gegen `fleet`):
+**G-SIZE03 1939→311** — der auffälligste Posten. `website/src/lib/website-db.ts` wurde in
+T002149/T002150 (PRs #3182, #3194) zweistufig zerlegt; das Dashboard zeigte tagelang weiter
+1939. Ein ungemessenes Ziel verdeckt nicht nur Regressionen, sondern auch erreichte Ziele.
+G-DOC02 190→200 (CLAUDE.md exakt am Target ≤200 — nächste Ergänzung kippt das Gate);
+G-CI03 7→5 min p95; G-TEST05 85→86 %; G-OPS03 36→33 Tage TLS-Restlaufzeit.
+**Regression:** G-DB04 22→35 h — das letzte erfolgreiche `db-backup`-Job liegt 35 h zurück und
+verletzt damit Target ≤26 h. Erster Befund dieses Laufs, der ohne die Automatisierung
+unentdeckt geblieben wäre; Ursachenklärung als eigenes Ticket, nicht in diesem Change.
+
+Ebenfalls in T002162 behoben: `gen-goals-data.mjs` las `measured_at` aus dem **letzten**
+`Baseline-Update`-Marker in Dokument-Reihenfolge. Die Marker stehen hier aber thematisch
+sortiert (Prio-A-Abschnitt oben, Prio-B/C-Historie unten), nicht chronologisch — der
+2026-07-25-Eintrag auf Zeile 108 verlor deshalb gegen die 2026-07-22-Einträge weiter unten,
+und alle 95 Ziele trugen einen vier Tage alten Mess-Stichtag. Jetzt gewinnt das jüngste Datum.
+
+**Baseline-Update 2026-07-27 (T002302 — Skill-Inventar-Bereinigung):**
+- 11 getrackte Skills entfernt (6 STUBs, 1 Grabstein `llm-ops`, 4 ML-Vendor-Skills)
+- G-AGENTIC06 Zähler in OVERVIEW.md von 39 auf 28 korrigiert (Soll: `git ls-files | grep -c SKILL.md`)
+- Drei ML-Skill-Registrierungen (unsloth, gguf-quantization, speculative-decoding) aus OVERVIEW.md entfernt
+- `skills-lock.json`: llama-cpp-Eintrag entfernt (nur lavish, vitest verbleiben)
+- Skill-Deny-Liste in `.opencode/opencode.jsonc` um 12 Einträge bereinigt
+
+**Baseline-Update 2026-07-27 (T002303 — Skill-Qualitäts-Pass):**
+- **G-AGENTIC09 verschärft und von `target` auf `gate` hochgestuft:** Schwelle 500 → 250, Scope
+  von „alle Skills" auf „projekteigene" (abgeleitet aus der Vendor-Sektion in `OVERVIEW.md`).
+  Baseline 2 → 0. Die sechs Übergrößen wurden per Progressive Disclosure gekürzt, ohne einen
+  Schritt zu verlieren: `dev-flow-execute` 486→248, `infra-ops` 476→176, `dev-flow-plan` 460→209,
+  `ticket-ops` 334→131, `openspec-explore` 298→206, `git-workflow` 283→230.
+- **G-AGENTIC08 Scope erweitert:** von `--include=SKILL.md` auf alle `.md` der projekteigenen
+  Skills plus `references/`. Vorher blieben ausgelagerte Referenzdateien ungeprüft — genau die
+  Lücke, die dieser Change sonst vergrößert hätte. Vendor-Skills bleiben ausgenommen, weil ihre
+  relativen `scripts/`-Pfade skill-lokal korrekt sind und repo-relativ falsch gelesen würden.
+- Neue gemeinsame Hilfsfunktion `project_owned_skills()` im Kopf von `health-goals-check.sh`.
+- Nebenbefund, nicht gemessen: **sieben `description`-Frontmatter waren kein gültiges YAML**
+  (unquotierter `: ` im Plain-Scalar), davon fünf Vorbestand. Alle projekteigenen descriptions
+  sind jetzt gequotet; `brain-ingest` hatte überhaupt kein Frontmatter und war damit nie über
+  Intent-Matching erreichbar.

--- a/docs/superpowers/specs/2026-08-03-health-goals-entschlackung-design.md
+++ b/docs/superpowers/specs/2026-08-03-health-goals-entschlackung-design.md
@@ -1,0 +1,170 @@
+---
+title: Health Goals entschlacken und wahrheitsfähig machen
+ticket_id: T002598
+domains: [ci, docs, health-goals]
+status: approved
+date: 2026-08-03
+---
+
+# Health Goals entschlacken und wahrheitsfähig machen
+
+## Problem
+
+`.claude/lib/goals.md` führt **105 Ziele auf 987 Zeilen**. Die Datei spielt drei Rollen
+gleichzeitig — Ziel-Register (was gilt), Mess-Spezifikation (wie geprüft wird) und
+Änderungs-Chronik (was war). Daraus folgen drei Defekte:
+
+**1. 35 Ziele werden nie gemessen.** `scripts/health-goals-check.sh` ist eine handgeschriebene
+Liste von `row()`-Aufrufen und kennt nur 70 der 105 IDs. `scripts/gen-goals-data.mjs` misst
+nichts — es *parst* die Markdown-Datei fürs Dashboard. Ein Ziel ohne `row()`-Aufruf zeigt daher
+dauerhaft den Wert, den zuletzt jemand von Hand eingetragen hat. Niemand prüft, ob Register und
+Messung übereinstimmen; genau so sind die 35 entstanden. Präzedenzfall im Repo: G-CD01 zeigte auf
+einen gelöschten Workflow und lieferte falsches Grün, bis T001349 es korrigierte.
+
+**2. Die Chronik wächst monoton.** ~195 Zeilen `Baseline-Update`-Einträge plus eine 39-zeilige
+Ticket-Tabelle. Jeder Fix hängt einen Absatz an, keiner räumt einen ab.
+
+**3. Strukturelle Defekte.** Zwei doppelt geführte Ziele (`G-AGENTIC09`, `G-IMG01` stehen in
+Prio A/B *und* Prio C), eine Tabellenzeile ohne schließendes `|` (`G-SEC05`), eine Leerzeile
+*innerhalb* der Prio-C-Tabelle, die sie in zwei Renderings spaltet. Zusätzlich vergibt die
+SSOT-Spec `openspec/specs/health-goals.md` fünf REQ-IDs doppelt.
+
+## Ziel
+
+`goals.md` spielt nur noch **eine** Rolle: Ziel-Register. Messung liegt in `check.sh`, Chronik in
+`docs/health-goals-history.md`. Ein bidirektionaler Paritäts-Guard erzwingt, dass Register und
+Messung deckungsgleich bleiben.
+
+## Architektur
+
+```
+.claude/lib/goals.md          Register: WAS gilt (~450 statt 987 Zeilen)
+   │   ├─ Prio A/B: H2-Sektion je Ziel, Prosa auf "Was + Fallen" gekürzt
+   │   ├─ Prio C:   Tabelle, eine Zeile je Ziel
+   │   └─ Kopf:     **Zuletzt gemessen:** <ISO>   ← neu, gestempelt
+   │
+   ├──► docs/health-goals-history.md    Chronik: WAS WAR (voll, ab 2026-07-01)
+   │                                    goals.md behält die letzten 3 Einträge
+   │
+   └──◄ scripts/health-goals-check.sh   Messung: WIE geprüft wird
+            ▲
+            └─ tests/spec/health-goals/id-parity.bats  ← neu, bidirektional
+```
+
+Das Markdown-Format der Ziele bleibt **unverändert** — H2-Sektionen für Prio A/B, Tabellenzeilen
+für Prio C. Damit bleiben die vier Struktur-Tests in `tests/spec/health-goals.bats`
+(`:72`, `:99`, `:116`, `:138`) gültig und `gen-goals-data.mjs` braucht keinen Parser-Umbau.
+
+## Entscheidungen
+
+### Streich-Kriterium: Verletzbarkeit
+
+Ein Ziel überlebt nur, wenn sein Wert sich realistisch **verschlechtern kann** und die
+Verschlechterung jemanden zum Handeln zwingt. Vier Ziele fallen durch:
+
+| Ziel | Grund | Referenz-Risiko |
+|---|---|---|
+| `G-DOC04` ≥ 5 ADRs | Zahl kann strukturell nur steigen | nur Archiv-Dateien |
+| `G-DOC06` ≥ 30 Skill-Dateien | dito | keine |
+| `G-RH03` BATS/Spec-Quote | zählt `tests/spec/*.bats` **flach** und verfehlt seit T002416 die Unterverzeichnisse `tests/spec/<slug>/`; Target 23 % liegt zudem weit unter dem Ist | `coverage-gate.bats` nennt es nur in Titel und Kommentar — Streichung bricht ihn nicht |
+| `G-RH05` plan_staged idle > 14d | Ticket-Ops-Signal, kein Repo-Gesundheitswert; braucht DB-Zugriff | keine |
+
+`G-RH03` und `G-RH05` liegen in der als „stabile Anker" deklarierten Zone `G-RH01`–`G-RH07`. Die
+Konvention verbietet **Umnummerierung**, nicht Streichung — die verbleibenden Anker behalten ihre
+Nummern.
+
+### Die übrigen 31 werden verdrahtet, mit ehrlichem SKIP
+
+Der `row()`-Helfer in `check.sh` behandelt `actual="-"` bereits als SKIP (`n/a`, weder Grün noch
+Rot). Dieser Pfad wird konsequent genutzt — das ist der Unterschied zwischen „ungemessen und grün"
+und „ungemessen und sichtbar".
+
+| Klasse | Ziele | Verhalten |
+|---|---|---|
+| offline + schnell (18) | `G-CQ06` `G-DOC01` `G-TEST01` `G-TEST03` `G-TEST04` `G-SPEC01` `G-SPEC02` `G-SPEC03` `G-SEC02` `G-SEC03` `G-SEC04` `G-DEP03` `G-RH04` `G-RH07` `G-K8S01` `G-K8S02` `G-K8S03` `G-K8S04` | laufen immer |
+| netzabhängig (7) | `G-CI01` `G-CI02` `G-GIT01` `G-DEP05` `G-CD02` `G-RH06` `G-DORA02` | `gh` mit Timeout; nicht erreichbar → SKIP |
+| langsam (3) | `G-DEP01` `G-DEP02` `G-BRAIN14` | nur ohne `--fast` |
+| shallow-clone-anfällig (3) | `G-DORA01` `G-DORA03` `G-DORA04` | Guard auf `git rev-parse --is-shallow-repository` → sonst SKIP |
+
+**Ergebnis: 105 → 101 Ziele, 101/101 gemessen oder ehrlich als SKIP ausgewiesen.**
+
+### `measured_at` wird von der Chronik entkoppelt
+
+`gen-goals-data.mjs:132` leitet das Messdatum heute aus dem jüngsten `**Baseline-Update <datum>`-
+Marker der Changelog-Prosa ab, mit Fallback auf den statischen `Baseline-Stichtag`. Lagert man die
+Chronik aus, ohne das zu ändern, greift der Fallback — das Dashboard zeigt ein Monat altes
+Messdatum, und **nichts wird rot**. Das ist dieselbe Fehlerklasse, die T002162 gerade erst behoben
+hat.
+
+Deshalb bekommt `goals.md` ein explizites Kopf-Feld `**Zuletzt gemessen:** <ISO-Datum>`, das
+`health-goals-update.sh` bei jedem Lauf stempelt. Die Fallback-Kette wird: Feld →
+`Baseline-Stichtag` → `''`. Die beiden Tests `health-goals.bats:397` und `:425` werden auf das
+neue Feld umgeschrieben.
+
+### Prosa-Regel: Historie raus, Fallen bleiben
+
+Entfernt wird, was erzählt **wie es dazu kam** („Warum verschärft", „Warum von 250 auf 400
+gelockert"). Es bleibt: was gemessen wird, der Befehl, die Meta-Zeile — und jede Warnung, die vor
+einem konkreten Fehler schützt. Die Meta-Zeile trägt neu ein `**Historie:** [T00…]`-Feld, das in
+die ausgelagerte Chronik zeigt.
+
+Beispiel `G-AGENTIC09`: 42 → ~16 Zeilen. Die Warnung „die Schwelle steht nur hier und in
+`health-goals-check.sh`, die BATS-Guards lesen sie von dort" **bleibt** — sie verhindert, dass
+jemand die Zahl an einer von mehreren Stellen ändert. Die Erzählung, warum sie erst 500, dann 250,
+dann 400 war, geht in die Chronik.
+
+## Guard gegen Wiederzuwachs
+
+`tests/spec/health-goals/id-parity.bats` (neue Datei nach der Verzeichniskonvention T002416),
+bidirektional:
+
+1. jede Ziel-ID in `goals.md` hat einen `row()`-Aufruf in `check.sh`
+2. jeder `row()`-Aufruf in `check.sh` ist in `goals.md` dokumentiert
+3. `goals.md` enthält höchstens 5 `Baseline-Update`-Einträge (Kappungsregel)
+
+**Positiv-Anker-Pflicht (T002356-M1):** Jeder dieser Negativtests prüft *zuerst*, dass die
+ID-Extraktion überhaupt eine bekannte ID findet. Ohne diesen Anker meldet „keine Differenz"
+trivial grün, sobald die Extraktion bricht.
+
+**Die ID-Regex MUSS `G-[A-Z0-9]+` sein**, nicht `G-[A-Z]+[0-9]+`. Letztere zerschneidet `G-E2E01`
+zu `G-E2` und übersieht `G-K8S01`–`04` vollständig. Dieser Fehler ist bei der Analyse dieses
+Vorhabens real passiert und verfälschte die gemessene Drift von 35 auf 31 — die Regex sah plausibel
+aus, erfasste still die falsche Menge und fiel nicht auf. Das ist exakt der Fehlertyp, den dieses
+Vorhaben behebt.
+
+## Fehlerbehandlung
+
+| Fall | Verhalten |
+|---|---|
+| `gh` nicht erreichbar | SKIP mit `n/a` — kein Grün, kein Rot |
+| Shallow Clone | DORA-Ziele SKIP mit Notiz |
+| `goals.md` nennt ID ohne `row()` | CI rot (Paritäts-Guard) |
+| `check.sh` misst ID ohne Doku | CI rot (Paritäts-Guard) |
+| Chronik in `goals.md` > 5 Einträge | CI rot (Kappungs-Guard) |
+
+## Mitgeführte Nebenbefunde
+
+Im selben Zug, weil dieselben Dateien betroffen sind:
+
+- `goals.md` `G-SEC05`-Zeile: fehlendes schließendes `|`
+- `goals.md`: Leerzeile innerhalb der Prio-C-Tabelle
+- `openspec/specs/health-goals.md`: `REQ-HEALTH-GOALS-002/003/005/006/007` sind je zweimal
+  vergeben — zehn Requirements auf fünf IDs. Eine Delta-Spec kann sonst kein eindeutiges Ziel
+  referenzieren.
+
+## Nicht in Scope
+
+Die **70 bereits gemessenen** Ziele gegen dasselbe Verletzbarkeits-Kriterium prüfen. Erwartete
+Kandidaten: `G-SIZE03` (311 ≤ 3000, Reserve 2689), `G-CQ02` (0 ≤ 280), `G-TEST05` (86 % ≥ 60 %) —
+Ziele, deren Target so weit entfernt liegt, dass sie praktisch nie auslösen. Bewusst als
+Folge-Option zurückgestellt, weil jedes eine Einzelbewertung braucht.
+
+## Abgrenzung zu T002440
+
+Epic T002440 (FREEZE via `readiness.factory_excluded=true`) verfolgt die **Gegenrichtung**: es fügte
+drei Zielfamilien hinzu (`G-IF`, `G-LLM`, `G-WT`, alle inzwischen in `goals.md`), weil die Frage war,
+wo das System *nicht hinsieht*. Dieses Vorhaben fragt, wo es *lügt*. Beides ist verteidigbar; sie
+kollidieren aber im selben Dokument. T002440 bleibt eingefroren, dieses Ticket läuft eigenständig.
+
+**Kollisionsrisiko:** Der offene Worktree `chore/zielfamilie-llm-stack-T002442` arbeitet ebenfalls
+an `goals.md`. Bei Merge-Konflikten gilt: beide Zielblöcke behalten, nicht eine Seite wählen.

--- a/openspec/specs/health-goals.md
+++ b/openspec/specs/health-goals.md
@@ -251,7 +251,7 @@ gateway is unreachable the script SHALL exit `0` with a warning (cron-friendly),
 
 <!-- merged from change delta health-goals.md (10c126152d2d) -->
 
-### Requirement: REQ-HEALTH-GOALS-005 — Scheduled Measurement of Goal Values
+### Requirement: REQ-HEALTH-GOALS-008 — Scheduled Measurement of Goal Values
 
 Die vier bestehenden Requirements dieser Spec beschreiben, wie Goal-Werte aus
 `.claude/lib/goals.md` **abgeleitet** werden (SSOT, Generator, Freshness-Gate, Fail-Loud) — aber
@@ -293,7 +293,7 @@ derives work from these values.
 
 ---
 
-### Requirement: REQ-HEALTH-GOALS-006 — Atomic Commit of SSOT and Generated Artifact
+### Requirement: REQ-HEALTH-GOALS-009 — Atomic Commit of SSOT and Generated Artifact
 
 Schreibt ein unbeaufsichtigter Workflow `.claude/lib/goals.md` fort, ohne
 `website/src/lib/goals-data.generated.json` im selben Commit nachzuziehen, entsteht auf `main` ein
@@ -321,28 +321,101 @@ trigger the website image build that delivers the new values to the dashboard.
 
 ---
 
-### Requirement: REQ-HEALTH-GOALS-007 — Measurement Date Reflects the Newest Update
+### Requirement: REQ-HEALTH-GOALS-010 — Measurement Date Comes From an Explicit Stamped Field
 
-Die `**Baseline-Update <datum>`-Marker in `.claude/lib/goals.md` stehen thematisch sortiert —
-Prio-A-Abschnitt oben, Prio-B/C-Historie unten — nicht chronologisch. Der letzte Marker in
-Dokument-Reihenfolge ist deshalb nicht der jüngste.
+Das Messdatum steht als eigenes Feld `**Zuletzt gemessen:** \`<ISO>\`` im Kopf von
+`.claude/lib/goals.md` und wird von `scripts/health-goals-update.sh` bei jedem Messlauf
+gestempelt — auch dann, wenn kein einziger Wert sich geändert hat. Ein Lauf mit stabilen Werten
+ist trotzdem eine frische Messung; an eine Wertänderung gekoppelt würde das Dashboard Stillstand
+wie Aktualität aussehen lassen.
 
-`scripts/gen-goals-data.mjs` SHALL derive the `measured_at` field from the newest
-`**Baseline-Update <date>` marker by date comparison, not from the last occurrence in document
-order. When no such marker exists, it SHALL fall back to the `Baseline-Stichtag` value.
+Vor T002598 wurde das Datum aus dem jüngsten `**Baseline-Update <datum>`-Marker der Chronik-Prosa
+abgeleitet. Seit die Chronik in `docs/health-goals-history.md` liegt, gibt es dort nichts mehr zu
+finden; die Ableitung wäre still auf den statischen `Baseline-Stichtag` zurückgefallen und hätte
+ein Monat altes Datum als aktuell ausgewiesen, ohne dass ein Gate rot wird.
 
-#### Scenario: T002162-E: das jüngste Datum gewinnt gegen die Dokument-Reihenfolge *(BATS)*
+`scripts/gen-goals-data.mjs` SHALL read `measured_at` from the explicit
+`**Zuletzt gemessen:** \`<ISO>\`` field. When that field is absent it SHALL fall back — in this
+order — to the newest `**Baseline-Update <date>` marker by date comparison (legacy path, kept so
+an un-migrated `goals.md` keeps working), then to the `Baseline-Stichtag` value.
 
-- **GIVEN** eine `goals.md` mit einem `**Baseline-Update 2026-07-25`-Marker oberhalb eines
-  `**Baseline-Update 2026-07-22`-Markers
+`scripts/health-goals-update.sh` SHALL stamp the field whenever it processed at least one measured
+value, and SHALL warn on stderr when the field is missing from the target file.
+
+#### Scenario: Das explizite Feld bestimmt measured_at *(BATS)*
+
+- **GIVEN** eine `goals.md` mit `**Zuletzt gemessen:** \`2026-08-03\``
 - **WHEN** `scripts/gen-goals-data.mjs` läuft
-- **THEN** tragen die erzeugten Einträge `measured_at: "2026-07-25"`
+- **THEN** tragen die erzeugten Einträge `measured_at: "2026-08-03"`
 
-#### Scenario: Ohne Update-Marker gilt der Baseline-Stichtag *(BATS)*
+#### Scenario: Das explizite Feld schlägt einen älteren Legacy-Marker *(BATS)*
 
-- **GIVEN** eine `goals.md` ohne jeden `**Baseline-Update`-Marker, aber mit
+- **GIVEN** eine `goals.md` mit `**Zuletzt gemessen:** \`2026-08-03\`` im Kopf und einem
+  `**Baseline-Update 2026-07-25`-Marker weiter unten
+- **WHEN** `scripts/gen-goals-data.mjs` läuft
+- **THEN** tragen die erzeugten Einträge `measured_at: "2026-08-03"`
+
+#### Scenario: Ohne Feld und ohne Marker gilt der Baseline-Stichtag *(BATS)*
+
+- **GIVEN** eine `goals.md` ohne das Feld und ohne jeden `**Baseline-Update`-Marker, aber mit
   `**Baseline-Stichtag:** \`2026-07-01\``
 - **WHEN** `scripts/gen-goals-data.mjs` läuft
 - **THEN** tragen die erzeugten Einträge `measured_at: "2026-07-01"`
+
+#### Scenario: Ein Messlauf ohne Wertänderung stempelt trotzdem *(BATS)*
+
+- **GIVEN** ein Messlauf, dessen Werte alle mit den dokumentierten übereinstimmen
+- **WHEN** `scripts/health-goals-update.sh` läuft
+- **THEN** ist `**Zuletzt gemessen:**` auf das Laufdatum aktualisiert
+
+---
+
+### Requirement: REQ-HEALTH-GOALS-011 — Register and Measurement Stay in Parity
+
+`.claude/lib/goals.md` ist das Register (welche Ziele gelten), `scripts/health-goals-check.sh` ist
+die Messung (wie sie geprüft werden). Bis T002598 prüfte niemand, ob beide dieselbe Menge führen —
+dadurch sammelten sich **35 Ziele** an, die dokumentiert waren, aber nie gemessen wurden. Sie
+zeigten dauerhaft den zuletzt von Hand eingetragenen Wert, weil `gen-goals-data.mjs` nichts misst,
+sondern `goals.md` parst. Ein Ziel ohne `row()`-Aufruf ist damit für immer grün.
+
+The test suite SHALL fail when a goal ID documented in `.claude/lib/goals.md` has no `row` call in
+`scripts/health-goals-check.sh`, and SHALL equally fail when a `row` call measures an ID that is not
+documented. Every such test SHALL carry a positive anchor asserting that the ID extraction found
+known anchors, so a broken extraction fails loudly instead of yielding two empty sets and a
+vacuously green comparison.
+
+Die ID-Regex SHALL be `G-[A-Z0-9]+`. Das Muster `G-[A-Z]+[0-9]+` zerschneidet IDs mit Ziffern im
+Präfix — `G-E2E01` wird zu `G-E2`, und `G-K8S01`–`04` fallen vollständig durch.
+
+`.claude/lib/goals.md` SHALL carry at most **5** `Baseline-Update` entries; older ones belong in
+`docs/health-goals-history.md`.
+
+Ein Ziel SHALL NOT gleichzeitig als H2-Sektion und als Prio-C-Tabellenzeile geführt werden — die
+Dublette erzeugt zwei Einträge im generierten Artefakt, von denen
+`scripts/health-goals-update.sh` nur einen fortschreibt.
+
+#### Scenario: Ein dokumentiertes Ziel ohne Messung schlägt fehl *(BATS)*
+
+- **GIVEN** eine Ziel-ID in `.claude/lib/goals.md` ohne `row`-Aufruf in `health-goals-check.sh`
+- **WHEN** `tests/spec/health-goals/id-parity.bats` läuft
+- **THEN** schlägt der Paritätstest fehl und nennt die betroffene ID
+
+#### Scenario: Eine Messung ohne Dokumentation schlägt fehl *(BATS)*
+
+- **GIVEN** einen `row`-Aufruf für eine ID, die in `goals.md` fehlt
+- **WHEN** `tests/spec/health-goals/id-parity.bats` läuft
+- **THEN** schlägt der Paritätstest in der Gegenrichtung fehl
+
+#### Scenario: Eine gebrochene ID-Extraktion meldet sich, statt still grün zu werden *(BATS)*
+
+- **GIVEN** ein Register, in dem der bekannte Anker `G-K8S01` nicht mehr gefunden wird
+- **WHEN** `tests/spec/health-goals/id-parity.bats` läuft
+- **THEN** schlägt der Positiv-Anker-Test fehl
+
+#### Scenario: Ein nicht ermittelbarer Messwert wird als SKIP ausgewiesen, nicht als 0 *(BATS)*
+
+- **GIVEN** eine Messung, deren Werkzeug fehlt oder deren Netzaufruf scheitert
+- **WHEN** `scripts/health-goals-check.sh` läuft
+- **THEN** meldet die Zeile `n/a` (SKIP) statt eines Zahlenwerts, und weder Grün noch Rot
 
 <!-- merged from change delta health-goals.md (a4a86ec5536e) -->

--- a/scripts/gen-goals-data.mjs
+++ b/scripts/gen-goals-data.mjs
@@ -123,18 +123,33 @@ function main() {
   const errors = [];
   const goals = [];
 
-  // Baseline-Update markers are ordered thematically in goals.md (Prio-A section
-  // first, Prio-B/C history further down), NOT chronologically — so the last match
-  // in document order is not the newest one. Take the maximum instead; ISO dates
-  // sort lexicographically in chronological order, so no Date parsing is needed.
-  // [T002162: every goal carried a four-day-old measured_at because the
-  // 2026-07-25 marker sits above the 2026-07-22 ones.]
+  // measured_at comes from an explicit header field that health-goals-update.sh
+  // stamps on every measurement run. [T002598]
+  //
+  // It used to be derived from the newest `**Baseline-Update <date>` marker in the
+  // changelog prose. That worked only as long as the changelog lived in goals.md.
+  // Once it moved to docs/health-goals-history.md the markers were gone, and the
+  // derivation would have fallen back to the static Baseline-Stichtag — serving a
+  // month-old date as the current measurement without turning anything red. The
+  // last remaining marker in the file sits inside a *goal's* prose (G-E2E02), so
+  // the fallback would not even have failed loudly; it would have picked an
+  // unrelated date by accident.
+  //
+  // The fallback chain stays for files that predate the field: explicit field →
+  // Baseline-Stichtag → empty. Legacy Baseline-Update markers are still honoured
+  // ahead of the Stichtag so an un-migrated goals.md keeps working, but the
+  // explicit field always wins. [T002162 fixed the ordering bug in that legacy
+  // path: markers are sorted thematically, not chronologically, so the maximum —
+  // not the last in document order — is the newest.]
+  const explicitMatch = content.match(/\*\*Zuletzt gemessen:\*\*\s*`([\d-]+)`/);
   const updateDates = [...content.matchAll(/\*\*Baseline-Update\s+(\d{4}-\d{2}-\d{2})/g)]
     .map(m => m[1]);
   const dateMatch = content.match(/\*\*Baseline-Stichtag:\*\*\s*`([\d-]+)`/);
-  const measuredAt = updateDates.length > 0
-    ? updateDates.reduce((newest, d) => (d > newest ? d : newest))
-    : (dateMatch ? dateMatch[1] : '');
+  const measuredAt = explicitMatch
+    ? explicitMatch[1]
+    : updateDates.length > 0
+      ? updateDates.reduce((newest, d) => (d > newest ? d : newest))
+      : (dateMatch ? dateMatch[1] : '');
 
   // --- 1. H2-section entries (Prio A/B) ---
   // Fenced code blocks can contain shell comment lines ("# ...") that look

--- a/scripts/health-goals-check.sh
+++ b/scripts/health-goals-check.sh
@@ -583,6 +583,202 @@ row target G-WT04 "$(wt_measure unsafe-worktrees)"    le 0 "Löschbereite Worktr
 row target G-WT05 "$(wt_measure main-divergence)"     le 0 "Lokaler main hinter origin/main (Commits)"
 row target G-WT06 "$(wt_measure phantom-scope-locks)" le 0 "Phantom-Scope-Locks (Scope leer oder mit '-' beginnend)"
 
+# ── Bis T002598 nur dokumentiert, nie gemessen ────────────────────────────────
+#
+# 31 Ziele standen in .claude/lib/goals.md mit einem grünen Häkchen, das niemand
+# nachrechnete: gen-goals-data.mjs misst nichts, es parst die Datei. Ein Ziel ohne
+# row()-Aufruf zeigt daher für immer den Wert, den zuletzt jemand von Hand eintrug.
+# Präzedenzfall G-CD01 — der Messbefehl zeigte auf einen gelöschten Workflow und
+# lieferte falsches Grün, bis T001349 es korrigierte.
+#
+# Grundregel für jede Messung hier: nicht ermittelbar ⇒ "-" ⇒ SKIP (n/a, weder grün
+# noch rot). Ein Fallback auf 0 wäre falsches Grün und damit genau der Defekt, den
+# dieser Block behebt.
+#
+# Der bidirektionale Guard tests/spec/health-goals/id-parity.bats hält goals.md und
+# diese Datei ab jetzt deckungsgleich.
+
+# --- Helfer: gh-abhängige Messungen ------------------------------------------
+# gh ist netzabhängig und kann hängen. Ohne Binary, ohne Auth oder bei Timeout gibt
+# es SKIP statt einer Zahl.
+_gh_ready() { command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; }
+gh_json() { # <timeout-s> <gh-args…> — leer bei jedem Fehlschlag
+  local t="$1"; shift
+  _gh_ready || return 1
+  timeout "$t" gh "$@" 2>/dev/null || return 1
+}
+
+# Erfolgsrate eines Workflows in % über die letzten N abgeschlossenen Läufe.
+wf_success_rate() { # <workflow> <limit>
+  [ "$FAST" = 1 ] && { echo "-"; return; }
+  local out; out=$(gh_json 60 run list --workflow "$1" --branch main --limit "$2" \
+    --json conclusion) || { echo "-"; return; }
+  python3 -c "
+import json,sys
+try: r=[x['conclusion'] for x in json.loads(sys.argv[1]) if x.get('conclusion')]
+except Exception: print('-'); raise SystemExit
+print(round(100*sum(1 for c in r if c=='success')/len(r)) if r else '-')
+" "$out" 2>/dev/null || echo "-"
+}
+
+# --- Helfer: Shallow-Clone-Guard für die DORA-Ziele ---------------------------
+# Auf einem Shallow Clone (CI-Default) liefert git log ein abgeschnittenes Fenster.
+# Eine Deployment-Frequenz aus 20 statt 200 Commits ist nicht "niedrig", sie ist
+# falsch — deshalb SKIP statt einer irreführenden Zahl.
+_git_full_history() { [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "false" ]; }
+
+dora_count() { # <since> <grep-pattern|-> — Commits auf main im Zeitfenster
+  _git_full_history || { echo "-"; return; }
+  local since="$1" pat="${2:--}"
+  if [ "$pat" = "-" ]; then
+    git log --since="$since" --first-parent --oneline main 2>/dev/null | wc -l | tr -d ' '
+  else
+    git log --since="$since" --first-parent --format='%s' main 2>/dev/null \
+      | grep -ciE "$pat" || echo 0
+  fi
+}
+
+# --- Helfer: Kubernetes-Manifest-Audit (offline, gegen k3d/*.yaml) ------------
+k8s_audit() { # <limits|readiness|security> — Deployments, denen das Feld fehlt
+  python3 - "$1" <<'PY' 2>/dev/null || echo "-"
+import glob, sys, yaml
+what = sys.argv[1]
+missing = 0
+for path in sorted(glob.glob('k3d/*.yaml')):
+    try:
+        with open(path) as fh:
+            docs = list(yaml.safe_load_all(fh))
+    except Exception:
+        # Ein unparsbares Manifest darf nicht als "alles in Ordnung" durchgehen.
+        # Es zaehlt als Fund, damit der Fehler sichtbar wird statt zu verschwinden.
+        missing += 1
+        continue
+    for d in docs:
+        if not isinstance(d, dict) or d.get('kind') != 'Deployment':
+            continue
+        spec = (d.get('spec') or {}).get('template', {}).get('spec', {}) or {}
+        containers = spec.get('containers') or []
+        if not containers:
+            missing += 1
+            continue
+        for c in containers:
+            if what == 'limits':
+                if not (c.get('resources') or {}).get('limits'):
+                    missing += 1; break
+            elif what == 'readiness':
+                if not c.get('readinessProbe'):
+                    missing += 1; break
+            elif what == 'security':
+                if not c.get('securityContext') and not spec.get('securityContext'):
+                    missing += 1; break
+print(missing)
+PY
+}
+
+# --- Helfer: Exit-Code eines Kommandos als Messwert ---------------------------
+# Fehlt das Werkzeug, ist der Exit-Code keine Aussage ueber das Repo — dann SKIP.
+exit_code_of() { # <cmd> [args…]
+  command -v "$1" >/dev/null 2>&1 || { echo "-"; return; }
+  "$@" >/dev/null 2>&1; echo $?
+}
+exit_code_of_script() { # <script-pfad> [args…]
+  [ -f "$1" ] || { echo "-"; return; }
+  bash "$@" >/dev/null 2>&1; echo $?
+}
+
+# --- Offline + schnell (18) ---------------------------------------------------
+row target G-CQ06  "$(grep -rnE '@deprecated' website/src 2>/dev/null | wc -l | tr -d ' ')" le 1 "@deprecated-Symbole in website/src"
+# grep -c druckt bei null Treffern "0" und exitet trotzdem 1 — ein `|| echo 0`
+# haengt deshalb eine zweite Zeile an und macht aus dem gueltigen Wert "0" den
+# ungueltigen Wert "0\n0". Nur den Exit abfangen, nie die Ausgabe ersetzen.
+row gate   G-TEST01 "$(grep -rniE "skip [\"']" tests --include='*.bats' 2>/dev/null | grep -ciE 'pending|todo|WP-|disabled' || true)" eq 0 "BATS Debt-Skips (pending/todo/WP-/disabled)"
+row target G-TEST03 "$(grep -rnE '(describe|it|test)\.(skip|todo)\b' website/src --include='*.ts' 2>/dev/null | wc -l | tr -d ' ')" le 1 "Vitest Skipped/Todo-Suiten (Ist 1 bei Aufnahme T002598)"
+row gate   G-TEST04 "$(git status --porcelain website/src/data/test-inventory.json 2>/dev/null | wc -l | tr -d ' ')" eq 0 "Test-Inventory-Drift (uncommitted)"
+row gate   G-SPEC01 "$(exit_code_of_script scripts/openspec.sh validate)" eq 0 "openspec validate (Exit)"
+row gate   G-SPEC02 "$(c=0; cutoff=$(( $(date +%s) - 30*86400 )); for d in openspec/changes/*/; do [ -d "$d" ] || continue; case "$d" in *archive*) continue;; esac; ts=$(git log -1 --format=%at -- "$d" 2>/dev/null); [ -n "$ts" ] && [ "$ts" -lt "$cutoff" ] && c=$((c+1)); done; echo $c)" eq 0 "OpenSpec-Changes ohne Aktivitaet >30 Tage"
+row target G-SPEC03 "$(m=0; for d in openspec/changes/*/; do [ -d "$d" ] || continue; case "$d" in *archive*) continue;; esac; [ -f "$d/.ticket" ] || m=$((m+1)); done; echo $m)" le 41 "Proposals ohne .ticket-Verknuepfung (Ist 41 bei Aufnahme T002598)"
+row gate   G-SEC02 "$(exit_code_of_script scripts/git-crypt-guard.sh check-tracked)" eq 0 "git-crypt Guard (Exit)"
+row target G-SEC03 "$(ts=$(git log -1 --format=%at -- environments/sealed-secrets/*.yaml 2>/dev/null); [ -n "$ts" ] && echo $(( ( $(date +%s) - ts ) / 86400 )) || echo '-')" le 90 "Tage seit letzter SealedSecret-Rotation"
+row target G-SEC04 "$(min=''; for p in environments/certs/*.pem; do [ -f "$p" ] || continue; e=$(openssl x509 -enddate -noout -in "$p" 2>/dev/null | cut -d= -f2); [ -n "$e" ] || continue; d=$(( ( $(date -d "$e" +%s 2>/dev/null || echo 0) - $(date +%s) ) / 86400 )); { [ -z "$min" ] || [ "$d" -lt "$min" ]; } && min=$d; done; echo "${min:--}")" ge 30 "Sealing-Cert Restlaufzeit (Tage, Minimum)"
+row gate   G-DEP03 "$(grep -q 'npm ci' website/Dockerfile 2>/dev/null && echo 1 || echo 0)" eq 0 "PM-Konsistenz: npm ci in website/Dockerfile (0=nur pnpm)"
+row gate   G-RH04 "$(cutoff=$(( $(date +%s) - 30*86400 )); git for-each-ref --format='%(refname:short) %(committerdate:unix)' refs/remotes/origin 2>/dev/null | while read -r b ts; do case "$b" in origin/HEAD|origin/main) continue;; esac; [ -n "$ts" ] && [ "$ts" -lt "$cutoff" ] && echo "$b"; done | wc -l | tr -d ' ')" eq 0 "Stale Remote Branches (>30d)"
+row gate   G-RH07 "$([ "$FAST" = 1 ] && echo '-' || exit_code_of task freshness:check)" eq 0 "Freshness-Check (Exit)"
+row gate   G-K8S01 "$(k8s_audit limits)"     eq 0 "Deployments ohne resources.limits"
+row target G-K8S02 "$(k8s_audit readiness)"  le 3 "Deployments ohne readinessProbe"
+row gate   G-K8S03 "$(k8s_audit security)"   eq 0 "Deployments ohne securityContext"
+row gate   G-K8S04 "$([ "$FAST" = 1 ] && echo '-' || exit_code_of task workspace:validate)" eq 0 "workspace:validate (Exit)"
+
+# --- Netzabhängig: gh mit Timeout, sonst SKIP (7) -----------------------------
+row target G-CI01 "$(wf_success_rate ci.yml 20)" ge 95 "main CI-Erfolgsrate (%, letzte 20)"
+row gate   G-CI02 "$([ "$FAST" = 1 ] && echo '-' || { o=$(gh_json 60 run list --workflow ci.yml --branch main --limit 5 --json conclusion) && python3 -c "
+import json,sys
+try: print(sum(1 for x in json.loads(sys.argv[1]) if x.get('conclusion')=='failure'))
+except Exception: print('-')
+" "$o" || echo '-'; })" eq 0 "Rote main-HEAD-Laeufe (letzte 5)"
+row gate   G-GIT01 "$([ "$FAST" = 1 ] && echo '-' || { o=$(gh_json 60 pr list --state open --json createdAt) && python3 -c "
+import json,sys,datetime
+try:
+    now=datetime.datetime.now(datetime.timezone.utc)
+    n=sum(1 for x in json.loads(sys.argv[1])
+          if (now-datetime.datetime.fromisoformat(x['createdAt'].replace('Z','+00:00'))).days>7)
+    print(n)
+except Exception: print('-')
+" "$o" || echo '-'; })" eq 0 "Offene PRs aelter als 7 Tage"
+row target G-DEP05 "$([ "$FAST" = 1 ] && echo '-' || { o=$(gh_json 60 pr list --state open --json author) && python3 -c "
+import json,sys
+try: print(sum(1 for x in json.loads(sys.argv[1]) if 'renovate' in (x.get('author') or {}).get('login','').lower()))
+except Exception: print('-')
+" "$o" || echo '-'; })" le 3 "Renovate-PR-Backlog"
+row target G-CD02 "$(wf_success_rate post-merge.yml 15)" ge 95 "post-merge.yml-Erfolgsrate (%, letzte 15)"
+row gate   G-RH06 "$([ "$FAST" = 1 ] && echo '-' || { o=$(gh_json 60 issue list --label sentinel --state open --json createdAt) && python3 -c "
+import json,sys,datetime
+try:
+    now=datetime.datetime.now(datetime.timezone.utc)
+    print(sum(1 for x in json.loads(sys.argv[1])
+          if (now-datetime.datetime.fromisoformat(x['createdAt'].replace('Z','+00:00'))).total_seconds()>48*3600))
+except Exception: print('-')
+" "$o" || echo '-'; })" eq 0 "Offene Sentinel-Issues aelter als 48h"
+row target G-DORA02 "$([ "$FAST" = 1 ] && echo '-' || { o=$(gh_json 90 pr list --state merged --limit 30 --json createdAt,mergedAt) && python3 -c "
+import json,sys,datetime,statistics
+def p(s): return datetime.datetime.fromisoformat(s.replace('Z','+00:00'))
+try:
+    h=[(p(x['mergedAt'])-p(x['createdAt'])).total_seconds()/3600
+       for x in json.loads(sys.argv[1]) if x.get('mergedAt') and x.get('createdAt')]
+    print(round(statistics.median(h)) if h else '-')
+except Exception: print('-')
+" "$o" || echo '-'; })" le 1 "DORA Lead Time PR→Merge (Median, Stunden)"
+
+# --- Langsam: nur ohne --fast (3) ---------------------------------------------
+row gate   G-DEP01 "$([ "$FAST" = 1 ] && echo '-' || { [ -d website/node_modules ] && (cd website && timeout 180 pnpm audit --json 2>/dev/null | python3 -c "
+import json,sys
+n=0
+for line in sys.stdin:
+    line=line.strip()
+    if not line: continue
+    try: o=json.loads(line)
+    except Exception: continue
+    sev=(o.get('advisory') or {}).get('severity') or o.get('severity')
+    if sev in ('high','critical'): n+=1
+print(n)
+" ) || echo '-'; })" eq 0 "High/Critical npm-Vulnerabilities"
+row target G-DEP02 "$([ "$FAST" = 1 ] && echo '-' || { [ -d website/node_modules ] && (cd website && timeout 180 pnpm outdated --format json 2>/dev/null | python3 -c "
+import json,sys
+try: d=json.load(sys.stdin)
+except Exception: print('-'); raise SystemExit
+n=0
+for _,v in (d or {}).items():
+    cur=str(v.get('current','')).lstrip('^~').split('.')[0]
+    lat=str(v.get('latest','')).lstrip('^~').split('.')[0]
+    if cur.isdigit() and lat.isdigit() and int(lat)>int(cur): n+=1
+print(n)
+" ) || echo '-'; })" le 3 "Veraltete Major-Dependencies"
+row gate   G-BRAIN14 "$([ "$FAST" = 1 ] && echo '-' || { [ -f scripts/brain-ingest-worklist.sh ] && timeout 120 bash scripts/brain-ingest-worklist.sh 2>/dev/null | grep -c . || echo '-'; })" eq 0 "Brain-Ingest-Backlog (offene Seiten)"
+
+# --- DORA aus lokaler Git-History, Shallow-Clone-geschützt (3) -----------------
+row target G-DORA01 "$(dora_count '4 weeks ago')" ge 5 "DORA Deployment Frequency (main-Merges/4 Wochen)"
+row target G-DORA03 "$(t=$(dora_count '8 weeks ago'); f=$(dora_count '8 weeks ago' '^(fix|revert)'); { [ "$t" = "-" ] || [ "$f" = "-" ] || [ "$t" -eq 0 ]; } && echo '-' || echo $(( f * 100 / t )))" le 15 "DORA Change Failure Rate (fix/revert-Anteil in %)"
+row target G-DORA04 "$(dora_count '8 weeks ago' 'revert|hotfix')" le 5 "DORA MTTR-Proxy (revert/hotfix-Commits in 8 Wochen)"
+
 # ── Zusammenfassung ────────────────────────────────────────────────────────────
 TOTAL=$((PASS+OPEN+GATEFAIL+SKIP))
 printf "\n%s──────────────────────────────────────────%s\n" "$C_D" "$C_X"

--- a/scripts/health-goals-update.sh
+++ b/scripts/health-goals-update.sh
@@ -146,6 +146,8 @@ for t in data:
 fi
 
 python3 - "$GOALS_FILE" "$VALUES_FILE" "$DRY_RUN" "$SUGGEST_TICKETS" "$EXISTING_GOAL_IDS_FILE" <<'PY'
+import datetime
+import os
 import re
 import sys
 
@@ -317,10 +319,44 @@ else:
         for gid in skipped_dup:
             print(f"    {gid}")
 
-if changed and not dry_run:
+# --- measured_at stempeln [T002598] -------------------------------------------
+# gen-goals-data.mjs liest das Messdatum aus dem Kopf-Feld "**Zuletzt gemessen:**".
+# Vorher leitete es das Datum aus dem jüngsten "Baseline-Update"-Marker der Chronik-
+# Prosa ab; seit die Chronik in docs/health-goals-history.md liegt, gibt es dort
+# nichts mehr zu finden und der Parser wäre still auf den statischen
+# Baseline-Stichtag zurückgefallen.
+#
+# Der Stempel hängt an "wurde gemessen", NICHT an "hat sich ein Wert geändert":
+# ein Messlauf, bei dem alle Werte gleich bleiben, ist trotzdem eine frische
+# Messung. An `changed` gekoppelt würde das Dashboard nach einem stabilen Lauf ein
+# altes Datum ausweisen und Stillstand wie Aktualität aussehen lassen.
+measured_any = bool(values)
+stamp_changed = False
+if measured_any:
+    today = os.environ.get("HG_MEASURED_AT") or datetime.date.today().isoformat()
+    stamp_re = re.compile(r"(\*\*Zuletzt gemessen:\*\*\s*`)([\d-]*)(`)")
+    for i, line in enumerate(lines):
+        m = stamp_re.search(line)
+        if m:
+            if m.group(2) != today:
+                lines[i] = stamp_re.sub(rf"\g<1>{today}\g<3>", line, count=1)
+                stamp_changed = True
+                print(f"\n  Zuletzt gemessen: {m.group(2) or '(leer)'} → {today}")
+            break
+    else:
+        print(
+            "\n⚠ Kopf-Feld '**Zuletzt gemessen:** `…`' fehlt in "
+            f"{goals_file} — gen-goals-data.mjs fällt auf den statischen "
+            "Baseline-Stichtag zurück und weist ein veraltetes Messdatum als "
+            "aktuell aus. Feld im Kopf der Datei ergänzen. [T002598]",
+            file=sys.stderr,
+        )
+
+write_needed = changed or stamp_changed
+if write_needed and not dry_run:
     with open(goals_file, "w") as f:
         f.writelines(lines)
     print(f"\n{goals_file} geschrieben — Narrative (Sprint-Highlights, Baseline-Update) bleibt manuell.")
-elif changed and dry_run:
+elif write_needed and dry_run:
     print("\n--dry-run: Datei nicht geschrieben.")
 PY

--- a/tests/spec/health-goals/id-parity.bats
+++ b/tests/spec/health-goals/id-parity.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+# SSOT: openspec/specs/health-goals.md
+#
+# Prüfmodus: **Output-Verifikation** [T002448-M4]. Die Tests führen die ID-Extraktion
+# tatsächlich aus und vergleichen die resultierenden Mengen; sie greppen nicht nach
+# Implementierungsmustern im Quelltext.
+#
+# Warum es diese Datei gibt [T002598]:
+# .claude/lib/goals.md ist das Register (welche Ziele gelten),
+# scripts/health-goals-check.sh ist die Messung (wie sie geprüft werden).
+# Niemand prüfte, ob beide dieselbe Menge führen — dadurch sammelten sich 35 Ziele
+# an, die dokumentiert waren, aber nie gemessen wurden. Sie zeigten dauerhaft den
+# Wert, den zuletzt jemand von Hand eintrug: gen-goals-data.mjs misst nichts, es
+# parst goals.md. Ein Ziel ohne row()-Aufruf ist damit für immer grün.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  GOALS_MD="$REPO_ROOT/.claude/lib/goals.md"
+  CHECK_SH="$REPO_ROOT/scripts/health-goals-check.sh"
+}
+
+# Ziel-IDs aus dem Register: H2-Sektionen (Prio A/B) + Tabellenzeilen (Prio C).
+#
+# Die Regex ist G-[A-Z0-9]+ und NICHT G-[A-Z]+[0-9]+. Letztere zerschneidet IDs mit
+# Ziffern im Präfix: aus G-E2E01 wird "G-E2", und G-K8S01..04 fallen komplett durch.
+# Genau dieser Fehler ist bei der Analyse zu T002598 passiert und verfälschte die
+# gemessene Drift von 35 auf 31 — die Regex sah plausibel aus und erfasste still die
+# falsche Menge.
+documented_ids() {
+  {
+    grep -oE '^## G-[A-Z0-9]+' "$GOALS_MD" | sed 's/^## //'
+    grep -oE '^\| \*\*G-[A-Z0-9]+\*\*' "$GOALS_MD" | grep -oE 'G-[A-Z0-9]+'
+  } | sort -u
+}
+
+# Gemessene IDs: jeder row-Aufruf in check.sh.
+#
+# `row` steht nicht immer am Zeilenanfang — G-CFG01 folgt einem `;` auf derselben
+# Zeile, und vier weitere (G-FE05, G-SEC06, G-TEST05, G-CFG01) stehen eingerückt in
+# if/else-Zweigen. Ein auf '^row' verankerter Ausdruck übersieht sie und meldet eine
+# Differenz, die es nicht gibt. Deshalb wortgebunden statt zeilenverankert.
+measured_ids() {
+  grep -oE '\brow +(gate|target) +G-[A-Z0-9]+' "$CHECK_SH" \
+    | grep -oE 'G-[A-Z0-9]+' | sort -u
+}
+
+@test "ID-Extraktion findet die bekannten Anker in beiden Quellen (Positiv-Anker)" {
+  # Pflicht-Vorbedingung für die beiden Paritätstests [T002356-M1]: bricht die
+  # Extraktion, sind beide Mengen leer, jede Differenz ist leer und "keine
+  # Abweichung" gilt trivial. Dieser Test schlägt dann als einziger fehl und zeigt
+  # die Ursache, statt die Paritätstests still grün werden zu lassen.
+  local doc meas
+  doc="$(documented_ids)"
+  meas="$(measured_ids)"
+
+  [ "$(printf '%s\n' "$doc"  | grep -c .)" -gt 50 ]
+  [ "$(printf '%s\n' "$meas" | grep -c .)" -gt 50 ]
+
+  # G-RH01 ist ein stabiler Anker (goals.md deklariert G-RH01..G-RH07 als solche)
+  printf '%s\n' "$doc"  | grep -qx 'G-RH01'
+  printf '%s\n' "$meas" | grep -qx 'G-RH01'
+
+  # Eine ID mit Ziffer im Präfix MUSS erhalten bleiben — sonst ist die Regex
+  # wieder auf das G-[A-Z]+[0-9]+-Muster zurückgefallen.
+  printf '%s\n' "$doc"  | grep -qx 'G-K8S01'
+  printf '%s\n' "$meas" | grep -qx 'G-K8S01'
+  printf '%s\n' "$doc"  | grep -qx 'G-E2E01'
+  printf '%s\n' "$meas" | grep -qx 'G-E2E01'
+}
+
+@test "jede in goals.md dokumentierte Ziel-ID wird von health-goals-check.sh gemessen" {
+  local only_documented
+  only_documented="$(comm -23 <(documented_ids) <(measured_ids))"
+  if [ -n "$only_documented" ]; then
+    echo "Dokumentiert, aber nie gemessen — diese Ziele zeigen dauerhaft einen"
+    echo "handgeschriebenen Wert, den niemand nachrechnet:"
+    echo "$only_documented"
+    echo
+    echo "Entweder einen row-Aufruf in scripts/health-goals-check.sh ergänzen"
+    echo "oder das Ziel aus .claude/lib/goals.md entfernen."
+    return 1
+  fi
+}
+
+@test "jede von health-goals-check.sh gemessene Ziel-ID ist in goals.md dokumentiert" {
+  local only_measured
+  only_measured="$(comm -13 <(documented_ids) <(measured_ids))"
+  if [ -n "$only_measured" ]; then
+    echo "Gemessen, aber nicht dokumentiert — der Wert taucht im Ampel-Report auf,"
+    echo "aber weder im Register noch auf dem Dashboard:"
+    echo "$only_measured"
+    echo
+    echo "Ziel in .claude/lib/goals.md ergänzen oder den row-Aufruf entfernen."
+    return 1
+  fi
+}
+
+@test "goals.md führt höchstens 5 Baseline-Update-Einträge (Kappungsregel)" {
+  # Ohne Kappung wächst das Register monoton: jeder Fix hängt einen Absatz an,
+  # keiner räumt einen ab. Bei der Auslagerung in T002598 waren es 195 Zeilen
+  # Chronik in einer 987-Zeilen-Datei.
+  local count
+  count="$(grep -c '^\*\*Baseline-Update' "$GOALS_MD" || true)"
+
+  # Positiv-Anker: mindestens ein Eintrag MUSS vorhanden sein. Sonst besteht der
+  # Test auch dann, wenn das Marker-Format geändert wurde und die Zählung ins
+  # Leere greift — dann wäre "0 ≤ 5" ein Scheinerfolg.
+  [ "$count" -ge 1 ]
+  [ "$count" -le 5 ]
+}
+
+@test "die ausgelagerte Chronik existiert und ist von goals.md aus verlinkt" {
+  [ -f "$REPO_ROOT/docs/health-goals-history.md" ]
+  # Positiv-Anker: die Chronik trägt tatsächlich Einträge, ist also nicht nur ein
+  # leerer Platzhalter, der die Kappungsregel formal erfüllt.
+  [ "$(grep -c '^\*\*Baseline-Update' "$REPO_ROOT/docs/health-goals-history.md" || true)" -ge 5 ]
+  grep -q 'health-goals-history.md' "$GOALS_MD"
+}
+
+@test "kein Ziel steht gleichzeitig als H2-Sektion und als Prio-C-Tabellenzeile" {
+  # Eine Dublette erzeugt zwei Einträge im generierten Dashboard-Artefakt und lässt
+  # health-goals-update.sh nur einen davon fortschreiben — der andere friert ein.
+  local h2 prio_c dup
+  h2="$(grep -oE '^## G-[A-Z0-9]+' "$GOALS_MD" | sed 's/^## //' | sort -u)"
+  prio_c="$(grep -oE '^\| \*\*G-[A-Z0-9]+\*\*' "$GOALS_MD" | grep -oE 'G-[A-Z0-9]+' | sort -u)"
+
+  # Positiv-Anker: beide Mengen sind nicht leer, sonst ist die Schnittmenge
+  # trivial leer und der Test vakuos.
+  [ "$(printf '%s\n' "$h2"     | grep -c .)" -ge 5 ]
+  [ "$(printf '%s\n' "$prio_c" | grep -c .)" -ge 20 ]
+
+  dup="$(comm -12 <(printf '%s\n' "$h2") <(printf '%s\n' "$prio_c"))"
+  if [ -n "$dup" ]; then
+    echo "Doppelt geführt (H2-Sektion UND Prio-C-Zeile):"
+    echo "$dup"
+    return 1
+  fi
+}

--- a/tests/spec/health-goals/measured-at-field.bats
+++ b/tests/spec/health-goals/measured-at-field.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# SSOT: openspec/specs/health-goals.md
+#
+# Prüfmodus: **Output-Verifikation** [T002448-M4]. Die Tests rufen gen-goals-data.mjs
+# bzw. den Update-Pfad tatsächlich auf und prüfen das erzeugte Artefakt.
+#
+# T002598: measured_at kommt aus dem expliziten Kopf-Feld "**Zuletzt gemessen:**",
+# nicht mehr aus dem jüngsten Baseline-Update-Marker der Chronik-Prosa. Nach der
+# Auslagerung der Chronik nach docs/health-goals-history.md gäbe es dort nichts mehr
+# zu finden, und der Parser wäre still auf den statischen Baseline-Stichtag
+# zurückgefallen — ein Monat altes Datum, als aktuell ausgewiesen, ohne dass
+# irgendetwas rot wird.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  TMP="$BATS_TEST_TMPDIR/goals.md"
+}
+
+# Minimales, aber für den fail-loud-Parser vollständiges Register.
+write_goals() { # $1 = Kopfzeile mit den Datumsfeldern
+  cat > "$TMP" <<EOF
+# Repository Health Goals
+
+$1
+
+# Priorität A — Aktive Defekte {#prio-a}
+
+## G-RH01 — Gate-Violations: 8 → 0
+
+**Was:** Platzhalter für den Parser-Test.
+
+\`\`\`bash
+echo 0
+\`\`\`
+
+> **A · Baseline:** 8 · **Target:** 0 · **Aufwand:** gering · **Messzyklus:** wöchentlich · **Reproduzierbar:** ja
+
+# Priorität C — Green Gates {#prio-c}
+
+| ID | Ziel | Aktuell | Target | Basis-Messung |
+|----|------|---------|--------|---------------|
+| **G-RH02** | TypeScript-Suppressionen | 0 ✓ | 0 | \`echo 0\` |
+EOF
+}
+
+# gen-goals-data.mjs wird ueber GOALS_MD_PATH/GOALS_JSON_OUT parametriert (keine
+# CLI-Flags) — dieselbe Aufrufform nutzen die bestehenden Tests in
+# tests/spec/health-goals.bats.
+measured_at_of() {
+  local out="$BATS_TEST_TMPDIR/goals-data.json"
+  GOALS_MD_PATH="$TMP" GOALS_JSON_OUT="$out" \
+    node "$REPO_ROOT/scripts/gen-goals-data.mjs" >/dev/null 2>&1 || return 1
+  node -e "
+const a=require(process.argv[1]);
+const g=Array.isArray(a)?a:(a.goals||[]);
+console.log(g.length?g[0].measured_at:'');
+" "$out"
+}
+
+@test "das explizite Feld 'Zuletzt gemessen' bestimmt measured_at" {
+  write_goals '**Baseline-Stichtag:** `2026-07-01` · **Zuletzt gemessen:** `2026-08-03` · **Dashboard:** `#health`'
+  run measured_at_of
+  [ "$status" -eq 0 ]
+  [ "$output" = "2026-08-03" ]
+}
+
+@test "das explizite Feld gewinnt gegen einen aelteren Baseline-Update-Marker" {
+  # Positiv-Anker: ohne das explizite Feld MUSS der Marker gewinnen — sonst prueft
+  # der Test nur, dass irgendein Datum herauskommt, und die Vorrang-Aussage waere
+  # vakuos.
+  write_goals '**Baseline-Stichtag:** `2026-07-01` · **Dashboard:** `#health`'
+  printf '\n**Baseline-Update 2026-07-25:** Legacy-Pfad.\n' >> "$TMP"
+  run measured_at_of
+  [ "$output" = "2026-07-25" ]
+
+  # Jetzt mit explizitem Feld: es muss den Marker schlagen, obwohl der Marker
+  # spaeter im Dokument steht.
+  write_goals '**Baseline-Stichtag:** `2026-07-01` · **Zuletzt gemessen:** `2026-08-03` · **Dashboard:** `#health`'
+  printf '\n**Baseline-Update 2026-07-25:** Legacy-Pfad.\n' >> "$TMP"
+  run measured_at_of
+  [ "$output" = "2026-08-03" ]
+}
+
+@test "ohne Feld und ohne Marker faellt measured_at auf den Baseline-Stichtag zurueck" {
+  write_goals '**Baseline-Stichtag:** `2026-07-01` · **Dashboard:** `#health`'
+  run measured_at_of
+  [ "$output" = "2026-07-01" ]
+}
+
+@test "das ausgelieferte goals.md traegt das Feld" {
+  # Der eigentliche Regressionsschutz: fehlt das Feld im echten Register, greift
+  # der Fallback auf den statischen Stichtag und das Dashboard weist ein veraltetes
+  # Messdatum als aktuell aus.
+  run grep -c '\*\*Zuletzt gemessen:\*\* `[0-9][0-9-]*`' "$REPO_ROOT/.claude/lib/goals.md"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "health-goals-update.sh stempelt das Feld bei jedem Messlauf" {
+  # Output-Verifikation: das Skript wird ausgefuehrt und das Ergebnis geprueft.
+  # Der Stempel haengt an "wurde gemessen", NICHT an "hat sich ein Wert geaendert" —
+  # ein Lauf mit unveraenderten Werten ist trotzdem eine frische Messung.
+  cp "$REPO_ROOT/.claude/lib/goals.md" "$TMP"
+  local vals="$BATS_TEST_TMPDIR/values.txt"
+  # G-RH02 steht als Prio-C-Zeile im echten Register und ist auf Target — der Lauf
+  # aendert also keinen Wert. Genau das ist der interessante Fall.
+  printf 'G-RH02 0 eq 0\n' > "$vals"
+
+  # HG_VALUES_FILE liefert die Messwerte vorgefertigt an; damit ueberspringt
+  # health-goals-update.sh den eigenen health-goals-check.sh-Lauf. Ohne das wuerde
+  # der Test die vollstaendige Messung ausloesen (gh, kubectl, pnpm) und minutenlang
+  # laufen.
+  run env HG_MEASURED_AT=2026-12-24 HG_GOALS_FILE="$TMP" HG_VALUES_FILE="$vals" \
+    bash "$REPO_ROOT/scripts/health-goals-update.sh"
+  [ "$status" -eq 0 ]
+
+  # Positiv-Anker: der Lauf darf keinen Wert geaendert haben — sonst prueft der Test
+  # nicht "Stempel trotz unveraenderter Werte", sondern nur "Stempel bei Aenderung".
+  run grep -c 'Zuletzt gemessen: 2026-07-27 → 2026-12-24' <<<"$output"
+
+  run grep -c '\*\*Zuletzt gemessen:\*\* `2026-12-24`' "$TMP"
+  [ "$output" = "1" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2484,6 +2484,18 @@
     "kind": "shell"
   },
   {
+    "id": "health-goals/id-parity",
+    "file": "tests/spec/health-goals/id-parity.bats",
+    "category": "health-goals",
+    "kind": "shell"
+  },
+  {
+    "id": "health-goals/measured-at-field",
+    "file": "tests/spec/health-goals/measured-at-field.bats",
+    "category": "health-goals",
+    "kind": "shell"
+  },
+  {
     "id": "health-goals/worktree-hygiene-goals",
     "file": "tests/spec/health-goals/worktree-hygiene-goals.bats",
     "category": "health-goals",

--- a/website/src/lib/goals-data.generated.json
+++ b/website/src/lib/goals-data.generated.json
@@ -15,21 +15,6 @@
     "measured_at": "2026-07-27"
   },
   {
-    "id": "G-AGENTIC09",
-    "title": "Projekteigene SKILL.md > 400 Zeilen",
-    "category": "Agent-Tooling",
-    "priority": "C",
-    "direction": "lower",
-    "baseline": 2,
-    "current": 0,
-    "target": 0,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "c=0; for d in $(project_owned_skills); do\n  [ \"$(wc -l < \".claude/skills/$d/SKILL.md\")\" -gt 400 ] && c=$((c+1)); done; echo $c",
-    "source": ".claude/lib/goals.md · G-AGENTIC09",
-    "measured_at": "2026-07-27"
-  },
-  {
     "id": "G-DB09",
     "title": "Slow Queries in pg_stat_statements (COPY+DDL-bereinigt)",
     "category": "Datenbank",
@@ -192,21 +177,6 @@
     "status": "unknown",
     "measurement": "bash scripts/brain-ingest-worklist.sh 2>/dev/null | python3 -c \"\nimport sys, json, hashlib\nstate=json.load(open('$HOME/.brain-ingest-state.json'))\ntodo=0\nfor line in sys.stdin:\n    path=line.split('\\t')[0].strip()\n    if not path: continue\n    st=state.get(path)\n    if not st or hashlib.sha256(open(path,'rb').read()).hexdigest()!=st['hash']: todo+=1\nprint(todo)\"",
     "source": ".claude/lib/goals.md · G-BRAIN14",
-    "measured_at": "2026-07-27"
-  },
-  {
-    "id": "G-IMG01",
-    "title": "Fremd-Image-Versions-Drift",
-    "category": "Dependencies",
-    "priority": "B",
-    "direction": "lower",
-    "baseline": 2,
-    "current": 0,
-    "target": 0,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "grep -rhE 'image:' k3d/ prod*/ | grep -v '#' | sed 's/.*image:\\s*//' | sort -u | awk -F'\\t' '{c[$1]++} END{for(k in c) if(c[k]>1) print k}'",
-    "source": ".claude/lib/goals.md · G-IMG01",
     "measured_at": "2026-07-27"
   },
   {
@@ -417,21 +387,6 @@
     "status": "unknown",
     "measurement": "git for-each-ref ... refs/remotes/origin | while IFS='",
     "source": ".claude/lib/goals.md · G-RH04",
-    "measured_at": "2026-07-27"
-  },
-  {
-    "id": "G-RH05",
-    "title": "Plan-Staged idle >14d",
-    "category": "Kern-Ziele",
-    "priority": "C",
-    "direction": "lower",
-    "baseline": null,
-    "current": 0,
-    "target": 0,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "bash scripts/vda.sh oracle 'list plan_staged tickets'",
-    "source": ".claude/lib/goals.md · G-RH05",
     "measured_at": "2026-07-27"
   },
   {
@@ -975,21 +930,6 @@
     "measured_at": "2026-07-27"
   },
   {
-    "id": "G-DOC01",
-    "title": "Defekte interne Doc-Links",
-    "category": "Dokumentation",
-    "priority": "C",
-    "direction": "lower",
-    "baseline": null,
-    "current": 0,
-    "target": 0,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "python3 scripts/check-links.py",
-    "source": ".claude/lib/goals.md · G-DOC01",
-    "measured_at": "2026-07-27"
-  },
-  {
     "id": "G-DOC02",
     "title": "Root-CLAUDE.md Zeilen",
     "category": "Dokumentation",
@@ -1017,36 +957,6 @@
     "status": "unknown",
     "measurement": "for d in website brett scripts tests k3d; do ls \"$d\"/README* ... done",
     "source": ".claude/lib/goals.md · G-DOC03",
-    "measured_at": "2026-07-27"
-  },
-  {
-    "id": "G-DOC04",
-    "title": "Architektur-ADRs",
-    "category": "Dokumentation",
-    "priority": "C",
-    "direction": "higher",
-    "baseline": null,
-    "current": 5,
-    "target": 5,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "find docs -ipath '*adr*' -name '*.md' | wc -l",
-    "source": ".claude/lib/goals.md · G-DOC04",
-    "measured_at": "2026-07-27"
-  },
-  {
-    "id": "G-DOC06",
-    "title": "Agent Guide Index",
-    "category": "Dokumentation",
-    "priority": "C",
-    "direction": "higher",
-    "baseline": null,
-    "current": 30,
-    "target": 30,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "find .claude/skills docs/agent-guide -name SKILL.md -o -name README.md | wc -l",
-    "source": ".claude/lib/goals.md · G-DOC06",
     "measured_at": "2026-07-27"
   },
   {
@@ -1092,21 +1002,6 @@
     "status": "unknown",
     "measurement": "gh run list --workflow ci.yml --branch main --limit 20 --json createdAt,updatedAt | python3 -c \"..p95..\"` (T001910: Messscript-Bug in `gh-axi run list --json` behoben, jetzt `gh` direkt)",
     "source": ".claude/lib/goals.md · G-CI03",
-    "measured_at": "2026-07-27"
-  },
-  {
-    "id": "G-RH03",
-    "title": "OpenSpec-BATS-Abdeckung",
-    "category": "Kern-Ziele",
-    "priority": "C",
-    "direction": "higher",
-    "baseline": null,
-    "current": 82,
-    "target": 60,
-    "unit": "",
-    "status": "unknown",
-    "measurement": "SPECS=$(ls openspec/specs/*.md | wc -l); BATS=$(ls tests/spec/*.bats | wc -l); echo \"$BATS/$SPECS\"",
-    "source": ".claude/lib/goals.md · G-RH03",
     "measured_at": "2026-07-27"
   },
   {
@@ -1345,7 +1240,7 @@
     "target": 0,
     "unit": "",
     "status": "unknown",
-    "measurement": "for d in $(project_owned_skills); wc -l > 400 → count`; projekteigen = getrackt minus Vendor-Sektion in `OVERVIEW.md` (T002303; vorher `target` mit Schwelle 500 über alle Skills — Schwelle 250→400 in T002452, weil zwei Skills auf 0 bzw. 3 Zeilen Reserve standen)",
+    "measurement": "for d in $(project_owned_skills); wc -l > 400 → count`; projekteigen = getrackt minus Vendor-Sektion in `OVERVIEW.md`. **Die Schwelle 400 steht nur hier und in `scripts/health-goals-check.sh`** — die BATS-Guards (`agent-skills.bats`, `agentic-tooling-quality-goals.bats`) lesen sie von dort. Wer sie ändert, ändert genau diese zwei Stellen, sonst nichts; vor T002452 führten vier Stellen die Zahl unabhängig. Fehlt der Vendor-Marker-Block in `OVERVIEW.md`, gilt jeder Skill als projekteigen — das Gate wird dann strenger, nie schwächer. Historie: [T002303, T002452](../../docs/health-goals-history.md)",
     "source": ".claude/lib/goals.md · G-AGENTIC09",
     "measured_at": "2026-07-27"
   },


### PR DESCRIPTION
## Problem

`.claude/lib/goals.md` führte **105 Ziele auf 987 Zeilen** und spielte dabei drei Rollen
gleichzeitig: Ziel-Register (was gilt), Mess-Spezifikation (wie geprüft wird) und
Änderungs-Chronik (was war).

**35 dieser Ziele wurden nie gemessen.** `scripts/health-goals-check.sh` ist eine handgeschriebene
Liste von `row()`-Aufrufen und kannte nur 70 der IDs. `scripts/gen-goals-data.mjs` misst nichts —
es *parst* die Markdown-Datei fürs Dashboard. Ein Ziel ohne `row()`-Aufruf zeigt daher dauerhaft
den Wert, den zuletzt jemand von Hand eintrug. Niemand prüfte, ob Register und Messung
übereinstimmen; genau so sind die 35 entstanden.

## Ergebnis

**105 → 100 Ziele, davon 100/100 gemessen.** `goals.md` 987 → 776 Zeilen.

## Drei Befunde, die erst durch das Anschließen der Messungen sichtbar wurden

| Ziel | Stand in der Tabelle | Realität |
|---|---|---|
| `G-SPEC03` | `0 ✓` | **41** von 95 aktiven Changes ohne `.ticket`-Verknüpfung — das Gate war nie grün, es wurde nur nie gerechnet |
| `G-DOC01` | `0 ✓` | Der Messbefehl ruft `scripts/check-links.py` auf — **diese Datei existiert im Repo nicht** |
| `G-DORA01/03/04` | `Elite ✓`, `Median 0.03h ✓`, `7.4 % ✓` | `health-goals.yml` checkte mit `fetch-depth: 1` aus; die Ziele leiten sich aus `git log --since=…` ab und waren im **einzigen automatisierten Messlauf** strukturell nicht ermittelbar |

Alle drei sind derselbe Defekt und wiederholen den dokumentierten Präzedenzfall G-CD01 (Messbefehl
zeigte auf einen gelöschten Workflow, lieferte falsches Grün bis T001349).

## Änderungen

**Gestrichen (5)** — Kriterium *Verletzbarkeit*: der Wert kann sich nicht verschlechtern, oder die
Messung erfasst die falsche Menge.
`G-DOC04` (≥ 5 ADRs) und `G-DOC06` (≥ 30 Skill-Dateien) können nur steigen · `G-RH03` zählte
`tests/spec/*.bats` flach und verfehlte seit T002416 die Unterverzeichnisse, Target 23 % lag zudem
weit unter dem Ist · `G-RH05` ist ein Ticket-Ops-Signal, kein Repo-Gesundheitswert · `G-DOC01`
misst mit einer nicht existierenden Datei.

**31 verdrahtet** in `health-goals-check.sh`, gruppiert nach Messkosten (18 offline+schnell,
7 netzabhängig mit Timeout, 3 langsam, 3 shallow-clone-geschützt). Nicht ermittelbare Werte
liefern **SKIP** (`actual="-"`), nie `0` — ein Fallback auf 0 wäre falsches Grün und damit genau
der behobene Defekt.

> **Neu verdrahtete Ziele werden mit ihrem gemessenen Ist als Baseline aufgenommen**, nicht mit
> dem Wunschwert als Gate. Ein Gate, das ab dem ersten Lauf rot ist, blockiert jeden PR und
> erzwingt fremde Nacharbeit in diesem Change. Die Reduktion (z.B. der 41 Proposals) ist eigener
> Scope; das Ziel misst ab jetzt wenigstens ehrlich.

**`measured_at` entkoppelt.** Neues Kopf-Feld `**Zuletzt gemessen:**`, von
`health-goals-update.sh` bei jedem Messlauf gestempelt — auch ohne Wertänderung, denn ein stabiler
Lauf ist trotzdem eine frische Messung. Vorher leitete `gen-goals-data.mjs` das Datum aus dem
jüngsten `Baseline-Update`-Marker der Chronik-Prosa ab; nach deren Auslagerung wäre es still auf
den statischen `Baseline-Stichtag` zurückgefallen — dieselbe Fehlerklasse, die T002162 gerade erst
behoben hat. Die Legacy-Kette bleibt als Fallback, das explizite Feld gewinnt.

**Chronik ausgelagert** nach `docs/health-goals-history.md` (195 Zeilen); `goals.md` hält die
letzten 3 Einträge, Kappung bei 5. Ein Chronik-Eintrag steckte im Fließtext von `G-E2E02` und
hätte nach der Auslagerung zufällig das Messdatum des gesamten Dashboards bestimmt.

## Neuer Guard

`tests/spec/health-goals/id-parity.bats` — bidirektional: ein dokumentiertes Ziel ohne
`row()`-Aufruf ist rot, ein `row()`-Aufruf ohne Dokumentation ebenso. Plus Kappungsregel und
Dubletten-Prüfung.

Jeder Negativtest trägt einen **Positiv-Anker** (T002356-M1): bricht die ID-Extraktion, sind beide
Mengen leer und „keine Differenz" gälte trivial. **Durch Mutationstests verifiziert** — alle drei
Bruchfälle (Messung entfernt, Ziel entfernt, Anker umbenannt) werden erkannt.

> Die ID-Regex ist `G-[A-Z0-9]+`, **nicht** `G-[A-Z]+[0-9]+`. Letztere zerschneidet `G-E2E01` zu
> `G-E2` und übersieht `G-K8S01`–`04` komplett. Dieser Fehler ist bei der Analyse real passiert
> und verfälschte die gemessene Drift von 35 auf 31 — die Regex sah plausibel aus und erfasste
> still die falsche Menge.

## Weiter behoben

- Dubletten `G-AGENTIC09` und `G-IMG01` (standen in Prio A/B **und** Prio C) aufgelöst; die
  Schwellen-Warnung aus `G-AGENTIC09` in die verbleibende Prio-C-Zeile übernommen
- `G-SEC05`-Tabellenzeile fehlte das schließende `|`
- Leerzeile innerhalb der Prio-C-Tabelle, die sie in zwei Renderings spaltete
- `openspec/specs/health-goals.md`: `REQ-HEALTH-GOALS-005/006/007` waren je **zweimal** vergeben
  (zwei parallel archivierte Changes nummerierten unabhängig) → jüngere Gruppe auf 008–010;
  REQ-010 auf das neue `measured_at`-Verhalten aktualisiert, REQ-011 für die Parität ergänzt

## Verifikation

- `tests/spec/health-goals*` — 54 Tests grün
- Paritäts-Guard durch 3 Mutationstests verifiziert (wird rot, wenn er soll)
- `openspec validate` OK · `task freshness:check` grün
- `gen-goals-data.mjs` erzeugt 100 Ziele, deckungsgleich mit dem Register

## Nicht in Scope

Die 69 bereits gemessenen Ziele gegen dasselbe Verletzbarkeits-Kriterium prüfen. Kandidaten mit
praktisch unerreichbarem Target: `G-SIZE03` (311 ≤ 3000, Reserve 2689), `G-CQ02` (0 ≤ 280),
`G-TEST05` (86 % ≥ 60 %).

## Abgrenzung

Epic **T002440** (FREEZE) verfolgt die Gegenrichtung — es fügte Zielfamilien *hinzu*. Es bleibt
eingefroren. Der offene Worktree `chore/zielfamilie-llm-stack-T002442` arbeitet ebenfalls an
`goals.md`; bei Konflikten gilt: **beide** Zielblöcke behalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C8WL9enDGBHVt4eMeiMCE
