### PR TITLE
chore(ci): E2E vom eingefrorenen korczewski-Brand entkoppeln, Daemon-Test entflaken [T002602]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,11 @@ on:
         required: false
         default: both
         type: choice
-        options: [both, mentolder, korczewski]
+        # korczewski ist entfernt, weil der Brand eingefroren ist und in der
+        # Job-Matrix unten nicht mehr vorkommt [T002602]. Bliebe die Option
+        # stehen, startete eine Auswahl einen Lauf ohne einen einzigen Job —
+        # ein stiller Erfolg, der wie ein bestandener Test aussieht.
+        options: [both, mentolder]
   schedule:
     - cron: "0 3 * * *"  # 03:00 UTC nightly
 
@@ -50,12 +54,26 @@ jobs:
             contact_email: info@mentolder.de
             contact_phone: "+49 151 508 32 601"
             service_pages: /coaching,/beratung
-          - cluster: korczewski
-            website_url: https://web.korczewski.de
-            prod_domain: korczewski.de
-            contact_email: info@korczewski.de
-            contact_phone: ""
-            service_pages: /ki-beratung,/software-dev,/deployment
+          # [T002602] korczewski deaktiviert, solange der Brand eingefroren ist.
+          # Seit 2026-07-23 sind die Flux-Kustomizations ks-korczewski /
+          # ks-website-korczewski / ks-jobs-korczewski auf suspend: true (T002479,
+          # Commit 9667b24ef, Grund: Kosten/Wartung) und saemtliche Deployments in
+          # workspace-korczewski und website-korczewski stehen live auf 0/0.
+          # web.korczewski.de hat damit keinen Backend-Pod; Traefik antwortet mit
+          # 503 "no available server", woran schon der global-db-cleanup-Setup
+          # scheitert. Folge war ein dauerhaft roter nightly-Lauf (0 von 8
+          # abgeschlossenen Laeufen gruen) — ein Rot, das nichts ueber die
+          # Testsuite aussagt und echte Regressionen bei mentolder ueberdeckt.
+          #
+          # Beim Aufheben der Suspension in flux/clusters/fleet/ks-korczewski.yaml
+          # diesen Block UND die korczewski-Option unter workflow_dispatch.inputs
+          # wieder aktivieren.
+          # - cluster: korczewski
+          #   website_url: https://web.korczewski.de
+          #   prod_domain: korczewski.de
+          #   contact_email: info@korczewski.de
+          #   contact_phone: ""
+          #   service_pages: /ki-beratung,/software-dev,/deployment
     env:
       SELECTED_CLUSTER: ${{ inputs.cluster }}
       EVENT_NAME: ${{ github.event_name }}

--- a/tests/spec/sdlc-cockpit/daemon-runtime-contract.bats
+++ b/tests/spec/sdlc-cockpit/daemon-runtime-contract.bats
@@ -74,8 +74,18 @@ setup() {
     > "${BATS_TEST_TMPDIR}/daemon.log" 2>&1 &
   echo $! > "${PIDFILE}"
 
+  # 30s statt der urspruenglichen 10s [T002602]: auf dem CI-Runner laeuft diese
+  # Suite unter `bats -j` parallel, und `npx tsx` braucht dort zum Aufloesen und
+  # Starten deutlich laenger als lokal bei warmem Cache. Beobachtet auf Shard 1
+  # als Flake in etwa jedem vierten Lauf — mit LEEREM daemon.log, weil der
+  # Prozess beim Abbruch noch gar nichts geschrieben hatte. Ausgeschlossen als
+  # Ursache wurden: volles /tmp (87G frei laut Diagnose-Step), Portkonflikt mit
+  # dem CI-Daemon (der laeuft auf 49152, dieser Test auf 49199) und ein echter
+  # Defekt (lokal gruen). Die Aussagekraft bleibt erhalten: ein wirklich kaputter
+  # Daemon beendet sich sofort und faellt weiterhin durch — nur das Warten auf
+  # einen langsamen Start ist grosszuegiger.
   local ok=0
-  for _ in $(seq 1 40); do
+  for _ in $(seq 1 120); do
     if curl -s -m 1 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
       ok=1
       break


### PR DESCRIPTION
Zwei unabhängige Ursachen für rotes CI, beide reine Wartung ohne Verhaltensänderung an der Software. Gefunden bei einem `repo-hygiene`-Durchlauf.

## 1. E2E (Live Production) — dauerhaft rot, 0 von 8 Läufen grün

Der nächtliche Workflow testet weiterhin `web.korczewski.de`, obwohl der Brand seit dem 2026-07-23 **bewusst eingefroren** ist:

- `ks-korczewski`, `ks-website-korczewski` und `ks-jobs-korczewski` stehen auf `suspend: true` (T002479, Commit `9667b24ef`, Grund: Kosten/Wartung)
- sämtliche Deployments in `workspace-korczewski` und `website-korczewski` stehen live auf **0/0**

Ohne Backend-Pod antwortet Traefik mit `503: no available server` — daran scheitert bereits das `global-db-cleanup`-Setup, bevor ein einziger Test läuft:

```
Error: [global-db-cleanup:setup] POST https://web.korczewski.de/api/admin/systemtest/purge-all-test-data → 503: no available server
```

Der Matrix-Eintrag ist deshalb kommentiert deaktiviert, mit Verweis auf die Suspension und einem Reaktivierungshinweis. Die `workflow_dispatch`-Option zieht mit: bliebe sie stehen, startete eine Auswahl von `korczewski` einen Lauf **ohne einen einzigen Job** — ein stiller Erfolg, der wie ein bestandener Test aussieht.

> **Diagnose-Hinweis für später:** Flux meldete für alle drei Kustomizations `READY=True`. Ein suspendierter Reconciler behält seinen letzten Zustand — **Flux-grün ist kein Verfügbarkeitssignal**. Der Nachweis kam aus `kubectl get deploy` (0/0), nicht aus dem Flux-Status.

## 2. Cockpit-Daemon-Test — Flake auf Shard 1

`T002508 Daemon startet aus dem Checkout und antwortet auf /health` war in etwa jedem vierten Lauf rot, jeweils mit **leerem** `daemon.log` — der Prozess hatte beim Abbruch noch nichts geschrieben, war also nicht gecrasht, sondern noch nicht fertig.

Das Startfenster von 10 s (40 × 0.25 s) reicht auf dem CI-Runner unter paralleler `bats -j`-Last nicht für den `npx tsx`-Start; lokal bei warmem Cache genügt es.

Als Ursache ausgeschlossen:

| Hypothese | Befund |
|---|---|
| `/tmp` voll (vgl. T002517, ebenfalls Shard 1) | 87 GB frei, 6 % Inodes, Schreibprobe OK |
| Portkonflikt mit dem CI-Daemon | CI-Daemon auf 49152, Test auf 49199 |
| Echter Defekt am Daemon | lokal 6/6 grün |

Fenster auf 120 Iterationen (30 s) erhöht. Die Aussagekraft bleibt: ein wirklich kaputter Daemon beendet sich sofort und fällt weiterhin durch — nur das Warten auf einen langsamen Start ist großzügiger.

## Verifikation

- `task test:all` → Exit 0, 0 × `not ok`
- `task freshness:check` → Exit 0
- `tests/spec/sdlc-cockpit/daemon-runtime-contract.bats` → 6/6 grün
- `e2e.yml` parst, Job-Matrix nicht leer (`['mentolder']`)

Ticket: T002602
