### PR TITLE
fix(factory): auto-close-merged plan-only per Dateiinhalt statt Branch-Name [T002603]

### DIFF
--- a/scripts/factory/auto-close-merged.sh
+++ b/scripts/factory/auto-close-merged.sh
@@ -37,6 +37,42 @@ fi
 
 factory_resolve
 
+# T002598-M1: Decide whether a PR is plan-only by file content, not by branch
+# name. `gh pr view --json files` caps at 100 files, which hides implementation
+# files in large PRs (e.g. #3737 — scripts/openspec.sh was beyond the cap), so
+# use the paginated gh api instead. A plan-only PR changes only openspec/**
+# plan/archive files plus regenerated artifacts; any implementation file
+# (scripts/, tests/, k3d/, website/src/, .github/, brett/, docs/ non-generated)
+# makes it an execution PR that must auto-close.
+#
+# Returns 0 (plan-only) or 1 (execution / cannot determine).
+pr_is_plan_only() {
+  local pr_num="$1"
+  local files
+  files="$(gh api "repos/{owner}/{repo}/pulls/${pr_num}/files?per_page=100" --paginate --jq '.[].filename' 2>/dev/null)" || return 1
+  [[ -z "$files" ]] && return 1
+  local f
+  while IFS= read -r f; do
+    case "$f" in
+      openspec/*) continue ;;
+      # Generated artifacts — plan-only PRs regenerate these (openspec-status-map,
+      # freshness:regenerate). Everything else is implementation.
+      website/src/data/openspec-status.json) continue ;;
+      website/src/data/test-inventory.json) continue ;;
+      website/src/data/route-manifest.json) continue ;;
+      website/src/lib/learning-assets.generated.json) continue ;;
+      website/src/lib/goals-data.generated.json) continue ;;
+      website/src/lib/agent-guide.generated.json) continue ;;
+      docs/code-quality/repo-index.json) continue ;;
+      docs/code-quality/loc-budget.json) continue ;;
+      docs/generated/*) continue ;;
+      k3d/docs-content-built/*) continue ;;
+      *) return 1 ;;
+    esac
+  done <<< "$files"
+  return 0
+}
+
 # Pull the most recent 30 merged PRs with metadata (branch name for T001580).
 # The branch name is needed to skip plan-only PRs (chore/archive-*, openspec/* branches).
 PRS=$(gh pr list --state merged --limit 30 --json number,title,headRefName --template '{{range .}}{{.number}}	{{.title}}	{{.headRefName}}{{"\n"}}{{end}}')
@@ -54,11 +90,25 @@ echo "$PRS" | while IFS=$'\t' read -r pr_num title branch; do
   ticket=$(printf '%s' "$title" | sed -n 's/.*\[\(T[0-9]\{6\}\)\].*/\1/p' | head -1)
   [[ -z "$ticket" ]] && continue
 
-  # T001580 FIX: Skip plan-only PRs (chore/archive, openspec branches)
-  # These are implementation plans that shouldn't auto-close tickets.
-  if printf '%s\n' "$branch" | grep -qE '^chore/(archive|openspec)|^openspec/'; then
-    echo "auto-close-merged [T001580]: $ticket (PR #$pr_num, branch: $branch) — SKIP (plan-only PR)" >&2
+  # T001580 FIX: Skip plan-only PRs. These are implementation plans that shouldn't
+  # auto-close tickets. Decided by FILE CONTENT, not branch name (T002598-M1): the
+  # old branch heuristic `^chore/(archive|openspec)|^openspec/` wrongly matched
+  # EXECUTION branches like chore/openspec-ticket-links-T002573 (#3734) and
+  # chore/openspec-stragglers-T002577 (#3737), leaving those tickets open after a
+  # green merge. Archive branches (chore/archive-*, openspec/*) never carry
+  # implementation, so they stay a fast-path skip.
+  if printf '%s\n' "$branch" | grep -qE '^chore/archive-|^openspec/'; then
+    echo "auto-close-merged [T001580]: $ticket (PR #$pr_num, branch: $branch) — SKIP (archive/plan branch)" >&2
     continue
+  fi
+  # chore/openspec-* is ambiguous: it may be a plan-only branch (e.g.
+  # chore/openspec-archive-*) or an execution branch. Verify by file content.
+  if printf '%s\n' "$branch" | grep -qE '^chore/openspec-'; then
+    if pr_is_plan_only "$pr_num"; then
+      echo "auto-close-merged [T001580]: $ticket (PR #$pr_num, branch: $branch) — SKIP (plan-only PR)" >&2
+      continue
+    fi
+    echo "auto-close-merged [T001580]: $ticket (PR #$pr_num, branch: $branch) — kein plan-only (Implementierungsdateien) — schließe" >&2
   fi
 
   # Check partial plan completeness guard (T002105):

--- a/tests/spec/t001415-mishap-bundle.bats
+++ b/tests/spec/t001415-mishap-bundle.bats
@@ -148,3 +148,25 @@ setup() {
   # auto-enqueue.sh + auto-triage.sh calls live in the same loop block).
   awk '/while true/,/done$/{print}' "$WAKEUP" | grep -q 'auto-close-merged'
 }
+
+@test "T002598-M1: auto-close-merged.sh unterscheidet plan-only von Execution per Dateiinhalt, nicht per Branch-Name" {
+  # Regression: die alte Branch-Heuristik '^chore/(archive|openspec)' matchte auch
+  # Execution-Branches chore/openspec-ticket-links-T002573 (#3734) und
+  # chore/openspec-stragglers-T002577 (#3737) als plan-only und ließ deren Tickets
+  # nach grünem Merge offen. Die neue Logik:
+  #  - chore/archive-* + openspec/*  → unverändert plan-only-Fast-Path
+  #  - chore/openspec-*              → per Dateiinhalt (pr_is_plan_only) entschieden
+  local script="$REPO/scripts/factory/auto-close-merged.sh"
+  # Fast-Path bleibt für archive-Branches
+  grep -Eq "\^chore/archive-|\^openspec/" "$script"
+  # chore/openspec-* ist nicht mehr pauschal plan-only, sondern wird per Inhalt geprüft
+  grep -q 'chore/openspec-' "$script"
+  grep -q 'pr_is_plan_only' "$script"
+  # Die alte zu breite Heuristik '^chore/(archive|openspec)' darf nicht mehr als
+  # aktive Code-Zeile vorkommen (Kommentar-Verweis auf die Historie ist ok).
+  if grep -qE '^\s*(if )?printf.*grep -qE .?\^chore/\(archive\|openspec\)' "$script"; then
+    echo "T002598-M1: alte zu breite Branch-Heuristik noch vorhanden" >&2
+    false
+  fi
+}
+


### PR DESCRIPTION
## Problem

`scripts/factory/auto-close-merged.sh` skippt Execution-PRs auf `chore/openspec-*`-Branches fälschlich als "plan-only" und lässt deren Tickets nach grünem Merge offen. Belegt: T002573 (PR #3734) und T002577 (PR #3737) mussten manuell geschlossen werden — beide mit `[T00XXXX]` im PR-Titel und grünem Auto-Merge.

## Ursache

T001580-Heuristik matcht per Branch-Name `^chore/(archive|openspec)|^openspec/`. `chore/openspec-*` ist aber eine ambige Familie: `chore/openspec-archive-*` sind echte Plan/Archive-Branches, `chore/openspec-ticket-links-*` und `chore/openspec-stragglers-*` sind Execution-Branches. Der Branch-Name sagt nichts über den Inhalt aus.

## Fix (T002598-M1)

Entscheidung per **Dateiinhalt** statt Branch-Name:

- `chore/archive-*` + `openspec/*` → plan-only-Fast-Path (tragen nie Implementierung)
- `chore/openspec-*` → `pr_is_plan_only()`: plan-only nur wenn der PR ausschließlich `openspec/**` plus generierte Artefakte ändert; jede Implementierungsdatei (scripts/, tests/, k3d/, website/src/, .github/, brett/) → Execution-PR → schließen
- `gh pr view --json files` kappt bei 100 Dateien (verbarg `scripts/openspec.sh` in #3737) → `pr_is_plan_only()` nutzt `gh api ... --paginate`

Regressionstest in `tests/spec/t001415-mishap-bundle.bats`.

## Verifikation

- Klassifikation: #3734/#3737 → CLOSE (vorher falsch SKIP) · #3726/#3710 (`chore/archive-*`) → SKIP · #3697/#3701 (reine openspec-Chargen) → SKIP · #3693 (Guard-Fix mit scripts/) → CLOSE
- `task test:changed` 52/52 grün · `task freshness:check` grün · `task test:code-quality` grün
