### PR TITLE
chore(ops): gemma9-factory auf Single-Agent (parallel 1) [T002608]

### DIFF
--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -205,7 +205,7 @@
       "args": {
         "ctx": 98304,
         "ngl": 99,
-        "parallel": 2,
+        "parallel": 1,
         "cacheTypeK": "q4_0",
         "cacheTypeV": "q4_0",
         "loadMode": "mmap",
@@ -224,7 +224,7 @@
       ],
       "exclusiveGroup": "chat-gpu",
       "tools": "read_file,file_glob_search,grep_search,write_file,edit_file,get_datetime,exec_shell_command",
-      "notes": "Fein-getuntes Gemma 2 9B (Q4_K_M, 5.4 GB) für Factory-Agenten. T002587. GROSSES KONTEXT-FENSTER: Ersatz für gemma26-Factory als Dispatch-Subagent (nicht mehr Gemma4 26B nutzen) — mehr als 15 Aufgaben pro Session, dafür KV q4_0 wie beim 26B-Agenten-Loadout (T002501-Messung dort: q4_0 bei fitt 256 = 99328 ctx / 166 tok/s, Kurzkontext-Probe zeichengenau). targetMarginMib 128 gewinnt Kontext gegenüber 768. Gemessene ctx nach erstem Start in opencode agent-models.jsonc übernehmen. fit=false, weil -kvu den minCtx als Slot-Pool interpretiert und der gepinnte 98304-Wert stabil bleiben soll (T002599). 2 Slots mit unified KV (-kvu)."
+      "notes": "Fein-getuntes Gemma 2 9B (Q4_K_M, 5.4 GB) für Factory-Agenten. T002587. GROSSES KONTEXT-FENSTER: Ersatz für gemma26-Factory als Dispatch-Subagent (nicht mehr Gemma4 26B nutzen) — mehr als 15 Aufgaben pro Session, dafür KV q4_0 wie beim 26B-Agenten-Loadout (T002501-Messung dort: q4_0 bei fitt 256 = 99328 ctx / 166 tok/s, Kurzkontext-Probe zeichengenau). targetMarginMib 128 gewinnt Kontext gegenüber 768. Gemessene ctx nach erstem Start in opencode agent-models.jsonc übernehmen. fit=false, weil -kvu den minCtx als Slot-Pool interpretiert und der gepinnte 98304-Wert stabil bleiben soll (T002599). 2 Slots mit unified KV (-kvu). T002608: parallel bewusst auf 1 — Single-Agent-Betrieb, bis der Einzelpfad belegt funktioniert. -kvu bleibt in extraArgs: bei einem Slot wirkungslos, aber nicht schaedlich; der Guard aus T002286 verlangt nur die Umkehrung (np > 1 MUSS -kvu tragen). Vor einer Rueckkehr auf parallel > 1 zuerst den Einzelpfad verifizieren."
     },
     {
       "slug": "bge-embed-cpu",


### PR DESCRIPTION
## Warum

Vorgabe: gemma9-factory läuft zunächst **nur Single-Agent**, um erst einmal zu belegen, dass der Einzelpfad überhaupt funktioniert.

`args.parallel` 2 → 1.

## Messung vorher

- Server auf `:8092` meldete `total_slots: 2`
- Ein echter Completion-Request kam durch (8,5 s, `finish_reason: stop`)

## Nebenbefund: die laufende Unit war älter als die Konfiguration

```
Unit:          -fit on -fitt 128 -fitc 65536 -c 98304 -np 2   (kein -ngl)
loadouts.json: fit.enabled=false, ngl=99, ctx=98304, parallel=2
```

Die Unit fuhr mit **aktiviertem Auto-Fit**, während die Konfiguration ihn abschaltet. Änderungen an `loadouts.json` wirken erst beim Neustart des Loadouts (`POST /admin/loadouts/<slug>/start` → `startUnit()` schreibt die Unit neu). Die Umstellung erzwingt diese Regenerierung und räumt die Abweichung mit ab.

## `-kvu` bleibt

Bei einem Slot wirkungslos, aber nicht schädlich. Der Guard aus T002286 verlangt nur die Umkehrung (`np > 1` **muss** `-kvu` tragen). Es zu entfernen wäre eine eigene Änderung ohne Nutzen für dieses Ziel.

## Separat erfasst

Beim Verifizieren aufgefallen und **nicht** Teil dieses PRs: jede Antwort von gemma9 endet mit einem nicht gestrippten Sondertoken `<|message_sep|>` im `content` — reproduzierbar über mehrere Prompts, `finish_reason: stop`. Das Marker-Paar stammt aus `scripts/llm/templates/gemma2-tools.jinja` und ist für den Tool-Call-Parser gewollt; dass es im Klartext-`content` landet, ist es vermutlich nicht. Ein Fix dort berührt den Tool-Call-Pfad und gehört deshalb in einen eigenen Vorgang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCqtF4yXmbhf7rtBVdrp4N