### PR TITLE
chore(ops): gemma9-factory Auto-Fit wieder aktivieren, parallel bleibt 1 [T002608]

### DIFF
--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -198,13 +198,13 @@
       "model": "gemma9/gemma-2-9b-it-Q4_K_M.gguf",
       "port": 8092,
       "fit": {
-        "enabled": false,
+        "enabled": true,
         "targetMarginMib": 128,
-        "minCtx": 98304
+        "minCtx": 65536
       },
       "args": {
-        "ctx": 98304,
-        "ngl": 99,
+        "ctx": null,
+        "ngl": null,
         "parallel": 1,
         "cacheTypeK": "q4_0",
         "cacheTypeV": "q4_0",
@@ -224,7 +224,7 @@
       ],
       "exclusiveGroup": "chat-gpu",
       "tools": "read_file,file_glob_search,grep_search,write_file,edit_file,get_datetime,exec_shell_command",
-      "notes": "Fein-getuntes Gemma 2 9B (Q4_K_M, 5.4 GB) für Factory-Agenten. T002587. GROSSES KONTEXT-FENSTER: Ersatz für gemma26-Factory als Dispatch-Subagent (nicht mehr Gemma4 26B nutzen) — mehr als 15 Aufgaben pro Session, dafür KV q4_0 wie beim 26B-Agenten-Loadout (T002501-Messung dort: q4_0 bei fitt 256 = 99328 ctx / 166 tok/s, Kurzkontext-Probe zeichengenau). targetMarginMib 128 gewinnt Kontext gegenüber 768. Gemessene ctx nach erstem Start in opencode agent-models.jsonc übernehmen. fit=false, weil -kvu den minCtx als Slot-Pool interpretiert und der gepinnte 98304-Wert stabil bleiben soll (T002599). 2 Slots mit unified KV (-kvu). T002608: parallel bewusst auf 1 — Single-Agent-Betrieb, bis der Einzelpfad belegt funktioniert. -kvu bleibt in extraArgs: bei einem Slot wirkungslos, aber nicht schaedlich; der Guard aus T002286 verlangt nur die Umkehrung (np > 1 MUSS -kvu tragen). Vor einer Rueckkehr auf parallel > 1 zuerst den Einzelpfad verifizieren."
+      "notes": "T002608: parallel = 1 (Single-Agent), bis der Einzelpfad belegt funktioniert. -kvu bleibt: bei einem Slot wirkungslos, aber nicht schaedlich; der Guard aus T002286 verlangt nur die Umkehrung (np > 1 MUSS -kvu tragen). ctx und ngl bleiben ungepinnt (Guard: \"kein Loadout MIT --fit pinnt ctx oder ngl\"); die Obergrenze traegt --override-kv in extraArgs, der Boden ist fit.minCtx. fit MUSS aktiviert bleiben: mit fit.enabled=false und ngl=99 laedt der Server alle 43 Layer plus den vollen 98k-Kontext fest auf die GPU und belegt ~13,1 GB von 16 GB (Modell 5488 MiB + KV 4536 + 402 + Compute 903, gemessen 2026-08-03). Uebrig bleiben 2,9 GB — zu wenig fuer ein paralleles Finetuning (T002587). Mit Auto-Fit waren es ~3,8 GB belegt und 12,1 GB frei. Die Abweichung fiel erst auf, als der Loadout-Neustart die veraltete Unit regenerierte und fit.enabled=false damit erstmals wirksam wurde."
     },
     {
       "slug": "bge-embed-cpu",


### PR DESCRIPTION
## Was passiert ist

Das Umstellen auf `parallel: 1` (#3742) erzwang eine Regenerierung der systemd-Unit — und schaltete damit **erstmals scharf**, was `loadouts.json` längst trug, die veraltete Unit aber nie umsetzte:

```
Unit vorher:  -fit on -fitt 128 -fitc 65536 -c 98304   (kein -ngl)
Unit nachher: -fit off -c 98304 -ngl 99 -np 1
```

Gemessen mit **beiden** `nvidia-smi` (WSL und Windows, übereinstimmend):

| | belegt | frei |
|---|---|---|
| vorher (Auto-Fit) | ~3,8 GB | **12,1 GB** |
| nachher (gepinnt) | ~13,1 GB | **2,9 GB** |

Aufschlüsselung laut Journal: Modell 5488 MiB + KV 4536 + 402 + Compute 903 MiB. Haupttreiber ist der **Kontext**, nicht das Modell. 2,9 GB reichen für kein paralleles Finetuning (T002587) — genau das Ziel, für das der VRAM frei bleiben soll.

## Fix

`fit.enabled` zurück auf `true`, `minCtx: 65536`. `ctx` und `ngl` bleiben dabei **ungepinnt**.

Daran ist der erste Versuch dieser Wiederherstellung gescheitert: der Guard *„kein Loadout MIT --fit pinnt ctx oder ngl"* verbietet die Kombination — und die alte Unit trug `-fit on … -c 98304`, war also selbst regelwidrig. Der Test hat damit genau die Inkonsistenz gefangen, die ich sonst wieder eingebaut hätte. Die Obergrenze trägt `--override-kv` in `extraArgs`, den Boden `fit.minCtx`.

## `parallel: 1` bleibt

Der Single-Agent-Pfad ist live verifiziert:
- `total_slots = 1`
- Journal: `n_slots = 1, n_ctx_slot = 98304, kv_unified = true`
- echter Completion-Request kommt durch (`Paris`, `finish_reason: stop`)
- Proxy meldete beim Start `toolCallOk: true`

## Verifikation

`node --test` llm-proxy: 45 pass / 0 fail · BATS `tests/spec/local-llm-proxy/` grün · `task llm:loadouts:check` kanonisch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCqtF4yXmbhf7rtBVdrp4N