### PR TITLE
chore(ops): gemma9-factory VRAM-Marge auf 8 GB fuer paralleles Finetuning [T002608]

### DIFF
--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -199,8 +199,8 @@
       "port": 8092,
       "fit": {
         "enabled": true,
-        "targetMarginMib": 128,
-        "minCtx": 65536
+        "targetMarginMib": 8192,
+        "minCtx": 8192
       },
       "args": {
         "ctx": null,


### PR DESCRIPTION
## Der Hebel war ein anderer als gedacht

`targetMarginMib` → `-fitt` ist die **freizuhaltende** VRAM-Marge, kein Sparmodus. Bei `128` füllt Auto-Fit die Karte bis auf 128 MiB Rest. Gemessen mit gemma9 aktiv: **15929 MiB belegt, 69 MiB frei** von 16303. Für das Finetuning, für das der VRAM frei bleiben soll (T002587), blieb nichts.

`fit.targetMarginMib` 128 → **8192**, `fit.minCtx` 65536 → **8192**.

`minCtx` muss mit: bei 65536 könnte Auto-Fit die Marge gar nicht einhalten, weil allein der KV-Boden sie sprengt.

## Messwerte

| Baustein | MiB |
|---|---|
| Desktop-Baseline (ohne jedes Modell) | 1222 |
| gemma9 Modell-Buffer | 5488 |
| Compute-Buffer | 903 |
| KV bei 98k Kontext | 4938 (4536 + 402) |

Beide `nvidia-smi` (WSL und Windows) stimmten bei jeder Messung überein.

Mit 8 GB Marge behält gemma9 rund 6,6 GB — Modell vollständig auf der GPU, Kontext entsprechend kleiner. **Der Trade-off ist bewusst:** Kontextlänge gegen freies VRAM; auf 16 GB geht beides nicht gleichzeitig.

## `parallel: 1` bleibt

Live verifiziert: `total_slots = 1`, Journal `n_slots = 1`, `toolCallOk: true`, echter Completion-Request kommt durch.

## Nebenbefund für den Betrieb

**Die GPU wird nicht frei, indem man gemma9 stoppt.** Der Auto-Start des Proxys zieht dann sofort `gemma26-factory` (26B, `-fitt 256`) hoch und füllt sie erneut — während dieser Messung beobachtet. Wer die Karte wirklich leer braucht, muss die `chat-gpu`-Gruppe als ganze stilllegen.

## Verifikation

`node --test` llm-proxy 45 pass / 0 fail · BATS `tests/spec/local-llm-proxy/` grün · `task llm:loadouts:check` kanonisch

Die Marge wird nach dem Merge live gegengemessen; ich melde den tatsächlichen Wert nach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCqtF4yXmbhf7rtBVdrp4N