### PR TITLE
chore(mcp): T002XXX-Platzhalter auf T002601 + gofmt in mishap.go [T002601]

### DIFF
--- a/scripts/ticket-mcp/go/internal/tools/mishap.go
+++ b/scripts/ticket-mcp/go/internal/tools/mishap.go
@@ -95,7 +95,7 @@ func buildIncidentTicketArgs(entry MishapEntry, brand string) []string {
 }
 
 func createIncidentTicket(entry MishapEntry, brand string) (string, error) {
-	// T002XXX-Dedupe-Failsafe: Bevor ein Incident-Ticket entsteht, pruefen, ob
+	// T002601-Dedupe-Failsafe: Bevor ein Incident-Ticket entsteht, pruefen, ob
 	// bereits ein offenes Ticket mit demselben normalisierten Titel existiert.
 	// Wiederverwendung statt Duplikat — die selbe Störung darf nicht N Tickets
 	// erzeugen, bevor der Fix überhaupt dispatched wurde.
@@ -254,7 +254,7 @@ func findRollupTicketByTitle(tickets []rollupTicket, title string) (*rollupTicke
 }
 
 func findOrCreateRollupTicket(brand string) (string, error) {
-	// T002XXX-Dedupe: Der Container wird ZUERST ueber alle offenen Status gesucht,
+	// T002601-Dedupe: Der Container wird ZUERST ueber alle offenen Status gesucht,
 	// nicht nur plan_staged. Ein Container, den die Factory gerade nach in_progress
 	// bewegt hat, wurde von der plan_staged-Suche verpasst — der naechste Flush
 	// legte dann einen ZWEITEN Container an (beobachtet an T002597/T002601).
@@ -333,7 +333,9 @@ func RegisterMishapTools(s *server.MCPServer) {
 			component, _ := a["component"].(string)
 			mtype, _ := a["type"].(string)
 			brand, _ := a["brand"].(string)
-			if brand == "" { brand = "mentolder" }
+			if brand == "" {
+				brand = "mentolder"
+			}
 			validTypes := []string{"incident", "broken", "degraded", "suspicious", "security", "drift", "process"}
 			if !slices.Contains(validTypes, mtype) {
 				return mcp.NewToolResultError(fmt.Sprintf("Ungueltiger Typ: %s. Erlaubt: %s", mtype, strings.Join(validTypes, ", "))), nil
@@ -341,7 +343,9 @@ func RegisterMishapTools(s *server.MCPServer) {
 			entry := MishapEntry{Title: title, Description: description, Component: component, Type: mtype, ReportedAt: time.Now().UTC().Format(time.RFC3339)}
 			if isIncidentType(mtype) {
 				extID, err := createIncidentTicket(entry, brand)
-				if err != nil { return nil, err }
+				if err != nil {
+					return nil, err
+				}
 				return mcp.NewToolResultText(fmt.Sprintf("Incident-Ticket angelegt: %s (attention_mode=needs_human). Kein Buffer-Eintrag.", extID)), nil
 			}
 			buffer := readBuffer()
@@ -373,7 +377,9 @@ func RegisterMishapTools(s *server.MCPServer) {
 		mcp.NewTool("get_mishap_buffer", mcp.WithDescription("Zeigt den aktuellen Inhalt des Mishap-Buffers.")),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			buffer := readBuffer()
-			if len(buffer) == 0 { return mcp.NewToolResultText("Mishap-Buffer ist leer."), nil }
+			if len(buffer) == 0 {
+				return mcp.NewToolResultText("Mishap-Buffer ist leer."), nil
+			}
 			var lines []string
 			for i, e := range buffer {
 				lines = append(lines, fmt.Sprintf("%d. [%s] %s (%s) — %s", i+1, e.Type, e.Title, e.Component, e.ReportedAt))
@@ -388,10 +394,16 @@ func RegisterMishapTools(s *server.MCPServer) {
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			a := getArgs(req)
 			brand, _ := a["brand"].(string)
-			if brand == "" { brand = "mentolder" }
+			if brand == "" {
+				brand = "mentolder"
+			}
 			buffer := readBuffer()
-			if len(buffer) == 0 { return mcp.NewToolResultText("Mishap-Buffer ist leer."), nil }
-			if err := appendToRollupContainer(buffer, brand); err != nil { return nil, err }
+			if len(buffer) == 0 {
+				return mcp.NewToolResultText("Mishap-Buffer ist leer."), nil
+			}
+			if err := appendToRollupContainer(buffer, brand); err != nil {
+				return nil, err
+			}
 			writeBuffer([]MishapEntry{})
 			return mcp.NewToolResultText(fmt.Sprintf("%d Mishaps an den Rollup-Container angehaengt. Buffer geleert.", len(buffer))), nil
 		},
@@ -401,17 +413,27 @@ func RegisterMishapTools(s *server.MCPServer) {
 func BufferIsStale(entries []MishapEntry, now time.Time, maxAge time.Duration) bool {
 	for _, e := range entries {
 		t, err := time.Parse(time.RFC3339, e.ReportedAt)
-		if err != nil { continue }
-		if now.Sub(t) >= maxAge { return true }
+		if err != nil {
+			continue
+		}
+		if now.Sub(t) >= maxAge {
+			return true
+		}
 	}
 	return false
 }
 
 func FlushStaleBuffer(brand string, maxAge time.Duration) (string, error) {
 	buffer := readBuffer()
-	if len(buffer) == 0 { return "", nil }
-	if !BufferIsStale(buffer, time.Now(), maxAge) { return "", nil }
-	if err := appendToRollupContainer(buffer, brand); err != nil { return "", err }
+	if len(buffer) == 0 {
+		return "", nil
+	}
+	if !BufferIsStale(buffer, time.Now(), maxAge) {
+		return "", nil
+	}
+	if err := appendToRollupContainer(buffer, brand); err != nil {
+		return "", err
+	}
 	for _, e := range buffer {
 		if _, err := createFactoryFixTicket(e, brand); err != nil {
 			return "", err

--- a/scripts/ticket-mcp/go/internal/tools/mishap_test.go
+++ b/scripts/ticket-mcp/go/internal/tools/mishap_test.go
@@ -26,9 +26,13 @@ func TestIsIncidentType(t *testing.T) {
 func TestMishapEntryJSON(t *testing.T) {
 	entry := MishapEntry{Title: "Test", Description: "Desc", Component: "comp", Type: "broken", ReportedAt: "2026-06-21T10:00:00Z"}
 	data, err := json.Marshal(entry)
-	if err != nil { t.Fatal(err) }
+	if err != nil {
+		t.Fatal(err)
+	}
 	var decoded MishapEntry
-	if err := json.Unmarshal(data, &decoded); err != nil { t.Fatal(err) }
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
 	if decoded.Title != "Test" || decoded.Type != "broken" || decoded.Component != "comp" {
 		t.Errorf("JSON roundtrip failed: %+v", decoded)
 	}
@@ -74,25 +78,35 @@ func TestBufferIsStaleEmptyBuffer(t *testing.T) {
 }
 
 func TestGitCommonDirResolvesWorktreeGitFile(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil { t.Skip("git not available") }
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
 	main := t.TempDir()
 	run := func(dir string, args ...string) {
 		t.Helper()
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil { t.Fatalf("git %v: %v\n%s", args, err, out) }
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
 	}
 	run(main, "init", "-q", "-b", "main")
 	run(main, "config", "user.email", "t@example.invalid")
 	run(main, "config", "user.name", "t")
-	if err := os.WriteFile(filepath.Join(main, "f"), []byte("x"), 0644); err != nil { t.Fatal(err) }
+	if err := os.WriteFile(filepath.Join(main, "f"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	run(main, "add", "f")
 	run(main, "commit", "-qm", "init")
 	wt := filepath.Join(t.TempDir(), "wt")
 	run(main, "worktree", "add", "-q", "-b", "side", wt)
 	info, err := os.Stat(filepath.Join(wt, ".git"))
-	if err != nil { t.Fatal(err) }
-	if info.IsDir() { t.Skip("worktree .git is dir — precondition not met") }
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.IsDir() {
+		t.Skip("worktree .git is dir — precondition not met")
+	}
 	dir := gitCommonDir(wt)
 	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
 		t.Fatalf("gitCommonDir(%s) = %s is not dir (err=%v)", wt, dir, err)
@@ -103,9 +117,15 @@ func TestGitCommonDirResolvesWorktreeGitFile(t *testing.T) {
 }
 
 func TestRollupConstants(t *testing.T) {
-	if ROLLUP_TICKET_TITLE == "" { t.Error("ROLLUP_TICKET_TITLE must be set") }
-	if ROLLUP_BRANCH == "" { t.Error("ROLLUP_BRANCH must be set") }
-	if ROLLUP_CHANGE_DIR == "" { t.Error("ROLLUP_CHANGE_DIR must be set") }
+	if ROLLUP_TICKET_TITLE == "" {
+		t.Error("ROLLUP_TICKET_TITLE must be set")
+	}
+	if ROLLUP_BRANCH == "" {
+		t.Error("ROLLUP_BRANCH must be set")
+	}
+	if ROLLUP_CHANGE_DIR == "" {
+		t.Error("ROLLUP_CHANGE_DIR must be set")
+	}
 }
 
 // Flag helpers for args inspection.
@@ -318,7 +338,7 @@ func TestBuildersAreDeterministic(t *testing.T) {
 	}
 }
 
-// --- T002XXX: Factory-Konversion + Dedupe-Guard ---
+// --- T002601: Factory-Konversion + Dedupe-Guard ---
 
 func TestNormalizeTitle(t *testing.T) {
 	if normalizeTitle("  Foo  Bar\tBAZ  ") != "foo bar baz" {


### PR DESCRIPTION
## Was

Nachzieharbeit zu `d8bab57b1` (*fix(mcp): Mishap-Dedupe-Guard und direkte Factory-Fix-Konversion*).

1. **Platzhalter-Ticket-ID** — der Commit kam mit drei `T002XXX`-Kommentaren nach `main`:
   - `scripts/ticket-mcp/go/internal/tools/mishap.go:98` (Dedupe-Failsafe)
   - `scripts/ticket-mcp/go/internal/tools/mishap.go:257` (Container-Suche über alle offenen Status)
   - `scripts/ticket-mcp/go/internal/tools/mishap_test.go:321` (Test-Sektionsüberschrift)

   Ersetzt durch `T002601`. Die verbleibenden `T00XXXX`/`T002XXX` im Repo sind generische Platzhalter in Usage- und Doku-Texten und bleiben.

2. **gofmt** — derselbe Commit brachte einzeilige `if`-Blöcke ein (`if brand == "" { brand = "mentolder" }`), die `gofmt` aufbricht. CI hat kein `gofmt`-Gate, nur `go build` — der Drift wäre still liegen geblieben und hätte den nächsten Formatlauf in einen fremden Diff verwandelt.

## Kein Verhalten geändert

Nur Kommentare und Whitespace.

## Verifikation

- `go build ./...` → OK
- `go test ./internal/tools/` → ok, 0.043s
- `gofmt -l ./internal/tools/` → leer
- `task test:all` → EXIT=0, keine `not ok`-Zeilen
- `task freshness:check` → route-manifest OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCqtF4yXmbhf7rtBVdrp4N