### PR TITLE
fix(test): T001853-Guard ignoriert Kommentarzeilen [T002615]

### DIFF
--- a/tests/spec/workspace-deploy.bats
+++ b/tests/spec/workspace-deploy.bats
@@ -192,8 +192,32 @@ _website_deploy_block() {
   sed -n '/^  website:deploy:$/,/^  website:dev:$/p' "$TASKFILE"
 }
 
+# Liefert nicht auskommentierte Treffer auf Prod-Host-Affinitaeten in <dir>/*.yaml.
+# Kommentarzeilen sind ausgenommen: sie dokumentieren, sie konfigurieren nicht.
+# Exit 0 = Verstoss gefunden, Exit 1 = sauber (Status der letzten Pipeline-Stufe).
+_affinity_violations() {
+  grep -rnE 'gekko-hetzner|pk-hetzner' "$1"/*.yaml 2>/dev/null \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#'
+}
+
 @test "T001853: k3d base manifests carry no prod/remote host affinities (gekko-/pk-hetzner)" {
-  run bash -c "grep -l 'gekko-hetzner\|pk-hetzner' \"$PROJECT_DIR\"/k3d/*.yaml"
+  # Positiv-Anker VOR der Negativ-Aussage (T002356-M1): ein echter, nicht
+  # auskommentierter Eintrag MUSS gefunden werden — und eine reine Kommentarzeile
+  # darf NICHT anschlagen. Ohne diesen Anker bestuende die Aussage unten vakuos,
+  # sobald das Matching kaputt geht.
+  local probe; probe="$(mktemp -d)"
+  printf 'spec:\n  nodeName: pk-hetzner-8\n'                        > "$probe/real.yaml"
+  printf '# Vorfall-Notiz zu pk-hetzner-8\nspec:\n  nodeName: k3d\n' > "$probe/commented.yaml"
+
+  run _affinity_violations "$probe"
+  local hits="$output"
+  rm -rf "$probe"
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s\n' "$hits" | grep -c 'real.yaml')" -eq 1 ]
+  [ "$(printf '%s\n' "$hits" | grep -c 'commented.yaml')" -eq 0 ]
+
+  # Eigentliche Aussage: keine echten Affinitaeten in den Basis-Manifesten.
+  run _affinity_violations "$PROJECT_DIR/k3d"
   [ "$status" -ne 0 ]
 }
 


### PR DESCRIPTION
Behebt einen falsch-positiven Guard, der **jeden PR im Repo rot machte** — auch solche, die kein einziges File unter `k3d/` anfassen.

## Symptom

`tests/spec/workspace-deploy.bats`, Test 19 war auf `main` rot:

```
not ok 19 T001853: k3d base manifests carry no prod/remote host affinities (gekko-/pk-hetzner)
```

## Ursache

Der Guard war ein reiner Inhalts-Grep ohne Kommentar-Ausschluss:

```bash
run bash -c "grep -l 'gekko-hetzner\|pk-hetzner' \"$PROJECT_DIR\"/k3d/*.yaml"
```

Die einzigen Treffer in `k3d/*.yaml` stehen in **Kommentarzeilen** von `k3d/llm-gpu.yaml` (~53–57) — einer Erläuterung zu einem VolumeAttachment-/Scheduling-Vorfall vom 2026-08-03.

Gegenprobe vor dem Fix: **0** Nicht-Kommentar-Treffer im gesamten `k3d/`. Es lag also kein Manifest-Verstoß vor.

Bemerkenswert: Das S3-Gate im selben Repo nimmt Kommentarzeilen ausdrücklich aus. Dem T001853-Guard fehlte dieselbe Ausnahme — gute Dokumentationspraxis in einem Manifest machte damit die gesamte CI rot.

## Fix

Matching in den Helper `_affinity_violations()` gezogen, der Kommentarzeilen ausschließt. Der Helper nimmt ein Verzeichnis entgegen, wodurch er gegen ein Probe-Verzeichnis testbar wird.

## Rot → Grün, belegt

| Schritt | Ergebnis |
|---|---|
| Vor dem Fix | `not ok 19` |
| Nach dem Fix | `ok 19` |
| **Gegentest** — echter `nodeName: pk-hetzner-8` in `k3d/` | `not ok 19` — der Guard fängt weiterhin |
| **Gegentest** — reine Kommentarzeile in `k3d/` | `ok 19` — kein Fehlalarm mehr |

Der Positiv-Anker (T002356-M1) steckt zusätzlich **im Test selbst**: ein Probe-Verzeichnis mit `real.yaml` (echter Eintrag, muss gefunden werden) und `commented.yaml` (Kommentar, darf nicht gefunden werden) wird vor der Negativ-Aussage geprüft. Ohne ihn bestünde der Test vakuos, sobald das Matching kaputtginge.

## Verifikation

- `tests/spec/workspace-deploy.bats` — **59/59 grün**
- `task test:changed` — Exit 0, **0** Fehlschläge (vorher 1)
- `task freshness:check` — Exit 0

## Wirkung

Entblockiert die offenen PRs #3745 (T002587) und #3747 (T002606), die fachlich grün sind, aber wegen dieses fremden Fehlschlags nicht mergen konnten.
