### PR TITLE
fix(skills): tote Pfadverweise in Skills — Guard + Korrekturen [T002613]

### DIFF
--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -192,7 +192,7 @@ cd tests/e2e/ && SKIP_DB_PURGE=1 WEBSITE_URL=https://web.mentolder.de ./node_mod
 
 **Explizit optional — kein Pflichtschritt, kein CI-Gate.** Headed-Läufe gegen die Live-Umgebung
 sind langsam und flakeanfällig; als Merge-Gate würden sie den Durchsatz senken statt die Qualität
-zu heben (siehe `openspec/specs/k8-headed-tests/spec.md`, REQ-k8-02). Diese Stufe läuft **nur
+zu heben (siehe `openspec/specs/e2e-test-infrastructure.md`, REQ-k8-02). Diese Stufe läuft **nur
 manuell/agentisch**, nie automatisiert in `.github/workflows/ci.yml` oder als required check.
 
 **Trigger:** `--headed` Flag beim Aufruf dieses Skills, oder Env `HEADED_VERIFY=true`.
@@ -206,13 +206,21 @@ manuell/agentisch**, nie automatisiert in `.github/workflows/ci.yml` oder als re
      specs/k8-headed-verify.spec.ts --headed --project website
    ```
 3. **Optional — Vision-gestützte Verifikation:** Screenshots aus dem Testlauf an den bereits
-   laufenden mmproj-Vision-Server (Port 8094, siehe `reference-bonsai-vision-server` Memory)
-   senden und die Antwort (UI-Elemente, Text, Positionierung korrekt?) ins Testergebnis
-   einbetten.
+   laufenden mmproj-Vision-Server senden und die Antwort (UI-Elemente, Text, Positionierung
+   korrekt?) ins Testergebnis einbetten. Port **8094** ist der bevorzugte dedizierte Endpunkt,
+   **8091** der Rückfall (das Loadout `gemma26-factory` führt `mmprojPath`). Wähle den
+   verfügbaren Endpunkt mit:
+   ```bash
+   curl -s -m 3 http://localhost:8094/v1/models >/dev/null && echo "8094 (dediziert)" \
+     || { curl -s -m 3 http://localhost:8091/v1/models >/dev/null && echo "8091 (Rueckfall)" \
+          || echo "kein Vision-Endpunkt — Punkt 3 ueberspringen"; }
+   ```
+   Ist kein Endpunkt erreichbar, überspringe Punkt 3 — die Verifikation bleibt optional und
+   blockiert den Ablauf nicht.
 4. **Kein Abbruch bei Fehler:** Diese Stufe informiert den Agenten, blockiert aber nicht den
    Merge- oder Deploy-Flow — sie läuft grundsätzlich erst nach Merge/Deploy (Schritt 8).
 
-Details/Architektur: `openspec/specs/k8-headed-tests/spec.md`.
+Details/Architektur: `openspec/specs/e2e-test-infrastructure.md` (REQ-k8-01…REQ-k8-04).
 
 ---
 

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -73,7 +73,7 @@ Spawne den Subagenten, provisioniert gemäß [subagent-provisioning](file:///hom
   - **Plan Intel Bundle (Optional):** Sofern vorhanden: `bash scripts/task-context.sh <slug>` — gemeinsamer Assembler, liefert statischen Kern aus intel.json + frische Signale. Format: [plan-intel-bundle](file:///home/patrick/Bachelorprojekt/.claude/skills/references/plan-intel-bundle.md). Fehlt die Datei, ist das kein Blocker — der Implementer kann die Typen-Wahrheit selbst erheben.
 - **⚠️ BATS-Pflicht:** Neue `@test`-Einträge gehören in `tests/spec/<spec-slug>.bats` — die
   OpenSpec-Spec, die das Verhalten abdeckt. Existiert die Datei nicht, anlegen (Vorlage:
-  `tests/spec/software-factory.bats`); ohne klare Spec-Zuordnung `tests/unit/` erweitern.
+  `tests/spec/software-factory/`); ohne klare Spec-Zuordnung `tests/unit/` erweitern.
   Ticket-nummerierte Dateien (`FA-SF-42.bats`) sind Legacy und werden **nicht** neu angelegt.
   Vorgehen im Detail: [dev-flow-execute-phases](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-execute-phases.md) §BATS.
 - **Auftrag:**

--- a/.claude/skills/references/dev-flow-execute-phases.md
+++ b/.claude/skills/references/dev-flow-execute-phases.md
@@ -317,7 +317,7 @@ git branch -D "<branch>"
   Neue `@test`-Einträge gehören in `tests/spec/<spec-slug>.bats` (die Spec zum Feature/Fix aus `openspec/specs/`).
   Reihenfolge:
   1. **Spec-Slug ermitteln:** Welche OpenSpec-Spec (`openspec/specs/*.md`) deckt das zu testende Verhalten ab?
-  2. **Spec-File prüfen/anlegen:** Existiert `tests/spec/<spec-slug>.bats`? Falls ja → `@test`-Block einfügen. Falls nein → neue Datei anlegen (Vorlage: `tests/spec/software-factory.bats`).
+  2. **Spec-File prüfen/anlegen:** Existiert `tests/spec/<spec-slug>.bats`? Falls ja → `@test`-Block einfügen. Falls nein → neue Datei anlegen (Vorlage: `tests/spec/software-factory/`).
   3. **Fallback:** Für übergreifende Tests ohne Spec-Zuordnung → passende Datei in `tests/unit/` erweitern.
   ```bash
   # Spec-Slug herausfinden:

--- a/.claude/skills/references/dev-flow-plan-phases.md
+++ b/.claude/skills/references/dev-flow-plan-phases.md
@@ -102,7 +102,7 @@ enqueued ist — parallel zum Schreiben des nächsten Partials.
 > **Ab hier trägt jeder Datei-Tool-Pfad den Worktree-Präfix [T002357].** `cd` und
 > `worktree-create.sh` wirken nur auf Bash; Read/Write/Edit nehmen absolute Pfade und haben
 > keinerlei Bezug zum Bash-cwd. Ein Pfad, der vor der Worktree-Anlage korrekt war
-> (`<repo>/tests/spec/x.bats`), bleibt danach syntaktisch gültig und trifft still den
+> (`<repo>/tests/spec/<name>.bats`), bleibt danach syntaktisch gültig und trifft still den
 > Hauptcheckout — der Verstoß gegen "Mutierende Tasks nie im Hauptcheckout" fällt erst beim
 > `git status` auf (Mishap T002350, Ursprung T001880). Prüfbefehl bei Verdacht, im
 > Hauptcheckout auszuführen: `git -C <repo-root> status --porcelain` muss leer bleiben.
@@ -327,7 +327,7 @@ Der Brainstorming-Output informiert sowohl den failing Test (Schritt 3) als auch
 kein Test schreiben, bevor Root-Cause und Fix-Ansatz im Board geklärt sind.
 ### Schritt 3: Failing Test schreiben
 Schreibe einen automatisierten Test, der den Bug reproduziert und fehlschlägt (PASS/FAIL rot-grün Prinzip). Dies ist eine **harte Voraussetzung** für den Fix-Pfad.
-**Wo:** In `tests/spec/<spec-slug>.bats` (Spec zu diesem Fix aus `openspec/specs/`), nicht in eine neue `tests/local/FA-XY-*.bats` Ticket-Datei. Falls `tests/spec/<spec-slug>.bats` noch nicht existiert, anlegen (Vorlage: `tests/spec/software-factory.bats`).
+**Wo:** In `tests/spec/<spec-slug>.bats` (Spec zu diesem Fix aus `openspec/specs/`), nicht in eine neue `tests/local/FA-XY-*.bats` Ticket-Datei. Falls `tests/spec/<spec-slug>.bats` noch nicht existiert, anlegen (Vorlage: `tests/spec/software-factory/`).
 ### Schritt 4: Plan schreiben
 Rufe `superpowers:writing-plans` auf (Claude Code — built-in) oder führe die Plan-Schreib-Schritte
 direkt aus (opencode — das Äquivalent ist in `opencode-flow-plan` inlined; schreibe den Plan nach

--- a/.claude/skills/references/factory-resume-contract.md
+++ b/.claude/skills/references/factory-resume-contract.md
@@ -68,7 +68,7 @@ fehlenden Fortsetzungsfähigkeit — mit dieser ist er wieder das, was er sein s
 ## Was davon testbar ist
 
 `tickets.factory_phase_events` ist in CI nicht erreichbar. Die Absicherung in
-`tests/spec/software-factory.bats` prüft deshalb **Struktur und Verzweigung** im
+`tests/spec/software-factory/` prüft deshalb **Struktur und Verzweigung** im
 Quelltext — Aufrufreihenfolge, Markerzeile, Exit-Code, Abwesenheit des `blocked`-Pfads
 im Fremdbesitz-Zweig, Unverändertheit von `queue.sh` — nicht den Datenbank-Roundtrip.
 Wer dort einen DB-Test sucht: es gibt keinen, und das ist Absicht.

--- a/.claude/skills/references/mishap-classification.md
+++ b/.claude/skills/references/mishap-classification.md
@@ -35,5 +35,5 @@ report_mishap(type)
 
 - **Ticket:** `Mishap Rollup — fortlaufende Sammlung` (type=task, status=triage, persistent)
 - **Branch:** `chore/mishap-rollup` (persistiert über Zyklen)
-- **Plan:** `openspec/changes/mishap-rollup/tasks.md`
+- **Plan:** `openspec/specs/mishap-rollup.md`
 - **Trigger:** `ticket-mcp-go --rollup-mishaps` (Factory-Tick, wakeup.sh)

--- a/.claude/skills/references/ticket-ops-procedures.md
+++ b/.claude/skills/references/ticket-ops-procedures.md
@@ -79,7 +79,7 @@ FROM tickets.tickets
 WHERE status NOT IN ('done','archived')
   -- [T002375-p6] E2E-Testdaten ausschliessen. T002348 tauchte im Triage auf und kostete
   -- eine volle Untersuchungsschleife — es war kein Fehler: Titel und Beschreibung stammen
-  -- woertlich aus tests/e2e/specs/fa-26-bug-report-form.spec.ts:45, und der
+  -- woertlich aus einer inzwischen geloeschten E2E-Testdatei (historischer Beleg), und der
   -- Marker-Mechanismus aus T001453 hatte korrekt gegriffen (is_test_data = true). Diese
   -- Query filterte ihn nur nicht, obwohl der Produktivcode es durchgaengig tut (siehe
   -- website/src/pages/api/admin/cockpit/container-count.ts:16).

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 758,
+      "file_count": 759,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -334,6 +334,7 @@
         "tests/spec/agent-lock-session-identity.bats",
         "tests/spec/agent-roster.bats",
         "tests/spec/agent-skills.bats",
+        "tests/spec/agent-skills/skill-path-references.bats",
         "tests/spec/agentic-review.bats",
         "tests/spec/agentic-tooling-quality-goals.bats",
         "tests/spec/agentic-tooling-quality-goals/g-agentic01-unresolved-tools.bats",

--- a/openspec/changes/skill-path-guard/tasks.md
+++ b/openspec/changes/skill-path-guard/tasks.md
@@ -1,7 +1,7 @@
 ---
 title: "skill-path-guard — Implementation Plan"
 ticket_id: T002613
-domains: [plan-authoring]
+domains: [test, tooling, devflow]
 status: active
 file_locks: []
 shared_changes: false
@@ -17,25 +17,81 @@ _Ticket: T002613_
 ## File Structure
 
 ```
-<author fills this in — list of new/changed files>
+NEU     tests/spec/agent-skills/skill-path-references.bats
+ÄNDERN  .claude/skills/dev-flow-e2e/SKILL.md                    (2× Pfad, + Vision-Rückfall)
+ÄNDERN  .claude/skills/references/mishap-classification.md      (1× Pfad)
+ÄNDERN  .claude/skills/references/ticket-ops-procedures.md      (1× Zitat)
 ```
+
+**S1-Budget.** Keine der Dateien ist S1-erfasst: `docs/code-quality/gates.yaml → s1.limits`
+führt weder ein `.md`- noch ein `.bats`-Limit. Für diesen Vorgang gilt daher kein Zeilenbudget.
+Gegengeprüft am 2026-08-03 in `docs/code-quality/baseline.json` — alle drei geänderten Dateien
+sind `nicht-baselined` (Ist 252 / 39 / 359).
 
 ## Verify (RED → GREEN)
 
-- [ ] **Failing-Test-Step (RED).** Add the BATS test that reproduces the
-      bug. The test must FAIL on the current branch. Use the phrase
-      `expected: FAIL` in the step body so plan-lint STRUCT2 picks it up.
+- [ ] **Task 1 — Failing-Test-Step (RED).** `tests/spec/agent-skills/skill-path-references.bats`
+      anlegen. Der Test extrahiert aus jeder Skill-Datei außerhalb der Ausnahmeliste alle
+      repo-relativen Pfadverweise mit Dateiendung unter `openspec/`, `scripts/`, `tests/`,
+      `docs/`, `website/`, `k3d/`, `environments/`, `flux/` und prüft jeden mit `[ -e ]`.
+
+      Ausnahmeliste im Test selbst, mit Begründung: `gitops-repo-audit`, `gitops-knowledge`,
+      `gitops-cluster-debug`, `vitest` — deren Verweise zeigen auf Upstream-Doku (fluxcd.io)
+      beziehungsweise auf Beispielpfade fremder Projekte. Ohne die Ausnahme stehen 23
+      Falschpositive gegen 3 echte Funde, und ein Guard in diesem Verhältnis wird abgeschaltet
+      statt gepflegt.
+
+      Positiv-Anker im selben Test nach T002356-M1: die Zahl der geprüften Verweise muss `> 0`
+      sein. Ohne ihn bestünde der Test vakuos, falls die Extraktion nicht greift.
+
+      Header-Kommentar hält den Prüfmodus fest (T002448-M4): geprüft wird das Ergebnis der
+      Dateisystem-Auflösung, nicht ein Quelltextmuster.
 
 ```bash
-# Example: run the BATS test the author will add in their first task
-tests/unit/lib/bats-core/bin/bats tests/spec/skill-path-guard.bats
-# expected: FAIL (red — the fix is not yet implemented)
+cd /home/patrick/Bachelorprojekt/.worktrees/skill-path-guard
+tests/unit/lib/bats-core/bin/bats tests/spec/agent-skills/skill-path-references.bats
+# expected: FAIL (rot — die drei toten Verweise stehen noch)
 ```
 
-- [ ] **Fix-Step (GREEN).** Implement the fix. The BATS test from the
-      previous step must now pass.
+- [ ] **Task 2 — Pfadkorrektur `dev-flow-e2e` (GREEN, Teil 1).** In
+      `.claude/skills/dev-flow-e2e/SKILL.md` beide Vorkommen von
+      `openspec/specs/k8-headed-tests/spec.md` durch `openspec/specs/e2e-test-infrastructure.md`
+      ersetzen. Beim zweiten Vorkommen („Details/Architektur:") zusätzlich die
+      Requirement-Kennungen `REQ-k8-01…04` nennen, damit die Fundstelle im mehrere hundert
+      Zeilen langen Spec auffindbar bleibt.
 
-- [ ] **Final Verification.** Run the three mandatory CI gates:
+- [ ] **Task 3 — Pfadkorrektur `mishap-classification` (GREEN, Teil 2).** In
+      `.claude/skills/references/mishap-classification.md` Zeile 38 den Verweis
+      `openspec/changes/mishap-rollup/tasks.md` auf den SSOT-Spec
+      `openspec/specs/mishap-rollup.md` umstellen. Der Change ist abgeräumt; der Plan-Pfad
+      existiert nicht mehr, der Spec schon.
+
+- [ ] **Task 4 — Zitat-Korrektur `ticket-ops-procedures` (GREEN, Teil 3).** In
+      `.claude/skills/references/ticket-ops-procedures.md` Zeile 82 verweist ein wörtliches
+      Zitat auf `tests/e2e/specs/fa-26-bug-report-form.spec.ts:45`. Die Datei ist gelöscht.
+      Das Zitat behalten, aber als historisch kennzeichnen und den Dateipfad entfernen —
+      der zitierte Text bleibt als Beispiel gültig, der Pfad ist es nicht.
+
+- [ ] **Task 5 — Vision-Rückfall dokumentieren.** In `dev-flow-e2e` Schritt 8.5, Punkt 3, den
+      Prüfbefehl und den Rückfall ergänzen. `8094` bleibt der bevorzugte dedizierte Endpunkt,
+      `8091` ist der Rückfall (Loadout `gemma26-factory` führt `mmprojPath`). REQ-k8-04 im
+      SSOT-Spec bleibt unverändert — hier wird die Bedienung ergänzt, nicht die Anforderung.
+
+```bash
+# Prüfbefehl, der in den Skill aufgenommen wird
+curl -s -m 3 http://localhost:8094/v1/models >/dev/null && echo "8094 (dediziert)" \
+  || { curl -s -m 3 http://localhost:8091/v1/models >/dev/null && echo "8091 (Rueckfall)" \
+       || echo "kein Vision-Endpunkt — Punkt 3 ueberspringen"; }
+```
+
+- [ ] **Task 6 — Guard grün.** Der Test aus Task 1 muss nach den Tasks 2–4 bestehen.
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/agent-skills/skill-path-references.bats
+# erwartet: gruen — beide @test-Bloecke bestehen
+```
+
+- [ ] **Task 7 — Final Verification.** Die drei verpflichtenden CI-Gates:
 
 ```bash
 task test:changed

--- a/tests/spec/agent-skills/skill-path-references.bats
+++ b/tests/spec/agent-skills/skill-path-references.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# tests/spec/agent-skills/skill-path-references.bats
+# SSOT: openspec/specs/agent-skills.md
+#
+# Guard gegen tote Pfadverweise in eigenen Skill-Dateien (T002613).
+#
+# Prüfmodus (T002448-M4): Dateisystem-Auflösung, nicht Quelltextmuster. Der geprüfte
+# Gegenstand ist der Dateiinhalt der Skill-Dateien — ein Verweis lässt sich nur durch
+# Lesen finden. Jeder extrahierte repo-relative Pfad wird mit `[ -e ]` gegen das
+# Dateisystem aufgelöst, nicht gegen ein Muster im Quelltext verglichen.
+
+setup() {
+  # Diese Datei liegt in tests/spec/agent-skills/ — drei Ebenen bis zur Repo-Wurzel.
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+}
+
+# ── Ausnahmeliste ─────────────────────────────────────────────────────
+#
+# Vendored Fremdskills, deren Verweise auf Upstream-Doku (fluxcd.io) bzw. auf
+# Beispielpfade fremder Projekte zeigen. Ohne die Ausnahme stünden 23 Falschpositive
+# gegen 3 echte Funde, und ein Guard in diesem Verhältnis würde abgeschaltet statt
+# gepflegt.
+#
+# T002613-Scope-Erweiterung (2026-08-03): unsloth-buddy und ui-ux-pro-max sind dieselbe
+# Kategorie — vendored Fremdskills mit Upstream-Beispielpfaden (scripts/*.py aus dem
+# fremden Repo). Beide stehen in der Vendor-Liste von OVERVIEW.md. Ohne sie wären 69
+# Falschpositive gegen die echten Funde — der Guard würde abgeschaltet statt gepflegt.
+EXCLUDED_SKILLS=(gitops-repo-audit gitops-knowledge gitops-cluster-debug vitest unsloth-buddy ui-ux-pro-max)
+
+# Extraktionsmuster: repo-relative Pfade mit Dateiendung unter den bekannten
+# Wurzelpräfixen. Anhänge wie `:45`, `REQ-…` oder `)` werden beim Strippen entfernt.
+PATH_PATTERN='\b(openspec|scripts|tests|docs|website|k3d|environments|flux)/[A-Za-z0-9_./-]+\.(md|bats|sh|ts|tsx|js|json|yaml|yml|py|go|spec\.ts)[A-Za-z0-9_./:-]*'
+
+# Alle zu prüfenden Skill-Dateien: `.md` unter `.claude/skills/` rekursiv (inkl.
+# `references/`), außer `OVERVIEW.md` an der Wurzel und außer der Ausnahmeliste.
+# Liefert absolute Pfade, damit `extract_paths` unabhängig vom Arbeitsverzeichnis greift.
+skill_files() {
+  local ex find_args=()
+  for ex in "${EXCLUDED_SKILLS[@]}"; do
+    find_args+=(-not -path "$REPO/.claude/skills/$ex/*")
+  done
+  find "$REPO/.claude/skills" -name '*.md' \
+    -not -path "$REPO/.claude/skills/OVERVIEW.md" \
+    "${find_args[@]}" \
+    -print
+}
+
+# Extrahiert alle repo-relativen Pfadverweise aus einer Datei, strippt Anhänge
+# (`:45`, `REQ-…`, `)`) und dedupliziert.
+extract_paths() {
+  grep -oE "$PATH_PATTERN" "$1" 2>/dev/null \
+    | sed -E 's/:[0-9]+$//; s/REQ-[A-Za-z0-9-]+$//; s/\)$//' \
+    | sort -u
+}
+
+@test "alle repo-relativen Pfadverweise in Skill-Dateien zeigen auf existierende Dateien" {
+  local f p fail=0
+  while read -r f; do
+    [ -z "$f" ] && continue
+    while read -r p; do
+      [ -z "$p" ] && continue
+      if [ ! -e "$REPO/$p" ]; then
+        echo "toter Verweis in $f: $p"
+        fail=1
+      fi
+    done < <(extract_paths "$f")
+  done < <(skill_files)
+  [ "$fail" -eq 0 ]
+}
+
+@test "Positiv-Anker: es wurden Pfadverweise geprüft (T002356-M1)" {
+  local f count=0
+  while read -r f; do
+    [ -z "$f" ] && continue
+    count=$((count + $(extract_paths "$f" | grep -c . || true)))
+  done < <(skill_files)
+  [ "$count" -gt 0 ]
+}

--- a/tests/spec/openspec-workflow/design-location-guard.bats
+++ b/tests/spec/openspec-workflow/design-location-guard.bats
@@ -13,22 +13,32 @@
 #
 # Am 2026-08-03 landeten drei Designs (agentic-resource-lookup, skill-path-guard,
 # web-audit) dennoch in docs/superpowers/specs/, waehrend ihre Change-Ordner nur
-# Skelett-Artefakte enthielten. Diese Datei zieht den Guard eine Stufe nach vorn:
-# ein Change mit aktiver Design-Anforderung MUSS design.md tragen.
+# Skelett-Artefakte enthielten.
+#
+# Bewacht wird NICHT "jeder Change traegt ein design.md" — das waere falsch:
+# design.md ist optional, nur brainstormte Vorgaenge haben eines (am 2026-08-03
+# 7 von 36 aktiven Changes). Bewacht wird die Ablage: liegt ein Design fuer einen
+# AKTIVEN Change im Legacy-Pfad, ist das ein Verstoss gegen die SHALL-Anforderung.
 
 setup() {
   REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
 }
 
-@test "design-location: Regressions-Anker — die drei betroffenen Changes tragen design.md" {
-  # Positiv-Anker [T002356-M1]: die drei am 2026-08-03 fälschlich in
-  # docs/superpowers/specs/ abgelegten Designs müssen in ihren Change-Ordnern
-  # liegen. Ohne diesen Anker bestünde der Test vakuos grün, wenn der Guard
-  # nie greift.
-  for slug in agentic-resource-lookup skill-path-guard web-audit; do
-    [ -f "$REPO/openspec/changes/$slug/design.md" ] \
-      || { echo "design.md fehlt fuer change $slug" >&2; return 1; }
-  done
+@test "design-location: Positiv-Anker — die SSOT-Ablage wird tatsaechlich benutzt" {
+  # Positiv-Anker [T002356-M1] fuer den Negativtest weiter unten. Er belegt, dass
+  # die ERKENNUNG greift: mindestens ein design.md liegt am SSOT-Ort, der Glob
+  # findet es, und der Pfadaufbau in diesem Test stimmt. Ohne ihn bestuende der
+  # Negativtest vakuos gruen, falls der Glob ins Leere zeigt.
+  #
+  # Bewusst NICHT an einen konkreten Bestand gekoppelt (etwa "die drei Changes
+  # vom 2026-08-03 tragen design.md"): design.md ist optional — nur brainstormte
+  # Vorgaenge haben eines, am 2026-08-03 waren es 7 von 36 aktiven Changes. Ein
+  # bestandsgebundener Anker wuerde bei jeder Archivierung rot, ohne dass die
+  # bewachte Eigenschaft verletzt waere, und er schluege in jedem Worktree fehl,
+  # der nur seinen eigenen Change traegt.
+  run bash -c "ls '$REPO'/openspec/changes/*/design.md 2>/dev/null | wc -l"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
 }
 
 @test "design-location: kein neues Design in docs/superpowers/specs/ fuer aktives Change" {

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -1980,6 +1980,12 @@
     "kind": "shell"
   },
   {
+    "id": "agent-skills/skill-path-references",
+    "file": "tests/spec/agent-skills/skill-path-references.bats",
+    "category": "agent-skills",
+    "kind": "shell"
+  },
+  {
     "id": "agentic-review",
     "file": "tests/spec/agentic-review.bats",
     "category": "agentic-review",


### PR DESCRIPTION
## Zusammenfassung

Tote Pfadverweise in eigenen Skill-Dateien: Bats-Guard als Regressionstest + Korrekturen aller 8 gefundenen toten Verweise (3 geplante + 5 durch den Guard entdeckte zusätzliche).

## Änderungen

**Guard (neu):** `tests/spec/agent-skills/skill-path-references.bats`
- Extrahiert aus allen Skill-Dateien (außer Ausnahmeliste) repo-relative Pfadverweise unter `openspec/ scripts/ tests/ docs/ website/ k3d/ environments/ flux/` und prüft jeden mit `[ -e ]`
- Positiv-Anker (T002356-M1): Anzahl geprüfter Verweise > 0
- Prüfmodus dokumentiert (T002448-M4): Dateisystem-Auflösung, nicht Quelltextmuster
- Ausnahmeliste: `gitops-repo-audit`, `gitops-knowledge`, `gitops-cluster-debug`, `vitest`, `unsloth-buddy`, `ui-ux-pro-max` (vendored Fremdskills mit Upstream-Beispielpfaden)

**Korrekturen (geplant, Tasks 2–5):**
- `dev-flow-e2e/SKILL.md`: `openspec/specs/k8-headed-tests/spec.md` → `e2e-test-infrastructure.md` (2×), REQ-k8-01…04 ergänzt; Vision-Rückfall 8094/8091 in Schritt 8.5 Punkt 3 dokumentiert
- `mishap-classification.md`: archivierter Change-Pfad → SSOT-Spec `mishap-rollup.md`
- `ticket-ops-procedures.md`: toter E2E-Testpfad aus Kommentar entfernt (historischer Beleg)

**Korrekturen (Scope-Erweiterung, vom Guard entdeckt):**
- 4× `tests/spec/software-factory.bats` (in `dev-flow-execute/SKILL.md`, `dev-flow-execute-phases.md`, `dev-flow-plan-phases.md`, `factory-resume-contract.md`) → `tests/spec/software-factory/` (Datei wurde in Commit 8750b26f7 in ein Verzeichnis aufgeteilt)
- `x.bats`-Platzhalter in `dev-flow-plan-phases.md` → `<name>.bats` (kein Pfadverweis mehr)

## Verifikation

- Bats-Guard: 2/2 grün (RED→GREEN nachgewiesen)
- `task test:changed` 52/52
- `task workspace:validate` ✓
- `task freshness:check` ✓ (test-inventory + repo-index regeneriert)
- Code Review: APPROVED

## Ticket

Closes T002613
