### PR TITLE
chore(mcp): kubectl-Pfad in Systemd-Units korrigieren [T002636]

### DIFF
--- a/scripts/bge-mcp/bge-forward-embed.service
+++ b/scripts/bge-mcp/bge-forward-embed.service
@@ -23,7 +23,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/kubectl --context fleet port-forward -n workspace svc/llm-gateway-embed 8081:8081
+ExecStart=/usr/local/bin/kubectl --context fleet port-forward -n workspace svc/llm-gateway-embed 8081:8081
 # Kein Ratenlimit-Abbruch: bei einem Rollout kann der Forward mehrfach in kurzer
 # Folge sterben. Ohne StartLimitIntervalSec=0 gaebe systemd nach 5 Versuchen auf
 # und liesse genau den Zustand zurueck, den diese Unit verhindern soll.

--- a/scripts/bge-mcp/bge-forward-rerank.service
+++ b/scripts/bge-mcp/bge-forward-rerank.service
@@ -18,7 +18,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/kubectl --context fleet port-forward -n workspace svc/llm-gateway-rerank 8093:8081
+ExecStart=/usr/local/bin/kubectl --context fleet port-forward -n workspace svc/llm-gateway-rerank 8093:8081
 Restart=always
 RestartSec=3
 StartLimitIntervalSec=0

--- a/scripts/mcp-gateway/mcp-gateway.service
+++ b/scripts/mcp-gateway/mcp-gateway.service
@@ -14,7 +14,7 @@ After=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=/home/patrick/Bachelorprojekt
-ExecStart=/usr/bin/kubectl --context fleet port-forward -n default svc/claude-code-mcp-monolith 18080:8080 13000:3000 13001:3001 13002:3002
+ExecStart=/usr/local/bin/kubectl --context fleet port-forward -n default svc/claude-code-mcp-monolith 18080:8080 13000:3000 13001:3001 13002:3002
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
## Summary

Drei Systemd-Unit-Dateien referenzieren `ExecStart=/usr/bin/kubectl`. Auf diesem Host existiert kein kubectl unter `/usr/bin` — die kanonische Installation ist `/usr/local/bin/kubectl` (`scripts/install-dev-tools.sh`). Deshalb scheiterte `mcp-gateway.service` mit `status=203/EXEC` (Pfad nicht gefunden), und die bge-forward-Units liefen nur dank lokaler Overrides.

**Geändert:** `ExecStart=/usr/bin/kubectl` → `/usr/local/bin/kubectl` in

- `scripts/mcp-gateway/mcp-gateway.service`
- `scripts/bge-mcp/bge-forward-embed.service`
- `scripts/bge-mcp/bge-forward-rerank.service`

Der Context (`--context fleet`) bleibt korrekt — nur der kubectl-Pfad war falsch.

## Test Plan

- `task test:changed` grün (52 Tests, inkl. `tests/spec/llm-pipeline/bge-usecase-reachability.bats`)
- `rg 'usr/bin/kubectl' scripts/ tests/` → keine Treffer
- Lokal verifiziert: nach korrigiertem Pfad startet `mcp-gateway.service` (ActiveState=running), alle MCP-Endpoints antworten wieder (13001/13003/18080: HTTP 200/406 statt 000)