### PR TITLE
fix(infra): bge-embed/-rerank Thread-Oversubscription gegen CPU-Quota [T002661]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 794,
+      "file_count": 795,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -451,6 +451,7 @@
         "tests/spec/lavish.bats",
         "tests/spec/llm-local-dev.bats",
         "tests/spec/llm-pipeline.bats",
+        "tests/spec/llm-pipeline/bge-thread-quota.bats",
         "tests/spec/llm-pipeline/bge-usecase-reachability.bats",
         "tests/spec/llm-pipeline/gemma-thinking-budget.bats",
         "tests/spec/llm-pipeline/index-repo-embed-port.bats",

--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -108,6 +108,18 @@ spec:
             - "8192"
             - "-np"
             - "4"
+            # T002661: -t MUSS zur CPU-Quota passen. Ohne das Flag waehlt
+            # llama.cpp nproc — im Container 8 (der Node hat 8 Kerne, cgroup
+            # maskiert nproc nicht), waehrend limits.cpu 2000m nur 2 Kerne
+            # erlaubt. Gemessen am 2026-08-04: 5003/9172 Perioden gedrosselt
+            # (54,5 %), throttled_usec 2028s gegen usage_usec 1181s — laenger
+            # gedrosselt als gerechnet. Alle Threads synchronisieren an jeder
+            # Layer-Barriere, ein gedrosselter haelt also den ganzen Batch bis
+            # zum Periodenende an: 10,7s fuer 13 Tokens.
+            # Wird limits.cpu geaendert, muss -t mitgezogen werden.
+            # Guard: tests/spec/llm-pipeline/bge-thread-quota.bats
+            - "-t"
+            - "2"
             - "--embeddings"
           env:
             - name: CUDA_VISIBLE_DEVICES
@@ -228,6 +240,13 @@ spec:
             - "8192"
             - "-np"
             - "4"
+            # T002661: analog zu bge-embed — -t an limits.cpu (2000m = 2 Kerne)
+            # gebunden. Hier war die Drosselung bisher nur latent (145/12354
+            # Perioden, 1,2 %), weil das Deployment kaum Last sieht; unter
+            # Rerank-Batches traefe es dasselbe Muster.
+            # Guard: tests/spec/llm-pipeline/bge-thread-quota.bats
+            - "-t"
+            - "2"
             - "--reranking"
           env:
             - name: CUDA_VISIBLE_DEVICES

--- a/tests/spec/llm-pipeline/bge-thread-quota.bats
+++ b/tests/spec/llm-pipeline/bge-thread-quota.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/spec/llm-pipeline/bge-thread-quota.bats [T002661]
+#
+# PRÜFMODUS: Output-Verifikation. Die Assertions laufen gegen den gerenderten
+# Kustomize-Build von `k3d/` — also gegen das Artefakt, das Flux tatsächlich
+# anwendet — nicht per grep gegen den Manifest-Quelltext. Ein Patch in einem
+# Overlay, der `-t` wieder entfernt, fällt damit auf; ein Quelltext-grep würde
+# ihn übersehen.
+#
+# HINTERGRUND: k3d/llm-gpu.yaml setzte für beide llama.cpp-Container kein `-t`.
+# llama.cpp wählt dann nproc — im Container 8, während limits.cpu 2000m nur
+# 2 Kerne Quota gibt. Gemessen an bge-embed auf pk-hetzner-4 am 2026-08-04:
+# 5003 von 9172 Scheduling-Perioden gedrosselt (54,5 %), throttled_usec 2028 s
+# gegen usage_usec 1181 s — der Container wurde länger gedrosselt als er
+# rechnete. Folge: 10,7 s für ein Embedding von 13 Tokens.
+#
+# Bei llama.cpp ist Oversubscription überproportional teuer, weil alle Threads
+# an jeder Layer-Barriere synchronisieren: ist die Quota einer 100-ms-Periode
+# aufgebraucht, friert der Kernel alle Threads bis zum Periodenende ein.
+
+setup_file() {
+  export REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  export RENDERED="${BATS_FILE_TMPDIR}/k3d-rendered.yaml"
+  kubectl kustomize "${REPO_ROOT}/k3d" >"${RENDERED}" 2>/dev/null || true
+}
+
+# Gibt die args des llama-cpp-Containers eines Deployments als Zeilen aus.
+_llama_args() {
+  yq eval-all "select(.kind == \"Deployment\" and .metadata.name == \"$1\")
+    | .spec.template.spec.containers[]
+    | select(.name == \"llama-cpp\")
+    | .args[]" "${RENDERED}" 2>/dev/null
+}
+
+# Gibt limits.cpu des llama-cpp-Containers aus (z.B. '2000m' oder '2').
+_llama_cpu_limit() {
+  yq eval-all "select(.kind == \"Deployment\" and .metadata.name == \"$1\")
+    | .spec.template.spec.containers[]
+    | select(.name == \"llama-cpp\")
+    | .resources.limits.cpu" "${RENDERED}" 2>/dev/null
+}
+
+# '2000m' -> 2 ; '2' -> 2 ; '1500m' -> 1 (abgerundet, mindestens 1)
+_cpu_to_cores() {
+  local raw="$1" cores
+  if [[ "$raw" == *m ]]; then
+    cores=$(( ${raw%m} / 1000 ))
+  else
+    cores="${raw%%.*}"
+  fi
+  [ "$cores" -ge 1 ] 2>/dev/null || cores=1
+  echo "$cores"
+}
+
+# Wert des -t-Flags aus einer args-Liste (die Zeile nach '-t').
+_thread_flag() {
+  printf '%s\n' "$1" | grep -A1 '^-t$' | tail -n1
+}
+
+@test "bge-embed: -t ist gesetzt und überschreitet die CPU-Quota nicht" {
+  local args limit cores threads
+  args="$(_llama_args bge-embed)"
+
+  # Positiv-Anker [T002356-M1]: ohne ihn bestünde der Test vakuos, sobald der
+  # Build fehlschlägt oder der Container umbenannt wird — die Kandidatenliste
+  # wäre leer und jede Aussage über sie trivial wahr.
+  [ -n "$args" ]
+  printf '%s\n' "$args" | grep -qx -- '--embeddings'
+
+  limit="$(_llama_cpu_limit bge-embed)"
+  [ -n "$limit" ] && [ "$limit" != "null" ]
+  cores="$(_cpu_to_cores "$limit")"
+
+  printf '%s\n' "$args" | grep -qx -- '-t'
+  threads="$(_thread_flag "$args")"
+  [ -n "$threads" ]
+  [ "$threads" -ge 1 ]
+  [ "$threads" -le "$cores" ]
+}
+
+@test "bge-rerank: -t ist gesetzt und überschreitet die CPU-Quota nicht" {
+  local args limit cores threads
+  args="$(_llama_args bge-rerank)"
+
+  [ -n "$args" ]
+  printf '%s\n' "$args" | grep -qx -- '--reranking'
+
+  limit="$(_llama_cpu_limit bge-rerank)"
+  [ -n "$limit" ] && [ "$limit" != "null" ]
+  cores="$(_cpu_to_cores "$limit")"
+
+  printf '%s\n' "$args" | grep -qx -- '-t'
+  threads="$(_thread_flag "$args")"
+  [ -n "$threads" ]
+  [ "$threads" -ge 1 ]
+  [ "$threads" -le "$cores" ]
+}
+
+@test "bge-thread-quota: der laufende bge-embed-Pod trägt -t in seinen args" {
+  if ! kubectl --context "${BGE_CTX:-fleet}" get deploy bge-embed \
+      -n "${BGE_NS:-workspace}" -o name >/dev/null 2>&1; then
+    skip "kein fleet-Cluster erreichbar (offline/CI)"
+  fi
+  local args
+  args="$(kubectl --context "${BGE_CTX:-fleet}" get deploy bge-embed \
+    -n "${BGE_NS:-workspace}" \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="llama-cpp")].args}' 2>/dev/null)"
+
+  # Positiv-Anker: erst belegen, dass wir echte args gelesen haben.
+  [ -n "$args" ]
+  [[ "$args" == *"--embeddings"* ]]
+
+  [[ "$args" == *'"-t"'* ]]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2628,6 +2628,12 @@
     "kind": "shell"
   },
   {
+    "id": "llm-pipeline/bge-thread-quota",
+    "file": "tests/spec/llm-pipeline/bge-thread-quota.bats",
+    "category": "llm-pipeline",
+    "kind": "shell"
+  },
+  {
     "id": "llm-pipeline/bge-usecase-reachability",
     "file": "tests/spec/llm-pipeline/bge-usecase-reachability.bats",
     "category": "llm-pipeline",


### PR DESCRIPTION
## Problem

Ein Embedding von 13 Tokens über `llm-gateway-embed` dauerte **10,7 s** — stabil auch warm (10,87 s / 10,75 s). Zum Vergleich: ein Rerank über 5 Dokumente (119 Tokens, teurerer Cross-Encoder) braucht 3,38 s. Durch Rechenaufwand ist das nicht erklärbar.

## Ursache

`k3d/llm-gpu.yaml` setzte für beide llama.cpp-Container **kein `-t`**. llama.cpp wählt dann `nproc`. Im Container gilt:

| Messwert (`bge-embed`, `pk-hetzner-4`, cgroup) | Wert |
|---|---|
| `nproc` | **8** |
| `cpu.max` (aus `limits.cpu: 2000m`) | `200000 100000` → **2 Kerne** |
| `nr_periods` / `nr_throttled` | 9172 / **5003 (54,5 %)** |
| `throttled_usec` | **2028 s** |
| `usage_usec` | 1181 s |

Der Container wurde **länger gedrosselt, als er rechnete**.

Bei llama.cpp ist Oversubscription überproportional teuer: alle Threads synchronisieren an jeder Layer-Barriere. Ist die Quota einer 100-ms-Periode aufgebraucht, friert der Kernel *alle acht* ein, und die Barriere hält bis zum Periodenbeginn. Kleine Anfragen trifft das am härtesten, weil sich die Wartezeit über wenig Arbeit amortisiert.

`bge-rerank` trägt dasselbe Muster; dort war die Drosselung mit 145/12354 Perioden (1,2 %) bisher nur latent, weil das Deployment kaum Last sieht.

## Änderung

`-t 2` für beide Container, gebunden an `limits.cpu: 2000m`. Kommentar im Manifest hält fest, dass `-t` bei einer Änderung des CPU-Limits mitgezogen werden muss.

## Verifikation

Neuer Guard `tests/spec/llm-pipeline/bge-thread-quota.bats` (3 Tests). Er prüft den **gerenderten Kustomize-Build** statt den Manifest-Quelltext — ein Overlay-Patch, der `-t` wieder entfernt, fällt damit ebenfalls auf. Jeder Test trägt einen Positiv-Anker vor der eigentlichen Aussage (T002356-M1).

- Vor der Änderung: 3 von 3 rot, und zwar erst an der `-t`-Assertion (die Anker liefen durch — der Test ist nicht vakuos).
- Nach der Änderung: Tests 1 und 2 grün.
- Test 3 prüft das **laufende** Deployment und bleibt rot, bis Flux reconciled hat; in CI skippt er mangels Cluster-Zugang. Er ist bewusst die Rollout-Verifikation.
- `tests/spec/llm-pipeline.bats`: 55 ok / 0 not ok, keine Regression.
- `kubectl kustomize k3d/` baut sauber (10019 → 10023 Zeilen = exakt die 4 neuen arg-Einträge).

`task workspace:validate` konnte lokal nicht laufen: es validiert gegen einen k3d-API-Server auf `127.0.0.1:6445`, der hier nicht läuft. Der Kustomize-Build selbst ist wie oben belegt grün.

## Nach dem Merge

Die Latenz nach der Reconciliation nachmessen. Erwartung: deutlich unter den bisherigen 10,7 s. Sinkt sie unter 3 s, verschwindet als Nebeneffekt auch das Symptom aus T002659 (Probe-Timeout `--max-time 3` in `openspec-embed-local.sh`) — jenes Ticket bleibt dennoch gültig, weil ein Timeout unterhalb der realen Latenz grundsätzlich falsch dimensioniert ist.

## Nebenbefund

Kein `fleet`-Node hat eine GPU (`nvidia.com/gpu` = `<none>` auf allen fünf). Der Dateiname `k3d/llm-gpu.yaml` ist historisch irreführend; `-ngl 0` und `CUDA_VISIBLE_DEVICES=""` sind dort nicht Notbremse, sondern alternativlos. Nicht Teil dieses PRs.

## Abgrenzung

Nicht dasselbe wie T002580 (dort `limits.memory` 2Gi → 3Gi gegen die OOMKilled-Schleife, bereits umgesetzt). Dieser Fehler betrifft die CPU-Seite und war davon unberührt.

Verwandt: T002658, T002659, T002580, T002551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaVvgek5pDfWeEiWbymCPR