### PR TITLE
fix(agents): worktree-create meldet gescheiterten stash pop, stage-plan nach dem Commit [T002673]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -164,8 +164,10 @@ SSOT für Ticket-Anlage, Stage und Embedding: [ticket-stage-procedure](file:///h
 
 Dort steht auch der Ticket-Claim für diesen Schritt (`bash scripts/agent-lock.sh claim ticket "$TICKET_EXT_ID" …`, Session-Koordination [T000510]) — er muss laufen, bevor der Pre-Commit-Guard in Schritt 5 die Lock-Datei liest.
 
-> **`--hold`-Pflicht für interaktive Stage-Calls:** Der Aufruf von `stage-plan` in diesem Schritt MUSS `--hold` setzen (siehe `ticket-stage-procedure.md`). Dadurch wird `readiness.execution_released=false` gesetzt, was das Ticket vom Factory-Dispatch zurückhält, bis `dev-flow-execute` es explizit freigibt. Ohne `--hold` würde die Factory das Ticket sofort nach dem Stage-Commit dispatchen können, bevor der Operator die Ausführung freigegeben hat.
-### Schritt 5: Commit & Push — dann STOPP
+> **`--hold`-Pflicht für interaktive Stage-Calls:** Der Aufruf von `stage-plan` MUSS `--hold` setzen (siehe `ticket-stage-procedure.md`). Dadurch wird `readiness.execution_released=false` gesetzt, was das Ticket vom Factory-Dispatch zurückhält, bis `dev-flow-execute` es explizit freigibt. Ohne `--hold` würde die Factory das Ticket sofort dispatchen können, bevor der Operator die Ausführung freigegeben hat.
+
+> **⚠ `stage-plan` läuft NACH dem Commit aus Schritt 5, nicht hier [T002673].** In diesem Schritt werden nur **Ticket angelegt und geclaimt** — der Claim muss vor dem Pre-Commit-Guard liegen, der Stage-Aufruf nicht. Grund: `stage-plan` liest die Plandatei über `git cat-file -p "${branch}:${plan}"` aus dem **Branch-Commit**, nicht aus dem Arbeitsbaum (`scripts/vda/ticket/stage-plan.sh`). Vor dem Commit steht dort noch das `propose`-Skeleton, und die `touched_files`-Ableitung meldet dann `keine Pfade ableitbar` und lässt die Spalte leer — ohne dass es auffällt, weil die Meldung nur auf stderr steht und der Stage trotzdem Erfolg meldet. Die Ableitung selbst funktioniert (`scripts/plan-touched-files.sh` liefert gegen die reale Datei die vollständige Liste). `stage-plan` ist idempotent und vereinigt `touched_files` in SQL, ein späterer Zweitaufruf ist also unschädlich — die richtige Reihenfolge erspart ihn nur.
+### Schritt 5: Commit & Push, dann stagen — dann STOPP
 **Pre-Commit Guard (PFLICHT — Schritt 5) [T001268]:**
 Bevor der plan-stage Commit läuft, MUSS der Operator verifizieren:
 1. **Do not commit on main / Nicht auf main committen:**
@@ -190,6 +192,15 @@ Erst nach diesen drei Checks darf `git commit` und `git push` laufen. Damit verw
 git add openspec/changes/<slug>/
 git commit -m "chore(plans): stage <slug> for execution [$TICKET_EXT_ID]"
 git push -u origin $(git branch --show-current)
+
+# ERST JETZT stagen [T002673] — stage-plan liest den Plan aus dem Branch-Commit,
+# vorher stünde dort noch das propose-Skeleton und touched_files bliebe leer.
+# --partials N = Anzahl der Partials aus dem `## Partials`-Manifest (1..9, Pflicht).
+bash scripts/ticket.sh stage-plan \
+  --id "$TICKET_EXT_ID" \
+  --branch "$(git branch --show-current)" \
+  --plan "openspec/changes/<slug>/tasks.md" \
+  --partials <N> --hold
 ```
 ### Schritt 6: Optionaler Plan-Review (interaktiv)
 Bevor du den Plan committest und Ausführungsoptionen anzeigst, kannst du den Plan annotierbar rendern (`bash scripts/plan-review/plan-review.sh render openspec/changes/<slug>/tasks.md`) und im Browser reviewen. Details: [plan-review-ui](file:///home/patrick/Bachelorprojekt/.claude/skills/references/plan-review-ui.md).

--- a/.claude/skills/references/ticket-stage-procedure.md
+++ b/.claude/skills/references/ticket-stage-procedure.md
@@ -1,3 +1,12 @@
+> **⚠ Reihenfolge: erst committen, dann stagen [T002673].** Schritt 4.5 legt das Ticket an und
+> claimt es; der eigentliche `stage-plan`-Aufruf gehört **hinter** den Plan-Commit aus Schritt 5.
+> `stage-plan.sh` liest die Plandatei per `git cat-file -p "${branch}:${plan}"` aus dem
+> **Branch-Commit**, nicht aus dem Arbeitsbaum. Läuft es vor dem Commit, findet es dort das
+> `propose`-Skeleton, meldet `touched_files: keine Pfade aus '<plan>' ableitbar` auf stderr und
+> lässt die Spalte leer — der Aufruf gilt trotzdem als erfolgreich. Der Aufruf ist idempotent
+> und vereinigt `touched_files` in SQL; ein Zweitaufruf nach dem Commit repariert es also,
+> die richtige Reihenfolge erspart ihn.
+
 ### Schritt 4.5: Ticket anlegen oder wiederverwenden
 Prüfe ob ein bestehendes Ticket-ID übergeben wurde (z.B. von `feature-intake`).
 **MCP-first** (`ticket-mcp`) — wenn noch kein `TICKET_EXT_ID` gesetzt ist, ein neues Ticket anlegen (Rückgabe-Parsing: MCP-Tool-Guide §ticket-mcp).

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 796,
+      "file_count": 797,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -648,6 +648,7 @@
         "tests/spec/workspace-deploy-secrets-scope.bats",
         "tests/spec/workspace-deploy.bats",
         "tests/spec/worktree-divergence-guard-T002387.bats",
+        "tests/spec/worktree-divergence-guard/stash-restore-visible.bats",
         "tests/sql/software-history.sql",
         "tests/unit/.coverage-allowlist",
         "tests/unit/T000617-alert-rules.bats",

--- a/scripts/worktree-create.sh
+++ b/scripts/worktree-create.sh
@@ -106,6 +106,27 @@ if [ "${WT_SKIP_NAME_CHECK:-0}" != "1" ]; then
   fi
 fi
 
+# [T002673] Spielt den Auto-Stash zurueck. Scheitert der Pop, wird das LAUT
+# gemeldet statt verschluckt — die uncommitteten Aenderungen des Aufrufers liegen
+# dann noch im Stash, und ohne Hinweis haelt er sie fuer wiederhergestellt.
+# Rueckgabe immer 0: der Worktree ist trotzdem nutzbar, und ein Abbruch waere
+# hier schaedlicher als die Warnung (der Stash bliebe genauso liegen).
+_wc_stash_pop_or_warn() {
+  if git stash pop >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "" >&2
+  echo "⚠  worktree-create: DEINE UNCOMMITTETEN AENDERUNGEN LIEGEN NOCH IM STASH." >&2
+  echo "   Der automatische 'git stash pop' ist fehlgeschlagen — meist ein Konflikt" >&2
+  echo "   mit inzwischen gemergten main-Aenderungen. Der neue Worktree ist nutzbar," >&2
+  echo "   aber der Haupt-Checkout hat deine Aenderungen NICHT zurueck." >&2
+  echo "" >&2
+  echo "   Zurueckholen:  git stash apply stash@{0}    # 'worktree-create-auto-stash'" >&2
+  echo "   Auflisten:     git stash list" >&2
+  echo "" >&2
+  return 0
+}
+
 # T001302/T001332: Divergence guard — auto-sync if local main is behind origin/main,
 # reject if truly diverged.
 # Only fires when origin/main exists (e.g. real upstream repos), so BATS tests with
@@ -120,25 +141,40 @@ if git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
         echo "       Aktueller Branch: $CURRENT_BRANCH. Bitte: git checkout main" >&2
         exit 1
       fi
+      # [T002673] Der Auto-Stash darf nicht stillschweigend liegenbleiben.
+      # Vorher stand hier `git stash push … 2>/dev/null || true` und spiegelbildlich
+      # `git stash pop 2>/dev/null || true`. Beides verschluckte Meldung UND
+      # Exit-Code. Scheiterte der Pop — typisch, wenn der Stash mit inzwischen
+      # gemergten main-Aenderungen kollidiert — meldete das Skript trotzdem
+      # "ready", und die uncommitteten Aenderungen des Aufrufers lagen unbemerkt
+      # im Stash. Real passiert am 2026-08-04.
+      # Guard: tests/spec/worktree-divergence-guard/stash-restore-visible.bats
       _needs_pop=false
       if ! git diff --quiet HEAD 2>/dev/null; then
-        git stash push -m "worktree-create-auto-stash" 2>/dev/null || true
-        _needs_pop=true
+        if git stash push -m "worktree-create-auto-stash" >/dev/null; then
+          _needs_pop=true
+        else
+          # Kein `|| true`: laeuft das Skript hier weiter, poppt der Schritt
+          # unten einen FREMDEN Stash-Eintrag in den Haupt-Checkout.
+          echo "FATAL: worktree-create: konnte den dirty Haupt-Checkout nicht stashen." >&2
+          echo "       Abbruch, damit kein fremder Stash-Eintrag angewendet wird." >&2
+          exit 1
+        fi
       fi
       if [ "$CURRENT_BRANCH" = "main" ]; then
         git pull --rebase origin main 2>/dev/null || {
           echo "FATAL: auto-sync failed — could not pull origin/main into main." >&2
-          $_needs_pop && git stash pop 2>/dev/null || true
+          if $_needs_pop; then _wc_stash_pop_or_warn; fi
           exit 1
         }
       else
         git fetch origin +refs/heads/main:refs/remotes/origin/main 2>/dev/null || {
           echo "FATAL: auto-sync failed — could not fast-forward main." >&2
-          $_needs_pop && git stash pop 2>/dev/null || true
+          if $_needs_pop; then _wc_stash_pop_or_warn; fi
           exit 1
         }
       fi
-      $_needs_pop && git stash pop 2>/dev/null || true
+      if $_needs_pop; then _wc_stash_pop_or_warn; fi
       echo "worktree-create: local main synced to origin/main" >&2
     else
       echo "FATAL: local 'main' has diverged from 'origin/main'." >&2

--- a/tests/spec/worktree-divergence-guard/stash-restore-visible.bats
+++ b/tests/spec/worktree-divergence-guard/stash-restore-visible.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# tests/spec/worktree-divergence-guard/stash-restore-visible.bats [T002673]
+#
+# PRÜFMODUS: Output-Verifikation. Der Test baut ein echtes Repo-Paar (bare
+# origin + Klon), erzeugt genau die Lage, in der `git stash pop` scheitern muss,
+# ruft `scripts/worktree-create.sh` als Kommando auf und prüft dessen Ausgabe.
+# Kein Source-Grep — der bestehende Nachbartest zu derselben Datei
+# (worktree-divergence-guard-T002387.bats) arbeitet so, hier ist das Verhalten
+# aber direkt beobachtbar.
+#
+# HINTERGRUND: Das Skript stasht einen dirty Haupt-Checkout, um `git pull
+# --rebase origin main` fahren zu können, und poppt danach zurück:
+#
+#   git stash push -m "worktree-create-auto-stash" 2>/dev/null || true
+#   ...
+#   $_needs_pop && git stash pop 2>/dev/null || true
+#
+# Scheitert der Pop — typisch, wenn der Stash mit inzwischen gemergten
+# main-Änderungen kollidiert — verschluckt `2>/dev/null || true` Meldung UND
+# Exit-Code. Das Skript meldet "ready", der Aufrufer hält seine Änderungen für
+# wiederhergestellt, und sie liegen im Stash. Real aufgetreten am 2026-08-04.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/worktree-create.sh"
+  ORIGIN="${BATS_TEST_TMPDIR}/origin.git"
+  CLONE="${BATS_TEST_TMPDIR}/clone"
+
+  git init -q --bare -b main "$ORIGIN"
+  git clone -q "$ORIGIN" "$CLONE"
+  cd "$CLONE" || return 1
+  git config user.email "test@example.invalid"
+  git config user.name "Test"
+  git config commit.gpgsign false
+
+  echo "zeile-eins" > shared.txt
+  git add shared.txt
+  git commit -qm "base"
+  git branch -M main
+  git push -q origin main
+
+  # origin bekommt einen Commit, der dieselbe Zeile ändert -> local main liegt
+  # zurück, und ein Stash auf dieser Datei kollidiert beim Pop.
+  local upstream="${BATS_TEST_TMPDIR}/upstream"
+  git clone -q -b main "$ORIGIN" "$upstream"
+  git -C "$upstream" config user.email "test@example.invalid"
+  git -C "$upstream" config user.name "Test"
+  git -C "$upstream" config commit.gpgsign false
+  echo "zeile-eins-vom-remote" > "$upstream/shared.txt"
+  git -C "$upstream" commit -qam "remote ändert dieselbe Zeile"
+  git -C "$upstream" push -q origin main
+
+  git fetch -q origin
+
+  # Dirty im Haupt-Checkout, dieselbe Zeile -> Pop-Konflikt garantiert.
+  echo "zeile-eins-lokal-uneingecheckt" > shared.txt
+}
+
+# Regressionsschutz für den Normalfall: bei SAUBEREM Haupt-Checkout gibt es
+# nichts zu stashen, und das Skript muss den Fast-Forward-Pfad trotzdem
+# vollständig durchlaufen. Der Test deckt die Variante ab, in der die
+# Rückspiel-Logik fälschlich auch ohne vorherigen Stash anspringt oder den
+# Ablauf abbricht.
+#
+# Ausdrücklich NICHT belegt: dass `$_needs_pop && cmd` unter `set -e` abbräche.
+# Nachgemessen am 2026-08-04 — tut es nicht, weil Bash Fehler in AND-Listen vom
+# errexit ausnimmt. Die `if`-Form im Skript ist eine Lesbarkeitsentscheidung,
+# keine Fehlerbehebung; dieser Kommentar steht hier, damit niemand die
+# Begründung später aus dem Testnamen zurückliest.
+@test "worktree-create: sauberer Haupt-Checkout laeuft trotz Fast-Forward durch" {
+  git checkout -q -- shared.txt   # dirty-Zustand aus setup() zuruecknehmen
+  git diff --quiet HEAD
+
+  run bash "$SCRIPT" fix/clean-probe-T000002 "${BATS_TEST_TMPDIR}/wt-clean"
+
+  # Positiv-Anker: das Skript hat den Fast-Forward-Pfad ueberhaupt betreten.
+  [[ "$output" == *"behind origin/main"* ]]
+
+  # Und ist nicht daran gestorben.
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ready on"* ]]
+}
+
+@test "worktree-create: gescheiterter stash pop wird laut gemeldet, nicht verschluckt" {
+  run bash "$SCRIPT" fix/stash-probe-T000001 "${BATS_TEST_TMPDIR}/wt"
+
+  # Positiv-Anker [T002356-M1]: erst belegen, dass das Skript überhaupt gelaufen
+  # ist und den Stash-Pfad erreicht hat. Ohne ihn wäre die Aussage über die
+  # Warnung trivial wahr, sobald das Skript früher abbricht.
+  [ -n "$output" ]
+  [[ "$output" == *"stash"* ]] || [[ "$output" == *"Stash"* ]]
+
+  # Der Stash darf nicht unbemerkt liegenbleiben: entweder wurde er sauber
+  # zurückgespielt (dann ist die Arbeitskopie wieder dirty), oder das Skript
+  # sagt unmissverständlich, dass er liegengeblieben ist.
+  local stash_count
+  stash_count="$(git stash list | grep -c 'worktree-create-auto-stash' || true)"
+  if [ "$stash_count" -gt 0 ]; then
+    # Liegengeblieben -> die Ausgabe MUSS darauf hinweisen und den Namen nennen.
+    [[ "$output" == *"worktree-create-auto-stash"* ]]
+    [[ "$output" == *"git stash"* ]]
+  else
+    # Sauber zurückgespielt -> die lokale Änderung ist wieder da.
+    grep -q "zeile-eins-lokal-uneingecheckt" shared.txt
+  fi
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3694,5 +3694,11 @@
     "file": "tests/spec/worktree-divergence-guard-T002387.bats",
     "category": "worktree-divergence-guard-T002387",
     "kind": "shell"
+  },
+  {
+    "id": "worktree-divergence-guard/stash-restore-visible",
+    "file": "tests/spec/worktree-divergence-guard/stash-restore-visible.bats",
+    "category": "worktree-divergence-guard",
+    "kind": "shell"
   }
 ]


### PR DESCRIPTION
Zwei Reibungen derselben Werkzeugkette, beide vom selben Muster: **ein Teilerfolg, der wie Erfolg aussieht.**

## 1. `worktree-create.sh` verliert Änderungen still

Das Skript stasht einen dirty Haupt-Checkout, um `git pull --rebase origin main` fahren zu können, und poppt danach zurück:

```bash
git stash push -m "worktree-create-auto-stash" 2>/dev/null || true
...
$_needs_pop && git stash pop 2>/dev/null || true
```

`2>/dev/null || true` verschluckt Meldung **und** Exit-Code. Scheitert der Pop — typisch, wenn der Stash mit inzwischen gemergten `main`-Änderungen kollidiert — meldet das Skript trotzdem `ready on branch …`, und die uncommitteten Änderungen liegen unbemerkt im Stash.

Real passiert am 2026-08-04: gefunden nur, weil zufällig `capabilities.yaml` nachgeschlagen wurde. Das ist gefährlicher als ein hartes Scheitern — ein sichtbarer Fehler hätte sofort zum Stash geführt.

**Änderungen:**
- `git stash push` ohne Unterdrückung. Schlägt *er* fehl, wird abgebrochen statt weiterzulaufen — sonst poppt der Schritt unten einen **fremden** Stash-Eintrag in den Haupt-Checkout.
- `git stash pop` über `_wc_stash_pop_or_warn()`: bei Fehlschlag eine laute Warnung mit Rückhol-Befehl. Rückgabe bleibt 0, der Worktree ist ja nutzbar.

## 2. `stage-plan` läuft vor dem Commit

`dev-flow-plan` Schritt 4.5 rief `stage-plan` **vor** dem Plan-Commit aus Schritt 5 auf. `stage-plan.sh` liest die Plandatei aber per `git cat-file -p "${branch}:${plan}"` aus dem **Branch-Commit**, nicht aus dem Arbeitsbaum — dort stand zu dem Zeitpunkt noch das `propose`-Skeleton.

Ergebnis: `touched_files: keine Pfade ableitbar`, Spalte bleibt leer, Aufruf gilt trotzdem als erfolgreich. Die Ableitung selbst funktioniert einwandfrei (`plan-touched-files.sh` liefert gegen die reale Datei die vollständige Liste).

Der Stage-Aufruf wandert hinter den Commit; der Ticket-Claim bleibt in 4.5, weil der Pre-Commit-Guard ihn liest.

## Verifikation

`tests/spec/worktree-divergence-guard/stash-restore-visible.bats` — zwei Tests gegen ein echtes bare-origin/Klon-Paar mit garantiertem Pop-Konflikt. Output-Verifikation, kein Source-Grep (der Nachbartest zur selben Datei arbeitet so, hier ist das Verhalten aber direkt beobachtbar).

- Vor dem Fix: rot an der Assertion auf den Rückhol-Hinweis — die Positiv-Anker liefen durch, der Test ist also nicht vakuos.
- Nach dem Fix: 2/2 grün.
- Bestandstests zu `worktree-create.sh` (`divergence-guard.bats`, `worktree-divergence-guard-T002387.bats`): 6/6 grün.

### Was der PR ausdrücklich *nicht* belegt

Meine ursprüngliche Vermutung war, `$_needs_pop && cmd` breche unter `set -e` ab, wenn nichts zu stashen war. **Nachgemessen: tut es nicht** — Bash nimmt Fehler in AND-Listen vom `errexit` aus. Die `if`-Form im Skript ist eine Lesbarkeitsentscheidung, keine Fehlerbehebung. Das steht so im Testkommentar, damit niemand die Begründung später aus dem Testnamen zurückliest.

Verwandt: T002672, T002659, T002661 (dieselbe Fehlerklasse), T002387 (früherer Fix an derselben Datei).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaVvgek5pDfWeEiWbymCPR