### PR TITLE
fix(website): Infra-Allowlist in BUILD_TARGET=sdlc-Route-Filter [T002675]

### DIFF
--- a/tests/spec/sdlc-isolation/build-target-split.bats
+++ b/tests/spec/sdlc-isolation/build-target-split.bats
@@ -8,7 +8,39 @@ setup() {
   BUILD_WEBSITE_YML="$REPO_ROOT/.github/workflows/build-website.yml"
   SDLC_PAGES_DIR="$REPO_ROOT/website/src/pages/sdlc"
   ADMIN_PAGES_DIR="$REPO_ROOT/website/src/pages/admin"
+  BUILD_TARGET_MJS="$REPO_ROOT/website/src/integrations/build-target.mjs"
+  SDLC_CONSOLE_YAML="$REPO_ROOT/k3d/sdlc-stack/sdlc-console.yaml"
 }
+
+# ── T002675: Infra-Allowlist im BUILD_TARGET=sdlc-Filter ──────────────────
+# Die sdlc-console probet /api/health und braucht /api/auth/* + /login für den
+# OIDC-Login. Diese Routen müssen im sdlc-Route-Manifest erhalten bleiben,
+# sonst crasht der Container in der Probe-Schleife (HTTP 404, T002675).
+
+@test "T002675: build-target.mjs enthaelt Infra-Allowlist /api/health und /api/auth/" {
+  [ -f "$BUILD_TARGET_MJS" ] || { echo "MISSING: $BUILD_TARGET_MJS"; return 1; }
+  grep -q "/api/health" "$BUILD_TARGET_MJS" \
+    || { echo "MISSING '/api/health' in der Infra-Allowlist von build-target.mjs"; return 1; }
+  grep -q "/api/auth/" "$BUILD_TARGET_MJS" \
+    || { echo "MISSING '/api/auth/' in der Infra-Allowlist von build-target.mjs"; return 1; }
+}
+
+@test "T002675: sdlc-console Probe-Pfad /api/health ist von der Allowlist abgedeckt" {
+  [ -f "$SDLC_CONSOLE_YAML" ] || { echo "MISSING: $SDLC_CONSOLE_YAML"; return 1; }
+  [ -f "$BUILD_TARGET_MJS" ] || { echo "MISSING: $BUILD_TARGET_MJS"; return 1; }
+  # Proben dürfen nie auf eine Route zeigen, die der sdlc-Filter entfernt.
+  probe_path=$(grep -A2 "readinessProbe:" "$SDLC_CONSOLE_YAML" | grep "path:" | head -1 | sed -E 's/.*path: *"?([^" ]+)"?.*/\1/')
+  [ -n "$probe_path" ] || { echo "FAIL: keine Probe-Path in $SDLC_CONSOLE_YAML gefunden"; return 1; }
+  grep -q "$probe_path" "$BUILD_TARGET_MJS" \
+    || { echo "FAIL: Probe-Path '$probe_path' ist nicht in der build-target.mjs-Allowlist"; return 1; }
+}
+
+@test "T002675: build-target.mjs haelt /login.astro als Infra-Route (Login-Seite)" {
+  [ -f "$BUILD_TARGET_MJS" ] || { echo "MISSING: $BUILD_TARGET_MJS"; return 1; }
+  grep -qE "login\.astro" "$BUILD_TARGET_MJS" \
+    || { echo "MISSING '/login.astro' in der Infra-Allowlist von build-target.mjs"; return 1; }
+}
+
 
 # Assertion 1: build-website.yml enthält die drei negativen Pfad-Muster.
 @test "T002624: build-website.yml enthaelt negativen Pfad-Filter für pages/sdlc (RED vor Task 5)" {

--- a/website/src/integrations/build-target.mjs
+++ b/website/src/integrations/build-target.mjs
@@ -16,19 +16,44 @@
 /** @typedef {{ component?: string; pathname?: string }} ResolvedRoute */
 
 /**
+ * Infrastrukturelle Routen, die in JEDEM Build-Ziel erhalten bleiben müssen
+ * (T002675). Ohne diese Allowlist filtert BUILD_TARGET=sdlc sie aus dem
+ * Route-Manifest und die sdlc-console crasht in der Probe-Schleife (HTTP 404
+ * auf /api/health) bzw. der OIDC-Login bricht ab (/api/auth/callback fehlt,
+ * /login fehlt):
+ *   - /api/health   → Liveness/Readiness-Probe (k3d/sdlc-stack/sdlc-console.yaml)
+ *   - /api/auth/*   → OIDC-Login-Oberfläche (login, callback, me, logout)
+ *   - /login.astro  → Login-Seite (sdlc-Seiten redirecten auf /login)
+ */
+const INFRA_ROUTE_SUBSTRINGS = ['/api/health', '/api/auth/'];
+const INFRA_ROUTE_SUFFIXES = ['/login.astro'];
+
+/** @param {string} component */
+function isInfraRoute(component) {
+  if (INFRA_ROUTE_SUBSTRINGS.some((s) => component.includes(s))) return true;
+  return INFRA_ROUTE_SUFFIXES.some((s) => component.endsWith(s));
+}
+
+/**
+ * @param {string} component
+ * @param {'prod'|'sdlc'|string|undefined} buildTarget
+ */
+function keepRoute(component, buildTarget) {
+  if (isInfraRoute(component)) return true;
+  const isSdlc = component.includes('/sdlc/') || component.includes('\\sdlc\\');
+  if (buildTarget === 'prod') return !isSdlc;
+  if (buildTarget === 'sdlc') return isSdlc;
+  return true;
+}
+
+/**
  * @param {ResolvedRoute[]} routes
  * @param {'prod'|'sdlc'|string|undefined} buildTarget
  * @returns {ResolvedRoute[]}
  */
 export function filterRoutesByBuildTarget(routes, buildTarget) {
   if (!buildTarget) return routes;
-  return routes.filter((route) => {
-    const component = route.component || '';
-    const isSdlc = component.includes('/sdlc/') || component.includes('\\sdlc\\');
-    if (buildTarget === 'prod') return !isSdlc;
-    if (buildTarget === 'sdlc') return isSdlc;
-    return true;
-  });
+  return routes.filter((route) => keepRoute(route.component || '', buildTarget));
 }
 
 /** @param {import('astro').RouteData} routeData */
@@ -44,14 +69,9 @@ export default function buildTargetIntegration() {
     hooks: {
       'astro:build:ssr'({ manifest }) {
         if (!buildTarget || !manifest?.routes) return;
-        const keep = (route) => {
-          const component = routeComponent(route?.routeData);
-          const isSdlc = component.includes('/sdlc/') || component.includes('\\sdlc\\');
-          if (buildTarget === 'prod') return !isSdlc;
-          if (buildTarget === 'sdlc') return isSdlc;
-          return true;
-        };
-        manifest.routes = manifest.routes.filter(keep);
+        manifest.routes = manifest.routes.filter((route) =>
+          keepRoute(routeComponent(route?.routeData), buildTarget)
+        );
       },
     },
   };

--- a/website/src/integrations/build-target.test.ts
+++ b/website/src/integrations/build-target.test.ts
@@ -10,6 +10,8 @@ describe('build-target integration', () => {
     { component: '/app/src/pages/sdlc/pipeline.astro', pathname: '/sdlc/pipeline' },
     { component: '/app/src/pages/sdlc/api/ops/status.ts', pathname: '/sdlc/api/ops/status' },
     { component: '/app/src/pages/api/auth/login.ts', pathname: '/api/auth/login' },
+    { component: '/app/src/pages/api/health.ts', pathname: '/api/health' },
+    { component: '/app/src/pages/login.astro', pathname: '/login' },
   ];
 
   it('keeps all routes when BUILD_TARGET is not set', () => {
@@ -19,18 +21,21 @@ describe('build-target integration', () => {
 
   it('removes SDLC routes when BUILD_TARGET=prod', () => {
     const result = filterRoutesByBuildTarget(mockRoutes, 'prod');
-    expect(result).toHaveLength(4);
+    expect(result).toHaveLength(6);
     expect(result.find((r) => r.pathname === '/')).toBeDefined();
     expect(result.find((r) => r.pathname === '/kontakt')).toBeDefined();
     expect(result.find((r) => r.pathname === '/admin/rechnungen')).toBeDefined();
+    expect(result.find((r) => r.pathname === '/api/auth/login')).toBeDefined();
+    expect(result.find((r) => r.pathname === '/api/health')).toBeDefined();
+    expect(result.find((r) => r.pathname === '/login')).toBeDefined();
     expect(result.find((r) => r.pathname === '/sdlc/cockpit')).toBeUndefined();
     expect(result.find((r) => r.pathname === '/sdlc/pipeline')).toBeUndefined();
     expect(result.find((r) => r.pathname === '/sdlc/api/ops/status')).toBeUndefined();
   });
 
-  it('keeps only SDLC routes when BUILD_TARGET=sdlc', () => {
+  it('keeps SDLC + infra routes when BUILD_TARGET=sdlc', () => {
     const result = filterRoutesByBuildTarget(mockRoutes, 'sdlc');
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(6);
     expect(result.find((r) => r.pathname === '/sdlc/cockpit')).toBeDefined();
     expect(result.find((r) => r.pathname === '/sdlc/pipeline')).toBeDefined();
     expect(result.find((r) => r.pathname === '/sdlc/api/ops/status')).toBeDefined();
@@ -39,10 +44,23 @@ describe('build-target integration', () => {
     expect(result.find((r) => r.pathname === '/admin/rechnungen')).toBeUndefined();
   });
 
-  it('removes all non-SDLC routes including api/auth when BUILD_TARGET=sdlc', () => {
+  it('keeps infrastructural routes for liveness probes and OIDC login when BUILD_TARGET=sdlc (T002675)', () => {
     const result = filterRoutesByBuildTarget(mockRoutes, 'sdlc');
     const paths = result.map((r) => r.pathname);
-    expect(paths).not.toContain('/api/auth/login');
+    expect(paths).toContain('/api/health');
+    expect(paths).toContain('/api/auth/login');
+    expect(paths).toContain('/login');
+  });
+
+  it('keeps all /api/auth/* and /api/health routes when BUILD_TARGET=sdlc', () => {
+    const infraOnly = [
+      { component: '/app/src/pages/api/health.ts', pathname: '/api/health' },
+      { component: '/app/src/pages/api/auth/callback.ts', pathname: '/api/auth/callback' },
+      { component: '/app/src/pages/api/auth/me.ts', pathname: '/api/auth/me' },
+      { component: '/app/src/pages/api/auth/logout.ts', pathname: '/api/auth/logout' },
+    ];
+    const result = filterRoutesByBuildTarget(infraOnly, 'sdlc');
+    expect(result).toHaveLength(4);
   });
 
   it('returns empty array when no routes match BUILD_TARGET=sdlc', () => {


### PR DESCRIPTION
## Fix T002675

**Symptom:** sdlc-console probet /api/health, das im BUILD_TARGET=sdlc-Image per Konstruktion fehlt → Liveness/Readiness-Probe HTTP 404 → Container-Restart-Schleife, `task sdlc:deploy` haengt bei rollout status. OIDC-Login unmoeglich (/api/auth/callback gefiltert).

**Ursache:** `filterRoutesByBuildTarget` behaelt bei BUILD_TARGET=sdlc nur Routen mit /sdlc/-Komponentenpfad.

**Fix:** Infra-Allowlist in build-target.mjs — /api/health, /api/auth/* und /login.astro bleiben in jedem Build-Ziel erhalten (genutzt von `filterRoutesByBuildTarget` und dem astro:build:ssr-Hook).

**Verifikation:**
- vitest build-target.test.ts: 6/6 grün (inkl. neue Allowlist-Fälle)
- BATS tests/spec/sdlc-isolation/build-target-split.bats: 9/9 grün (inkl. Probe↔Allowlist-Sync-Invariant)
- task freshness:check: grün

Closes T002675