### PR TITLE
fix(infra): pocket-id-client-seed terminiert mit Bootstrap-Hinweis statt silent Backoff [T002676]

### DIFF
--- a/docs/runbooks/pocket-id-bootstrap.md
+++ b/docs/runbooks/pocket-id-bootstrap.md
@@ -1,0 +1,52 @@
+# Pocket-ID-Bootstrap (frische Instanz) — T002676
+
+Einmaliges manuelles Vorgehen für jeden **neu aufgesetzten** Cluster. Pocket ID
+erzeugt API-Keys ausschliesslich in der UI (Session); sie lassen sich nicht per
+Secret oder Env vorgeben. Ohne Admin-User existiert also kein Key — Henne-Ei,
+das der `pocket-id-client-seed`-Job nicht selbst auflösen kann.
+
+## Symptome
+
+- Job `pocket-id-client-seed` steht auf `Failed` (BackoffLimitExceeded), Pod-Log:
+  `HTTP 401` vom Admin-API (`GET /api/oidc/clients`).
+- `oidc_clients` hat 0 Zeilen; jeder Login gegen `auth.<domain>` endet mit
+  "The requested OAuth 2.0 Client does not exist."
+
+## Manuelle Schritte (einmalig)
+
+1. **Ersten Admin anlegen:** <http://auth.localhost/setup> mit Passkey
+   (WebAuthn). Chromium ist nötig — Firefox gewährt `*.localhost` keinen
+   Secure Context für WebAuthn.
+2. **API-Key erzeugen:** Pocket-ID-UI → Einstellungen → API-Keys → neuen Key
+   erstellen.
+3. **Key in `workspace-secrets` schreiben:**
+   ```bash
+   kubectl -n workspace patch secret workspace-secrets --type merge \
+     -p '{"stringData":{"POCKET_ID_API_KEY":"<key>"}}'
+   ```
+   (Für den Dev-Cluster zusätzlich in `website-secrets` im `website`-Namespace,
+   falls das dort referenziert wird.)
+4. **Seed-Job neu starten:**
+   ```bash
+   kubectl -n workspace delete job pocket-id-client-seed
+   # Job wird beim nächsten workspace:deploy / Flux-Reconcile neu erzeugt,
+   # oder manuell: kubectl -n workspace apply -f k3d/pocket-id-client-seed.yaml
+   ```
+
+## Hilfreiche Kommandos
+
+Sobald ein User existiert, kann ein One-Time-Access-Token direkt ausgegeben
+werden (Login ohne Passkey-Flow in der Konsole):
+
+```bash
+kubectl exec -n workspace <pocket-id-pod> -c pocket-id -- \
+  /app/pocket-id one-time-access-token <user>
+```
+
+## Warum nicht automatisiert?
+
+Pocket ID (2.x) hasht API-Keys vor dem Speichern (`api_keys.key` varchar(255),
+Unique-Constraint) — ein Klartext-Seed per SQL oder Secret wird von der API
+nicht akzeptiert (HTTP 401, gemessen 2026-08-04). Der `pocket-id-client-seed`
+Job terminiert bei 401/403 mit einer handlungsleitenden Meldung, die auf diese
+Datei verweist, statt still in BackoffLimitExceeded zu laufen (T002676).

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -204,13 +204,30 @@ spec:
               # POST (create) for every single row before `set -e` finally
               # kills the script, and restartPolicy: OnFailure repeats this
               # on every retry, each time adding more zombie oidc_clients
-              # rows (T001992). Only a genuine 401/403 aborts here --
-              # $CURL_RETRY (incl. --retry-connrefused) still covers
-              # transient connection refusals during pod startup (T001327).
+              # rows (T001992). $CURL_RETRY (incl. --retry-connrefused) still
+              # covers transient connection refusals during pod startup (T001327).
               auth_check_code=$(curl -fsS $CURL_RETRY -o /dev/null -w '%{http_code}' -H "$AUTH" "${API}/api/oidc/clients" </dev/null 2>/dev/null || echo "000")
               case "$auth_check_code" in
+                2??)
+                  # API-Key akzeptiert -- weiter mit dem Client-Seeding.
+                  ;;
                 401|403)
-                  echo "ERROR: POCKET_ID_API_KEY rejected by Pocket-ID (HTTP ${auth_check_code}) -- aborting before processing any client row. Check for API-key drift (see T001992)." >&2
+                  # T002676: auf einer FRISCHEN Instanz gibt es per Konstruktion
+                  # keinen User und damit keinen API-Key -- der Key kann nur in der
+                  # Pocket-ID-UI (Session) erzeugt werden, nicht per Secret/Env.
+                  # Der Job kann das nicht selbst aufloesen; statt still in
+                  # BackoffLimitExceeded zu laufen, terminiert er mit einer
+                  # handlungsleitenden Meldung.
+                  echo "ERROR: POCKET_ID_API_KEY von Pocket-ID abgelehnt (HTTP ${auth_check_code}) -- Abbruch vor der Verarbeitung irgendeiner Client-Zeile." >&2
+                  echo "  Ursache 1 (frische Instanz, T002676): API-Keys entstehen ausschliesslich in der Pocket-ID-UI. Bootstrap-Schritte: docs/runbooks/pocket-id-bootstrap.md" >&2
+                  echo "  Ursache 2 (Drift, T001992): der Key wurde rotiert/geaendert und workspace-secrets haengt hinterher." >&2
+                  exit 1
+                  ;;
+                *)
+                  # 000 (Verbindung fehlgeschlagen) oder unerwarteter Status
+                  # (z.B. 5xx): nicht blind weiterlaufen, sonst landen die
+                  # upsert()-Versuche im "client not found"-Pfad (T001992-Bugklasse).
+                  echo "ERROR: POCKET_ID_API_KEY kann nicht verifiziert werden (HTTP ${auth_check_code}) -- Pocket-ID nicht erreichbar oder unerwartete Antwort. Abbruch." >&2
                   exit 1
                   ;;
               esac

--- a/tests/spec/pocket-id-client-seed-early-abort.bats
+++ b/tests/spec/pocket-id-client-seed-early-abort.bats
@@ -46,3 +46,38 @@ setup() {
   [ "$status" -eq 0 ]
   echo "$output" | grep -qE '401.*403|403.*401|"401"\)|"403"\)'
 }
+
+# ── T002676: frische Instanz (Deadlock) ────────────────────────────────────
+# Auf einem frischen Cluster existiert per Konstruktion kein API-Key (Henne-Ei).
+# Der 401/403-Abbruch muss eine handlungsleitende Meldung mit Bootstrap-Hinweis
+# ausgeben statt still in BackoffLimitExceeded zu laufen.
+
+@test "pocket-id-client-seed: 401/403-Abbruch verweist auf das Bootstrap-Runbook (T002676)" {
+  run grep -A8 '401|403)' "$MANIFEST"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "runbooks/pocket-id-bootstrap.md" \
+    || { echo "FAIL: 401/403-Zweig verweist nicht auf docs/runbooks/pocket-id-bootstrap.md"; return 1; }
+}
+
+@test "pocket-id-client-seed: auth-check faengt unerwartete Status (nicht 2xx/401/403) ab (T002676)" {
+  # 2xx-Zweig muss im auth-check case existieren
+  run grep -A3 'auth_check_code' "$MANIFEST"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '2??' \
+    || { echo "FAIL: kein 2xx-Zweig im auth-check case"; return 1; }
+  # Wildcard-Zweig (*) muss NACH dem case stehen (kein stilles Durchfallen)
+  run grep -n 'auth_check_code' "$MANIFEST"
+  [ "$status" -eq 0 ]
+  case_line="${lines[0]%%:*}"
+  wild_line=""
+  for ln in $(grep -n '\*)$' "$MANIFEST" | cut -d: -f1); do
+    if [ "$ln" -gt "$case_line" ]; then wild_line="$ln"; break; fi
+  done
+  [ -n "$wild_line" ] \
+    || { echo "FAIL: kein Wildcard-Zweig nach dem auth-check case"; return 1; }
+}
+
+@test "pocket-id-client-seed: Bootstrap-Runbook existiert (T002676)" {
+  [ -f "${REPO_ROOT}/docs/runbooks/pocket-id-bootstrap.md" ] \
+    || { echo "MISSING: docs/runbooks/pocket-id-bootstrap.md"; return 1; }
+}


### PR DESCRIPTION
## Fix T002676

**Symptom:** Auf frischer Instanz steht `pocket-id-client-seed` dauerhaft auf Failed (BackoffLimitExceeded, HTTP 401) — API-Key ist per Konstruktion nicht vorgebbar (Pocket ID hasht Keys, Erzeugung nur in der UI/Session), also Henne-Ei.

**Fix:**
1. 401/403-Abbruch verweist jetzt handlungsleitend auf das neue Runbook `docs/runbooks/pocket-id-bootstrap.md` (Setup → Admin → API-Key → Secret patchen → Job neu starten)
2. Auth-Check fängt zusätzlich unerwartete Status (nicht 2xx/401/403) ab statt im 'client not found'-Pfad weiterzulaufen (T001992-Bugklasse)
3. Neues Runbook mit den manuellen Bootstrap-Schritten

**Verifikation:**
- BATS tests/spec/pocket-id-client-seed-early-abort.bats: 5/5 grün (+ weitere pocket-id-Spec-Suiten grün)
- `task workspace:validate`: ✓ Manifests valid
- `task freshness:check`: grün

Closes T002676