### PR TITLE
fix(website): OIDC-Discovery-Pfad in probeProvider korrigieren [T002680]

### DIFF
--- a/openspec/changes/e2-sdlc-local-stack/tasks.d/p3-auth.md
+++ b/openspec/changes/e2-sdlc-local-stack/tasks.d/p3-auth.md
@@ -29,9 +29,12 @@ u.a.) — Import-Stil beibehalten.
         `POCKET_ID_FALLBACK_URL` — **fehlt eine der beiden, ist kein Fallback konfiguriert**
         (Prod-Pfad unverändert)
 - [ ] **1.2** Funktion `resolveAuthProvider(): Promise<AuthProvider>` mit:
-      - Health-Probe auf den Primary (`GET <internalUrl>/api/oidc/.well-known/openid-configuration`
-        oder `/health` — beim Implementieren gegen die Pocket-ID-API verifizieren, welche Route
-        existiert; bei 2xx → `local`)
+      - Health-Probe auf den Primary (bei 2xx → `local`). Die Route ist gegen die laufende
+        Pocket-ID-Instanz verifiziert (T002680, 2026-08-08): es gilt
+        `GET <internalUrl>/.well-known/openid-configuration`.
+        **`/api/oidc/.well-known/openid-configuration` antwortet mit 404** — dieser Pfad stand
+        hier zunächst als unverifiziertes Beispiel und wurde wörtlich implementiert, wodurch
+        jede Probe fehlschlug und der Token-Exchange in Prod abbrach.
       - Primary nicht erreichbar UND Fallback konfiguriert → Probe auf den Fallback; bei 2xx →
         `fleet`
       - Beide nicht erreichbar (oder Fehler) → `null` (fail-closed)

--- a/website/src/lib/auth/provider.test.ts
+++ b/website/src/lib/auth/provider.test.ts
@@ -22,6 +22,24 @@ function resetEnv() {
   process.env = { ...originalEnv };
 }
 
+// probeProvider() versucht mehrere Discovery-Pfade pro Host. Mocks, die an der
+// Aufrufreihenfolge haengen (mockRejectedValueOnce...), kippen deshalb, sobald
+// sich die Zahl der Pfade aendert — und schreiben ausserdem den geprobten Pfad
+// fest, was den 404-Bug in probeProvider ueberhaupt erst zementiert hatte.
+// Dieser Helper mockt nach HOST: erreichbar oder nicht, unabhaengig davon,
+// ueber welchen Pfad und in welcher Reihenfolge gefragt wird.
+function mockReachableHosts(hosts: string[]) {
+  global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (hosts.some((h) => url.startsWith(h))) return { ok: true } as Response;
+    throw new Error(`unreachable: ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+// Der Pfad, unter dem Pocket ID die OIDC-Discovery tatsaechlich serviert
+// (verifiziert gegen die laufende Instanz, 2026-08-04).
+const REAL_DISCOVERY_PATH = '/.well-known/openid-configuration';
+
 beforeEach(() => {
   clearProviderCache();
   vi.resetAllMocks();
@@ -77,7 +95,7 @@ describe('resolveEndpointsSync', () => {
       POCKET_ID_FALLBACK_FRONTEND_URL: 'https://auth.example.net',
       POCKET_ID_FALLBACK_URL: 'https://auth.example.net',
     });
-    global.fetch = vi.fn().mockRejectedValueOnce(new Error('primary down')).mockResolvedValueOnce({ ok: true } as Response);
+    mockReachableHosts(['https://auth.example.net']);
     const provider = await resolveAuthProvider();
     expect(provider?.id).toBe('fleet');
     const ep = resolveEndpointsSync();
@@ -106,9 +124,7 @@ describe('resolveAuthProvider', () => {
       POCKET_ID_FALLBACK_FRONTEND_URL: 'https://auth.example.net',
       POCKET_ID_FALLBACK_URL: 'https://auth.example.net',
     });
-    global.fetch = vi.fn()
-      .mockRejectedValueOnce(new Error('primary down'))
-      .mockResolvedValueOnce({ ok: true } as Response);
+    mockReachableHosts(['https://auth.example.net']);
     const provider = await resolveAuthProvider();
     expect(provider?.id).toBe('fleet');
     expect(provider?.frontendUrl).toBe('https://auth.example.net');
@@ -136,9 +152,37 @@ describe('resolveAuthProvider', () => {
     expect(provider?.id).toBe('local');
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
-      'http://pocket-id:1411/api/oidc/.well-known/openid-configuration',
+      `http://pocket-id:1411${REAL_DISCOVERY_PATH}`,
       expect.anything(),
     );
+  });
+
+  // Regression: probeProvider() probte ausschliesslich
+  // /api/oidc/.well-known/openid-configuration. Pocket ID antwortet dort mit
+  // 404 (gemessen gegen den lokalen SDLC-Stack und gegen fleet), womit JEDER
+  // Provider als unerreichbar galt — primary wie fallback. resolveEndpoints()
+  // warf dann AuthUnavailableError und der Token-Exchange brach mit
+  // auth_error=exchange_failed ab, waehrend der Authorize-Redirect (ueber
+  // resolveEndpointsSync, ohne Probe) weiter funktionierte und den Fehler
+  // verdeckte.
+  it('erkennt einen Provider, der NUR den echten Discovery-Pfad serviert', async () => {
+    setEnv({
+      POCKET_ID_FRONTEND_URL: 'http://auth.localhost',
+      POCKET_ID_URL: 'http://pocket-id:1411',
+    });
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      // Genau das Verhalten der realen Instanz: der alte Pfad ist 404.
+      if (url.endsWith('/api/oidc/.well-known/openid-configuration')) {
+        return { ok: false, status: 404 } as Response;
+      }
+      if (url.endsWith(REAL_DISCOVERY_PATH)) return { ok: true } as Response;
+      throw new Error(`unerwartete URL: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const provider = await resolveAuthProvider();
+    expect(provider).not.toBeNull();
+    expect(provider?.id).toBe('local');
   });
 });
 
@@ -193,15 +237,24 @@ describe('provider cache', () => {
       POCKET_ID_FRONTEND_URL: 'http://auth.localhost',
       POCKET_ID_URL: 'http://pocket-id:1411',
     });
-    global.fetch = vi.fn()
-      .mockResolvedValueOnce({ ok: true } as Response)
-      .mockRejectedValueOnce(new Error('down'))
-      .mockResolvedValueOnce({ ok: true } as Response);
-    await resolveAuthProvider();
+    // Ergebnisse pruefen, nicht Aufrufzahlen: probeProvider() darf mehrere
+    // Discovery-Pfade versuchen, ohne dass dieser Test kippt. Entscheidend
+    // ist, dass ein Fehlschlag nicht dauerhaft gecacht wird und ein spaeter
+    // wieder erreichbarer Provider erneut gefunden wird.
+    let reachable = true;
+    global.fetch = vi.fn(async () => {
+      if (!reachable) throw new Error('down');
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+
+    expect((await resolveAuthProvider())?.id).toBe('local');
+
+    reachable = false;
     clearProviderCache();
-    await resolveAuthProvider();
+    expect(await resolveAuthProvider()).toBeNull();
+
+    reachable = true;
     clearProviderCache();
-    await resolveAuthProvider();
-    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect((await resolveAuthProvider())?.id).toBe('local');
   });
 });

--- a/website/src/lib/auth/provider.ts
+++ b/website/src/lib/auth/provider.ts
@@ -43,18 +43,38 @@ export function clearProviderCache(): void {
   cacheExpiresAt = 0;
 }
 
+// Pocket ID serviert die OIDC-Discovery unter /.well-known/openid-configuration.
+// Der zuvor allein geprobte Pfad /api/oidc/.well-known/... liefert 404 —
+// verifiziert aus dem Website-Pod auf fleet gegen POCKET_ID_URL und gegen den
+// lokalen SDLC-Stack (T002680, 2026-08-08). Damit schlug probeProvider()
+// IMMER fehl, fuer primary
+// wie fallback: resolveAuthProvider() lieferte null und resolveEndpoints()
+// warf AuthUnavailableError. Sichtbar wurde das erst beim Token-Exchange
+// ("No auth provider reachable for token exchange" -> auth_error=exchange_failed),
+// weil der Authorize-Redirect ueber resolveEndpointsSync() laeuft, das ohne
+// Probe auf 'local' zurueckfaellt.
+//
+// Beide Pfade werden geprobt, damit der Fix nicht an einer Pocket-ID-Version
+// haengt: der erste Treffer gewinnt.
+const DISCOVERY_PATHS = [
+  '/.well-known/openid-configuration',
+  '/api/oidc/.well-known/openid-configuration',
+];
+
 async function probeProvider(internalUrl: string): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 3000);
-    const res = await fetch(`${internalUrl}/api/oidc/.well-known/openid-configuration`, {
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-    return res.ok;
-  } catch {
-    return false;
+  for (const path of DISCOVERY_PATHS) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3000);
+      const res = await fetch(`${internalUrl}${path}`, { signal: controller.signal });
+      clearTimeout(timeout);
+      if (res.ok) return true;
+    } catch {
+      // naechsten Pfad versuchen; erst wenn alle scheitern, gilt der
+      // Provider als nicht erreichbar.
+    }
   }
+  return false;
 }
 
 export async function resolveAuthProvider(): Promise<AuthProvider | null> {


### PR DESCRIPTION
## Symptom

Anmeldung auf `auth.mentolder.de` gelingt, der Rück-Redirect auf `web.mentolder.de` scheitert (`auth_error=exchange_failed`). Prod-Log des Website-Pods:

```
{"level":50,"service":"website","msg":"[auth] No auth provider reachable for token exchange"}
GET /api/auth/callback 302 (61ms)
```

## Root Cause

`probeProvider()` probte ausschließlich `<internalUrl>/api/oidc/.well-known/openid-configuration`. Pocket ID serviert die Discovery unter `/.well-known/openid-configuration` — der geprobte Pfad liefert **404**. Gemessen aus dem Website-Pod auf `fleet` gegen das echte `POCKET_ID_URL`:

```
/api/oidc/.well-known/openid-configuration -> 404
/.well-known/openid-configuration          -> 200
```

Damit galt **jeder** Provider als unerreichbar (primary wie fallback), `resolveAuthProvider()` lieferte `null`, `resolveEndpoints()` warf `AuthUnavailableError`.

## Warum der Login trotzdem startet

Login-Redirect und Callback nehmen unterschiedliche Wege durch denselben Resolver:

| Route | Pfad | Ergebnis |
|---|---|---|
| `/api/auth/login` | `resolveEndpointsSync()` — **ohne** Probe, Fallback auf `id:'local'` | Redirect korrekt → Login funktioniert |
| `/api/auth/callback` | `resolveEndpoints()` — **mit** Probe | 404 → `null` → `AuthUnavailableError` |

Der großzügigere Sync-Fallback verdeckte den Konfigurationsfehler bis nach der Credential-Eingabe.

## Nicht die Ursache

Die tatsächlich genutzten Endpunkte waren nie defekt — die Health-Probe prüfte schlicht einen Pfad, der mit ihnen nichts zu tun hat:

```
/api/oidc/token    -> 400   (existiert, mag nur die leere Testanfrage nicht)
/api/oidc/userinfo -> 401
```

Ebenfalls ausgeschlossen: `POCKET_ID_URL` ist korrekt cross-namespace gesetzt (`http://pocket-id.workspace.svc.cluster.local:1411`), kein Fallback konfiguriert.

## Fix

Beide Pfade werden geprobt, erster Treffer gewinnt — so hängt der Fix nicht an einer Pocket-ID-Version.

## Verifikation

Der Regressionstest ist **rot gegen den alten Provider** (`origin/main`) und grün mit dem Fix:

```
FAIL  erkennt einen Provider, der NUR den echten Discovery-Pfad serviert
AssertionError: expected null not to be null
```

```
✓ src/lib/auth/provider.test.ts   (15 tests)
✓ src/lib/auth/magic-link.test.ts (15 tests)
✓ src/pages/api/auth/callback.test.ts, me.test.ts, e2e-login.test.ts (19 tests)
```

Zusätzlich entkoppelt: Die Mock-Strategie der Bestandstests hing an der `fetch`-Aufrufreihenfolge und schrieb damit den geprobten Pfad fest — genau das zementierte den Bug. Gemockt wird jetzt nach **Host** statt nach Aufrufreihenfolge.

## Spec

`p3-auth.md` 1.2 verlangte, die Route beim Implementieren gegen die Pocket-ID-API zu verifizieren. Dieser Schritt wurde übersprungen und der Beispielpfad wörtlich implementiert. Der verifizierte Pfad steht jetzt dort, damit die nächste Implementierung den Bug nicht reproduziert.

Regression aus #3781 (T002625).

🤖 Generated with [Claude Code](https://claude.com/claude-code)