### PR TITLE
fix(website): ungeprobten Login-Rueckfall sichtbar machen [T002682]

### DIFF
--- a/website/src/lib/auth/provider.test.ts
+++ b/website/src/lib/auth/provider.test.ts
@@ -7,6 +7,7 @@ import {
   hasFallbackConfigured,
   AuthUnavailableError,
 } from './provider';
+import { logger } from '../logger';
 
 vi.mock('../logger', () => ({
   logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
@@ -256,5 +257,55 @@ describe('provider cache', () => {
     reachable = true;
     clearProviderCache();
     expect((await resolveAuthProvider())?.id).toBe('local');
+  });
+});
+
+// T002682: resolveEndpointsSync() ist grosszuegiger als resolveEndpoints() —
+// es faellt ohne Probe auf 'local' zurueck. Dadurch baut /api/auth/login eine
+// funktionierende Authorize-URL, obwohl kein Provider erreichbar ist; der
+// Nutzer scheitert erst im Callback, nach der Credential-Eingabe. Genau das
+// verdeckte T002680.
+//
+// Gewaehlt ist "tolerant + laut": der Login bleibt tolerant (ein kurzer
+// Pocket-ID-Aussetzer sperrt niemanden aus), aber der Rueckfall wird
+// protokolliert. Differenziert nach Grund, damit der Kaltstart kein
+// Fehler-Rauschen erzeugt.
+describe('resolveEndpointsSync — Sichtbarkeit des ungeprobten Rueckfalls', () => {
+  it('loggt auf Fehler-Level, wenn eine FRISCHE Probe fehlschlug (probe-failed)', async () => {
+    setEnv({
+      POCKET_ID_FRONTEND_URL: 'http://auth.localhost',
+      POCKET_ID_URL: 'http://pocket-id:1411',
+    });
+    global.fetch = vi.fn(async () => {
+      throw new Error('down');
+    }) as unknown as typeof fetch;
+
+    // Probe laufen lassen -> cachedProvider === null, TTL noch gueltig.
+    expect(await resolveAuthProvider()).toBeNull();
+    vi.mocked(logger.error).mockClear();
+
+    const ep = resolveEndpointsSync();
+
+    // Tolerant: Endpoints werden trotzdem geliefert, der Login bricht nicht ab.
+    expect(ep.auth).toBe('http://auth.localhost/authorize');
+    // Laut: der ignorierte Ausfall ist sichtbar.
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.error).mock.calls[0]).toEqual([
+      expect.objectContaining({ reason: 'probe-failed' }),
+      expect.stringContaining('[auth]'),
+    ]);
+  });
+
+  it('schweigt beim Kaltstart, solange nie geprobt wurde (never-probed)', () => {
+    setEnv({
+      POCKET_ID_FRONTEND_URL: 'http://auth.localhost',
+      POCKET_ID_URL: 'http://pocket-id:1411',
+    });
+    // clearProviderCache() lief in beforeEach -> cachedProvider === undefined.
+    const ep = resolveEndpointsSync();
+
+    expect(ep.auth).toBe('http://auth.localhost/authorize');
+    // Kein Wissen ueber einen Ausfall -> kein Fehler-Rauschen bei jedem Boot.
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/website/src/lib/auth/provider.ts
+++ b/website/src/lib/auth/provider.ts
@@ -127,6 +127,49 @@ export async function resolveEndpoints(): Promise<{
   return buildEndpoints(provider);
 }
 
+// Warum resolveEndpointsSync() auf den ungeprobten Zweig faellt. Die drei Faelle
+// sind NICHT gleich schwerwiegend:
+//
+//   'never-probed'  — es gab in diesem Prozess noch keine Probe. Kein Wissen
+//                     ueber den Provider, also auch kein ignoriertes Wissen.
+//   'cache-expired' — die letzte Probe ist aelter als PROVIDER_CACHE_TTL.
+//                     Veraltetes Wissen; der Provider kann laengst zurueck sein.
+//   'probe-failed'  — eine FRISCHE Probe hat ergeben, dass kein Provider
+//                     erreichbar ist (cachedProvider === null, TTL laeuft noch).
+//                     Hier liegt positives Wissen ueber den Ausfall vor und der
+//                     Sync-Pfad baut trotzdem eine Login-URL. Genau dieser Fall
+//                     verdeckte T002680 bis nach der Credential-Eingabe.
+type SyncFallbackReason = 'never-probed' | 'cache-expired' | 'probe-failed';
+
+/**
+ * Wird aufgerufen, kurz bevor resolveEndpointsSync() Endpoints aus einem NICHT
+ * geprobten Provider baut. Aktuell ein No-op — das Verhalten ist damit exakt das
+ * bisherige (fail-open, siehe Variante b unten).
+ *
+ * TODO(T002682): Verhalten festlegen. Zur Wahl stehen:
+ *
+ *   a) fail-closed — bei 'probe-failed' (ggf. auch 'cache-expired') werfen.
+ *      Der Login schlaegt sofort sichtbar fehl statt erst im Callback.
+ *      ACHTUNG: Der einzige Produktions-Aufrufer ist getLoginUrl() in
+ *      website/src/lib/auth.ts:90. Die Funktion ist synchron und gibt `string`
+ *      zurueck; ein Wurf muss dort und in /api/auth/login behandelt werden
+ *      (503 statt kaputtem Redirect). Das ist der teuerste, aber ehrlichste Weg.
+ *
+ *   b) fail-open — No-op belassen. Robust gegen kurzes Pocket-ID-Flackern,
+ *      verschiebt den Fehler aber weiterhin hinter die Credential-Eingabe.
+ *
+ *   c) tolerant + laut — Login bleibt tolerant, aber der Rueckfall wird
+ *      protokolliert bzw. als Health-Signal exponiert. Naheliegender Kompromiss;
+ *      dann vermutlich nach `reason` differenzieren, damit 'never-probed' beim
+ *      Kaltstart kein Fehler-Rauschen erzeugt.
+ *
+ * Die Wahl praegt das Verhalten bei JEDEM kuenftigen Pocket-ID-Ausfall — sie ist
+ * eine Betriebs-, keine Implementierungsentscheidung.
+ */
+function onUnprobedFallback(_reason: SyncFallbackReason, _provider: AuthProvider): void {
+  // TODO(T002682): siehe oben.
+}
+
 export function resolveEndpointsSync(): {
   auth: string;
   token: string;
@@ -136,11 +179,22 @@ export function resolveEndpointsSync(): {
   if (cachedProvider !== undefined && cachedProvider !== null && Date.now() < cacheExpiresAt) {
     return buildEndpoints(cachedProvider);
   }
-  return buildEndpoints({
+
+  const cacheStillValid = Date.now() < cacheExpiresAt;
+  const reason: SyncFallbackReason =
+    cachedProvider === undefined
+      ? 'never-probed'
+      : cachedProvider === null && cacheStillValid
+        ? 'probe-failed'
+        : 'cache-expired';
+
+  const fallback: AuthProvider = {
     id: 'local',
     frontendUrl: getPrimaryFrontendUrl(),
     internalUrl: getPrimaryInternalUrl(),
-  });
+  };
+  onUnprobedFallback(reason, fallback);
+  return buildEndpoints(fallback);
 }
 
 function buildEndpoints(provider: AuthProvider) {

--- a/website/src/lib/auth/provider.ts
+++ b/website/src/lib/auth/provider.ts
@@ -1,3 +1,5 @@
+import { logger } from '../logger';
+
 export interface AuthProvider {
   id: 'local' | 'fleet';
   frontendUrl: string;
@@ -143,31 +145,39 @@ type SyncFallbackReason = 'never-probed' | 'cache-expired' | 'probe-failed';
 
 /**
  * Wird aufgerufen, kurz bevor resolveEndpointsSync() Endpoints aus einem NICHT
- * geprobten Provider baut. Aktuell ein No-op — das Verhalten ist damit exakt das
- * bisherige (fail-open, siehe Variante b unten).
+ * geprobten Provider baut.
  *
- * TODO(T002682): Verhalten festlegen. Zur Wahl stehen:
+ * Gewaehlt ist "tolerant + laut" (T002682): der Login bleibt tolerant — ein
+ * kurzer Pocket-ID-Aussetzer sperrt niemanden aus, und ein bereits laufender
+ * Flow kommt durch. Aber der Rueckfall wird sichtbar, statt bis zum Callback
+ * zu schweigen.
  *
- *   a) fail-closed — bei 'probe-failed' (ggf. auch 'cache-expired') werfen.
- *      Der Login schlaegt sofort sichtbar fehl statt erst im Callback.
- *      ACHTUNG: Der einzige Produktions-Aufrufer ist getLoginUrl() in
- *      website/src/lib/auth.ts:90. Die Funktion ist synchron und gibt `string`
- *      zurueck; ein Wurf muss dort und in /api/auth/login behandelt werden
- *      (503 statt kaputtem Redirect). Das ist der teuerste, aber ehrlichste Weg.
+ * Verworfen wurde fail-closed (sofortiger Wurf): der einzige Produktions-
+ * Aufrufer getLoginUrl() (website/src/lib/auth.ts) ist synchron und liefert
+ * `string`; ein Wurf muesste bis /api/auth/login als 503 durchgereicht werden.
+ * Das macht aus jedem Sekunden-Aussetzer eine harte Sperre — ein hoher Preis
+ * fuer Sichtbarkeit, die auch ein Log liefert.
  *
- *   b) fail-open — No-op belassen. Robust gegen kurzes Pocket-ID-Flackern,
- *      verschiebt den Fehler aber weiterhin hinter die Credential-Eingabe.
- *
- *   c) tolerant + laut — Login bleibt tolerant, aber der Rueckfall wird
- *      protokolliert bzw. als Health-Signal exponiert. Naheliegender Kompromiss;
- *      dann vermutlich nach `reason` differenzieren, damit 'never-probed' beim
- *      Kaltstart kein Fehler-Rauschen erzeugt.
- *
- * Die Wahl praegt das Verhalten bei JEDEM kuenftigen Pocket-ID-Ausfall — sie ist
- * eine Betriebs-, keine Implementierungsentscheidung.
+ * Differenziert nach Grund, weil die drei Faelle nicht gleich schwer wiegen:
+ * nur 'probe-failed' ignoriert FRISCHES Wissen ueber einen Ausfall und ist
+ * deshalb Fehler-Level. 'never-probed' ist der Normalfall beim Kaltstart und
+ * schweigt, sonst raucht jedes Pod-Start-Log voll.
  */
-function onUnprobedFallback(_reason: SyncFallbackReason, _provider: AuthProvider): void {
-  // TODO(T002682): siehe oben.
+function onUnprobedFallback(reason: SyncFallbackReason, provider: AuthProvider): void {
+  if (reason === 'never-probed') return;
+
+  const context = { reason, providerId: provider.id, frontendUrl: provider.frontendUrl };
+
+  if (reason === 'probe-failed') {
+    logger.error(
+      context,
+      '[auth] Login-Redirect nutzt ungeprobten Provider, obwohl die letzte Probe fehlschlug — ' +
+        'der Nutzer wird sich anmelden und erst im Callback scheitern',
+    );
+    return;
+  }
+
+  logger.warn(context, '[auth] Login-Redirect nutzt Provider mit abgelaufener Probe');
 }
 
 export function resolveEndpointsSync(): {


### PR DESCRIPTION
Folgearbeit zu #3807 (T002680). Der dortige Pfad-Fix behob den Ausfall — **nicht** die Asymmetrie, die ihn so spät sichtbar machte.

## Problem

Login-Redirect und Callback nehmen unterschiedliche Wege durch denselben Resolver:

| Route | Pfad | Verhalten bei totem Provider |
|---|---|---|
| `/api/auth/login` | `resolveEndpointsSync()` — **ohne** Probe | baut trotzdem eine gültige Authorize-URL |
| `/api/auth/callback` | `resolveEndpoints()` — **mit** Probe | `AuthUnavailableError` |

Folge: Der Nutzer meldet sich vollständig an und scheitert erst **danach**. Bei T002680 sah der Login dadurch bis zum letzten Schritt gesund aus, während die Fehlkonfiguration seit #3781 bestand.

## Entscheidung: tolerant + laut

Der Rückfall bleibt bestehen — ein kurzer Pocket-ID-Aussetzer sperrt niemanden aus und ein laufender Flow kommt durch — aber er wird protokolliert statt zu schweigen.

**Verworfen: fail-closed.** Der einzige Produktions-Aufrufer `getLoginUrl()` ist synchron und liefert `string`; ein Wurf müsste bis `/api/auth/login` als 503 durchgereicht werden. Das macht aus jedem Sekunden-Aussetzer eine harte Sperre — ein hoher Preis für Sichtbarkeit, die auch ein Log liefert.

## Drei Gründe, nicht einer

Der Rückfall-Zweig deckte drei Zustände ab, die vorher ununterscheidbar waren und **nicht gleich schwer wiegen**:

| Grund | Bedeutung | Reaktion |
|---|---|---|
| `probe-failed` | frische Probe schlug fehl — das Wissen wird ignoriert | `logger.error` |
| `cache-expired` | veraltetes Wissen, Provider kann längst zurück sein | `logger.warn` |
| `never-probed` | Normalfall beim Kaltstart, gar kein Wissen | schweigt |

`never-probed` stumm zu lassen ist kein Nachlassen: sonst schreibt jeder Pod-Start eine Fehlerzeile und die Meldung verliert genau die Bedeutung, für die sie da ist.

## Verifikation

Der `probe-failed`-Test schlägt gegen die vorige No-op-Fassung fehl:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
```

Der `never-probed`-Test ist sein Gegenpol — er verhindert, dass ich das pauschal überall logge.

```
✓ src/lib/auth/ + src/pages/api/auth/  (51 tests)
tsc --noEmit: sauber
```

Kein Verhaltenswechsel im Login-Pfad selbst: Endpoints werden weiterhin geliefert, nur zusätzlich protokolliert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)