### PR TITLE
fix(website): Error-Log-Store auf die richtige Datenbank zeigen [T002681]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -872,7 +872,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1752,
+      "file_count": 1753,
       "files": [
         "website/.build-trigger",
         "website/.design-sync/NOTES.md",
@@ -1753,6 +1753,7 @@
         "website/src/lib/logger.ts",
         "website/src/lib/logging/browser-collector.test.ts",
         "website/src/lib/logging/browser-collector.ts",
+        "website/src/lib/logging/error-log-store-pool.test.ts",
         "website/src/lib/logging/error-log-store.test.ts",
         "website/src/lib/logging/error-log-store.ts",
         "website/src/lib/logging/error-report.test.ts",

--- a/website/src/lib/logging/error-log-store-pool.test.ts
+++ b/website/src/lib/logging/error-log-store-pool.test.ts
@@ -1,0 +1,88 @@
+// Prueft die KONFIGURATION des Error-Log-Pools — nicht sein Query-Verhalten.
+//
+// Modus: command output verification. Die Tests rufen getErrorLogPool() auf und
+// pruefen das Argument, mit dem `pg.Pool` tatsaechlich konstruiert wurde; sie
+// greppen nicht die Quelle.
+//
+// Warum es diese Datei gibt (T002681): error-log-store.test.ts injiziert den Pool
+// per __setPoolForTesting() und ueberspringt damit die Erzeugung vollstaendig.
+// Genau die einzige so uebersprungene Zeile war falsch — sie las `DATABASE_URL`,
+// das im Website-Runtime nie gesetzt ist (es ist die Migrations-Variable). `pg`
+// faellt ohne connectionString auf localhost:5432 zurueck, wo im Pod keine
+// Datenbank laeuft. Ergebnis: seit Anlage der Tabelle am 2026-07-03 stand
+// error_log auf 0 Zeilen, waehrend jeder Schreibversuch still in einem
+// console.error endete.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.hoisted, weil vi.mock() nach oben gezogen wird und die Factory sonst auf
+// eine noch nicht initialisierte Variable zugreift. Die Konfigurationen werden
+// gesammelt statt ueber vi.fn().mock.calls gelesen — das haelt die Assertions
+// frei von Tuple-Typgymnastik.
+const { FakePool, poolConfigs } = vi.hoisted(() => {
+  const poolConfigs: Array<{ connectionString?: string; lookup?: unknown }> = [];
+  class FakePool {
+    query = () => Promise.resolve({ rows: [] });
+    constructor(cfg: { connectionString?: string; lookup?: unknown }) {
+      poolConfigs.push(cfg);
+    }
+  }
+  return { FakePool, poolConfigs };
+});
+vi.mock('pg', () => ({ Pool: FakePool, default: { Pool: FakePool } }));
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  poolConfigs.length = 0;
+  vi.resetModules();
+});
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+async function freshPool() {
+  const mod = await import('./error-log-store');
+  return mod.getErrorLogPool();
+}
+
+describe('getErrorLogPool — Verbindungskonfiguration', () => {
+  it('nutzt SESSIONS_DATABASE_URL, dieselbe Quelle wie der uebrige DB-Zugriff', async () => {
+    process.env = {
+      ...originalEnv,
+      SESSIONS_DATABASE_URL: 'postgresql://u:p@db.example.test:5432/website',
+      DATABASE_URL: undefined,
+    };
+
+    await freshPool();
+
+    expect(poolConfigs).toHaveLength(1);
+    expect(poolConfigs[0].connectionString).toBe('postgresql://u:p@db.example.test:5432/website');
+  });
+
+  // Regressionstest zu T002681. Gegen die alte Fassung ist connectionString hier
+  // `undefined` -> pg verbindet auf localhost:5432 -> jeder Fehler-Log geht
+  // verloren. Der Default MUSS auf die geteilte Datenbank zeigen.
+  it('faellt ohne jede Env-Variable NICHT auf localhost zurueck', async () => {
+    process.env = { ...originalEnv, SESSIONS_DATABASE_URL: undefined, DATABASE_URL: undefined };
+
+    await freshPool();
+
+    expect(poolConfigs).toHaveLength(1);
+    expect(poolConfigs[0].connectionString).toBeTruthy();
+    expect(poolConfigs[0].connectionString).toContain('shared-db.workspace.svc.cluster.local');
+    expect(poolConfigs[0].connectionString).not.toContain('localhost');
+  });
+
+  // Der Default-Host ist ein DNS-Name. Das Website-Image ist musl-basiert, wo
+  // getaddrinfo hinter der kube-proxy-DNAT mit EAI_AGAIN scheitert — derselbe
+  // Grund, aus dem db-pool.ts einen eigenen lookup mitgibt. Ohne ihn waere der
+  // Pool zwar richtig adressiert, aber nicht aufloesbar.
+  it('gibt einen eigenen DNS-lookup mit (musl/kube-proxy)', async () => {
+    process.env = { ...originalEnv, SESSIONS_DATABASE_URL: undefined, DATABASE_URL: undefined };
+
+    await freshPool();
+
+    expect(poolConfigs).toHaveLength(1);
+    expect(typeof poolConfigs[0].lookup).toBe('function');
+  });
+});

--- a/website/src/lib/logging/error-log-store.ts
+++ b/website/src/lib/logging/error-log-store.ts
@@ -1,4 +1,5 @@
 import { Pool } from 'pg';
+import dns from 'dns';
 
 // A dedicated, lazily-created pool — NOT the shared src/lib/db-pool.ts
 // singleton. logger.ts's errorPersistStream dynamically imports this module
@@ -7,9 +8,50 @@ import { Pool } from 'pg';
 // in db-pool.ts's heavier module-level setup (DNS lookup, timeouts) that way
 // caused Vitest "environment torn down" crashes in otherwise-unrelated test
 // files. A plain, on-demand pg.Pool avoids that.
+//
+// T002681: Die Verbindungsdaten spiegeln db-pool.ts bewusst wider, statt es zu
+// importieren — der Import ist genau das, was die Vitest-Abstuerze ausloeste.
+// Die Duplizierung ist der Preis dafuer; wer den Wert dort aendert, aendert ihn
+// auch hier. Vorher stand hier `process.env.DATABASE_URL`: das ist die
+// MIGRATIONS-Variable (src/db/migrate.ts wirft, wenn sie fehlt) und im
+// Website-Runtime nie gesetzt. `pg` faellt ohne connectionString still auf
+// localhost:5432 zurueck, wo im Pod nichts lauscht — error_log stand deshalb
+// seit dem 2026-07-03 auf 0 Zeilen.
+const ERROR_LOG_DB_URL = process.env.SESSIONS_DATABASE_URL
+  || process.env.DATABASE_URL
+  || 'postgresql://website:devwebsitedb@shared-db.workspace.svc.cluster.local:5432/website';
+
+// Node's DNS-Resolver statt musl-getaddrinfo — siehe die ausfuehrliche
+// Begruendung in db-pool.ts (musl oeffnet einen *connected* UDP-Socket; nach der
+// kube-proxy-DNAT kommt die CoreDNS-Antwort von der Pod-IP und wird verworfen,
+// Ergebnis EAI_AGAIN). Ohne das waere der Pool zwar richtig adressiert, der
+// Default-Host aber nicht aufloesbar.
+function nodeLookup(
+  hostname: string,
+  _opts: unknown,
+  cb: (err: Error | null, addr: string, family: number) => void,
+) {
+  dns.resolve4(hostname, (err, addrs) => cb(err ?? null, addrs?.[0] ?? '', 4));
+}
+
+// `lookup` steht nicht im oeffentlichen pg.PoolConfig-Typ (durchgereichte
+// libpq-Option) — derselbe Cast wie in db-pool.ts.
+//
+// Timeouts: bis T002681 verband der Pool auf localhost und scheiterte sofort
+// mit ECONNREFUSED. Jetzt geht er ueber das Netz und kann haengen. persistError()
+// laeuft im Fehlerpfad — ein blockierender Insert wuerde ausgerechnet dann
+// Requests festhalten, wenn ohnehin etwas kaputt ist.
+const errorLogPoolConfig = {
+  connectionString: ERROR_LOG_DB_URL,
+  lookup: nodeLookup,
+  connectionTimeoutMillis: 2_000,
+  idleTimeoutMillis: 30_000,
+  statement_timeout: 2_000,
+} as unknown as import('pg').PoolConfig;
+
 let _pool: Pool | null = null;
 export function getErrorLogPool(): Pool {
-  if (!_pool) _pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  if (!_pool) _pool = new Pool(errorLogPoolConfig);
   return _pool;
 }
 


### PR DESCRIPTION
Beim Debuggen von T002680 (#3807) aufgefallen. Unabhängiger Bug, bewusst getrennt gehalten.

## Symptom

Jeder `logger.error()` im Website-Pod endete in:

```
[error-log] persistError insert failed: AggregateError [ECONNREFUSED]:
    Error: connect ECONNREFUSED ::1:5432
    Error: connect ECONNREFUSED 127.0.0.1:5432
```

## Root Cause

`error-log-store.ts` las `process.env.DATABASE_URL`. Das ist im Repo die **Migrations**-Variable (`src/db/migrate.ts` wirft hart, wenn sie fehlt) und im Website-Runtime nie gesetzt — im Pod verifiziert:

```
DATABASE_URL=[LEER]
```

`pg` fällt ohne `connectionString` still auf `localhost:5432` zurück, wo im Pod nichts lauscht.

## Wie lange das schon so ist

Die Tabelle existiert korrekt in der `website`-DB — und ist leer:

```
 Schema |   Name    | Type  |  Owner
--------+-----------+-------+---------
 public | error_log | table | website

SELECT count(*) FROM error_log;  ->  0
```

Seit Anlage am 2026-07-03 wurde **nie** ein Fehler persistiert. Der Store hat nie funktioniert.

Das ist besonders teuer, weil genau diese Tabelle beim Diagnostizieren von Prod-Fehlern die erste Anlaufstelle wäre. Bei T002680 musste stattdessen über `kubectl logs` gearbeitet werden — der Login-Ausfall war in der Oberfläche unsichtbar.

## Fix

`SESSIONS_DATABASE_URL` — dieselbe Quelle wie der übrige DB-Zugriff (`db-pool.ts`), im Pod gesetzt auf `shared-db.workspace.svc.cluster.local:5432/website`. `DATABASE_URL` bleibt als Fallback für lokale Skripte; der Default zeigt wie in `db-pool.ts` auf die geteilte DB statt auf localhost.

Zwei Dinge kommen mit, beide direkte Folgen davon, dass der Pool jetzt erstmals wirklich verbindet:

- **`nodeLookup`** — der Default-Host ist ein DNS-Name, das Image musl-basiert. Ohne den Resolver-Workaround wäre der Pool zwar richtig adressiert, der Host aber nicht auflösbar (`EAI_AGAIN` hinter der kube-proxy-DNAT). Gleiche Begründung wie in `db-pool.ts`.
- **Timeouts** — vorher scheiterte die Verbindung sofort mit `ECONNREFUSED`, jetzt geht sie übers Netz und kann hängen. `persistError()` läuft im Fehlerpfad; ein blockierender Insert würde ausgerechnet dann Requests festhalten, wenn ohnehin etwas kaputt ist.

Die Verbindungsdaten **spiegeln** `db-pool.ts`, statt es zu importieren — genau dieser Import löste die im Code dokumentierten Vitest-Abstürze aus. Die Duplizierung ist der bewusste Preis dafür und im Code vermerkt.

## Warum eine neue Testdatei

`error-log-store.test.ts` injiziert den Pool per `__setPoolForTesting()` und überspringt die Erzeugung vollständig. Die einzige so ausgesparte Zeile war die falsche — deshalb prüft die neue Datei genau die Konstruktion.

Alle drei Tests schlagen gegen die alte Fassung fehl:

```
AssertionError: expected undefined to be 'postgresql://u:p@db.example.test:5432…'
AssertionError: expected undefined to be truthy
AssertionError: expected 'undefined' to be 'function'
```

```
✓ src/lib/logging/  (33 tests)
tsc --noEmit: sauber
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)