### PR TITLE
fix(factory): Watchdog filtert Ticket-Typen per Ausschlussliste [T002674]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 797,
+      "file_count": 798,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -414,6 +414,7 @@
         "tests/spec/factory-escalation-ladder.bats",
         "tests/spec/factory-merge-hooks.bats",
         "tests/spec/factory-reclaim-lock-respect.bats",
+        "tests/spec/factory-watchdog/stale-type-coverage.bats",
         "tests/spec/feature-product-linking.bats",
         "tests/spec/fix-ci-concurrency.bats",
         "tests/spec/fix-ticket-tracking-T002279.bats",

--- a/scripts/factory/watchdog.sh
+++ b/scripts/factory/watchdog.sh
@@ -15,10 +15,40 @@
 set -euo pipefail
 HERE="$(dirname "${BASH_SOURCE[0]}")"
 source "$HERE/lib.sh"
+
+# [T002674] Ausschlussliste statt Allowlist — dieselbe Lektion, die queue.sh
+# unter T002329/T002333/T002407 bereits gelernt hat und dort ausformuliert
+# kommentiert: eine positive Typenliste altert in die UNSICHERE Richtung, weil
+# jeder neue Typ per Default durchfaellt. Der Watchdog wurde damals nicht
+# nachgezogen und filterte weiter auf type IN ('feature','feat','task','chore').
+# Gemessen am 2026-08-04: 'feature' und 'task' haben null Zeilen (bei der
+# Typ-Konsolidierung abgeloest), waehrend 'fix' mit 670 Zeilen der
+# zweithaeufigste Typ ist — und komplett unsichtbar war. Folge: drei haengende
+# fix-Tickets belegten alle drei Slots 2h54m lang ohne ein einziges
+# factory_phase_events; der Watchdog haette nach 30 Minuten zurueckgesetzt.
+# Ausgeschlossen bleiben nur die Typen, die nie selbst einen Slot belegen:
+# 'project' (Epic-Container) und 'incident' (needs_human) — identisch zu queue.sh.
+STALE_EXCLUDED_TYPES="'project','incident'"
+STALE_MIN="${FACTORY_STALE_MIN:-30}"
+
+_stale_query() {
+  printf "SELECT external_id, type FROM tickets.tickets WHERE type NOT IN (%s) AND status='in_progress' AND updated_at < now() - make_interval(mins => %s);" \
+    "$STALE_EXCLUDED_TYPES" "$STALE_MIN"
+}
+
+# Diagnosemodus: gibt die Stale-Query aus, ohne Cluster oder DB anzufassen.
+# Steht bewusst VOR factory_resolve — im Stoerfall ist der Cluster oft genau das,
+# was nicht erreichbar ist, und dann muss die Frage "welche Tickets sieht der
+# Watchdog ueberhaupt?" trotzdem beantwortbar bleiben.
+# Guard: tests/spec/factory-watchdog/stale-type-coverage.bats
+if [[ "${1:-}" == "--print-stale-query" ]]; then
+  _stale_query
+  exit 0
+fi
+
 BRAND="${BRAND:-}"
 factory_resolve
 [[ -n "${FACTORY_DRY_RESOLVE:-}" ]] && { echo "resolved: ctx=${FACTORY_CTX} ns=${FACTORY_NS}"; exit 0; }
-STALE_MIN="${FACTORY_STALE_MIN:-30}"
 # After this many consecutive stale rounds WITHOUT real phase progress a ticket is
 # handed to `ticket.sh unfactory` instead of being reset into the queue again
 # (T002361). At the 30-minute default that is ~90 minutes before a human is asked.
@@ -29,7 +59,7 @@ MAX_ATTEMPTS="${FACTORY_MAX_ATTEMPTS:-3}"
 # the same level more often before escalating.
 MAX_INFRA_ATTEMPTS="${FACTORY_INFRA_MAX_ATTEMPTS:-3}"
 
-mapfile -t stale < <(printf "SELECT external_id, type FROM tickets.tickets WHERE type IN ('feature','feat','task','chore') AND status='in_progress' AND updated_at < now() - make_interval(mins => %s);" "$STALE_MIN" | factory_psql)
+mapfile -t stale < <(_stale_query | factory_psql)
 
 # Zombie-Worktree-Cleanup: a hung pipeline leaves .worktrees/sf-* behind. Remove the
 # worktree whose branch matches this ticket (idempotent; never fails the loop).
@@ -172,10 +202,16 @@ SQL
     fi
   fi
   attempt_note=" [${failure_class:-MODEL} ${attempt}/${max_allowed} | tier=${tier_name}]"
-  if [[ -n "$plan_ref" && "$ticket_type" == "feature" ]]; then
+  # [T002674] Zweite Stelle mit veralteten Typnamen: 'feature' und 'task' haben
+  # null Zeilen, also fiel JEDES Ticket mit Plan in den triage-Zweig und wurde
+  # zum vollen Re-Plan gezwungen — genau das, was T001850 verhindern wollte.
+  # 'feat' geht nach backlog (dort dispatcht queue.sh die Feature-Lane),
+  # alle uebrigen Arbeits-Typen nach plan_staged (die "staged tickets of any
+  # workable type"-Lane, ohne lastenheft-Gate).
+  if [[ -n "$plan_ref" && ( "$ticket_type" == "feature" || "$ticket_type" == "feat" ) ]]; then
     reset_status="backlog"
     reset_msg="Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write, class=${failure_class:-MODEL}). Plan already staged (${plan_ref}) — resuming via backlog instead of restarting from Scout.${attempt_note}"
-  elif [[ -n "$plan_ref" && "$ticket_type" == "task" ]]; then
+  elif [[ -n "$plan_ref" ]]; then
     reset_status="plan_staged"
     reset_msg="Watchdog: pipeline stale > ${STALE_MIN}min (no phase progress write, class=${failure_class:-MODEL}). Plan already staged (${plan_ref}) — resuming via plan_staged instead of restarting from Scout.${attempt_note}"
   else

--- a/tests/spec/factory-watchdog/stale-type-coverage.bats
+++ b/tests/spec/factory-watchdog/stale-type-coverage.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# tests/spec/factory-watchdog/stale-type-coverage.bats [T002674]
+#
+# PRÜFMODUS: Output-Verifikation. Der Test ruft `watchdog.sh --print-stale-query`
+# als Kommando auf und prüft dessen stdout. Kein Source-Grep: die Query wird vom
+# Skript selbst gerendert, ein Umbau der Bedingung schlägt hier also durch, auch
+# wenn der Quelltext ganz anders aussieht.
+#
+# HINTERGRUND: Der Watchdog wählte die stale-Kandidaten über eine Allowlist:
+#   WHERE type IN ('feature','feat','task','chore') AND status='in_progress' …
+# Gemessen am 2026-08-04 nennt diese Liste zwei Typen, die es gar nicht mehr gibt
+# (`feature` 0 Zeilen, `task` 0 Zeilen — beide bei der Typ-Konsolidierung
+# abgelöst), und übersieht fünf existierende: `fix` (670 Zeilen, zweithäufigster
+# Typ), `refactor`, `perf`, `test`, `incident`.
+#
+# Folge: drei hängende fix-Tickets belegten alle drei Factory-Slots 2h54m lang
+# ohne ein einziges factory_phase_events. Der Watchdog hätte sie nach 30 Minuten
+# zurückgesetzt — er sah sie nie. Die Factory nahm derweil kein weiteres Ticket
+# an und meldete lediglich "keine ready plan_staged Tickets".
+#
+# Eine Allowlist altert in die unsichere Richtung: jeder neue Typ ist per Default
+# unsichtbar. Deshalb prüft dieser Test auf eine Denylist-Formulierung.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  WD="$REPO_ROOT/scripts/factory/watchdog.sh"
+}
+
+@test "watchdog: stale-Query erfasst type=fix" {
+  run bash "$WD" --print-stale-query
+
+  # Positiv-Anker [T002356-M1]: erst belegen, dass überhaupt eine Query kam.
+  # Ohne ihn wäre jede Aussage über ihren Inhalt trivial wahr, sobald das Skript
+  # den Modus nicht kennt und leer beendet.
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  [[ "$output" == *"status='in_progress'"* ]]
+
+  # Kernaussage: ein fix-Ticket darf nicht durch den Typ-Filter fallen.
+  # Entweder gibt es gar keinen Typ-Filter, oder 'fix' ist nicht ausgeschlossen.
+  if [[ "$output" == *"type IN ("* ]]; then
+    [[ "$output" == *"'fix'"* ]]
+  fi
+  [[ "$output" != *"NOT IN"*"'fix'"* ]]
+}
+
+@test "watchdog: stale-Query erfasst auch refactor, perf, test und chore" {
+  run bash "$WD" --print-stale-query
+
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+
+  # Diese Typen existieren real in der Datenbank und belegen Slots wie jeder
+  # andere. Eine Allowlist, die sie vergisst, macht sie fuer den Watchdog blind.
+  local t
+  for t in refactor perf test chore; do
+    if [[ "$output" == *"type IN ("* ]]; then
+      [[ "$output" == *"'$t'"* ]]
+    fi
+    [[ "$output" != *"NOT IN"*"'$t'"* ]]
+  done
+}
+
+@test "watchdog: project und incident bleiben ausgeschlossen" {
+  run bash "$WD" --print-stale-query
+
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+
+  # Positiv-Anker: erst belegen, dass ueberhaupt eine Ausschlussliste existiert —
+  # sonst waere die Aussage "X ist ausgeschlossen" gegen eine Query ohne Filter
+  # trivial falsch und gegen eine leere Ausgabe trivial wahr.
+  [[ "$output" == *"NOT IN"* ]]
+
+  # 'project' ist der Epic-Container, 'incident' ist needs_human — beide werden
+  # von queue.sh nie dispatcht, koennen also keinen Slot belegen. Der Ausschluss
+  # ist mit queue.sh abgestimmt (T002329/T002333/T002407); weichen die beiden
+  # Listen auseinander, sieht der Watchdog Tickets, die es gar nicht geben kann.
+  [[ "$output" == *"'project'"* ]]
+  [[ "$output" == *"'incident'"* ]]
+}
+
+@test "watchdog: --print-stale-query fasst die Datenbank nicht an" {
+  # Der Diagnosemodus muss ohne Cluster/DB funktionieren — sonst ist er im
+  # Fehlerfall, also genau dann, wenn man ihn braucht, nicht benutzbar.
+  run env FACTORY_CTX=does-not-exist bash "$WD" --print-stale-query
+
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  [[ "$output" == *"in_progress"* ]]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2418,6 +2418,12 @@
     "kind": "shell"
   },
   {
+    "id": "factory-watchdog/stale-type-coverage",
+    "file": "tests/spec/factory-watchdog/stale-type-coverage.bats",
+    "category": "factory-watchdog",
+    "kind": "shell"
+  },
+  {
     "id": "feature-product-linking",
     "file": "tests/spec/feature-product-linking.bats",
     "category": "feature-product-linking",


### PR DESCRIPTION
Lag seit dem 2026-08-04 fertig auf einem lokalen Branch ohne PR. Ticket ist `severity=critical`, `status=in_progress`.

## Problem

`scripts/factory/watchdog.sh` selektierte stale Kandidaten per **Allowlist**:

```sql
WHERE type IN ('feature','feat','task','chore') AND status='in_progress'
```

`fix` fehlt darin. Gemessen am 2026-08-04: `feature` und `task` haben **null** Zeilen (bei der Typ-Konsolidierung abgelöst), während `fix` mit **670 Zeilen** der zweithäufigste Typ ist — und für den Watchdog komplett unsichtbar war.

Folge: Drei hängende `fix`-Tickets belegten alle drei Factory-Slots 2 h 54 min lang, ohne ein einziges `factory_phase_events` zu schreiben. Der Watchdog hätte nach 30 Minuten zurückgesetzt — er sah sie nur nie. Nach außen meldete `auto-enqueue` lediglich „keine ready plan_staged Tickets", was nach *nichts zu tun* aussieht statt nach *kein Platz*.

## Fix

Ausschlussliste statt Allowlist — dieselbe Lektion, die `queue.sh` unter T002329/T002333/T002407 bereits gelernt hat und dort auskommentiert trägt. Eine positive Typenliste altert in die **unsichere** Richtung: jeder neue Typ fällt per Default durch.

Ausgeschlossen bleiben nur Typen, die nie selbst einen Slot belegen: `project` (Epic-Container) und `incident` (needs_human) — identisch zu `queue.sh`.

Dazu ein `--print-stale-query`-Diagnosemodus, der bewusst **vor** `factory_resolve` steht: Im Störfall ist der Cluster oft genau das, was nicht erreichbar ist — die Frage „welche Tickets sieht der Watchdog überhaupt?" muss trotzdem beantwortbar bleiben. Das macht die Query zugleich testbar, ohne Datenbank.

## Verifikation

Alle vier Tests schlagen gegen die Fassung auf `main` fehl und sind mit dem Fix grün:

```
gegen origin/main:                          mit Fix:
not ok 1 stale-Query erfasst type=fix       ok 1
not ok 2 … auch refactor, perf, test, chore ok 2
not ok 3 project und incident ausgeschlossen ok 3
not ok 4 --print-stale-query fasst DB nicht an ok 4
```

Test 3 ist der Gegenpol: Er verhindert, dass die Denylist einfach alles durchlässt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)