### PR TITLE
fix(ci): repo-index.json aus dem PR-Weg nehmen [T002687]

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,6 +48,13 @@ fi
 # the same commit (see T001388). Keep this list in sync with `task
 # freshness:regenerate` and the FILES list in `Taskfile.yml` `freshness:check`.
 # Best-effort: never blocks the commit if task or node is unavailable.
+#
+# Bewusst NICHT enthalten: docs/code-quality/repo-index.json [T002687]. Wuerde
+# es hier auto-gestaged, landete es in jedem Commit und damit in jedem PR — und
+# seine acht file_count-Zaehler kollidieren zwischen parallelen PRs
+# zwangslaeufig. Es wird nirgends gelesen (quality:check scannt live) und von
+# freshness-regen.yml auf main aktuell gehalten.
+# Guard: tests/spec/ci-cd/generated-artifacts-registry.bats
 _FRESHNESS_FILES=(
   website/src/data/test-inventory.json
   website/src/data/route-manifest.json
@@ -56,7 +63,6 @@ _FRESHNESS_FILES=(
   website/src/data/openspec-status.json
   docs/diagrams/architecture.md
   website/src/lib/sdlc/goals-data.generated.json
-  docs/code-quality/repo-index.json
   docs/agent-guide/10-ziele.md
   docs/agent-guide/20-werkzeuge.md
   docs/agent-guide/30-bausteine.md

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1240,6 +1240,15 @@ tasks:
       # --- Phase 1: diff-check each file ---
       - |
         ERRORS=0
+        # NICHT in dieser Liste: docs/code-quality/repo-index.json [T002687].
+        # Es enthaelt acht file_count-Zaehler; jeder PR mit einer hinzugefuegten
+        # oder entfernten Datei aendert dieselbe Zeile, womit parallele PRs
+        # zwangslaeufig kollidieren — merge=ours greift auf GitHub nicht, und ein
+        # konfliktbehafteter PR unterdrueckt dort die CI. Die Datei wird nirgends
+        # gelesen (quality:check scannt live per trackedFiles -> git ls-files),
+        # ist also reines Reporting. freshness-regen.yml haelt sie auf main
+        # aktuell; sie muss dafuer nicht durch jeden PR wandern.
+        #
         # ACHTUNG: FILES ist ein Shell-String, der unten per Wortsplitting
         # durchlaufen wird — KEINE Kommentare hineinschreiben. Jedes Wort gilt
         # als Pfad; ein Kommentar erzeugt Phantom-Eintraege wie "an" oder "PR"
@@ -1258,7 +1267,6 @@ tasks:
           website/src/data/openspec-status.json
           docs/diagrams/architecture.md
           website/src/lib/sdlc/goals-data.generated.json
-          docs/code-quality/repo-index.json
           docs/agent-guide/10-ziele.md
           docs/agent-guide/20-werkzeuge.md
           docs/agent-guide/30-bausteine.md

--- a/scripts/hooks/check-freshness-artifacts.sh
+++ b/scripts/hooks/check-freshness-artifacts.sh
@@ -30,25 +30,19 @@ if [[ -z "$BASE" || -z "$HEAD_SHA" ]]; then
   exit 2
 fi
 
-# [T002686] Der Ausloeser war eine gemeinsame `.bats`-Bedingung fuer beide
-# Artefakte. Das war fuer repo-index.json zu eng: es zaehlt ALLE getrackten
-# Dateien (scan.mjs -> git ls-files), wird also von jeder hinzugefuegten oder
-# entfernten Datei stale — unabhaengig vom Typ. Dreimal an einem Tag lief CI
-# genau darauf: T002681 und T002684 (je eine .test.ts, der Hook schwieg) sowie
-# T002674 (.bats, der Hook warnte). Jedes Artefakt bekommt deshalb seine eigene
-# Bedingung.
+# [T002687] repo-index.json wird hier NICHT mehr eingefordert. Es gehoert seit
+# T002687 nicht mehr in PRs: seine acht file_count-Zaehler machen Konflikte
+# zwischen parallelen PRs unvermeidbar, es wird nirgends gelesen (quality:check
+# scannt live per trackedFiles -> git ls-files) und freshness-regen.yml haelt es
+# auf main aktuell. Ein Hook, der es einfordert, wuerde genau die Kollision
+# wieder herbeifuehren.
 #
-# test-inventory.json speist sich aus *.bats und *.sh unter tests/ sowie
-# tests/e2e/specs/*.spec.ts (build-test-inventory.sh). Hier zaehlt auch eine
-# reine Aenderung, weil @test-Namen die Inventar-IDs bilden.
+# [T002686] Geblieben ist die artefaktgenaue Bedingung: test-inventory.json
+# speist sich aus *.bats und *.sh unter tests/ sowie tests/e2e/specs/*.spec.ts
+# (build-test-inventory.sh). Hier zaehlt auch eine reine Aenderung, weil
+# @test-Namen die Inventar-IDs bilden — nicht nur Hinzufuegen/Loeschen.
 
 changed="$(git diff --name-only "${BASE}..${HEAD_SHA}" 2>/dev/null)"
-# Nur Hinzufuegen/Loeschen aendert die Dateimenge, die repo-index.json zaehlt.
-added_deleted="$(git diff --name-only --diff-filter=AD "${BASE}..${HEAD_SHA}" 2>/dev/null)"
-
-_needs_repo_index() {
-  [[ -n "$added_deleted" ]]
-}
 
 _needs_test_inventory() {
   printf '%s\n' "$changed" | grep -qE '\.bats$|^tests/.*\.sh$|^tests/e2e/specs/.*\.spec\.ts$'
@@ -63,9 +57,6 @@ _require() {
   fi
 }
 
-# Beide werden EINZELN geprueft — ein gemeinsamer ODER-grep war der Fehler der
-# Vorgaengerfassung (siehe Vorgeschichte oben).
-_needs_repo_index     && _require "docs/code-quality/repo-index.json"
 _needs_test_inventory && _require "website/src/data/test-inventory.json"
 
 exit "$rc"

--- a/tests/spec/ci-cd/pre-push-artifact-guard.bats
+++ b/tests/spec/ci-cd/pre-push-artifact-guard.bats
@@ -52,19 +52,37 @@ _commit_bats_with() {
   git rev-parse HEAD
 }
 
-@test "check-freshness-artifacts: meldet repo-index, wenn nur test-inventory im Push liegt" {
+# [T002687] repo-index.json wird nicht mehr eingefordert — es gehoert nicht mehr
+# in PRs (file_count-Kollisionen zwischen parallelen PRs; nirgends gelesen;
+# freshness-regen.yml haelt es auf main aktuell). Die frueheren Tests
+# "meldet repo-index, wenn nur test-inventory im Push liegt" und
+# "meldet beide, wenn keines im Push liegt" kodierten das alte Verhalten und
+# sind durch die beiden folgenden ersetzt.
+@test "check-freshness-artifacts: schweigt, wenn test-inventory im Push liegt" {
   local head
   head="$(_commit_bats_with website/src/data/test-inventory.json)"
 
   run bash "$SCRIPT" "$BASE_SHA" "$head"
 
-  # Positiv-Anker [T002356-M1]: erst belegen, dass das Skript überhaupt lief und
-  # etwas ausgab — sonst wäre jede Aussage über die Ausgabe trivial wahr.
-  [ -n "$output" ]
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
 
-  [[ "$output" == *"repo-index.json"* ]]
-  [[ "$output" != *"test-inventory.json"* ]]
+@test "check-freshness-artifacts: fordert repo-index NIE ein" {
+  # Negativaussage mit Positiv-Anker [T002356-M1]: der erste Teil belegt, dass
+  # das Skript ueberhaupt anschlaegt und etwas ausgibt. Ohne ihn waere
+  # "repo-index kommt nicht vor" bei jeder leeren Ausgabe trivial wahr — auch
+  # wenn der Hook gar nicht mehr liefe.
+  local head
+  head="$(_commit_bats_with)"
+
+  run bash "$SCRIPT" "$BASE_SHA" "$head"
+
+  [ -n "$output" ]
+  [[ "$output" == *"test-inventory.json"* ]]
   [ "$status" -ne 0 ]
+
+  [[ "$output" != *"repo-index.json"* ]]
 }
 
 @test "check-freshness-artifacts: meldet test-inventory, wenn nur repo-index im Push liegt" {
@@ -79,17 +97,11 @@ _commit_bats_with() {
   [ "$status" -ne 0 ]
 }
 
-@test "check-freshness-artifacts: meldet beide, wenn keines im Push liegt" {
-  local head
-  head="$(_commit_bats_with)"
-
-  run bash "$SCRIPT" "$BASE_SHA" "$head"
-
-  [ -n "$output" ]
-  [[ "$output" == *"repo-index.json"* ]]
-  [[ "$output" == *"test-inventory.json"* ]]
-  [ "$status" -ne 0 ]
-}
+# [T002687] Der Test "meldet beide, wenn keines im Push liegt" stand hier. Seit
+# nur noch test-inventory eingefordert wird, deckt ihn "fordert repo-index NIE
+# ein" oben vollstaendig ab — dieselbe Ausgangslage (kein Artefakt im Push),
+# dieselbe Assertion plus die Negativaussage. Ein zweiter Test mit identischem
+# Aufbau haette keinen eigenen Erkenntniswert.
 
 @test "check-freshness-artifacts: schweigt, wenn beide im Push liegen" {
   local head
@@ -122,10 +134,10 @@ _commit_bats_with() {
   [ -z "$output" ]
 }
 
-@test "check-freshness-artifacts: fordert repo-index bei NEUER Nicht-Test-Datei" {
-  # Der Fall, der dreimal an einem Tag durch den Hook fiel (T002681, T002684):
-  # eine hinzugefuegte .test.ts ist keine .bats-Datei, macht repo-index.json aber
-  # trotzdem stale.
+# [T002687] Frueher forderte dieser Fall repo-index.json ein. Seit repo-index
+# nicht mehr in PRs gehoert, ist eine hinzugefuegte Nicht-Test-Datei fuer den
+# Hook belanglos — genau das entlastet PRs von der Kollisionsquelle.
+@test "check-freshness-artifacts: schweigt bei NEUER Nicht-Test-Datei" {
   mkdir -p website/src/lib
   echo "export const x = 1;" > website/src/lib/neu.test.ts
   git add website/src/lib/neu.test.ts
@@ -135,16 +147,31 @@ _commit_bats_with() {
 
   run bash "$SCRIPT" "$BASE_SHA" "$head"
 
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"docs/code-quality/repo-index.json"* ]]
-  # test-inventory speist sich nicht aus .test.ts -> darf hier NICHT gefordert
-  # werden. Ohne diese Zeile wuerde der Test auch bei einer pauschalen
-  # "fordere immer beides"-Regel bestehen.
-  [[ "$output" != *"test-inventory.json"* ]]
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }
 
-@test "check-freshness-artifacts: fordert repo-index auch beim LOESCHEN einer Datei" {
-  # tests/spec/alt.bats stammt aus dem Fixture-Setup.
+@test "check-freshness-artifacts: fordert test-inventory bei NEUER .bats-Datei" {
+  # Der positive Gegenpol zu den beiden Schweige-Tests: ohne ihn koennte der
+  # Hook vollstaendig kaputt sein und alle "schweigt"-Aussagen blieben wahr.
+  mkdir -p tests/spec
+  echo '@test "neu" { true; }' > tests/spec/neu.bats
+  git add tests/spec/neu.bats
+  git commit -qm "add bats file"
+  local head
+  head="$(git rev-parse HEAD)"
+
+  run bash "$SCRIPT" "$BASE_SHA" "$head"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"website/src/data/test-inventory.json"* ]]
+  [[ "$output" != *"repo-index.json"* ]]
+}
+
+@test "check-freshness-artifacts: fordert test-inventory beim LOESCHEN einer .bats-Datei" {
+  # tests/spec/alt.bats stammt aus dem Fixture-Setup. Loeschen entfernt ihre
+  # Eintraege aus dem Inventar — hier bleibt die Forderung also bestehen,
+  # anders als bei repo-index (T002687).
   git rm -q tests/spec/alt.bats
   git commit -qm "delete file"
   local head
@@ -153,5 +180,6 @@ _commit_bats_with() {
   run bash "$SCRIPT" "$BASE_SHA" "$head"
 
   [ "$status" -eq 1 ]
-  [[ "$output" == *"docs/code-quality/repo-index.json"* ]]
+  [[ "$output" == *"website/src/data/test-inventory.json"* ]]
+  [[ "$output" != *"repo-index.json"* ]]
 }


### PR DESCRIPTION
Folgearbeit zu #3820 (T002686). Jener PR hat die fünf Register konsistent gemacht — **aber die Kollisions-Ursache nicht beseitigt.**

## Der Konflikt ist strukturell garantiert

`docs/code-quality/repo-index.json` enthält acht `file_count`-Zähler, einen pro Subsystem. Jeder PR mit einer hinzugefügten oder entfernten Datei ändert **dieselbe Zeile** im betroffenen Subsystem. Parallele PRs kollidieren damit zwangsläufig, nicht zufällig.

`merge=ours` hilft dort nicht: Der Driver ist lokal registriert (per `git check-attr` bestätigt), aber **GitHub kennt keine benutzerdefinierten Merge-Driver** und berechnet den Konflikt serverseitig. Ein konfliktbehafteter PR unterdrückt dort zusätzlich die CI.

Gemessen heute: PR #3817 musste **zweimal** rebased und neu generiert werden — einmal nach #3816/#3818, einmal nach #3820. Beide Male lautete der Konflikt auf `file_count`.

## Warum das gefahrlos geht

`repo-index.json` wird **nirgends gelesen**:

```
$ grep -rn "repo-index" scripts/ website/src --include=*.mjs --include=*.ts
scripts/code-quality/scan.mjs:22:  *  - Selbstreferenz von `docs/code-quality/repo-index.json`: …   ← nur ein Kommentar
```

`quality:check` scannt live über `trackedFiles()` → `git ls-files`. Die Datei ist reines Reporting; kein Gate hängt inhaltlich an ihr. Sie aus dem PR-Weg zu nehmen schwächt deshalb **keine** Prüfung.

## Was sich ändert

Entfernt aus `freshness:check` FILES, `_FRESHNESS_FILES` (pre-commit Auto-Stage) und `check-freshness-artifacts.sh` (pre-push). Damit landet sie nie mehr in einem PR; `freshness-regen.yml` hält sie auf `main` aktuell.

`.gitattributes` behält `merge=ours` — für lokale Merges und die Post-Merge-Commits schadet es nicht.

**Das Gate bleibt für die übrigen 14 Artefakte fail-closed.**

| | vorher | nachher |
|---|---|---|
| PR mit neuer/gelöschter Datei | ändert `file_count` → Kollision mit jedem parallelen PR | Datei bleibt außen vor |
| `quality:check` | scannt live | unverändert |
| `repo-index.json` auf main | über PRs + post-merge | nur post-merge |

## Tests

Vier Fälle kodierten die alte Forderung und sind ersetzt. Neu:

- **`fordert repo-index NIE ein`** — mit Positiv-Anker (`[ -n "$output" ]`, `test-inventory` wird gefordert), damit die Negativaussage nicht trivial wahr wird, falls der Hook gar nicht mehr liefe.
- **`fordert test-inventory bei NEUER .bats-Datei`** — der positive Gegenpol zu den beiden Schweige-Tests. Ohne ihn könnte der Hook vollständig kaputt sein und alle „schweigt"-Aussagen blieben wahr.

Entfallen ist `meldet beide, wenn keines im Push liegt`: identische Ausgangslage wie der NIE-Test, kein eigener Erkenntniswert.

```
25 Guard-Tests grün, 0 rot
  (pre-push-artifact-guard + generated-artifacts-registry + pre-commit-freshness)
task freshness:check  →  ✓ All generated artifacts are fresh, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)