### PR TITLE
fix(website): Coaching-Inhalte nur an on-premises-Provider [T002657]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       # handgepflegte Liste ab jetzt gegen die vorhandenen Dateien.
       # mcp-bridge.test.mjs uses vitest (vi.mock) — run separately from node:test files.
       - name: llm-proxy routing + readiness (always)
-        run: npx vitest run scripts/llm-proxy/mcp-bridge.test.mjs && node --test scripts/llm-proxy/discovery-probe-auth.test.mjs scripts/llm-proxy/exclusive-conflict.test.mjs scripts/llm-proxy/fixups.test.mjs scripts/llm-proxy/gpu-lock.test.mjs scripts/llm-proxy/loadouts.test.mjs scripts/llm-proxy/models.test.mjs scripts/llm-proxy/runner.test.mjs scripts/llm-proxy/server.test.mjs scripts/llm-proxy/strip-markers.test.mjs
+        run: npx vitest run scripts/llm-proxy/mcp-bridge.test.mjs && node --test scripts/llm-proxy/discovery-probe-auth.test.mjs scripts/llm-proxy/exclusive-conflict.test.mjs scripts/llm-proxy/fixups.test.mjs scripts/llm-proxy/gpu-lock.test.mjs scripts/llm-proxy/loadouts.test.mjs scripts/llm-proxy/local-only.test.mjs scripts/llm-proxy/models.test.mjs scripts/llm-proxy/runner.test.mjs scripts/llm-proxy/server.test.mjs scripts/llm-proxy/strip-markers.test.mjs
 
       - name: API auth regression gate
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -758,7 +758,7 @@ tasks:
       # gegen die tatsaechlich vorhandenen Dateien.
       # mcp-bridge.test.mjs uses vitest (vi.mock) — run separately from node:test files.
       - npx vitest run scripts/llm-proxy/mcp-bridge.test.mjs
-      - node --test scripts/llm-proxy/discovery-probe-auth.test.mjs scripts/llm-proxy/exclusive-conflict.test.mjs scripts/llm-proxy/fixups.test.mjs scripts/llm-proxy/gpu-lock.test.mjs scripts/llm-proxy/loadouts.test.mjs scripts/llm-proxy/models.test.mjs scripts/llm-proxy/runner.test.mjs scripts/llm-proxy/server.test.mjs scripts/llm-proxy/strip-markers.test.mjs
+      - node --test scripts/llm-proxy/discovery-probe-auth.test.mjs scripts/llm-proxy/exclusive-conflict.test.mjs scripts/llm-proxy/fixups.test.mjs scripts/llm-proxy/gpu-lock.test.mjs scripts/llm-proxy/loadouts.test.mjs scripts/llm-proxy/local-only.test.mjs scripts/llm-proxy/models.test.mjs scripts/llm-proxy/runner.test.mjs scripts/llm-proxy/server.test.mjs scripts/llm-proxy/strip-markers.test.mjs
 
   test:factory:
     desc: "Run the offline-safe Software Factory regression bats (tests/spec/software-factory/ + tests/local/FA-AR-*). Live-DB cases skip without a reachable cluster, so this is CI-safe."

--- a/openspec/changes/coaching-daten-lokal-only/tasks.md
+++ b/openspec/changes/coaching-daten-lokal-only/tasks.md
@@ -51,7 +51,7 @@ Die drei Punkte, an denen dieser Vorgang typischerweise falsch umgesetzt wird:
 
 ## Tasks
 
-- [ ] **RED bestaetigen.** Der Test liegt bereits im Branch. Erwartet sind 3 rote von 4;
+- [x] **RED bestaetigen.** Der Test liegt bereits im Branch. Erwartet sind 3 rote von 4;
       der gruene ist der Positiv-Anker (`on_premises` laeuft durch — heute mangels Guard
       trivial). Der aussagekraeftigste Fehlschlag ist der letzte: er meldet
       `ECONNREFUSED` statt einer Residenz-Ablehnung und belegt damit, dass der Netzaufruf
@@ -62,7 +62,7 @@ cd website && npx vitest run src/lib/coaching-data-residency.test.ts
 # expected: FAIL (rot — weder dataResidency im Provider-Typ noch ein Guard)
 ```
 
-- [ ] **Migration schreiben.** `scripts/migrations/2026-08-04-provider-config-data-residency.sql`:
+- [x] **Migration schreiben.** `scripts/migrations/2026-08-04-provider-config-data-residency.sql`:
 
 ```sql
 ALTER TABLE tickets.provider_config
@@ -77,18 +77,18 @@ ALTER TABLE tickets.provider_config
       llm-proxy-Zugang), damit Coaching nach dem Guard nutzbar bleibt. Die
       DeepSeek-Zeilen werden nicht umgewidmet.
 
-- [ ] **`data_residency` durchreichen.** In `website/src/lib/provider-config.ts` die
+- [x] **`data_residency` durchreichen.** In `website/src/lib/provider-config.ts` die
       Spalte in die SELECT-Liste und in den Rueckgabetyp aufnehmen. Fehlender oder
       NULL-Wert wird auf `external` normalisiert — die Normalisierung gehoert hierher,
       damit sie nicht an jeder Aufrufstelle wiederholt werden muss.
 
-- [ ] **Guard einziehen.** In `website/src/lib/openai-compatible-session-agent.ts` prueft
+- [x] **Guard einziehen.** In `website/src/lib/openai-compatible-session-agent.ts` prueft
       `resolveProvider` die Residenz und wirft bei allem ausser `on_premises` einen
       Fehler, der Provider und Grund nennt. Der Wurf erfolgt VOR dem Aufbau des
       OpenAI-Clients und vor jedem `create`-Aufruf. Kein Fallback auf einen anderen
       Provider.
 
-- [ ] **Gruen sehen (Coaching-Guard).** Der Vitest-Test
+- [x] **Gruen sehen (Coaching-Guard).** Der Vitest-Test
       `website/src/lib/coaching-data-residency.test.ts` liegt bereits im Branch und muss
       jetzt vollstaendig durchlaufen — inklusive des Falls, der die Ablehnung vor dem
       Netzaufruf nachweist.
@@ -97,7 +97,7 @@ ALTER TABLE tickets.provider_config
 cd website && npx vitest run src/lib/coaching-data-residency.test.ts
 ```
 
-- [ ] **Lokal-only im Proxy.** `server.mjs` nimmt die Anforderung entgegen (Header
+- [x] **Lokal-only im Proxy.** `server.mjs` nimmt die Anforderung entgegen (Header
       `x-llm-local-only: 1`), `discovery.mjs` beruecksichtigt sie bei der Auswahl: nur
       Backends lokaler Art kommen infrage, und ist keines verfuegbar, schlaegt die
       Anfrage fehl statt auf ein `openai-remote`-Backend zu substituieren. Gewoehnliche
@@ -105,7 +105,7 @@ cd website && npx vitest run src/lib/coaching-data-residency.test.ts
       nicht ueber Backend-Namen — eine Namensliste veraltet still, sobald ein Backend
       hinzukommt.
 
-- [ ] **Proxy-Tests.** `scripts/llm-proxy/local-only.test.mjs` nach der Konvention des
+- [x] **Proxy-Tests.** `scripts/llm-proxy/local-only.test.mjs` nach der Konvention des
       Verzeichnisses (`node:test`, Funktionen aufrufen und Rueckgabe pruefen): lokal-only
       waehlt kein remote-Backend, wird lokal bedient wenn moeglich, schlaegt bei
       gedrainten Backends fehl, und eine gewoehnliche Anfrage faellt weiterhin auf remote.
@@ -114,22 +114,22 @@ cd website && npx vitest run src/lib/coaching-data-residency.test.ts
 node --test scripts/llm-proxy/local-only.test.mjs
 ```
 
-- [ ] **Coaching auf den lokal-only-Weg legen.** Der Coaching-Pfad setzt die
+- [x] **Coaching auf den lokal-only-Weg legen.** Der Coaching-Pfad setzt die
       lokal-only-Anforderung, wenn er ueber den Proxy geht. Damit behaelt er Slot-Queue
       und Loadout-Verwaltung, ohne die Prioritaetskette zum Ausweichen zu erben.
 
-- [ ] **Bestandsdaten pruefen, nicht umhaengen.** Belegen, dass die 13 Sessions auf
+- [x] **Bestandsdaten pruefen, nicht umhaengen.** Belegen, dass die 13 Sessions auf
       `ki_config_id = 82` nach der Migration in den Guard laufen. Sie bleiben, wie sie
       sind — es sind Testdaten, und ihr Fehlschlag ist der sichtbare Beleg, dass der
       Guard greift. Ein stilles Umhaengen wuerde die Pruefung verstecken.
 
-- [ ] **Test-Inventar regenerieren.** Zwei neue Testdateien bedeuten neue Eintraege.
+- [x] **Test-Inventar regenerieren.** Zwei neue Testdateien bedeuten neue Eintraege.
 
 ```bash
 task test:inventory
 ```
 
-- [ ] **Final Verification.** Die drei Pflicht-Gates:
+- [x] **Final Verification.** Die drei Pflicht-Gates:
 
 ```bash
 task test:changed

--- a/scripts/llm-proxy/discovery.mjs
+++ b/scripts/llm-proxy/discovery.mjs
@@ -108,27 +108,59 @@ export function startDiscovery(getBackends, intervalMs) {
   return { timer: t, probeNow: tick };
 }
 
-/** @returns {{backend:import('./backends.mjs').Backend, servedModel:string, substituted:boolean}|null} */
-export function resolveModel(requestedId, getBackends) {
-  const backends = getBackends();
-  const byName = (n) => backends.find((b) => b.name === n);
+/**
+ * Backend-Arten, die auf eigener Infrastruktur laufen [T002657].
+ *
+ * Bewusst eine POSITIVliste, obwohl T002674 fuer den Watchdog das Gegenteil
+ * gelernt hat — entscheidend ist die Richtung, in die eine Liste altert. Beim
+ * Watchdog liess eine Allowlist neue Typen unbemerkt durchfallen: sie alterte
+ * ins Unsichere. Hier ist es umgekehrt: ein kuenftiges, unbekanntes `kind` gilt
+ * als NICHT lokal, faellt also aus dem lokal-only-Weg heraus und fuehrt zum
+ * Fehlschlag statt zur Uebertragung. Dieselbe Regel wie bei data_residency:
+ * eine fehlende Zusage ist keine Zusage.
+ *
+ * Gefiltert wird ueber `kind`, nicht ueber Backend-Namen — eine Namensliste
+ * veraltet still, sobald ein Backend hinzukommt.
+ */
+const LOCAL_BACKEND_KINDS = new Set(['llamacpp', 'lmstudio']);
+
+/** @param {{kind?:string}} b */
+export function isLocalBackend(b) {
+  return LOCAL_BACKEND_KINDS.has(b?.kind);
+}
+
+/**
+ * @param {string} requestedId
+ * @param {() => import('./backends.mjs').Backend[]} getBackends
+ * @param {{localOnly?: boolean}} [opts] localOnly: nur eigene Infrastruktur;
+ *   ist keine verfuegbar, wird NICHT auf ein remote-Backend substituiert,
+ *   sondern null geliefert (der Aufrufer meldet das als Fehlschlag).
+ * @returns {{backend:import('./backends.mjs').Backend, servedModel:string, substituted:boolean}|null}
+ */
+export function resolveModel(requestedId, getBackends, opts = {}) {
+  const localOnly = opts.localOnly === true;
+  // Gewoehnliche Anfragen behalten ihren Fallback unveraendert — der
+  // lokal-only-Weg ist eine zusaetzliche Einschraenkung, keine Umstellung.
+  const eligible = getBackends().filter((b) => !localOnly || isLocalBackend(b));
+  const byName = (n) => eligible.find((b) => b.name === n);
   const isServing = (n) => {
     const h = health.get(n);
     return h?.healthy && !h.draining;
   };
-  const healthyNames = (id) => (catalog.get(id) || []).filter(isServing);
+  const isEligible = (n) => eligible.some((b) => b.name === n);
+  const healthyNames = (id) => (catalog.get(id) || []).filter((n) => isServing(n) && isEligible(n));
 
   const exact = healthyNames(requestedId);
   if (exact.length) return { backend: byName(exact[0]), servedModel: requestedId, substituted: false };
 
-  for (const b of backends) {
+  for (const b of eligible) {
     const aliased = b.modelAliases[requestedId];
     if (aliased && healthyNames(aliased).includes(b.name) && isServing(b.name)) {
       return { backend: b, servedModel: aliased, substituted: true };
     }
   }
 
-  for (const b of backends) {
+  for (const b of eligible) {
     const h = health.get(b.name);
     if (h?.healthy && !h.draining && h.models.length) return { backend: b, servedModel: h.models[0], substituted: true };
   }

--- a/scripts/llm-proxy/local-only.test.mjs
+++ b/scripts/llm-proxy/local-only.test.mjs
@@ -1,0 +1,89 @@
+// scripts/llm-proxy/local-only.test.mjs
+// [T002657] Lokal-only-Anforderung: Coaching-Inhalte duerfen die eigene
+// Infrastruktur nicht verlassen — auch nicht ueber die Prioritaetskette des
+// Proxys.
+//
+// Pruefmodus: command output verification [T002448-M4] — die Tests rufen
+// resolveModel() auf und pruefen, WELCHES Backend zurueckkommt. Kein Grep auf
+// die Implementierung: dass ein kind-Filter im Quelltext steht, belegt nicht,
+// dass die Auswahl ihn auch anwendet.
+//
+// Der Kern ist der dritte Test: ohne ihn wuerde ein resolveModel, das bei
+// lokal-only einfach das erstbeste Backend nimmt, die beiden ersten Tests
+// bestehen, solange lokale Backends zufaellig vorne stehen.
+//
+// Run: node --test scripts/llm-proxy/local-only.test.mjs
+import { test, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveModel, isLocalBackend, _testSeed } from './discovery.mjs'
+
+/** Backends wie sie backends.mjs liefert — remote steht bewusst VORNE. */
+const BACKENDS = [
+  { name: 'remote-deepseek', kind: 'openai-remote', priority: 1, baseUrl: 'https://api.deepseek.com',
+    modelAliases: {}, aliases: {}, fixups: [] },
+  { name: 'local-gptoss', kind: 'llamacpp', priority: 2, baseUrl: 'http://127.0.0.1:8081',
+    modelAliases: {}, aliases: {}, fixups: [] },
+  { name: 'local-studio', kind: 'lmstudio', priority: 3, baseUrl: 'http://127.0.0.1:1234',
+    modelAliases: {}, aliases: {}, fixups: [] },
+]
+const getBackends = () => BACKENDS
+
+function seed({ remoteHealthy = true, localHealthy = true } = {}) {
+  _testSeed({
+    backends: [
+      { name: 'remote-deepseek', healthy: remoteHealthy, models: ['shared-model'] },
+      { name: 'local-gptoss', healthy: localHealthy, models: ['shared-model'] },
+      { name: 'local-studio', healthy: localHealthy, models: ['studio-only'] },
+    ],
+  })
+}
+
+beforeEach(() => seed())
+
+test('isLocalBackend: llamacpp und lmstudio sind lokal, openai-remote nicht', () => {
+  assert.equal(isLocalBackend({ kind: 'llamacpp' }), true)
+  assert.equal(isLocalBackend({ kind: 'lmstudio' }), true)
+  assert.equal(isLocalBackend({ kind: 'openai-remote' }), false)
+  // Ein kuenftiges, unbekanntes kind gilt als NICHT lokal — die Liste altert
+  // ins Sichere: fehlende Zusage ist keine Zusage.
+  assert.equal(isLocalBackend({ kind: 'irgendwas-neues' }), false)
+  assert.equal(isLocalBackend({}), false)
+})
+
+test('lokal-only waehlt kein remote-Backend, obwohl es dasselbe Modell fuehrt und vorne steht', () => {
+  // Positiv-Anker: ohne localOnly gewinnt das remote-Backend (Reihenfolge).
+  const normal = resolveModel('shared-model', getBackends)
+  assert.equal(normal.backend.name, 'remote-deepseek')
+
+  const local = resolveModel('shared-model', getBackends, { localOnly: true })
+  assert.equal(local.backend.name, 'local-gptoss')
+  assert.equal(local.backend.kind, 'llamacpp')
+})
+
+test('lokal-only schlaegt fehl, statt auf remote zu substituieren', () => {
+  seed({ remoteHealthy: true, localHealthy: false })
+
+  // Positiv-Anker: gewoehnliche Anfragen werden weiterhin bedient — sonst
+  // waere das null unten auch bei einem komplett kaputten resolveModel wahr.
+  const normal = resolveModel('shared-model', getBackends)
+  assert.equal(normal.backend.name, 'remote-deepseek')
+
+  const local = resolveModel('shared-model', getBackends, { localOnly: true })
+  assert.equal(local, null, 'lokal-only darf nicht auf ein remote-Backend ausweichen')
+})
+
+test('lokal-only substituiert innerhalb der lokalen Backends', () => {
+  // Modell nur auf dem lmstudio-Backend: die Substitution bleibt erlaubt,
+  // solange sie lokal bleibt.
+  const local = resolveModel('studio-only', getBackends, { localOnly: true })
+  assert.equal(local.backend.name, 'local-studio')
+  assert.equal(local.substituted, false)
+})
+
+test('gewoehnliche Anfrage behaelt ihren Fallback unveraendert', () => {
+  seed({ remoteHealthy: true, localHealthy: false })
+  const routed = resolveModel('gibt-es-nicht', getBackends)
+  assert.ok(routed, 'ohne localOnly muss der Fallback greifen')
+  assert.equal(routed.backend.name, 'remote-deepseek')
+  assert.equal(routed.substituted, true)
+})

--- a/scripts/llm-proxy/server.mjs
+++ b/scripts/llm-proxy/server.mjs
@@ -134,8 +134,23 @@ async function proxyV1(req, res, subpath) {
     const e = auto.failed;
     return sendJson(res, e.status ?? 502, { error: { code: e.code ?? 'start_error', message: e.message } });
   }
-  const routed = resolveModel(body.model, getBackends);
-  if (!routed) return sendJson(res, 503, { error: { code: 'no_backend', message: 'no healthy backend' } });
+  // [T002657] Lokal-only-Anforderung: der Aufrufer verlangt, dass die Inhalte
+  // die eigene Infrastruktur nicht verlassen. Ohne diesen Weg faellt eine
+  // korrekt auf on-premises umgestellte Coaching-Konfiguration beim naechsten
+  // Trainingslauf ueber die Prioritaetskette wieder auf ein remote-Backend
+  // zurueck — der Guard in der Website waere dann umgangen, ohne dass jemand
+  // etwas falsch gemacht haette.
+  const localOnly = String(req.headers['x-llm-local-only'] ?? '') === '1';
+  const routed = resolveModel(body.model, getBackends, { localOnly });
+  if (!routed) {
+    // Bewusst KEINE Substitution auf ein remote-Backend: bei lokal-only ist
+    // Fehlschlagen das richtige Ergebnis, Ausweichen waere der Schaden.
+    return localOnly
+      ? sendJson(res, 503, { error: { code: 'no_local_backend', message:
+          'x-llm-local-only: 1 angefordert, aber kein lokales Backend verfuegbar — '
+          + 'es wurde NICHT auf ein remote-Backend ausgewichen' } })
+      : sendJson(res, 503, { error: { code: 'no_backend', message: 'no healthy backend' } });
+  }
 
   const { backend, servedModel, substituted } = routed;
   // sanitizeToolSchemaPatterns laeuft UNBEDINGT, nicht als benannter Fixup:

--- a/scripts/migrations/2026-08-04-provider-config-data-residency.sql
+++ b/scripts/migrations/2026-08-04-provider-config-data-residency.sql
@@ -1,0 +1,57 @@
+-- T002657 — Datenresidenz als ausgesprochene Zusage, nicht als Annahme.
+--
+-- Coaching-Inhalte duerfen nur an Provider gehen, die sich als on-premises
+-- deklarieren. Am 2026-08-04 zeigten 13 von 18 coaching.sessions auf
+-- ki_config_id=82 (provider='deepseek', api.deepseek.com, Key gesetzt) —
+-- die erste echte Session waere dorthin gegangen, waehrend das Projekt
+-- "All data stays on-premises (DSGVO by design)" als Kernaussage fuehrt.
+--
+-- Warum eine neue Spalte und nicht eu_endpoint: eu_endpoint beschreibt den
+-- RECHTSRAUM eines fremden Betreibers, nicht die BETREIBERSCHAFT. Ein
+-- EU-gehosteter Fremdanbieter ist weiterhin ein Fremdanbieter. Die Spalte
+-- bleibt unangetastet, sie wird fuer die Rechtsraum-Frage weiter gebraucht.
+--
+-- Der DEFAULT traegt die Absicht: Bestandszeilen werden 'external'. Wer
+-- on-premises sein will, muss es aussprechen. Eine fehlende Deklaration ist
+-- damit keine stillschweigende Zusage — ein vergessener Eintrag fuehrt zum
+-- Fehlschlag, nicht zur Uebertragung.
+
+BEGIN;
+
+ALTER TABLE tickets.provider_config
+  ADD COLUMN IF NOT EXISTS data_residency text NOT NULL DEFAULT 'external';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conrelid = 'tickets.provider_config'::regclass
+       AND conname  = 'provider_config_data_residency_check'
+  ) THEN
+    ALTER TABLE tickets.provider_config
+      ADD CONSTRAINT provider_config_data_residency_check
+      CHECK (data_residency IN ('on_premises','external'));
+  END IF;
+END $$;
+
+-- Freigegeben werden die lokalen llm-proxy-Zugaenge. Ohne sie waere Coaching
+-- nach dem Guard gar nicht mehr nutzbar.
+--
+-- ABWEICHUNG VOM PLAN, bewusst und gemessen (2026-08-08): der Plan nannte
+-- 'local-cluster'. Diese Zeilen stehen jedoch auf enabled=false, und
+-- getProviderByName filtert auf enabled=true — die Freigabe waere wirkungslos
+-- geblieben und Coaching haette nach dem Guard KEINEN nutzbaren Provider mehr
+-- gehabt. Tatsaechlich aktiv sind 'llamacpp' und 'lmstudio' auf
+-- 127.0.0.1:18235, dem llm-proxy.
+--
+-- Dieselben zwei Arten fuehrt scripts/llm-proxy/discovery.mjs als
+-- LOCAL_BACKEND_KINDS. Die Definition von "lokal" steht damit an beiden Enden
+-- des Wegs auf derselben Grundlage statt auf zwei gepflegten Namenslisten.
+--
+-- Die DeepSeek-Zeilen werden NICHT umgewidmet — ihr Fehlschlag ist der
+-- sichtbare Beleg, dass der Guard greift.
+UPDATE tickets.provider_config
+   SET data_residency = 'on_premises'
+ WHERE provider IN ('llamacpp','lmstudio');
+
+COMMIT;

--- a/website/src/lib/coaching-data-residency.test.ts
+++ b/website/src/lib/coaching-data-residency.test.ts
@@ -1,0 +1,148 @@
+// coaching-data-residency.test.ts — T002657
+//
+// Coaching-Inhalte duerfen nur an Provider gehen, die sich als on-premises
+// deklarieren. Gemessen am 2026-08-04 zeigten 13 der 18 coaching.sessions auf
+// ki_config_id=82 (provider='deepseek', api.deepseek.com, Key gesetzt) — die
+// erste echte Session waere dorthin gegangen, waehrend das Projekt
+// "All data stays on-premises (DSGVO by design)" als Kernaussage fuehrt.
+//
+// Pruefmodus: Verhaltensverifikation. Die Tests RUFEN den Agenten auf und pruefen,
+// ob ein Aufruf beim Provider ankam (mockCreate) — sie greppen keine Quelle.
+// Der entscheidende Test ist "vor dem Netzaufruf": ein Guard im Fehlerpfad wuerde
+// den Payload bereits gesendet haben und danach ablehnen.
+//
+// Erwartung vor der Implementierung: ROT. Weder gibt es dataResidency im
+// Provider-Typ noch einen Guard, der darauf prueft.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockCreate = vi.fn();
+vi.mock('openai', () => ({
+  default: class {
+    chat = { completions: { create: (...a: unknown[]) => mockCreate(...a) } };
+  },
+}));
+
+vi.mock('./session-tools', () => ({
+  searchCoachingKnowledgeTool: vi.fn().mockResolvedValue([]),
+}));
+
+const { getProviderByNameMock } = vi.hoisted(() => ({
+  getProviderByNameMock: vi.fn(),
+}));
+vi.mock('./provider-config', () => ({
+  getProviderByName: (...a: unknown[]) => getProviderByNameMock(...a),
+}));
+
+import type { KiConfig } from './coaching-ki-config-db.ts';
+import { OpenAICompatibleSessionAgent } from './openai-compatible-session-agent';
+
+const baseConfig = (overrides: Partial<KiConfig> = {}): KiConfig => ({
+  id: 1,
+  brand: 'mentolder',
+  provider: 'deepseek',
+  isActive: true,
+  modelName: null,
+  displayName: 'DeepSeek',
+  createdAt: new Date(),
+  apiEndpoint: null,
+  apiKey: null,
+  maxTokens: 100,
+  temperature: null,
+  topP: null,
+  systemPrompt: null,
+  notes: null,
+  topK: null,
+  thinkingMode: false,
+  presencePenalty: null,
+  frequencyPenalty: null,
+  safePrompt: false,
+  randomSeed: null,
+  organizationId: null,
+  euEndpoint: false,
+  enabledFields: null,
+  ...overrides,
+});
+
+const baseOptions = () => ({
+  sessionId: 's-1',
+  stepNumber: 1,
+  coachInputs: {},
+  kiConfig: baseConfig(),
+  brand: 'mentolder',
+  history: [] as Array<{ role: 'user' | 'assistant'; content: string }>,
+  effectiveSystemPrompt: 'system',
+  assembledUserPrompt: 'hi',
+  stepName: 'reflect',
+});
+
+describe('T002657: Datenresidenz-Guard im Coaching-Pfad', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    getProviderByNameMock.mockReset();
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'ok' } }] });
+  });
+
+  it('lehnt einen Provider mit data_residency=external ab und sendet nichts', async () => {
+    getProviderByNameMock.mockResolvedValue({
+      provider: 'deepseek',
+      modelId: 'deepseek-v4-flash',
+      baseUrl: 'https://api.deepseek.com/v1',
+      apiKey: 'k',
+      dataResidency: 'external',
+    });
+
+    const agent = new OpenAICompatibleSessionAgent();
+    await expect(agent.generate(baseOptions() as never)).rejects.toThrow(/residency|on_premises|extern/i);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('laesst einen Provider mit data_residency=on_premises durch', async () => {
+    // Positiv-Anker: ohne ihn bestuende der Negativtest auch dann, wenn der Agent
+    // grundsaetzlich nichts mehr sendet.
+    getProviderByNameMock.mockResolvedValue({
+      provider: 'local-cluster',
+      modelId: 'gptoss-context',
+      baseUrl: 'http://127.0.0.1:18235/v1',
+      apiKey: '',
+      dataResidency: 'on_premises',
+    });
+
+    const agent = new OpenAICompatibleSessionAgent();
+    await agent.generate(baseOptions() as never);
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
+  it('behandelt eine fehlende Deklaration wie external', async () => {
+    // Eine fehlende Aussage ist keine Zusage. Faellt dieser Fall auf "erlauben",
+    // reicht ein vergessener Migrationseintrag fuer einen stillen Abfluss.
+    getProviderByNameMock.mockResolvedValue({
+      provider: 'deepseek',
+      modelId: 'deepseek-v4-flash',
+      baseUrl: 'https://api.deepseek.com/v1',
+      apiKey: 'k',
+      // dataResidency fehlt bewusst
+    });
+
+    const agent = new OpenAICompatibleSessionAgent();
+    await expect(agent.generate(baseOptions() as never)).rejects.toThrow(/residency|on_premises|extern/i);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('lehnt VOR dem Netzaufruf ab, nicht danach', async () => {
+    // Der Kern des Vorgangs: ein Guard im Fehlerpfad haette den Payload bereits
+    // gesendet. Der Provider antwortet hier mit einem Verbindungsfehler — kommt
+    // dieser statt der Residenz-Ablehnung durch, stand der Guard zu spaet.
+    getProviderByNameMock.mockResolvedValue({
+      provider: 'deepseek',
+      modelId: 'deepseek-v4-flash',
+      baseUrl: 'https://unerreichbar.invalid/v1',
+      apiKey: 'k',
+      dataResidency: 'external',
+    });
+    mockCreate.mockRejectedValue(new Error('ECONNREFUSED verbindung fehlgeschlagen'));
+
+    const agent = new OpenAICompatibleSessionAgent();
+    await expect(agent.generate(baseOptions() as never)).rejects.toThrow(/residency|on_premises|extern/i);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/website/src/lib/coaching-data-residency.test.ts
+++ b/website/src/lib/coaching-data-residency.test.ts
@@ -16,9 +16,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockCreate = vi.fn();
+/** Konfigurationen, mit denen der OpenAI-Client tatsaechlich gebaut wurde. */
+const clientConfigs: Array<Record<string, unknown>> = [];
 vi.mock('openai', () => ({
   default: class {
     chat = { completions: { create: (...a: unknown[]) => mockCreate(...a) } };
+    constructor(cfg: Record<string, unknown>) { clientConfigs.push(cfg); }
   },
 }));
 
@@ -144,5 +147,30 @@ describe('T002657: Datenresidenz-Guard im Coaching-Pfad', () => {
     const agent = new OpenAICompatibleSessionAgent();
     await expect(agent.generate(baseOptions() as never)).rejects.toThrow(/residency|on_premises|extern/i);
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // Zweiter Fluchtweg: der Guard oben laesst nur on-premises-Provider durch.
+  // Ist dieser Provider der llm-proxy, kann der ueber seine Prioritaetskette
+  // trotzdem auf ein remote-Backend ausweichen. Der Header verlangt, das zu
+  // unterlassen. Ohne diesen Test faellt sein Fehlen still aus — die Anfrage
+  // liefe weiterhin durch, nur eben moeglicherweise nach draussen.
+  it('fordert vom Proxy lokal-only an, wenn der Provider durchgelassen wird', async () => {
+    clientConfigs.length = 0;
+    getProviderByNameMock.mockResolvedValue({
+      provider: 'local-cluster',
+      modelId: 'gpt-oss-20b',
+      baseUrl: 'http://127.0.0.1:8081/v1',
+      apiKey: 'not-required',
+      dataResidency: 'on_premises',
+    });
+
+    const agent = new OpenAICompatibleSessionAgent();
+    await agent.generate(baseOptions() as never);
+
+    // Positiv-Anker: der Aufruf ist tatsaechlich gelaufen und hat einen Client
+    // gebaut — sonst waere die Header-Aussage unten trivial erfuellt.
+    expect(mockCreate).toHaveBeenCalled();
+    expect(clientConfigs).toHaveLength(1);
+    expect(clientConfigs[0].defaultHeaders).toMatchObject({ 'x-llm-local-only': '1' });
   });
 });

--- a/website/src/lib/openai-compatible-session-agent.ts
+++ b/website/src/lib/openai-compatible-session-agent.ts
@@ -13,8 +13,48 @@ function gatewayOverrideFor(provider: string): string | null {
   return process.env.LLM_GATEWAY_URL || null;
 }
 
+/**
+ * Coaching-Inhalte duerfen nur an Provider gehen, die sich als on-premises
+ * deklarieren [T002657].
+ */
+export class DataResidencyError extends Error {
+  constructor(provider: string, residency: string) {
+    super(
+      `Coaching-Inhalte duerfen nur an on-premises-Provider gehen. `
+      + `Provider '${provider}' ist als data_residency='${residency}' deklariert — `
+      + `die Anfrage wurde NICHT gesendet.`,
+    );
+    this.name = 'DataResidencyError';
+  }
+}
+
+/**
+ * Zweiter Fluchtweg [T002657]. Der Guard oben stellt sicher, dass Coaching nur
+ * an einen on-premises-Provider geht. Ist dieser Provider der llm-proxy, kann
+ * der seinerseits ueber seine Prioritaetskette auf ein remote-Backend
+ * ausweichen — die Konfiguration waere korrekt und die Inhalte trotzdem
+ * draussen. Der Header verlangt vom Proxy, das zu unterlassen und lieber
+ * fehlzuschlagen (scripts/llm-proxy/server.mjs).
+ *
+ * Unbeteiligte Endpunkte ignorieren einen unbekannten Header — er ist deshalb
+ * unbedingt gesetzt und nicht an eine Endpunkt-Erkennung geknuepft. Eine
+ * solche Erkennung waere eine zweite Stelle, die veralten koennte.
+ */
+const LOCAL_ONLY_HEADERS = { 'x-llm-local-only': '1' } as const;
+
 async function resolveProvider(kiConfig: KiConfig) {
   const cfg = await getProviderByName(kiConfig.provider);
+
+  // Der Guard steht hier und NICHT im Fehlerpfad des Aufrufs: resolveProvider
+  // laeuft vor `new OpenAI(...)` und vor jedem `create`. Ein Guard, der erst
+  // die Antwort bewertet, haette den Payload bereits uebertragen — bei
+  // Coaching-Inhalten ist genau das der Schaden, der nicht mehr ruecknehmbar
+  // ist. Kein Fallback auf einen anderen Provider: still auf ein anderes Ziel
+  // auszuweichen wuerde dieselbe Frage nur verschieben.
+  if (cfg.dataResidency !== 'on_premises') {
+    throw new DataResidencyError(cfg.provider, cfg.dataResidency);
+  }
+
   return {
     endpoint: kiConfig.apiEndpoint ?? cfg.baseUrl ?? gatewayOverrideFor(cfg.provider),
     apiKey: kiConfig.apiKey ?? cfg.apiKey,
@@ -48,7 +88,7 @@ export class OpenAICompatibleSessionAgent implements SessionAgent {
     const enrichedSystem = await buildEnrichedSystemPrompt(effectiveSystemPrompt, assembledUserPrompt);
 
     const { default: OpenAI } = await import('openai');
-    const client = new OpenAI({ apiKey, baseURL: endpoint ?? undefined });
+    const client = new OpenAI({ apiKey, baseURL: endpoint ?? undefined, defaultHeaders: LOCAL_ONLY_HEADERS });
 
     const messages: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
       { role: 'system', content: enrichedSystem },
@@ -75,7 +115,7 @@ export class OpenAICompatibleSessionAgent implements SessionAgent {
     const enrichedSystem = await buildEnrichedSystemPrompt(effectiveSystemPrompt, assembledUserPrompt);
 
     const { default: OpenAI } = await import('openai');
-    const client = new OpenAI({ apiKey, baseURL: endpoint ?? undefined });
+    const client = new OpenAI({ apiKey, baseURL: endpoint ?? undefined, defaultHeaders: LOCAL_ONLY_HEADERS });
 
     const messages: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
       { role: 'system', content: enrichedSystem },

--- a/website/src/lib/provider-config.ts
+++ b/website/src/lib/provider-config.ts
@@ -2,6 +2,28 @@ import { pool } from './website-db';
 import type { Pool } from 'pg';
 import { logger } from './logger';
 
+/**
+ * Betreiberschaft des Providers [T002657]. NICHT zu verwechseln mit
+ * `eu_endpoint`: das beschreibt den Rechtsraum eines fremden Betreibers, nicht
+ * die Betreiberschaft selbst — ein EU-gehosteter Fremdanbieter ist weiterhin
+ * ein Fremdanbieter.
+ */
+export type DataResidency = 'on_premises' | 'external';
+
+/**
+ * Eine fehlende oder unbekannte Deklaration gilt als `external`. Das ist der
+ * Kern der Zusage: nur wer sich ausdruecklich als on-premises deklariert, gilt
+ * als solcher. Ein vergessener Migrationseintrag fuehrt damit zum Fehlschlag,
+ * nicht zur stillen Uebertragung.
+ *
+ * Die Normalisierung liegt bewusst HIER und nicht an den Aufrufstellen — sonst
+ * muesste jeder kuenftige Konsument sie wiederholen, und genau eine Stelle
+ * wuerde sie irgendwann vergessen.
+ */
+export function normalizeDataResidency(raw: unknown): DataResidency {
+  return raw === 'on_premises' ? 'on_premises' : 'external';
+}
+
 export interface ProviderChoice {
   provider: string;
   modelId: string;
@@ -9,12 +31,16 @@ export interface ProviderChoice {
   apiKey: string;
   contextWindow: number | null;
   contextBudget: number | null;
+  dataResidency: DataResidency;
 }
 
 const OPUS_MODEL = 'claude-opus-4-6';
+// dataResidency: 'external' — der Fallback ist ein Fremdanbieter. Ihn hier
+// versehentlich als on_premises zu fuehren wuerde den Guard genau dann
+// aushebeln, wenn die DB-Abfrage fehlschlaegt [T002657].
 const FALLBACK: Omit<ProviderChoice, 'apiKey'> = {
   provider: 'anthropic', modelId: 'claude-sonnet-4-6', baseUrl: null,
-  contextWindow: null, contextBudget: null,
+  contextWindow: null, contextBudget: null, dataResidency: 'external',
 };
 
 export class DisabledProviderError extends Error {
@@ -40,11 +66,13 @@ export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku'
     return {
       provider: 'anthropic', modelId: OPUS_MODEL, baseUrl: null,
       apiKey: process.env.ANTHROPIC_API_KEY || '', contextWindow: null, contextBudget: null,
+      dataResidency: 'external',
     };
   }
   try {
     const { rows } = await pool.query(
-      `SELECT pc.provider, pc.model_id, pc.base_url, pc.api_key, pc.context_window, pc.context_budget
+      `SELECT pc.provider, pc.model_id, pc.base_url, pc.api_key, pc.context_window, pc.context_budget,
+              pc.data_residency
          FROM tickets.provider_config pc
          LEFT JOIN tickets.provider_health ph ON ph.provider = pc.provider
         WHERE (pc.source = $1 OR pc.source = '*') AND pc.tier = $2 AND pc.enabled = true
@@ -54,11 +82,12 @@ export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku'
       [source, tier],
     );
     if (rows.length) {
-      const { provider, model_id, base_url, api_key, context_window, context_budget } = rows[0];
+      const { provider, model_id, base_url, api_key, context_window, context_budget, data_residency } = rows[0];
       const apiKey = (typeof api_key === 'string' && api_key) ? api_key : apiKeyForProvider(provider);
       return {
         provider, modelId: model_id, baseUrl: base_url ?? null, apiKey,
         contextWindow: context_window ?? null, contextBudget: context_budget ?? null,
+        dataResidency: normalizeDataResidency(data_residency),
       };
     }
   } catch (err) {
@@ -69,7 +98,7 @@ export async function getProviderConfig(source: string, tier: 'sonnet' | 'haiku'
 
 export async function getProviderByName(providerName: string, _brand?: string): Promise<ProviderChoice> {
   const { rows } = await pool.query(
-    `SELECT provider, model_id, base_url, api_key, context_window, context_budget
+    `SELECT provider, model_id, base_url, api_key, context_window, context_budget, data_residency
        FROM tickets.provider_config
       WHERE provider = $1 AND enabled = true
       LIMIT 1`,
@@ -78,11 +107,12 @@ export async function getProviderByName(providerName: string, _brand?: string): 
   if (!rows.length) {
     throw new DisabledProviderError(providerName);
   }
-  const { provider, model_id, base_url, api_key, context_window, context_budget } = rows[0];
+  const { provider, model_id, base_url, api_key, context_window, context_budget, data_residency } = rows[0];
   const apiKey = (typeof api_key === 'string' && api_key) ? api_key : apiKeyForProvider(provider);
   return {
     provider, modelId: model_id, baseUrl: base_url ?? null, apiKey,
     contextWindow: context_window ?? null, contextBudget: context_budget ?? null,
+    dataResidency: normalizeDataResidency(data_residency),
   };
 }
 


### PR DESCRIPTION
Am 2026-08-04 zeigten **13 von 18 `coaching.sessions`** auf einen externen LLM-Anbieter (`api.deepseek.com`, Key gesetzt), während das Projekt „All data stays on-premises (DSGVO by design)" als Kernaussage führt.

Der Vorgang schließt **beide** Wege, über die Inhalte nach draußen gelangen konnten. Nur einen zu schließen genügt nicht — das ist der Kern des Plans.

## Weg 1 — Provider-Auswahl in der Website

Neue Spalte `tickets.provider_config.data_residency` (`'on_premises'|'external'`, DEFAULT `'external'`). Der Default trägt die Absicht: Wer on-premises sein will, muss es aussprechen. `normalizeDataResidency()` behandelt NULL und fehlende Spalte wie `external` — **eine fehlende Deklaration ist keine Zusage.**

Der Guard steht in `resolveProvider()` **vor** dem Aufbau des OpenAI-Clients und vor jedem `create`-Aufruf. Ein Guard im Fehlerpfad hätte den Payload bereits übertragen; bei Coaching-Inhalten ist genau das der nicht rücknehmbare Schaden. Kein Fallback auf einen anderen Provider.

`eu_endpoint` bleibt unangetastet: Sie beschreibt den *Rechtsraum* eines fremden Betreibers, nicht die *Betreiberschaft*. Ein EU-gehosteter Fremdanbieter ist weiterhin ein Fremdanbieter.

## Weg 2 — Prioritätskette des llm-proxy

Ohne diesen Teil fällt eine korrekt umgestellte Konfiguration beim nächsten Lauf über den Proxy-Fallback wieder auf ein remote-Backend zurück: **der Guard wäre umgangen, ohne dass jemand etwas falsch gemacht hätte.**

`server.mjs` nimmt `x-llm-local-only: 1` entgegen, `resolveModel()` filtert dann auf lokale Backends und liefert `null` statt zu substituieren; der Server antwortet `503 no_local_backend`. Gewöhnliche Anfragen behalten ihren Fallback unverändert.

Lokal bestimmt sich über `kind` (`llamacpp`, `lmstudio`), nicht über Backend-Namen. Bewusst eine **Positiv**liste, obwohl #3816 (T002674) für den Watchdog das Gegenteil gelernt hat — entscheidend ist die Alterungsrichtung:

| | Watchdog (T002674) | hier (T002657) |
|---|---|---|
| Neuer, unbekannter Typ | fällt unbemerkt durch → **unsicher** | fällt aus dem lokal-only-Weg → **Fehlschlag statt Übertragung** |

## Abweichung vom Plan — gemessen am 2026-08-08

Der Plan nannte `local-cluster` als freizugebenden Provider. **Diese Zeilen stehen auf `enabled=false`**, und `getProviderByName` filtert auf `enabled=true` — die Freigabe wäre wirkungslos geblieben und Coaching hätte nach dem Guard *keinen* nutzbaren Provider mehr gehabt.

Tatsächlich aktiv sind `llamacpp` und `lmstudio` auf `127.0.0.1:18235` — dieselben zwei Arten, die `discovery.mjs` als `LOCAL_BACKEND_KINDS` führt. Die Definition von „lokal" steht damit an beiden Enden des Wegs auf derselben Grundlage statt auf zwei gepflegten Namenslisten.

Ebenfalls überholt: Die 13 Sessions auf `ki_config_id=82` existieren noch, **`ki_config` 82 selbst wurde inzwischen gelöscht**. Sie verweisen ins Leere und laufen gar nicht mehr in den Provider-Pfad. Sie bleiben unangetastet, wie der Plan es vorsieht.

## Migration ist bereits angewendet

Die Reihenfolge ist bindend — ohne die Spalte scheitert jedes `getProviderByName` mit einem SQL-Fehler. Angewendet auf die `website`-DB, Wirkung gemessen:

```
 data_residency | count |      provider
----------------+-------+--------------------
 external       |     4 | deepseek            ← fällt in den Guard
 on_premises    |    11 | llamacpp, lmstudio  ← Coaching bleibt nutzbar
```

## Tests

Der RED-Guard lag im Branch (3 von 4 rot). Ergänzt um einen **fünften** Test, der belegt, dass der lokal-only-Header tatsächlich am Client ankommt — ein still nicht gesetzter Header ist genau die Fehlerklasse dieses Tickets.

Dazu `scripts/llm-proxy/local-only.test.mjs` (5 Tests, command output verification). Der dritte ist der Kern: Ohne ihn bestünde ein `resolveModel`, das bei lokal-only einfach das erstbeste Backend nimmt.

```
vitest (coaching + provider-config)   15/15 passed
node --test scripts/llm-proxy/*        118 pass, 1 fail
   └─ mcp-bridge.test.mjs schlägt auch auf origin/main fehl (Bestand)
astro check                            0 errors
quality:check                          0 blocking
freshness:check                        exit 0
```

Closes T002657

🤖 Generated with [Claude Code](https://claude.com/claude-code)