### PR TITLE
fix(scripts): check-and-claim akzeptiert kein Flag als Scope [T002692][T002693]

### DIFF
--- a/scripts/agent-lock.sh
+++ b/scripts/agent-lock.sh
@@ -250,7 +250,13 @@ _self_claim_main_checkout() {
 # caller finds out. [T002363]
 _reject_arg() {
   echo "AGENT-LOCK: $1: unbekanntes Argument '$2'" >&2
-  echo "  Erwartet werden benannte Flags: --label <l> --worktree <p> --branch <b> --ticket <id>" >&2
+  # [T002692] Die Zeile nannte zuvor nur die Flags. Wer auf einen abgelehnten
+  # Aufruf hin '--ticket <id>' voranstellte, erzeugte damit einen Lock mit
+  # scope='--ticket' — die Meldung riet also zur kaputten Form. Scope und id
+  # gehoeren zuerst und positional.
+  echo "  Scope und id stehen zuerst und positional: $1 <scope> <id> [flags]" >&2
+  echo "  Erwartete Flags: --label <l> --worktree <p> --branch <b> --ticket <id>" >&2
+  echo "  Dabei ist --ticket die Ticket-REFERENZ, nicht der Scope." >&2
   [ "$1" = "check-and-claim" ] && echo "  sowie --status-check <pfad>" >&2
   return 0
 }
@@ -372,6 +378,24 @@ cmd_check() {
 # (0=ok, 1=held by other) but never writes a lock if the ticket-status DB check
 # signals the ticket is already done/merged. [T002038]
 cmd_check_and_claim() {
+  # [T002692/T002693] Scope und id sind POSITIONAL. Ohne diese Pruefung las
+  # `local scope="$1"` ein vorangestelltes Flag als Scope-Namen: aus
+  # `check-and-claim --ticket T002657` wurde ein Lock mit scope='--ticket',
+  # gemeldet mit Exit 0. So ein Lock wird von scope-basierten Abfragen und vom
+  # Reap nicht als ticket-Lock erkannt — er sperrt faktisch nichts und bleibt
+  # liegen. `--ticket` ist weiterhin gueltig, aber als Ticket-REFERENZ an einem
+  # Branch-Lock (`check-and-claim branch feature/x --ticket T123`).
+  #
+  # Ohne Argumente schlug zuvor `set -u` mit '$1: unbound variable' zu — eine
+  # Zeilennummer statt der erwarteten Form.
+  # Guard: tests/spec/software-factory/agent-lock-scope-argument.bats
+  if [ $# -lt 2 ] || [ "${1#-}" != "$1" ]; then
+    echo "AGENT-LOCK: check-and-claim erwartet <scope> <id> als Positionsargumente." >&2
+    echo "  Beispiel: agent-lock.sh check-and-claim ticket T002657 --label dev-flow-execute" >&2
+    echo "  Optionale Flags: --label <l> --worktree <p> --branch <b> --ticket <id> --status-check <pfad>" >&2
+    echo "  Hinweis: --ticket ist die Ticket-REFERENZ (z.B. an einem branch-Lock), kein Scope." >&2
+    return 2
+  fi
   local scope="$1" id="${2:-}"; shift 2 2>/dev/null || shift $#
   # --status-check <path> is optional: point to a script that returns 0 iff the
   # ticket is still live (plan_staged) and not yet done/merged.

--- a/tests/spec/software-factory/agent-lock-scope-argument.bats
+++ b/tests/spec/software-factory/agent-lock-scope-argument.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# [T002692/T002693] check-and-claim: Scope-Argument gegen Flags absichern.
+#
+# Pruefmodus: command output verification [T002448-M4] — die Tests RUFEN
+# agent-lock.sh auf und pruefen den entstandenen Lock bzw. die Ausgabe. Kein
+# Grep auf die Implementierung: dass eine Validierung im Quelltext steht,
+# belegt nicht, dass der Lock danach den richtigen Scope traegt.
+#
+# Beobachtet am 2026-08-08: `check-and-claim --ticket T002657 --label x` legte
+# einen Lock mit SCOPE='--ticket' an und meldete Exit 0. Ursache ist
+#   local scope="$1" id="${2:-}"
+# — das Flag wird als Scope gelesen, die ID als Bezeichner. Die Form sieht aus
+# wie ein Erfolg, erzeugt aber einen Lock, den scope-basierte Abfragen und der
+# Reap nicht als ticket-Lock erkennen. Er sperrt faktisch nichts.
+#
+# Verschaerfend empfahl _reject_arg genau diese Form ("Erwartet werden benannte
+# Flags: … --ticket <id>"), waehrend die Referenz-Doku
+# (.claude/skills/references/dev-flow-execute-phases.md) die korrekte
+# positionale Form zeigt.
+#
+# `--ticket` bleibt ein gueltiges Flag — aber als Ticket-REFERENZ an einem
+# Branch-Lock (`check-and-claim branch feature/x --ticket T123`), nicht als
+# Scope.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/agent-lock.sh"
+  TEST_ID="TSCOPEPROBE"
+}
+
+teardown() {
+  bash "$SCRIPT" release ticket "$TEST_ID" >/dev/null 2>&1 || true
+  bash "$SCRIPT" release --ticket "$TEST_ID" >/dev/null 2>&1 || true
+}
+
+@test "T002692: positionale Form legt einen Lock mit Scope 'ticket' an" {
+  # Positiv-Anker: ohne ihn koennte das Skript vollstaendig kaputt sein und die
+  # Negativaussagen unten blieben trotzdem wahr.
+  run bash "$SCRIPT" check-and-claim ticket "$TEST_ID" --label "scope probe"
+  [ "$status" -eq 0 ]
+
+  run bash "$SCRIPT" list
+  [[ "$output" == *"$TEST_ID"* ]]
+  # Die Scope-Spalte steht am Zeilenanfang.
+  local line
+  line="$(printf '%s\n' "$output" | grep -- "$TEST_ID" | head -1)"
+  [[ "$line" == ticket* ]]
+}
+
+@test "T002692: ein Flag als Scope wird abgelehnt statt als Scope-Name uebernommen" {
+  run bash "$SCRIPT" check-and-claim --ticket "$TEST_ID" --label "scope probe"
+
+  # Der Aufruf darf NICHT als Erfolg gelten.
+  [ "$status" -ne 0 ]
+
+  # Und er darf keinen Lock hinterlassen haben — schon gar keinen mit dem
+  # Flag-Namen als Scope. Geprueft wird gezielt die Zeile zu TEST_ID, nicht die
+  # gesamte Liste: dort koennen Locks fremder Sessions stehen, und ein Test, der
+  # daran scheitert, misst die Umgebung statt das Verhalten (beobachtet
+  # 2026-08-08 an einem parallel laufenden Vorgang).
+  run bash "$SCRIPT" list
+  local line
+  line="$(printf '%s\n' "$output" | grep -- "$TEST_ID" || true)"
+  [ -z "$line" ]
+}
+
+@test "T002693: check-and-claim ohne Argumente meldet die erwartete Form, nicht 'unbound variable'" {
+  run bash "$SCRIPT" check-and-claim
+
+  [ "$status" -ne 0 ]
+  # Der rohe Bash-Fehler darf nicht mehr durchschlagen.
+  [[ "$output" != *"unbound variable"* ]]
+  # Positiv: die Meldung nennt die erwartete Form.
+  [[ "$output" == *"check-and-claim"* ]]
+  [[ "$output" == *"scope"* || "$output" == *"ticket"* ]]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3432,6 +3432,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/agent-lock-scope-argument",
+    "file": "tests/spec/software-factory/agent-lock-scope-argument.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/conflict-gate",
     "file": "tests/spec/software-factory/conflict-gate.bats",
     "category": "software-factory",


### PR DESCRIPTION
Zwei Mishap-Tickets aus der Session vom 2026-08-08, beide in derselben Funktion.

## T002692 — ein Flag wurde als Scope gelesen

```bash
local scope="$1" id="${2:-}"
```

Aus `check-and-claim --ticket T002657 --label x` wurde ein Lock mit `scope='--ticket'` — **gemeldet mit Exit 0**:

```
SCOPE          ID          TOOL     STATE  LABEL
--ticket       T002657     claude   live   T002657 coaching data residency
```

Ein so gescopeter Lock wird von scope-basierten Abfragen und vom Reap nicht als ticket-Lock erkannt. **Er sperrt faktisch nichts und bleibt liegen.** Genau das ist in der Session passiert: Der Lock für T002657 lief die gesamte Implementierung über mit diesem Scope.

**Verschärfend:** `_reject_arg` empfahl aktiv die kaputte Form —

```
AGENT-LOCK: check-and-claim: unbekanntes Argument '--id'
  Erwartet werden benannte Flags: … --ticket <id>
```

— während die Referenz-Doku (`dev-flow-execute-phases.md:33`) die korrekte positionale Form zeigt. Wer der Fehlermeldung folgte, erzeugte den Defekt.

`--ticket` bleibt gültig, aber als Ticket-**Referenz** an einem Branch-Lock (`check-and-claim branch feature/x --ticket T123`), nicht als Scope. Die Meldung sagt das jetzt.

## T002693 — `unbound variable` statt Usage

```
$ bash scripts/agent-lock.sh check-and-claim
scripts/agent-lock.sh: line 375: $1: unbound variable
```

Dieselbe Vorab-Prüfung fängt das und nennt die erwartete Form.

## Tests

```
                                          main    Fix
ok 1  positionale Form erzeugt scope='ticket'  ✓      ✓   ← Positiv-Anker
    2  Flag als Scope wird abgelehnt           ✗      ✓
    3  ohne Argumente: keine 'unbound variable' ✗     ✓
```

Test 2 prüft gezielt die Zeile zur eigenen `TEST_ID` statt der gesamten Lock-Liste. Der erste Entwurf tat Letzteres und wurde prompt von einem parallel laufenden fremden Lock rot — ein Test, der daran scheitert, misst die Umgebung statt das Verhalten.

Regression: `agent-lock-force-claim.bats` + `agent-lock-session-identity.bats` bleiben grün (22 Tests). `freshness:check` exit 0.

Closes T002692
Closes T002693

🤖 Generated with [Claude Code](https://claude.com/claude-code)