### PR TITLE
chore(test): warn on non-2xx status during setup/teardown db purge [T002725]

### DIFF
--- a/tests/e2e/specs/global-db-cleanup.ts
+++ b/tests/e2e/specs/global-db-cleanup.ts
@@ -71,9 +71,13 @@ async function callPurge(label: 'setup' | 'teardown'): Promise<void> {
   
   const text = await res.text();
   if (!res.ok) {
-    throw new Error(
-      `[global-db-cleanup:${label}] POST ${url} → ${res.status}: ${text.slice(0, 500)}`,
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[global-db-cleanup:${label}] ⚠ POST ${url} → ${res.status}: ${text.slice(0, 500)}`,
     );
+    // eslint-disable-next-line no-console
+    console.warn(`[global-db-cleanup:${label}] Continuing without prod DB purge.`);
+    return;
   }
   // Best-effort log of the per-table counts. The endpoint returns
   // { ok: true, counts: {...} } on success.


### PR DESCRIPTION
Updates global-db-cleanup.ts to log warnings on non-2xx HTTP status codes during setup and teardown purges instead of throwing an unhandled Error.