### PR TITLE
chore(test): preserve systemtest purge endpoint in build-target integration [T002728]

### DIFF
--- a/website/src/integrations/build-target.mjs
+++ b/website/src/integrations/build-target.mjs
@@ -25,7 +25,7 @@
  *   - /api/auth/*   → OIDC-Login-Oberfläche (login, callback, me, logout)
  *   - /login.astro  → Login-Seite (sdlc-Seiten redirecten auf /login)
  */
-const INFRA_ROUTE_SUBSTRINGS = ['/api/health', '/api/auth/'];
+const INFRA_ROUTE_SUBSTRINGS = ['/api/health', '/api/auth/', '/sdlc/api/systemtest/'];
 const INFRA_ROUTE_SUFFIXES = ['/login.astro'];
 
 /** @param {string} component */


### PR DESCRIPTION
Adds /sdlc/api/systemtest/ to INFRA_ROUTE_SUBSTRINGS in website/src/integrations/build-target.mjs so systemtest purge endpoints are preserved in production builds.