### PR TITLE
test(website): add E2E tests for systemtest purge endpoint preservation [T002728]

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
         '**/fa-admin-live.spec.ts',  // unified live cockpit
         '**/fa-29-*.spec.ts',                   // Projekt-Cockpit E2E (T000752)
         '**/fa-53-systemtest-failure-loop.spec.ts',  // system-test failure kanban (Task 7)
+        '**/fa-59-*.spec.ts',                        // systemtest purge route preservation [T002728]
         '**/fa-54-coaching-sessions.spec.ts',        // coaching session wizard + auth gates (PR #826)
         '**/fa-55-lmstudio-integration.spec.ts',     // LM Studio / local-first LLM generate smoke test
         '**/fa-56-admin-assets.spec.ts',            // central asset management (PR #884)

--- a/tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts
+++ b/tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts
@@ -1,0 +1,27 @@
+// tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts
+//
+// FA-59 — Systemtest purge endpoint preservation in build-target integration [T002728].
+//
+// Verifies that systemtest infrastructure routes under /sdlc/api/systemtest/ (e.g. purge-all-test-data, cleanup-fixtures)
+// are preserved by build-target integration across environments and respond cleanly (e.g. 401/405/200, not 404).
+
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
+
+test.describe('FA-59: Systemtest purge endpoint preservation', { tag: ['@smoke', '@website'] }, () => {
+  test('T1: /sdlc/api/systemtest/purge-all-test-data route is preserved and reachable (not 404)', async ({ request }) => {
+    // Attempting a request to the purge endpoint
+    const response = await request.post(`${BASE}/sdlc/api/systemtest/purge-all-test-data`);
+    
+    // The route must exist and be preserved by build-target (so should not return 404)
+    expect(response.status()).not.toBe(404);
+  });
+
+  test('T2: /sdlc/api/systemtest/cleanup-fixtures route is preserved and reachable (not 404)', async ({ request }) => {
+    const response = await request.post(`${BASE}/sdlc/api/systemtest/cleanup-fixtures`);
+    
+    // The route must exist and be preserved by build-target (so should not return 404)
+    expect(response.status()).not.toBe(404);
+  });
+});

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -978,6 +978,12 @@
     "kind": "playwright"
   },
   {
+    "id": "FA-59",
+    "file": "tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts",
+    "category": "FA",
+    "kind": "playwright"
+  },
+  {
     "id": "FA-AR-01",
     "file": "tests/local/FA-AR-01-filter-diff.bats",
     "category": "FA",


### PR DESCRIPTION
Adds Playwright E2E spec FA-59 verifying systemtest purge endpoint preservation under build-target integration [T002728].