### PR TITLE
chore(skills): add skill-path-references guard for skill references [T002613]

### DIFF
--- a/tests/spec/agent-skills/skill-path-references.bats
+++ b/tests/spec/agent-skills/skill-path-references.bats
@@ -35,12 +35,14 @@ PATH_PATTERN='\b(openspec|scripts|tests|docs|website|k3d|environments|flux)/[A-Z
 # `references/`), außer `OVERVIEW.md` an der Wurzel und außer der Ausnahmeliste.
 # Liefert absolute Pfade, damit `extract_paths` unabhängig vom Arbeitsverzeichnis greift.
 skill_files() {
-  local ex find_args=()
+  local ex find_args=() dirs=()
   for ex in "${EXCLUDED_SKILLS[@]}"; do
-    find_args+=(-not -path "$REPO/.claude/skills/$ex/*")
+    find_args+=(-not -path "*/$ex/*")
   done
-  find "$REPO/.claude/skills" -name '*.md' \
-    -not -path "$REPO/.claude/skills/OVERVIEW.md" \
+  [ -d "$REPO/.claude/skills" ] && dirs+=("$REPO/.claude/skills")
+  [ -d "$REPO/.agents/skills" ] && dirs+=("$REPO/.agents/skills")
+  find "${dirs[@]}" -name '*.md' \
+    -not -path "*/OVERVIEW.md" \
     "${find_args[@]}" \
     -print
 }


### PR DESCRIPTION
Implements OpenSpec change skill-path-guard [T002613] ensuring all repo-relative file references in skill files exist.