### PR TITLE
fix(test): FA-SF-26 watchdog tests use stale-threshold instead of ineffective backdating [T002620]

### DIFF
--- a/tests/spec/software-factory/scheduling.bats
+++ b/tests/spec/software-factory/scheduling.bats
@@ -15,7 +15,12 @@
 
 load '_sf_common'
 
-setup()    { _sf_setup; }
+# factory-test-fixtures traegt die Endung .sh und ist damit nicht ueber `load`
+# erreichbar (bats sucht .bash); die Bestandstests sourcen es ebenso direkt
+# (Vorlage: orphan-slot-reap.bats). Ohne diesen Source scheitert jeder Live-Test
+# in dieser Datei, der `seed_test_feature` aufruft, mit "command not found"
+# (status 127) statt mit einem aussagekraeftigen Ergebnis.
+setup()    { _sf_setup; source tests/lib/factory-test-fixtures.sh; }
 teardown() { _sf_teardown; }
 
 # ── FA-SF-23-slots ──────────────────────────────────────────────#
@@ -161,19 +166,30 @@ teardown() { _sf_teardown; }
   [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
   local brand="${TEST_BRAND:-korczewski}"
   ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-wd-$$-a.txt")
-  env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1 >/dev/null
-  # Derive the namespace from the brand (do not rely on a FACTORY_NS default).
+  # Zustand direkt setzen statt `slots.sh claim`: dessen Subkommando schreibt
+  # pipeline_slot_meta, eine Spalte, die in prod fehlt (T002619) — der Claim
+  # scheiterte dort mit Exit 3, bevor der Test begann.
   local ns; case "$brand" in mentolder) ns=workspace ;; korczewski) ns=workspace-korczewski ;; esac
-  # Backdate updated_at by 40 minutes to simulate a hung pipeline.
   pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' --field-selector status.phase=Running -o name | head -1)
   kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
-    psql -U website -d website -qtAc "UPDATE tickets.tickets SET updated_at = now() - interval '40 minutes' WHERE external_id='$ext';"
-  run env BRAND="$brand" FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET pipeline_slot=1, status='in_progress' WHERE external_id='$ext';"
+  # Alterung ueber den Schwellwert statt ueber den Zeitstempel [T002620]:
+  # fn_lifecycle_ts ueberschreibt `updated_at := now()` bei JEDEM Update, ein
+  # Backdating bliebe wirkungslos und die Stale-Liste leer — dann liefe der
+  # Watchdog ohne Arbeit durch und der Test bestuende vakuos. ORPHAN_MIN=999
+  # blendet den Waisen-Sweep aus (Isolation, Spiegel von orphan-slot-reap.bats).
+  run env BRAND="$brand" FACTORY_STALE_MIN=0 FACTORY_ORPHAN_SLOT_MIN=999 \
+    bash scripts/factory/watchdog.sh
   [ "$status" -eq 0 ]
+  # POSITIV-ANKER [T002356-M1]: belegt, dass die Stale-Liste NICHT leer war.
   echo "$output" | jq -e --arg e "$ext" 'any(.[]; . == $e)'
   # Confirm status=triage and pipeline_slot cleared.
   st=$(BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh get --id "$ext" | jq -r '.status')
   [ "$st" = "triage" ]
+  # Slot-Freigabe nachpruefen — nicht nur den Status (der Testtitel verspricht beides).
+  slot=$(kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
+    psql -U website -d website -qtAc "SELECT COALESCE(pipeline_slot::text,'NULL') FROM tickets.tickets WHERE external_id='$ext';")
+  [ "$slot" = "NULL" ]
 }
 
 @test "FA-SF-26: a stale in_progress feature WITH a staged plan (FACTORY-PLAN-REF) is returned to backlog, not triage [T001850]" {
@@ -183,16 +199,19 @@ teardown() { _sf_teardown; }
   [ -n "${FACTORY_CTX:-}" ] || skip "no dev cluster context set"
   local brand="${TEST_BRAND:-korczewski}"
   ext=$(seed_test_feature "$brand" "tests/fixtures/sf-test-wd-$$-b.txt")
-  env BRAND="$brand" bash scripts/factory/slots.sh claim "$ext" 1 >/dev/null
-  # Simuliert, dass dev-flow-plan fuer dieses Ticket bereits einen Plan gestaged hat.
-  BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh add-comment --id "$ext" \
-    --body "FACTORY-PLAN-REF branch=feature/sf-test-wd-$$ plan=openspec/changes/sf-test-wd-$$/tasks.md" >/dev/null
+  # Zustand direkt setzen statt `slots.sh claim` (T002619) — siehe Test oben.
   local ns; case "$brand" in mentolder) ns=workspace ;; korczewski) ns=workspace-korczewski ;; esac
   pod=$(kubectl get pod -n "$ns" --context "$FACTORY_CTX" -l 'app in (shared-db, shared-db-dev)' --field-selector status.phase=Running -o name | head -1)
   kubectl exec -i "$pod" -n "$ns" --context "$FACTORY_CTX" -c postgres -- \
-    psql -U website -d website -qtAc "UPDATE tickets.tickets SET updated_at = now() - interval '40 minutes' WHERE external_id='$ext';"
-  run env BRAND="$brand" FACTORY_STALE_MIN=30 bash scripts/factory/watchdog.sh
+    psql -U website -d website -qtAc "UPDATE tickets.tickets SET pipeline_slot=1, status='in_progress' WHERE external_id='$ext';"
+  # Simuliert, dass dev-flow-plan fuer dieses Ticket bereits einen Plan gestaged hat.
+  BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh add-comment --id "$ext" \
+    --body "FACTORY-PLAN-REF branch=feature/sf-test-wd-$$ plan=openspec/changes/sf-test-wd-$$/tasks.md" >/dev/null
+  # Schwellwert 0 statt Zurueckdatieren [T002620] — siehe Test oben.
+  run env BRAND="$brand" FACTORY_STALE_MIN=0 FACTORY_ORPHAN_SLOT_MIN=999 \
+    bash scripts/factory/watchdog.sh
   [ "$status" -eq 0 ]
+  # POSITIV-ANKER [T002356-M1]: belegt, dass die Stale-Liste NICHT leer war.
   echo "$output" | jq -e --arg e "$ext" 'any(.[]; . == $e)'
   st=$(BRAND="$brand" TICKET_CTX="$FACTORY_CTX" bash scripts/ticket.sh get --id "$ext" | jq -r '.status')
   [ "$st" = "backlog" ]


### PR DESCRIPTION
## Summary
- `tickets.fn_lifecycle_ts` overwrites any `SET updated_at=<past>` with `now()` on every UPDATE, so the FA-SF-26 tests' 40-minute backdating never actually produced a stale ticket — the watchdog escalation path (status reset, slot release, comment, worktree cleanup) ran against an empty stale list and the tests passed vacuously (or failed for the wrong reason).
- Both FA-SF-26 tests now age the ticket via `FACTORY_STALE_MIN=0` (threshold-based, per the ticket's own diagnosis) instead of rewriting `updated_at`, use a direct `UPDATE` instead of `slots.sh claim` (avoids the `pipeline_slot_meta` gap from T002619), and add a positive anchor (`jq -e` over the returned JSON array) plus a `pipeline_slot=NULL` check, mirroring `orphan-slot-reap.bats` (T002610).
- Also sources `tests/lib/factory-test-fixtures.sh` in `scheduling.bats`'s `setup()` — without it every live `seed_test_feature` call in this file aborted with "command not found" (status 127), a latent gap since the T002503 file split that made live verification of this exact fix impossible until fixed.

## Test plan
- [x] `tests/unit/lib/bats-core/bin/bats -r tests/spec/software-factory*` — 541/541 green (both BATS conventions covered per T002696)
- [x] `task test:changed` — green (spec-selection missed this directory-form file due to an unrelated pre-existing gap in `scripts/find-changed-tests.sh`, worked around by running the direct `bats -r` invocation above; separate bug ticket filed)
- [x] `task freshness:regenerate` + `task freshness:check` — green, no drift
- [x] `bash scripts/plan-lint.sh openspec/changes/fix-watchdog-sf26-vakuos-T002620/tasks.md` — PASS
- [x] Live RED→GREEN proof against `k3d-mentolder-dev` (read-only stale-query, chosen over the full destructive `watchdog.sh` run to avoid touching two genuinely in-progress tickets — T002605, T002658 — that share the same ticket table): a throwaway `in_progress` ticket backdated 40 min shows `now() - updated_at = 00:00:00` (trigger overwrite confirmed) and is absent from the `STALE_MIN=30` stale query (RED, matches vacuous behavior); the same ticket appears in the `STALE_MIN=0` stale query (GREEN)

Closes T002620