### PR TITLE
fix(skills): Review-Findings für repo-hygiene Arbeitsbaum/Stashes [T002709]

### DIFF
--- a/.claude/skills/references/repo-hygiene-ops.md
+++ b/.claude/skills/references/repo-hygiene-ops.md
@@ -29,9 +29,13 @@ Stashes ansehen — sie sind die Quelle von Arbeit, die nirgendwo sonst auftauch
    git diff "stash@{N}^" "stash@{N}" -- <pfad>
    ```
 
+   Bei Stashes mit ungetrackten Dateien (`git stash push -u`) zeigt diese Zwei-Revisions-Form
+   die Untracked-Teilmenge nicht — ein leerer Diff ist dann kein Relevanzurteil.
+
 4. **Falle 2 — Relevanz entscheiden.** Der Stash-Diff gegen den eigenen Basiscommit sieht
    **immer** ungemergt aus — er beantwortet die Frage „ist der Stash noch relevant?" nicht.
-   Maßgeblich sind die konkreten Marker aus dem Stash-Diff, gesucht im heutigen `main`:
+   Maßgeblich sind die konkreten Marker aus dem Stash-Diff, gesucht im heutigen `main`
+   (vorher `git fetch origin main`, damit die remote-tracking Ref nicht veraltet ist):
 
    ```bash
    git grep -F <marker> origin/main -- <pfad>

--- a/tests/spec/repo-hygiene/worktree-stash-inspection.bats
+++ b/tests/spec/repo-hygiene/worktree-stash-inspection.bats
@@ -97,9 +97,21 @@ _make_stash_repo() {
 
   local wt="${BATS_TEST_TMPDIR}/relevance"
   _make_stash_repo "$wt"
+  # Die dokumentierte Form referenziert `origin/main` — der Fixture hat kein Origin-Remote.
+  # Ein remote-tracking ref reicht, damit die Form im Wegwerf-Repo ausführbar wird.
+  git -C "$wt" update-ref refs/remotes/origin/main main
+
+  # Die dokumentierte Marker-Prüfung wird aus der realen SSOT-Datei gelesen — nicht im Test
+  # nachgebaut. Dieselbe Extraktion wie in Block 2, angewendet auf die git-grep-Form.
+  local form
+  form="$(grep -F 'git grep' "$OPS" | grep 'main' | head -1 \
+          | sed 's/.*\(git grep[^`]*\).*/\1/')"
+  form="${form//<marker>/MARKER_ALPHA_T002709}"
+  form="${form//<pfad>/alpha.txt}"
+  [ -n "$form" ]
 
   # Vor dem Landen: der Marker ist nicht in main — die dokumentierte Prüfung sagt "behalten".
-  run bash -c "cd '$wt' && git grep -F MARKER_ALPHA_T002709 main -- alpha.txt"
+  run bash -c "cd '$wt' && $form"
   [ "$status" -ne 0 ]
 
   local before
@@ -110,6 +122,9 @@ _make_stash_repo() {
   printf 'MARKER_ALPHA_T002709\n' >> "$wt/alpha.txt"
   git -C "$wt" add -A
   git -C "$wt" commit -qm "landet in main"
+  # Das Fixture simuliert kein echtes Fetch; damit die dokumentierte `origin/main`-Form
+  # den neuen Stand sieht, muss die remote-tracking Ref nachgezogen werden.
+  git -C "$wt" update-ref refs/remotes/origin/main main
 
   # Kernaussage 1: der Stash-Diff ist UNVERÄNDERT. Er wird gegen den eigenen Basiscommit
   # gerechnet, der sich nicht bewegt — er trägt also kein Relevanzsignal, egal wie der
@@ -119,6 +134,6 @@ _make_stash_repo() {
   [ "$before" = "$after" ]
 
   # Kernaussage 2: die dokumentierte Prüfung gegen main löst die Entscheidung dagegen auf.
-  run bash -c "cd '$wt' && git grep -F MARKER_ALPHA_T002709 main -- alpha.txt"
+  run bash -c "cd '$wt' && $form"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Was

Review-Findings zu PR #3890 (gemergt), die dort zu spät kamen:

1. **Guard Block 3 testet jetzt die dokumentierte Form.** Statt `git grep -F MARKER_ALPHA_T002709 main -- alpha.txt` hart zu kodieren, extrahiert Block 3 die dokumentierte `git grep -F <marker> origin/main -- <pfad>`-Form aus der SSOT und führt sie aus (Fixture bekommt einen remote-tracking `origin/main`-Ref).
2. **Doku-Falle 2:** Halbsatz `git fetch origin main` vor der Marker-Prüfung ergänzt (remote-tracking Ref sonst veraltet).
3. **Doku-Falle 1:** Caveat für `git stash push -u`-Stashes — die Zwei-Revisions-Form zeigt die Untracked-Teilmenge nicht; leerer Diff ist kein Relevanzurteil.

## Verifikation

```bash
tests/unit/lib/bats-core/bin/bats tests/spec/repo-hygiene/worktree-stash-inspection.bats  # 3/3 ok
```
Die Kernel-Aussagen wurden vom Reviewer empirisch im Sandbox verifiziert (Zwei-Revisions-Form path-exakt, Stash-Diff ohne Relevanzsignal, Marker-Check unterscheidet gelandet/nicht-gelandet).