### PR TITLE
fix(factory): factory fix tickets use triage, not plan_staged [T002769]

### DIFF
--- a/openspec/changes/plan-staged-guard-T002769/design.md
+++ b/openspec/changes/plan-staged-guard-T002769/design.md
@@ -1,0 +1,36 @@
+# T002769: plan_staged-Guard in mishap.go
+
+## Problem
+
+`mishap.go` `buildFactoryFixTicketArgs()` erzeugt Fix-Tickets mit `--status plan_staged`, obwohl
+kein Plan existiert. Die Tickets (T002767–T002774, 8 Stück am 2026-08-09) blockieren die
+Factory-Queue: `dev-flow-execute` findet keinen Plan, `reconcile-ticket-status.sh` Pattern 4
+flagt sie als `attention_mode=needs_human`.
+
+Die Plan-Existenz wird an keiner Stelle vor dem Statuswechsel geprüft. `stage-plan.sh` hat einen
+Guard (`--plan` required, `git cat-file -e` check), aber `mishap.go` ruft `stage-plan` nie auf —
+es schreibt den Status direkt via `ticket.sh create --status plan_staged`.
+
+## Root Cause
+
+`mishap.go:175`: `"--status", "plan_staged"` in `buildFactoryFixTicketArgs()`. Der Kommentar
+(Z. 163–168) behauptet, die Factory handle `plan_staged`-Tickets ohne `FACTORY-PLAN-REF` via
+Scout→Design→Plan — aber `reconcile-ticket-status.sh` Pattern 4 widerlegt das: genau diese
+Tickets werden als `needs_human` geflagt, nicht dispatched.
+
+## Fix
+
+`buildFactoryFixTicketArgs()`: `--status plan_staged` → `--status triage`.
+
+Die Tickets durchlaufen danach den normalen Planungs-Flow (triage → planning → plan_staged →
+backlog), in dem die Plan-Existenz durch `stage-plan.sh` garantiert wird.
+
+Kein DB-Guard nötig — `stage-plan.sh` ist bereits fail-closed (erfordert `--plan` und prüft
+`git cat-file -e`). Der Fehler lag im Bypass dieses Guards durch `mishap.go`.
+
+## Nicht betroffen
+
+- `buildCreateRollupTicketArgs()`: Der Rollup-Container (`Mishap Rollup — fortlaufende Sammlung`)
+  bleibt `plan_staged`. Er wird von `mishap-rollup.sh` verwaltet, das selbst einen Plan erzeugt.
+- `buildFindRollupTicketArgs()`: Sucht weiter nach `plan_staged` Chore-Tickets (Container-Suche).
+- `buildIncidentTicketArgs()`: Incident-Tickets sind `triage` — bereits korrekt.

--- a/openspec/changes/plan-staged-guard-T002769/specs/mishap-tracking.md
+++ b/openspec/changes/plan-staged-guard-T002769/specs/mishap-tracking.md
@@ -1,0 +1,31 @@
+# Delta: mishap-tracking
+
+## MODIFIED Requirements
+
+### Requirement: Factory-Fix-Tickets verwenden nicht plan_staged ohne Plan
+
+Factory-Fix-Tickets, die von `mishap.go` aus nicht-kritischen Mishaps erzeugt werden, MÜSSEN
+`status=triage` verwenden. `status=plan_staged` ist ausschließlich Tickets vorbehalten, die via
+`stage-plan.sh` mit validiertem `--plan` und `--branch` gestaged wurden.
+
+#### Scenario: drift-Mishap erzeugt triage-Ticket
+
+- **GIVEN** ein nicht-kritischer Mishap vom Typ `drift` wird via `report_mishap` gemeldet
+- **AND** der Buffer-Schwellwert (10) ist erreicht
+- **WHEN** `buildFactoryFixTicketArgs` die Ticket-Args baut
+- **THEN** das Ticket hat `--status triage`
+- **AND** das Ticket hat NICHT `--status plan_staged`
+
+#### Scenario: Rollup-Container bleibt plan_staged
+
+- **GIVEN** der Mishap-Rollup-Container wird via `buildCreateRollupTicketArgs` angelegt
+- **WHEN** die Args gebaut werden
+- **THEN** der Container hat `--status plan_staged` (unverändert)
+- **AND** der Container wird weiterhin von `mishap-rollup.sh` verwaltet
+
+#### Scenario: Incident-Tickets unverändert
+
+- **GIVEN** ein Incident-Mishap (`broken`, `security`) wird gemeldet
+- **WHEN** `buildIncidentTicketArgs` die Ticket-Args baut
+- **THEN** das Ticket hat `--status triage` (unverändert)
+- **AND** `--attention-mode needs_human` (unverändert)

--- a/openspec/changes/plan-staged-guard-T002769/tasks.md
+++ b/openspec/changes/plan-staged-guard-T002769/tasks.md
@@ -1,0 +1,43 @@
+# T002769 — plan_staged-Guard in mishap.go
+
+> **Type:** fix | **Severity:** trivial | **Effort:** klein
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `scripts/ticket-mcp/go/internal/tools/mishap.go` | Status-Änderung in `buildFactoryFixTicketArgs()` |
+| `scripts/ticket-mcp/go/internal/tools/mishap_test.go` | Test-Erwartung anpassen + neuer Negativ-Test |
+
+## Tasks
+
+### 1. Failing Test schreiben (Rot)
+
+- [ ] `TestFactoryFixTicketArgs_PlanStaged` → `TestFactoryFixTicketArgs_NotPlanStaged`: Erwartung
+      von `--status plan_staged` auf `--status triage` ändern
+- [ ] Neuer Test: `TestFactoryFixTicketArgs_NeverUsesPlanStaged`: assertet, dass factory fix
+      tickets NIE `--status plan_staged` verwenden
+
+### 2. Code fixen (Grün)
+
+- [ ] `mishap.go:175`: `"--status", "plan_staged"` → `"--status", "triage"`
+- [ ] `mishap.go:200-208`: DoR-Flag-Setting entfernen (war nur für plan_staged-Lane-Autoenqueue
+      nötig; triage-Tickets brauchen keine 4/4 DoR zum Start)
+
+### 3. Verifikation
+
+- [ ] `cd scripts/ticket-mcp && go test ./internal/tools/ -run 'FactoryFix' -v`
+- [ ] `go build ./...` in `scripts/ticket-mcp/` (keine Kompilationsfehler)
+
+### 4. Recovery: Betroffene Tickets bereinigen
+
+- [ ] T002767–T002774 (8 Tickets ohne Plan, plan_staged) auf `triage` zurücksetzen
+- [ ] Je einen Kommentar anhängen: "T002769: plan_staged ohne Plan — auf triage zurückgesetzt
+      (Root-Cause-Guard jetzt aktiv)"
+
+## Test Strategy
+
+- **Positiv-Anker:** `buildFactoryFixTicketArgs` erzeugt `--type fix` und `--status triage`
+- **Negativ-Anker:** Kein `--status plan_staged` in factory fix args
+- **Regression:** Rollup-Container-Tests (`TestRollupCreateArgs_StatusIsPlanStaged`,
+  `TestRollupFindArgs_UsesChoreAndPlanStaged`) bleiben unverändert

--- a/scripts/ticket-mcp/go/internal/tools/mishap.go
+++ b/scripts/ticket-mcp/go/internal/tools/mishap.go
@@ -160,19 +160,18 @@ func mishapSeverity(mtype string) (severity, priority string) {
 	}
 }
 
-// buildFactoryFixTicketArgs erzeugt ein DIREKT dispatchenbares fix-Ticket:
-// type=fix, status=plan_staged, execution_released bleibt Default true.
-// Die plan_staged-Lane in queue.sh akzeptiert type NOT IN ('project','incident')
-// und ist damit die einzige Lane, die 'fix' OHNE Aenderung an der
-// T002327-geschuetzten backlog-Lane dispatchen kann. Der Dispatcher fuehrt
-// fuer solche Tickets Scout→Design→Plan selbst (branch/plan_path=null).
+// buildFactoryFixTicketArgs erzeugt ein fix-Ticket fuer den normalen
+// Planungs-Flow (triage → planning → plan_staged → backlog).
+// status=triage, weil zum Zeitpunkt der Mishap-Konversion KEIN Plan existiert.
+// plan_staged ist ausschliesslich Tickets vorbehalten, die via stage-plan.sh
+// mit validiertem --plan und --branch gestaged wurden (T002769).
 func buildFactoryFixTicketArgs(entry MishapEntry, brand string) []string {
 	sev, prio := mishapSeverity(entry.Type)
 	return []string{
 		"create", "--type", "fix", "--brand", brand,
 		"--title", entry.Title,
 		"--description", fmt.Sprintf("### Mishap-Fix\n\n**Typ:** %s | **Komponente:** %s\n\n%s", entry.Type, entry.Component, entry.Description),
-		"--status", "plan_staged", "--severity", sev, "--priority", prio,
+		"--status", "triage", "--severity", sev, "--priority", prio,
 		"--attention-mode", "ai_ready", "--areas", entry.Component,
 	}
 }
@@ -196,14 +195,6 @@ func createFactoryFixTicket(entry MishapEntry, brand string) (string, error) {
 	ext := strings.TrimSpace(out)
 	if i := strings.Index(ext, "|"); i >= 0 {
 		ext = ext[:i]
-	}
-	// DoR-Flags setzen, damit das Ticket in der plan_staged-Lane vollstaendig ist.
-	_, err = runner.RunTicket([]string{
-		"plan-meta", "set", "--id", ext,
-		"--readiness", "spec_skizziert=true,aufwand_geschaetzt=true,abhaengigkeiten_klar=true,offene_fragen_geklaert=true",
-	}, map[string]string{"BRAND": brand})
-	if err != nil {
-		return "", fmt.Errorf("plan-meta set fehlgeschlagen: %w", err)
 	}
 	return ext, nil
 }

--- a/scripts/ticket-mcp/go/internal/tools/mishap_test.go
+++ b/scripts/ticket-mcp/go/internal/tools/mishap_test.go
@@ -363,14 +363,14 @@ func TestMishapSeverityMapping(t *testing.T) {
 	}
 }
 
-func TestFactoryFixTicketArgs_PlanStaged(t *testing.T) {
+func TestFactoryFixTicketArgs_NotPlanStaged(t *testing.T) {
 	entry := MishapEntry{Title: "X", Description: "Y", Component: "c", Type: "drift", ReportedAt: ""}
 	args := buildFactoryFixTicketArgs(entry, "mentolder")
 	if !hasFlagValue(args, "--type", "fix") {
 		t.Errorf("factory fix must use --type fix; got %v", args)
 	}
-	if !hasFlagValue(args, "--status", "plan_staged") {
-		t.Errorf("factory fix must use --status plan_staged (T002327 lane); got %v", args)
+	if !hasFlagValue(args, "--status", "triage") {
+		t.Errorf("factory fix must use --status triage (T002769: no plan exists yet); got %v", args)
 	}
 	if !hasFlagValue(args, "--attention-mode", "ai_ready") {
 		t.Errorf("factory fix must be ai_ready; got %v", args)
@@ -383,5 +383,16 @@ func TestFactoryFixTicketArgs_PlanStaged(t *testing.T) {
 	}
 	if hasFlagValue(args, "--status", "backlog") {
 		t.Error("factory fix must not land in the T002327-protected backlog lane")
+	}
+}
+
+func TestFactoryFixTicketArgs_NeverUsesPlanStaged(t *testing.T) {
+	// T002769: Factory fix tickets have NO plan — they MUST NOT use plan_staged.
+	// plan_staged is reserved for tickets staged via stage-plan.sh with validated
+	// --plan and --branch.
+	entry := MishapEntry{Title: "X", Description: "Y", Component: "c", Type: "drift", ReportedAt: ""}
+	args := buildFactoryFixTicketArgs(entry, "mentolder")
+	if hasFlagValue(args, "--status", "plan_staged") {
+		t.Error("T002769: factory fix must NEVER use --status plan_staged — no plan exists. Use --status triage instead.")
 	}
 }


### PR DESCRIPTION
## Problem

`mishap.go` `buildFactoryFixTicketArgs()` erzeugte Fix-Tickets mit `--status plan_staged`, obwohl kein Plan existierte. 8 Tickets (T002767–T002774) blockierten die Factory-Queue ohne Plan.

`stage-plan.sh` hat zwar einen Guard (`--plan` required + `git cat-file -e`), aber `mishap.go` umging ihn komplett.

## Fix

- `mishap.go:175`: `--status plan_staged` → `--status triage`
- DoR-Flag-Pre-Setting entfernt (war nur für plan_staged-Lane nötig)
- Tests angepasst: `TestFactoryFixTicketArgs_NotPlanStaged` + neuer Negativ-Test

## Nicht betroffen

- Rollup-Container (`buildCreateRollupTicketArgs`) bleibt `plan_staged`
- Incident-Tickets (`buildIncidentTicketArgs`) unverändert `triage`