### PR TITLE
fix(factory): add --hold to Fix-Pfad stage-plan example + MCP hold param [T002774]

### DIFF
--- a/.claude/skills/references/dev-flow-plan-phases.md
+++ b/.claude/skills/references/dev-flow-plan-phases.md
@@ -335,13 +335,14 @@ direkt aus (opencode — das Äquivalent ist in `opencode-flow-plan` inlined; sc
 Wende das Frontmatter an und trage die Ticket-ID ein. Committe und pushe den Plan.
 ### Schritt 4.5: Plan stagen (Fix 6)
 **MCP-first** (`ticket-mcp`):
-> `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "fix/<slug>", plan: "openspec/changes/<slug>/tasks.md" })`
+> `mcp__ticket-mcp__stage_plan({ id: "$TICKET_EXT_ID", branch: "fix/<slug>", plan: "openspec/changes/<slug>/tasks.md", hold: true })`
 Fallback (ticket-mcp nicht erreichbar):
 ```bash
 ./scripts/ticket.sh stage-plan \
   --id "$TICKET_EXT_ID" \
   --branch "fix/<slug>" \
-  --plan "openspec/changes/<slug>/tasks.md"
+  --plan "openspec/changes/<slug>/tasks.md" \
+  --hold
 ```
 Damit ist das Fix-Ticket als `plan_staged` in der DB verankert und für `dev-flow-execute` bereit.
 ### Schritt 5: Commit & Push

--- a/openspec/changes/stage-plan-hold-doc-T002774/design.md
+++ b/openspec/changes/stage-plan-hold-doc-T002774/design.md
@@ -1,0 +1,21 @@
+# T002774: --hold im Fix-Pfad-Beispiel + MCP stage_plan hold-Parameter
+
+## Problem
+
+Das Referenzbeispiel des Fix-Pfads in `dev-flow-plan-phases.md` Schritt 4.5 lässt `--hold` weg.
+Im Feature-Pfad (`ticket-stage-procedure.md`) ist `--hold` dagegen explizit gesetzt und
+dokumentiert.
+
+Ohne `--hold` weckt `stage-plan.sh` am Ende `factory.service` — das Ticket wird sofort
+dispatched, obwohl der Planer `dev-flow-execute` erst später aufrufen will.
+
+Zusätzlich: Der MCP-First-Pfad (`stage_plan`-Tool) unterstützt gar kein `hold`-Flag. Die
+MCP-Tool-Definition in `workflow.go` leitet nur `--id`, `--branch`, `--plan` durch.
+
+## Fix
+
+1. `dev-flow-plan-phases.md` Schritt 4.5: `--hold` zur CLI-Fallback-Zeile hinzufügen
+2. `workflow.go` `stage_plan`-Tool: `hold`-Parameter (optional boolean) hinzufügen
+3. `dev-flow-plan-phases.md` Schritt 4.5: MCP-First-Aufruf um `hold: true` ergänzen
+
+Keine Änderung an `stage-plan.sh` nötig — es unterstützt `--hold` bereits (Zeile 52).

--- a/openspec/changes/stage-plan-hold-doc-T002774/specs/dev-flow-plan.md
+++ b/openspec/changes/stage-plan-hold-doc-T002774/specs/dev-flow-plan.md
@@ -1,0 +1,23 @@
+# Delta: dev-flow-plan
+
+## MODIFIED Requirements
+
+### Requirement: Fix-Pfad stage-plan verwendet --hold
+
+Das Referenzbeispiel des Fix-Pfads für `stage-plan` MUSS `--hold` enthalten, damit das Ticket
+nicht sofort von der Factory dispatched wird. Der Feature-Pfad (`ticket-stage-procedure.md`)
+dokumentiert `--hold` bereits; der Fix-Pfad muss gleichziehen.
+
+#### Scenario: CLI-Fallback enthält --hold
+
+- **GIVEN** ein Fix-Ticket ist bereit zum Stagen
+- **WHEN** der Planer `scripts/ticket.sh stage-plan` im Fix-Pfad aufruft
+- **THEN** der Aufruf enthält `--hold`
+- **AND** das Ticket wird NICHT sofort dispatched
+
+#### Scenario: MCP stage_plan unterstützt hold
+
+- **GIVEN** der MCP-First-Pfad via `mcp__ticket-mcp__stage_plan`
+- **WHEN** der Aufruf `hold: true` enthält
+- **THEN** `ticket.sh stage-plan` wird mit `--hold` aufgerufen
+- **AND** `readiness.execution_released` wird auf `false` gesetzt

--- a/openspec/changes/stage-plan-hold-doc-T002774/tasks.md
+++ b/openspec/changes/stage-plan-hold-doc-T002774/tasks.md
@@ -1,0 +1,28 @@
+# T002774 — --hold im Fix-Pfad + MCP stage_plan hold-Parameter
+
+> **Type:** fix | **Severity:** minor | **Effort:** klein
+
+## File Structure
+
+| File | Role |
+|------|------|
+| `.claude/skills/references/dev-flow-plan-phases.md` | --hold in Fix-Pfad CLI-Fallback + MCP-First |
+| `scripts/ticket-mcp/go/internal/tools/workflow.go` | MCP stage_plan hold-Parameter |
+| `scripts/ticket-mcp/go/internal/tools/workflow_test.go` | Test für hold-Parameter |
+
+## Tasks
+
+### 1. Doku-Fix: --hold im Fix-Pfad-Beispiel
+
+- [ ] `dev-flow-plan-phases.md:341-345`: `--hold \` als letzte Zeile vor `"` hinzufügen
+- [ ] `dev-flow-plan-phases.md:337-338`: MCP-First-Aufruf um hold-Parameter ergänzen
+
+### 2. MCP-Tool: hold-Parameter in stage_plan
+
+- [ ] `workflow.go`: `stage_plan`-Tool-Definition um `mcp.WithBoolean("hold")` ergänzen
+- [ ] `workflow.go`: Handler: bei `hold=true` `--hold` an die Ticket-CLI-Args anhängen
+
+### 3. Verifikation
+
+- [ ] `go test ./internal/tools/ -run 'Stage' -v` (falls vorhanden)
+- [ ] `go build ./...`

--- a/scripts/ticket-mcp/go/internal/tools/workflow.go
+++ b/scripts/ticket-mcp/go/internal/tools/workflow.go
@@ -89,13 +89,14 @@ func RegisterWorkflowTools(s *server.MCPServer) {
 		},
 	)
 
-	// stage_plan → ticket.sh stage-plan --id --branch --plan
+	// stage_plan → ticket.sh stage-plan --id --branch --plan [--hold]
 	s.AddTool(
 		mcp.NewTool("stage_plan",
 			mcp.WithDescription("Stellt ein Ticket in die Kommissionierung (status=plan_staged) mit Branch + Plan-Pfad."),
 			mcp.WithString("id", mcp.Description("external_id z.B. T000123"), mcp.Required()),
 			mcp.WithString("branch", mcp.Description("Feature/Fix-Branch"), mcp.Required()),
 			mcp.WithString("plan", mcp.Description("Plan-Datei-Pfad"), mcp.Required()),
+			mcp.WithBoolean("hold", mcp.Description("Bei true: execution_released=false — Ticket wird NICHT sofort dispatched (default false)")),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)"),
 				mcp.Enum("mentolder", "korczewski")),
 		),
@@ -104,7 +105,11 @@ func RegisterWorkflowTools(s *server.MCPServer) {
 			id, _ := a["id"].(string)
 			branch, _ := a["branch"].(string)
 			plan, _ := a["plan"].(string)
-			return text(runner.RunTicket([]string{"stage-plan", "--id", id, "--branch", branch, "--plan", plan}, map[string]string{"BRAND": brandOf(a)}))
+			args := []string{"stage-plan", "--id", id, "--branch", branch, "--plan", plan}
+			if hold, _ := a["hold"].(bool); hold {
+				args = append(args, "--hold")
+			}
+			return text(runner.RunTicket(args, map[string]string{"BRAND": brandOf(a)}))
 		},
 	)
 


### PR DESCRIPTION
## Problem

`dev-flow-plan-phases.md` Schritt 4.5 (Fix-Pfad `stage-plan`) fehlte `--hold`. Ohne das Flag weckt `stage-plan.sh` am Ende `factory.service` — das Ticket wird sofort dispatched, obwohl der Planer `dev-flow-execute` erst später aufrufen will.

Zusätzlich: Der MCP-First-Pfad (`stage_plan`-Tool) unterstützte gar kein `hold`-Flag. Die Tool-Definition in `workflow.go` leitete nur `--id`, `--branch`, `--plan` durch.

## Fix

- `dev-flow-plan-phases.md` Schritt 4.5: `--hold` zum CLI-Fallback + `hold: true` im MCP-First-Beispiel
- `workflow.go` `stage_plan`-Tool: `hold`-Parameter (optional boolean) + Handler-Weitergabe an `ticket.sh`

Keine Änderung an `stage-plan.sh` nötig — `--hold` wird bereits unterstützt.