### PR TITLE
chore(docs): AGENTS.md an den T002753-Stand angleichen, post-rewrite-Hook versionieren [T002782]

### DIFF
--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# post-rewrite: Laeuft nach git rebase / git commit --amend.
+#
+# Regeneriert openspec-status.json nach Rebase, weil die darin hartkodierten
+# Commit-SHAs durch den Rewrite obsolet werden. Ohne diesen Hook fuehrt jeder
+# Rebase auf einem Feature-Branch zu einem stale artefakt, das erst in CI
+# (freshness:check) auffaellt und den Merge blockiert.
+#
+# Die Regeneration ist absichtlich kein Commit — der naechste pre-push meldet
+# ein dirty working tree, und der Entwickler committed es bewusst. Das ist
+# sicherer als ein unsichtbarer Auto-Commit im Hook.
+set -euo pipefail
+
+# Nur bei rebase (nicht bei amend) — amend aendert keine SHAs anderer Commits.
+# Die stdin enthaelt die Liste der umgeschriebenen Commits (old new).
+is_rebase=false
+while IFS=' ' read -r old new; do
+  [[ -n "$old" && -n "$new" ]] && is_rebase=true
+done
+
+if ! $is_rebase; then
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[[ -z "$REPO_ROOT" ]] && exit 0
+
+STATUS_MAP="$REPO_ROOT/website/src/data/openspec-status.json"
+SCRIPT="$REPO_ROOT/scripts/openspec-status-map.sh"
+
+if [[ -x "$SCRIPT" && -f "$STATUS_MAP" ]]; then
+  echo "post-rewrite: regenerating openspec-status.json (SHAs changed after rebase)"
+  if bash "$SCRIPT" 2>/dev/null; then
+    echo "post-rewrite: openspec-status.json regenerated — commit before pushing"
+  else
+    echo "post-rewrite: WARNING — openspec-status-map.sh failed (non-fatal)" >&2
+  fi
+fi

--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -287,7 +287,7 @@
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
     "qwen": {
-      "description": "Local subagent for the qwen family (Qwen3-Coder-30B-A3B UD-Q4_K_XL, Loadout qwen3-coder-30b auf Port 8094, via llm-proxy :18235). Write-capable delegation; shares exclusiveGroup chat-gpu.",
+      "description": "Local subagent for the qwen family (Qwen3-Coder-30B-A3B UD-IQ3_XXS, Loadout qwen3-coder-30b auf Port 8094, via llm-proxy :18235). Write-capable delegation; shares exclusiveGroup chat-gpu.",
       "mode": "subagent",
       "model": "llamacpp-local/qwen3-coder-30b",
       "prompt": "{file:./prompts/local-subagent.md}",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ opencode reads its agents from `.opencode/agent-models.jsonc` — NOT `.agents/a
 | `orchestrator` | DeepSeek V4 Flash (OpenCode Go, 1M ctx), `mode: primary`, write-capable | Primary orchestrator — dispatches the local family subagents (`gptoss`/`devstral`/`gemma`/`qwen`) sequentially (llm-proxy serializes at max_inflight=1) |
 | `gptoss` | `llamacpp-local/gptoss-context` (gpt-oss-20b Q8_0, :8098) | Local bulk work, gpt-oss family. `write=deny`, `edit=allow` |
 | `devstral` | `llamacpp-local/devstral-quality` (Devstral-Small-2 24B, :8099) | Local work, devstral family |
-| `gemma` | `llamacpp-local/gemma4` (Gemma 4 12B Q4_K_M, :8090) | Local work, gemma family |
-| `qwen` | `llamacpp-local/qwen3-coder-30b` (Qwen3-Coder-30B, :8094) | Local work, qwen family |
-| `gemma26-primary` | `llamacpp-local/gptoss-context`, `mode: primary` | Fully-local tab-selectable agent; NOT summonable via `task` |
-| `gemma26-vision` | `llamacpp-local/gptoss-context`, `mode: primary` | Max context, no subagent dispatch. **Not actually vision-capable** since the switch off Gemma |
+| `gemma` | `llamacpp-local/gemma26-factory` (Gemma 4 26B A4B IQ4_XS, :8091) | Local work, gemma family |
+| `qwen` | `llamacpp-local/qwen3-coder-30b` (Qwen3-Coder-30B UD-IQ3_XXS, :8094) | Local work, qwen family |
+| `gemma26-primary` | `llamacpp-local/gemma26-factory`, `mode: primary` | Fully-local tab-selectable agent; NOT summonable via `task` |
+| `gemma26-vision` | `llamacpp-local/gemma26-factory`, `mode: primary` | Max local context (161024, measured), no subagent dispatch. **Vision-capable**: gemma26-factory loads mmproj-F16.gguf since T002753 |
 | `big-pickle` | `opencode-zen/big-pickle`, `mode: primary`, write-capable | Tab-selectable singleagent on OpenCode Zen — use while the free quota lasts, then switch to the deepseek primaries |
 | `deepseek-helper` | `deepseek/deepseek-v4-flash` (direct API), write-capable | Escalation when a local agent is stuck or context-exhausted |
 | `deepseek-pro` | `opencode-go/deepseek-v4-pro`, `mode: all`, write-capable | Deep analysis, complex debugging, hard refactors; tab-selectable AND task-dispatchable |
@@ -29,7 +29,7 @@ Dispatch:
 - `task` for the local family subagents (`gptoss`, `devstral`, `gemma`, `qwen`) and the deepseek agents — the `orchestrator` permission block lists exactly those names, no wildcards (T002298).
 - Local family agents `edit` but cannot `write` new files (`write=deny`) — the orchestrator creates new files from their output. Read-only work uses `delegate` (explore/general).
 - SSOT is `.opencode/agent-models.jsonc`. `docs/agent-guide/registry/agents.yaml` mirrors it but LAGS the config — trust the jsonc. Global config sync: `bash scripts/opencode-sync-agents.sh`.
-- **Local subagents are named by model FAMILY since 2026-08-04** (`gptoss`/`devstral`/`gemma`/`qwen`), each serving its own loadout through the llm-proxy. The old `gemma26-1/2`, `gemma9-1/2` names all pointed at gptoss-context — the name lied about the model. The four chat loadouts share `exclusiveGroup "chat-gpu"`: only one runs at a time. The retired Gemma loadouts (`gemma-factory`, `gemma-multiagent`, `gemma26-factory`, `gemma9-factory`) are still in loadouts.json with `fit.enabled=true` but their GGUFs are gone; `2026-08-03-retire-stale-model-ids.sql` disables their backends with `enabled=false`. `gemma26-primary`/`gemma26-vision` keep their historical names and run gptoss-context.
+- **Local subagents are named by model FAMILY since 2026-08-04** (`gptoss`/`devstral`/`gemma`/`qwen`), each serving its own loadout through the llm-proxy. The old `gemma26-1/2`, `gemma9-1/2` names all pointed at gptoss-context — the name lied about the model. Every GPU loadout shares `exclusiveGroup "chat-gpu"`: only one runs at a time (all of `loadouts.json` except the two CPU bge loadouts). The weightless loadouts (`gemma-factory`, `gemma-multiagent`, `gemma9-factory`) were removed on 2026-08-09 (T002753); `gemma`/`gemma26-primary`/`gemma26-vision` serve `gemma26-factory` (Gemma 4 26B A4B UD-IQ4_XS, 161024 ctx measured).
 
 ## Core Commands
 


### PR DESCRIPTION
## Was

Zwei fertige, aber nirgends versionierte Änderungen aus dem Hauptcheckout in `main` bringen — Ticket **T002782**.

### 1. AGENTS.md-Nachzug zu T002753

T002753 (done/shipped) räumte die Loadouts ohne Gewichte auf und verdrahtete gemma26/qwen mit gemessenem Maximalkontext. Sein `touched_files` enthielt `.opencode/agent-models.jsonc`, **nicht** aber `AGENTS.md` — die Agenten-Tabelle blieb auf dem Stand davor stehen und beschrieb Modelle, Ports und Fähigkeiten, die es so nicht mehr gibt.

Jede Zeile gegen die SSOT (`.opencode/agent-models.jsonc`, `scripts/llm/loadouts.json`) geprüft:

| Stelle | vorher | jetzt |
|---|---|---|
| `gemma` | `llamacpp-local/gemma4` (12B Q4_K_M, :8090) | `gemma26-factory` (26B A4B IQ4_XS, :8091) |
| `qwen` | Qwen3-Coder-30B (Quant ungenannt / UD-Q4_K_XL) | UD-IQ3_XXS, :8094 |
| `gemma26-primary` | `gptoss-context` | `gemma26-factory` |
| `gemma26-vision` | „**Not actually vision-capable**" | vision-fähig via `mmproj-F16.gguf` seit T002753 |
| Kontext | pauschal | 161024, gemessen |
| weightless Loadouts | „in loadouts.json, GGUFs sind weg" | am 2026-08-09 entfernt |

**Über den ursprünglichen Fund hinaus** (gleiche Ursache, beim Gegenlesen gefunden): „The four chat loadouts share `exclusiveGroup chat-gpu`" stimmte nicht mehr. Nachgezählt sind es **9 von 11** — alle außer den zwei CPU-bge-Loadouts.

### 2. `.githooks/post-rewrite` versionieren

Der Hook war ungetrackt und damit nur in einer einzigen Arbeitskopie wirksam. Er regeneriert `website/src/data/openspec-status.json` nach einem Rebase, weil die dort hartkodierten Commit-SHAs durch den Rewrite obsolet werden; ohne ihn fällt das stale Artefakt erst in CI (`freshness:check`) auf und blockiert den Merge. Mit `0755` committet wie die übrigen Hooks.

## Warum Chore

Reine Dokumentationskorrektur an bereits gemergtem Verhalten plus Entwickler-Werkzeug im Commit-Pfad. Kein Produktverhalten ändert sich.

## Verifikation

- `task test:changed` — 52/52 grün
- `task freshness:regenerate` — keine Artefakt-Änderung (alles aktuell)
- `task freshness:check` — Exit 0, route-manifest OK
- `bash -n .githooks/post-rewrite` — Syntax OK
- Aussage zu `chat-gpu` gegen `loadouts.json` nachgezählt: 11 gesamt, 9 mit Gruppe, die 2 ohne sind `bge-embed-cpu`/`bge-rerank-cpu`
- S1-Restbudget: für `.md`/`.jsonc`/extensionslos nicht anwendbar — mit Positiv-Kontrolle (`scripts/agent-lock.sh` → 265) bestätigt, dass die leere Ausgabe „nicht zutreffend" heißt und kein stiller Fehlschlag ist

## Herkunft

Der Arbeitsbaum des Hauptcheckouts wurde während eines `repo-hygiene`-Laufs von einer nebenläufigen Session gestasht (`stash@{0}`, Nachricht `repo-hygiene: pre-T002769-plan dirty main checkout`). Die Änderungen wurden von dort gesichert, gegen den aktuellen `main` mit `git apply --check` geprüft und in diesem Worktree neu aufgesetzt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NAwFqXtsPZMPVWEx7U65j
