### PR TITLE
fix(test): korrigiere tote SSOT-Referenz in dead-path-references.bats [T002772]

### DIFF
--- a/openspec/changes/dead-path-ssot-ref-T002772/design.md
+++ b/openspec/changes/dead-path-ssot-ref-T002772/design.md
@@ -1,0 +1,8 @@
+# T002772: Tote SSOT-Referenz in dead-path-references.bats
+
+## Problem
+`tests/spec/repo-hygiene/dead-path-references.bats` Zeile 3: `SSOT: openspec/specs/repo-hygiene.md`.
+Diese Datei existiert nicht.
+
+## Fix
+`openspec/specs/repo-hygiene.md` → `openspec/specs/agent-skills.md` (dort steht die repo-hygiene-Requirement).

--- a/openspec/changes/dead-path-ssot-ref-T002772/specs/agent-skills.md
+++ b/openspec/changes/dead-path-ssot-ref-T002772/specs/agent-skills.md
@@ -1,0 +1,8 @@
+# Delta: agent-skills
+
+## MODIFIED Requirements
+
+### Requirement: dead-path-references.bats referenziert existierende SSOT
+Die SSOT-Kopfzeile in `tests/spec/repo-hygiene/dead-path-references.bats` MUSS auf
+`openspec/specs/agent-skills.md` zeigen (existiert), nicht auf
+`openspec/specs/repo-hygiene.md` (existiert nicht).

--- a/openspec/changes/dead-path-ssot-ref-T002772/specs/agent-skills.md
+++ b/openspec/changes/dead-path-ssot-ref-T002772/specs/agent-skills.md
@@ -6,3 +6,9 @@
 Die SSOT-Kopfzeile in `tests/spec/repo-hygiene/dead-path-references.bats` MUSS auf
 `openspec/specs/agent-skills.md` zeigen (existiert), nicht auf
 `openspec/specs/repo-hygiene.md` (existiert nicht).
+
+#### Scenario: SSOT-Kopfzeile verweist auf agent-skills.md
+
+- **GIVEN** die Datei `tests/spec/repo-hygiene/dead-path-references.bats`
+- **WHEN** die SSOT-Kopfzeile gelesen wird
+- **THEN** sie verweist auf `openspec/specs/agent-skills.md`

--- a/openspec/changes/dead-path-ssot-ref-T002772/tasks.md
+++ b/openspec/changes/dead-path-ssot-ref-T002772/tasks.md
@@ -1,0 +1,7 @@
+# T002772 — Tote SSOT-Referenz korrigieren
+
+> **Type:** fix | **Severity:** trivial | **Effort:** klein
+
+## Tasks
+1. [ ] `tests/spec/repo-hygiene/dead-path-references.bats:3`: `repo-hygiene.md` → `agent-skills.md`
+2. [ ] Verifikation: `ls openspec/specs/agent-skills.md` existiert

--- a/tests/spec/repo-hygiene/dead-path-references.bats
+++ b/tests/spec/repo-hygiene/dead-path-references.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 # tests/spec/repo-hygiene/dead-path-references.bats
-# SSOT: openspec/specs/repo-hygiene.md
+# SSOT: openspec/specs/agent-skills.md
 #
 # Guard gegen tote Pfad-Referenzen (T002688, Vorgang A). Prüfmodus:
 # Kommando-Ergebnis-Verifikation — jede Prüfung extrahiert Kandidaten aus der


### PR DESCRIPTION
Zeile 3: `openspec/specs/repo-hygiene.md` (existiert nicht) → `openspec/specs/agent-skills.md` (existiert).