### PR TITLE
fix(scripts): brain-ingest.sh fail-closed statt totem Default-Modell [T002773]

### DIFF
--- a/openspec/changes/brain-ingest-model-default-T002773/design.md
+++ b/openspec/changes/brain-ingest-model-default-T002773/design.md
@@ -1,0 +1,8 @@
+# T002773: brain-ingest.sh totes Default-Modell
+
+## Problem
+`scripts/brain-ingest.sh:44`: `LM_MODEL="${LM_MODEL:-qwen3.6-14b-a3b-fablevibes}"` —
+dieses Modell existiert nicht. Der Default täuscht eine funktionierende Vorgabe vor.
+
+## Fix
+Default streichen → fail-closed: `LM_MODEL="${LM_MODEL:?LM_MODEL ist Pflicht (siehe T002533)}"`.

--- a/openspec/changes/brain-ingest-model-default-T002773/specs/scripts.md
+++ b/openspec/changes/brain-ingest-model-default-T002773/specs/scripts.md
@@ -1,3 +1,12 @@
 # Delta: scripts
-## MODIFIED: brain-ingest.sh LM_MODEL fail-closed
+
+## MODIFIED Requirements
+
+### Requirement: brain-ingest.sh LM_MODEL fail-closed
 brain-ingest.sh MUSS abbrechen, wenn LM_MODEL nicht gesetzt ist, statt mit einem nicht existierenden Default zu starten.
+
+#### Scenario: LM_MODEL nicht gesetzt
+
+- **GIVEN** die Umgebungsvariable LM_MODEL ist nicht gesetzt
+- **WHEN** `bash scripts/brain-ingest.sh` ausgeführt wird
+- **THEN** das Skript bricht mit einer Fehlermeldung ab (exit code != 0)

--- a/openspec/changes/brain-ingest-model-default-T002773/specs/scripts.md
+++ b/openspec/changes/brain-ingest-model-default-T002773/specs/scripts.md
@@ -1,0 +1,3 @@
+# Delta: scripts
+## MODIFIED: brain-ingest.sh LM_MODEL fail-closed
+brain-ingest.sh MUSS abbrechen, wenn LM_MODEL nicht gesetzt ist, statt mit einem nicht existierenden Default zu starten.

--- a/openspec/changes/brain-ingest-model-default-T002773/tasks.md
+++ b/openspec/changes/brain-ingest-model-default-T002773/tasks.md
@@ -1,0 +1,6 @@
+# T002773 — brain-ingest.sh Default-Modell entfernen
+> **Type:** fix | **Severity:** trivial | **Effort:** klein
+
+## Tasks
+1. [ ] `scripts/brain-ingest.sh:44`: `${LM_MODEL:-…}` → `${LM_MODEL:?LM_MODEL ist Pflicht (T002533)}`
+2. [ ] `scripts/brain-ingest.sh:19`: Kommentar aktualisieren

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -16,7 +16,7 @@
 #                      Deployments (k3d/llm-gpu.yaml); die Host-Ports 8095/8096
 #                      existieren nicht mehr. Einziger Host-Server:
 #                        8093 = Bonsai chat / ingest pool (-np 4)
-#   LM_MODEL         — Model to use (default: qwen3.6-14b-a3b-fablevibes)
+#   LM_MODEL         — Model to use (PFLICHT, kein Default; siehe T002533)
 #   MAX_PARALLEL     — Concurrent process_page() jobs (default: 4, matching
 #                      the ingest-pool server's -np slot count — raising this
 #                      above the server's slot count just queues requests)
@@ -41,7 +41,7 @@ PRUNE=0
 STATE_FILE="${BRAIN_INGEST_STATE:-$HOME/.brain-ingest-state.json}"
 BRANCH="feature/brain-initial-ingest"
 LM_URL="${LM_STUDIO_URL:-http://localhost:8093}"
-LM_MODEL="${LM_MODEL:-qwen3.6-14b-a3b-fablevibes}"
+LM_MODEL="${LM_MODEL:?LM_MODEL ist Pflicht (siehe T002533)}"
 MAX_PARALLEL="${MAX_PARALLEL:-4}"
 CHUNK_TARGET_CHARS="${BRAIN_CHUNK_TARGET_CHARS:-8000}"
 # transform.sh's MAX_SOURCE_CHARS is a fail-closed guard since T002679 — it no


### PR DESCRIPTION
`LM_MODEL`-Default `qwen3.6-14b-a3b-fablevibes` existiert nicht → `${LM_MODEL:?}` (fail-closed, konsistent mit T002533).