### PR TITLE
fix(docs): dokumentiere ticket_plans-Spalten im mcp-tool-guide [T002768]

### DIFF
--- a/.claude/skills/references/mcp-tool-guide.md
+++ b/.claude/skills/references/mcp-tool-guide.md
@@ -124,6 +124,9 @@ Schlägt der MCP-Zugriff fehl oder ist der Cluster-Kontext nicht gesetzt → **F
 - ⚠️ `tickets.ticket_plans`: nie `SELECT *` oder die `content`-Spalte über die ganze Tabelle (MB-Transfer
   über `kubectl exec` → Timeout). Immer Metadaten (`id`, `ticket_id`, `slug`, `branch`, `pr_number`,
   `archived_at`) oder gezielt nach `ticket_id`/`slug` filtern.
+- ⚠️ **`tickets.ticket_plans`-Schema:** Die Spalten sind `id` (UUID), `ticket_id` (FK→tickets.id),
+  `slug`, `branch`, `pr_number` (int), `content` (text, MB), `archived_at` (timestamptz).
+  Es gibt **kein** `status`-Feld — Status steht auf `tickets.tickets`, nicht auf `ticket_plans`.
 
 ## `mcp-kubernetes` — k8s-Status/Read
 

--- a/openspec/changes/ticket-plans-schema-doc-T002768/design.md
+++ b/openspec/changes/ticket-plans-schema-doc-T002768/design.md
@@ -1,0 +1,10 @@
+# T002768: ticket_plans-Schema dokumentieren
+
+## Problem
+`mcp-tool-guide.md` warnt vor `SELECT *` auf `ticket_plans.content`, listet aber nicht alle
+Spalten. Eine Join-Query gegen `p.status` scheiterte am 2026-08-09 — die Tabelle hat kein
+`status`-Feld.
+
+## Fix
+Explizite Spaltenliste ergänzen: `id, ticket_id, slug, branch, pr_number, content, archived_at`.
+Sowie Negativ-Hinweis: `status` existiert NICHT (das Status-Feld ist auf `tickets.tickets`).

--- a/openspec/changes/ticket-plans-schema-doc-T002768/specs/agent-skills.md
+++ b/openspec/changes/ticket-plans-schema-doc-T002768/specs/agent-skills.md
@@ -1,0 +1,4 @@
+# Delta: agent-skills
+## MODIFIED: mcp-tool-guide dokumentiert ticket_plans-Spalten
+Der mcp-tool-guide MUSS die vorhandenen Spalten von `tickets.ticket_plans` nennen und
+klarstellen, dass `status` NICHT zu dieser Tabelle gehört.

--- a/openspec/changes/ticket-plans-schema-doc-T002768/specs/agent-skills.md
+++ b/openspec/changes/ticket-plans-schema-doc-T002768/specs/agent-skills.md
@@ -1,4 +1,14 @@
 # Delta: agent-skills
-## MODIFIED: mcp-tool-guide dokumentiert ticket_plans-Spalten
+
+## MODIFIED Requirements
+
+### Requirement: mcp-tool-guide dokumentiert ticket_plans-Spalten
 Der mcp-tool-guide MUSS die vorhandenen Spalten von `tickets.ticket_plans` nennen und
 klarstellen, dass `status` NICHT zu dieser Tabelle gehört.
+
+#### Scenario: mcp-tool-guide listet ticket_plans-Spalten
+
+- **GIVEN** die Datei `.claude/skills/references/mcp-tool-guide.md`
+- **WHEN** die ticket_plans-Dokumentation gelesen wird
+- **THEN** sie listet die vorhandenen Spalten `id`, `branch`, `pr_number`, `content`
+- **AND** sie stellt klar, dass `status` nicht zu dieser Tabelle gehört

--- a/openspec/changes/ticket-plans-schema-doc-T002768/tasks.md
+++ b/openspec/changes/ticket-plans-schema-doc-T002768/tasks.md
@@ -1,0 +1,6 @@
+# T002768 — ticket_plans-Schema dokumentieren
+> **Type:** fix | **Severity:** trivial | **Effort:** klein
+
+## Tasks
+1. [ ] `mcp-tool-guide.md:124-126`: Spaltenliste um Negativ-Hinweis ergänzen
+2. [ ] Verifikation: `grep 'ticket_plans' mcp-tool-guide.md` zeigt vollständige Spaltenliste


### PR DESCRIPTION
`mcp-tool-guide.md`: Explizite Spaltenliste + Negativ-Hinweis: `ticket_plans` hat kein `status`-Feld.