### PR TITLE
chore(plans): Reaper für verwaiste in_progress-Tickets [T002770]

### DIFF
--- a/openspec/changes/reaper-orphan-tickets-T002770/design.md
+++ b/openspec/changes/reaper-orphan-tickets-T002770/design.md
@@ -1,0 +1,16 @@
+# T002770: Reaper für in_progress-Tickets ohne Lock, Branch oder Worktree
+
+## Problem
+
+Tickets in `in_progress` ohne aktive Session bleiben dauerhaft in diesem Status. Der
+Watchdog (`scripts/factory/watchdog.sh`) hat bereits einen Slot-Reaper (T002610), aber
+keinen Ticket-Status-Reaper. Die ticket-ops-Invariante "laufende Arbeit nicht anfassen"
+vertraut auf den Statuswert — der hier nichts mehr abbildet.
+
+## Fix
+
+Watchdog-Regel in `scripts/factory/watchdog.sh`: Wenn ein `in_progress`-Ticket nach
+einer Karenzzeit (z.B. 60min) weder einen Agent-Lock noch einen Remote-Branch hat,
+wird es auf `triage` zurückgesetzt und der Vorgang kommentiert.
+
+Existierender Slot-Reaper als Vorbild (Commit `63b1f766d`, PR #3756).

--- a/openspec/changes/reaper-orphan-tickets-T002770/specs/factory-watchdog.md
+++ b/openspec/changes/reaper-orphan-tickets-T002770/specs/factory-watchdog.md
@@ -1,4 +1,14 @@
 # Delta: factory-watchdog
-## ADDED: Ticket-Status-Reaper für verwaiste in_progress
+
+## ADDED Requirements
+
+### Requirement: Ticket-Status-Reaper für verwaiste in_progress
 Der Watchdog MUSS `in_progress`-Tickets ohne Agent-Lock und ohne Remote-Branch nach einer
 Karenzzeit auf `triage` zurücksetzen.
+
+#### Scenario: Verwaistes in_progress-Ticket wird zurückgesetzt
+
+- **GIVEN** ein Ticket mit Status `in_progress`, seit >24h ohne Agent-Lock und ohne Remote-Branch
+- **WHEN** der Watchdog läuft
+- **THEN** das Ticket wird auf `triage` zurückgesetzt
+- **AND** ein Kommentar dokumentiert die Zurücksetzung

--- a/openspec/changes/reaper-orphan-tickets-T002770/specs/factory-watchdog.md
+++ b/openspec/changes/reaper-orphan-tickets-T002770/specs/factory-watchdog.md
@@ -1,0 +1,4 @@
+# Delta: factory-watchdog
+## ADDED: Ticket-Status-Reaper für verwaiste in_progress
+Der Watchdog MUSS `in_progress`-Tickets ohne Agent-Lock und ohne Remote-Branch nach einer
+Karenzzeit auf `triage` zurücksetzen.

--- a/openspec/changes/reaper-orphan-tickets-T002770/tasks.md
+++ b/openspec/changes/reaper-orphan-tickets-T002770/tasks.md
@@ -1,0 +1,8 @@
+# T002770 — Reaper für verwaiste in_progress-Tickets
+> **Type:** fix | **Severity:** trivial | **Effort:** mittel
+
+## Tasks
+
+1. [ ] Watchdog-Regel: `in_progress`-Tickets ohne Lock + ohne Remote-Branch nach 60min → `triage`
+2. [ ] Kommentar mit Rückstellungsgrund ans Ticket hängen
+3. [ ] Verifikation: `bash scripts/factory/watchdog.sh --dry-run` zeigt betroffene Tickets

--- a/scripts/factory/watchdog.sh
+++ b/scripts/factory/watchdog.sh
@@ -285,4 +285,47 @@ for ext_id in "${orphan_slots[@]}"; do
   fi
 done
 
+# ── orphaned in_progress tickets (T002770) ────────────────────────────────
+# Tickets in in_progress ohne laufende Session (kein Agent-Lock, kein Remote-
+# Branch) sind Waisen: der Status bildet keine reale Arbeit mehr ab. Der
+# ticket-ops-Guard "laufende Arbeit nicht anfassen" vertraut auf den Statuswert
+# und uebersieht sie. Dieser Sweep setzt sie nach einer Karenzzeit zurueck.
+#
+# Drei unabhaengige Signale werden geprueft, bevor der Status angetastet wird:
+#   1. agent-lock check ticket → free (keine aktive Session)
+#   2. git ls-remote --heads origin → kein Branch (kein offener PR-Arbeitszweig)
+#   3. git worktree list → kein Worktree mit der Ticket-ID (kein lokaler Checkout)
+#
+# Karenzzeit ist separat parametrierbar (ORPHAN_TICKET_MIN), Default 60min.
+ORPHAN_TICKET_MIN="${FACTORY_ORPHAN_TICKET_MIN:-60}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$(dirname "${BASH_SOURCE[0]}")/../..")"
+mapfile -t orphan_tickets < <(printf "SELECT external_id FROM tickets.tickets WHERE status='in_progress' AND updated_at < now() - make_interval(mins => %s) AND type NOT IN ('project','incident') ORDER BY updated_at;" "$ORPHAN_TICKET_MIN" | factory_psql)
+
+for ext_id in "${orphan_tickets[@]}"; do
+  [[ -z "$ext_id" ]] && continue
+
+  # Signal 1: Agent-Lock
+  if bash "$REPO_ROOT/scripts/agent-lock.sh" check ticket "$ext_id" >/dev/null 2>&1; then
+    continue  # lock held — session is active
+  fi
+
+  # Signal 2: Remote-Branch (sucht Branches mit dem Ticket-Suffix)
+  if git ls-remote --heads origin "*/${ext_id}" 2>/dev/null | grep -q .; then
+    continue  # branch exists — work may still be in flight
+  fi
+
+  # Signal 3: Lokaler Worktree
+  if git worktree list 2>/dev/null | grep -qi "$ext_id"; then
+    continue  # local worktree — developer may be working offline
+  fi
+
+  # Alle drei Signale negativ → Waise. Zuruecksetzen auf triage.
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" update-status --id "$ext_id" --status triage >/dev/null 2>&1 \
+    || { echo "watchdog: WARN status reset for orphan $ext_id failed" >&2; continue; }
+  BRAND="$BRAND" TICKET_CTX="$FACTORY_CTX" bash "$HERE/../ticket.sh" add-comment --id "$ext_id" \
+    --body "Watchdog: in_progress > ${ORPHAN_TICKET_MIN}min ohne Agent-Lock, Remote-Branch oder Worktree — Status auf triage zuruecksgesetzt. [T002770]" >/dev/null 2>&1 \
+    || echo "watchdog: WARN audit comment for orphan ticket $ext_id failed" >&2
+  escalated=$(echo "$escalated" | jq -c --arg e "$ext_id" '. + [$e]')
+done
+
 echo "$escalated"


### PR DESCRIPTION
Watchdog-Regel: `in_progress`-Tickets ohne Agent-Lock und ohne Remote-Branch nach Karenzzeit auf `triage` zurücksetzen. Existierender Slot-Reaper (T002610) als Vorbild.