### PR TITLE
chore(plans): Prosa-Blocker in depends_on überführen [T002771]

### DIFF
--- a/.claude/skills/references/ticket-ops-procedures.md
+++ b/.claude/skills/references/ticket-ops-procedures.md
@@ -40,6 +40,27 @@ The triaging agent **autonomously decides** severity, component, areas, and read
 | **areas** | Extract from component + title context (e.g., "sealed-secret" → ["infra","security"], "oauth2-proxy" → ["auth"], "deployment" → ["infra"]), default to ["ops"] for generic tasks | Multi-area with no clear focus |
 | **readiness.flags** | `spec_skizziert: true` if description ≥ 100 chars, `aufwand_geschaetzt: false`, `abhaengigkeiten_klar: true` (if depends_on null/empty), `offene_fragen_geklaert: false` (default) | Description too thin (<30 chars) or explicitly asks clarifying questions |
 
+### Step 1.0: Prosa-Blocker-Erkennung [T002771]
+
+Vor oder parallel zur Vollständigkeitsprüfung: Jede Ticket-Beschreibung auf Schlüsselwörter
+scannen, die auf einen Blocker hinweisen:
+
+| Muster | Regex | Aktion |
+|--------|-------|--------|
+| `BLOCKIERT VON` | `(?i)blockiert\s+von` | Extrahiere folgende PR#- und T000XXX-Referenzen |
+| `hängt an` | `(?i)h(ä|ae)ngt\s+an` | Extrahiere folgende PR#- und T000XXX-Referenzen |
+| `ABHÄNGT VON` | `(?i)abh(ä|ae)ng(ig|t)\s+von` | Extrahiere folgende PR#- und T000XXX-Referenzen |
+
+Gefundene Referenzen:
+- **T000XXX**: In `depends_on` überführen, falls noch nicht vorhanden
+- **PR #N**: Via `gh pr view N --json state,mergedAt` prüfen:
+  - `state=MERGED` → Blocker ist aufgelöst; `abhaengigkeiten_klar=true` setzen
+  - `state=OPEN` → PR-ID in `depends_on` als Prosa notieren (kein FK möglich)
+
+**Positiv-Anker:** Ein Ticket mit `depends_on` nicht NULL **und** in der Beschreibung
+`BLOCKIERT VON:` **und** der referenzierte PR `state=MERGED` → `depends_on` bleibt
+unverändert (der Blocker wurde bereits formal erfasst).
+
 ### Step 1.1: Fetch open tickets (enriched)
 
 **MCP-first** (`mcp-postgres`, read-only): pass the query below to `mcp__mcp-postgres__query({ sql: "…" })`. Fallback: `psql -c "<query>"` via the `psql()` helper above.

--- a/openspec/changes/prosa-blocker-detection-T002771/design.md
+++ b/openspec/changes/prosa-blocker-detection-T002771/design.md
@@ -1,0 +1,18 @@
+# T002771: Prosa-Blocker in depends_on überführen
+
+## Problem
+
+Tickets mit Blockern als Fließtext ("BLOCKIERT VON: PR #3745 (T002587)...") in der
+Beschreibung haben keine `depends_on`-Einträge. Der Blocker bleibt auch nach Merge der
+referenzierten PR bestehen — es gibt keinen Mechanismus, der Prosa-Blocker automatisch
+auflöst.
+
+Beobachtet an T002629: PR #3745 war seit 5 Tagen gemergt, das Ticket stand immer noch
+mit DoR 0/4, weil `depends_on` NULL war und niemand die volle Beschreibung las.
+
+## Fix
+
+In `ticket-ops` Phase 1 (Completeness Triage): Nach dem Lesen der Beschreibung auf
+Schlüsselwörter prüfen (`BLOCKIERT VON`, `hängt an`, `ABHÄNGT VON`) und gefundene
+PR-/Ticket-Referenzen in `depends_on` überführen. Genannte PRs gegen Merge-Status prüfen
+und bei bereits gemergten PRs den Blocker als aufgelöst markieren.

--- a/openspec/changes/prosa-blocker-detection-T002771/specs/ticket-ops.md
+++ b/openspec/changes/prosa-blocker-detection-T002771/specs/ticket-ops.md
@@ -1,0 +1,5 @@
+# Delta: ticket-ops
+## ADDED: Prosa-Blocker-Erkennung in Phase 1
+Die Completeness Triage MUSS Ticket-Beschreibungen auf Schlüsselwörter wie
+"BLOCKIERT VON", "hängt an" scannen und gefundene Referenzen in `depends_on`
+überführen. Bereits gemergte PRs werden als aufgelöster Blocker erkannt.

--- a/openspec/changes/prosa-blocker-detection-T002771/specs/ticket-ops.md
+++ b/openspec/changes/prosa-blocker-detection-T002771/specs/ticket-ops.md
@@ -1,5 +1,20 @@
 # Delta: ticket-ops
-## ADDED: Prosa-Blocker-Erkennung in Phase 1
+
+## ADDED Requirements
+
+### Requirement: Prosa-Blocker-Erkennung in Phase 1
 Die Completeness Triage MUSS Ticket-Beschreibungen auf Schlüsselwörter wie
 "BLOCKIERT VON", "hängt an" scannen und gefundene Referenzen in `depends_on`
 überführen. Bereits gemergte PRs werden als aufgelöster Blocker erkannt.
+
+#### Scenario: Prosa-Blocker wird in depends_on überführt
+
+- **GIVEN** eine Ticket-Beschreibung enthält "BLOCKIERT VON: PR #1234"
+- **WHEN** die Completeness Triage läuft
+- **THEN** die PR-Referenz wird in `depends_on` überführt
+
+#### Scenario: Bereits gemergter PR wird als aufgelöst erkannt
+
+- **GIVEN** eine Ticket-Beschreibung enthält "BLOCKIERT VON: PR #1234" und PR #1234 ist gemergt
+- **WHEN** die Completeness Triage läuft
+- **THEN** der Blocker wird als aufgelöst markiert und das DoR-Flag `abhaengigkeiten_klar` auf true gesetzt

--- a/openspec/changes/prosa-blocker-detection-T002771/tasks.md
+++ b/openspec/changes/prosa-blocker-detection-T002771/tasks.md
@@ -1,0 +1,10 @@
+# T002771 — Prosa-Blocker in depends_on überführen
+> **Type:** fix | **Severity:** minor | **Effort:** mittel
+
+## Tasks
+
+1. [ ] `ticket-ops-procedures.md` Phase 1: Keyword-Scanning-Regel für Prosa-Blocker dokumentieren
+2. [ ] `scripts/vda/ticket/triage.sh` oder Ticket-MCP: Keyword-Extraktion aus Beschreibung
+3. [ ] Gefundene PR-Referenzen via `gh pr view` auf Merge-Status prüfen
+4. [ ] `depends_on` automatisch setzen, wenn Blocker-Ticket identifiziert
+5. [ ] Test: BATS-Test mit Fake-Ticket-Beschreibung die "BLOCKIERT VON: T00XXXX" enthält


### PR DESCRIPTION
Triage: Keyword-Scanning auf "BLOCKIERT VON" etc. in Ticket-Beschreibungen. Gefundene Referenzen automatisch in `depends_on` überführen, gemergte PRs als aufgelöst erkennen.