### PR TITLE
chore(plans): enforce delta spec header format in openspec-flow-plan and openspec-propose [T002772]

### DIFF
--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -77,15 +77,18 @@ When ready to implement, run /opsx:apply (`/opsx-apply` in opencode)
   new capability with no existing SSOT spec, use the `outputPath` filename unchanged.
   See CLAUDE.md "Delta-Spec-Konvention (T001304)".
 
-> **Spec-Directory Pflicht-Inhalt (T001974 Mishap 3).** Jeder Change-Ordner
+> **Spec-Directory Pflicht-Inhalt (T001974 Mishap 3 + T002772).** Jeder Change-Ordner
 > unter `openspec/changes/<slug>/specs/` muss mindestens **eine** `.md`-Datei
-> mit gültigem Delta-Spec-Format enthalten (`## ADDED Requirements` +
-> `### Requirement:`-Blöcke). `openspec:validate` schlägt fehl, wenn das
-> Verzeichnis leer ist oder nur Löschungen (`## REMOVED Requirements`) ohne
-> Hinzufügungen enthält. Löschen einer ungültigen Spec-Datei ohne Ersatz
-> erzeugt einen leeren `specs/`-Ordner — das schlägt ebenfalls fehl. Vor
-> dem Commit: `bash scripts/openspec.sh validate` (oder
-> `openspec validate <slug>`) ausführen.
+> mit gültigem Delta-Spec-Format enthalten. Der Abschnitts-Header MUSS exakt
+> `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`
+> oder `## RENAMED Requirements` lauten (nicht `## ADDED:` / `## MODIFIED:` ohne
+> "Requirements"). Jeder `### Requirement:`-Block MUSS mindestens einen
+> `#### Scenario:`-Block im GIVEN/WHEN/THEN-Format enthalten.
+> `openspec:validate` schlägt fehl, wenn das Verzeichnis leer ist oder nur
+> Löschungen (`## REMOVED Requirements`) ohne Hinzufügungen enthält. Löschen
+> einer ungültigen Spec-Datei ohne Ersatz erzeugt einen leeren `specs/`-Ordner
+> — das schlägt ebenfalls fehl. Vor dem Commit:
+> `bash scripts/openspec.sh validate` (oder `openspec validate <slug>`) ausführen.
       - Create the artifact file using `template` as the structure
       - Apply `context` and `rules` as constraints - but do NOT copy them into the file
       - Show brief progress: "Created <artifact-id>"

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -301,7 +301,7 @@ hier harte Voraussetzung, nicht Stilfrage. Der Test gehört nach `tests/spec/<sp
 (die Spec aus `openspec/specs/`), nicht in eine neue ticket-nummerierte Datei.
 
 - Lege Bug-Ticket an (via ticket-mcp `create_ticket`), schreibe failing Test, erstelle Plan, stage, commit und push.
-- Hinweis: Erstelle zusätzlich zu `design.md` auch `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` nach der T001304-Delta-Konvention.
+- Hinweis: Erstelle zusätzlich zu `design.md` auch `openspec/changes/<slug>/specs/<parent-ssot-slug>.md` nach der T001304-Delta-Konvention. **Pflicht-Format:** Die Delta-Spec MUSS exakt einen der vier Abschnitts-Header verwenden: `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements` oder `## RENAMED Requirements`. Jede Anforderung beginnt mit `### Requirement: <Titel>` und enthält **mindestens einen** `#### Scenario:`-Block im GIVEN/WHEN/THEN-Format. `## ADDED:` / `## MODIFIED:` (ohne "Requirements") und Szenario-lose Requirements werden von `scripts/openspec-validate.test.ts` → `validateTree` abgelehnt und blockieren den CI-Merge.
 - `--hold`-Pflicht für interaktive Stage-Calls: Der Aufruf von `stage-plan` in diesem Schritt
   MUSS `--hold` setzen. Dadurch wird das Ticket vom Factory-Dispatch zurückgehalten, bis
   `opencode-flow-execute` es explizit freigibt.


### PR DESCRIPTION
## Purpose

Die 5 Mishap-Fix-PRs #3905-#3909 waren alle durch CI blockiert, weil ihre Delta-Spec-Dateien nicht dem validierten Format entsprachen:

- `## ADDED:` / `## MODIFIED:` statt `## ADDED Requirements` / `## MODIFIED Requirements`
- Keine `#### Scenario:`-Blöcke unter `### Requirement:`

**Root Cause:** Die `openspec-flow-plan` und `openspec-propose` Skills dokumentierten das korrekte Format nicht explizit genug.

**Fix:** Beide Skills enthalten jetzt explizite Format-Vorgaben mit den vier gültigen Headern, dem Requirement→Scenario-Pattern und dem Hinweis auf die CI-Blockade durch `validateTree`.