### PR TITLE
test(ops): Guard fuer qwen3-coder — Loadout-Port und Proxy-Registrierung muessen uebereinstimmen [T002645]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 829,
+      "file_count": 830,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -489,6 +489,7 @@
         "tests/spec/local-llm-proxy/opencode-routes-via-proxy.bats",
         "tests/spec/local-llm-proxy/proxy-env-token-guard.bats",
         "tests/spec/local-llm-proxy/proxy-tests-registered.bats",
+        "tests/spec/local-llm-proxy/qwen3-coder-loadout.bats",
         "tests/spec/local-llm-proxy/ui-config-seed.bats",
         "tests/spec/lockfile-drift.bats",
         "tests/spec/main-commit-guard.bats",

--- a/openspec/changes/qwen3-coder-loadout/tasks.md
+++ b/openspec/changes/qwen3-coder-loadout/tasks.md
@@ -118,3 +118,39 @@ task test:changed
 task freshness:regenerate
 task freshness:check
 ```
+
+---
+
+## Nachtrag 2026-08-09 — der Plan wurde von der Wirklichkeit überholt
+
+Dieser Plan entstand am 2026-08-04 und beschreibt ein **neues** Loadout `qwen3-coder` auf
+Port 8097 mit `Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL.gguf`. Beides ist überholt und der
+Loadout-Schritt wäre heute **nicht ausführbar**:
+
+- Die Datei `…-UD-Q4_K_XL.gguf` existiert nicht. Unter `~/models/gguf/qwen3coder30/` liegen
+  `…-Q3_K_M.gguf` und `…-UD-IQ3_XXS.gguf`. Der seit T002753 bestehende Guard
+  `tests/spec/local-llm-proxy/loadout-model-files-exist.bats` ließe einen Eintrag auf die
+  fehlende Datei sofort rot fallen.
+- Das Loadout existiert bereits: **T002753** hat es am 2026-08-08 unter dem Slug
+  `qwen3-coder-30b` auf **Port 8094** mit **UD-IQ3_XXS** und KV `q4_0` angelegt.
+- Die Proxy-Registrierung existiert ebenfalls, aber unter anderem Namen als geplant:
+  `scripts/migrations/2026-08-04-llm-proxy-gemma-qwen-families.sql` legt das Backend
+  `llamacpp-qwen` auf `http://127.0.0.1:8094/v1` an; in der Datenbank steht es mit
+  `enabled = true`.
+
+Zwei der drei Deliverables waren damit erfüllt, ohne dass dieser Plan je ausgeführt wurde.
+Offen war allein der BATS-Guard.
+
+**Geliefert wurde deshalb ein anderer Test als geplant.** Statt „Eintrag existiert und meldet
+Port 8097" prüft `tests/spec/local-llm-proxy/qwen3-coder-loadout.bats`, dass Loadout und
+Proxy-Registrierung **denselben** Port nennen — die Invariante, die zwischen zwei getrennt
+gepflegten Quellen tatsächlich brechen kann. Belegt durch Mutationsprobe: wird der Port im
+Loadout auf 8097 verstellt (also auf den ursprünglich geplanten Wert), fällt der Test rot,
+während der Positiv-Anker grün bleibt.
+
+Die im Plan vorgesehene Eindeutigkeitsprüfung auf Ports wurde **verworfen**: Port 8091 wird
+von `gemma26-factory`, `gemma4-base` und `gemma4-tuned` geteilt, was durch die gemeinsame
+`exclusiveGroup "chat-gpu"` zulässig ist. Ein Guard „jeder Port genau einmal" wäre falsch.
+
+Der Loadout-Step und der Migrations-Step dieses Plans bleiben unausgeführt und sind es auch
+nicht mehr wert — sie würden ein Duplikat auf einem zweiten Port anlegen.

--- a/tests/spec/local-llm-proxy/qwen3-coder-loadout.bats
+++ b/tests/spec/local-llm-proxy/qwen3-coder-loadout.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# T002645 — Das qwen3-coder-Loadout und seine Proxy-Registrierung muessen denselben
+# Port nennen.
+#
+# PRUEFMODUS: Querschnitts-Konsistenz zwischen zwei Deklarationen (die in CLAUDE.md
+# benannte Ausnahme zu T002448-M4). Die Invariante existiert nicht im Laufzeitverhalten
+# einer einzelnen Komponente, sondern in der Beziehung zweier Quellen: scripts/llm/loadouts.json
+# sagt, auf welchem Port llama.cpp lauscht; die Migration in scripts/migrations/ sagt, wohin
+# der Proxy routet. Laufen sie auseinander, startet das Modell und der Proxy schickt trotzdem
+# ins Leere — ohne Fehlermeldung an der Stelle, an der man sucht.
+#
+# WARUM DIESER GUARD NACHTRAEGLICH ENTSTEHT: T002645 plante das Loadout auf Port 8097 mit
+# UD-Q4_K_XL. Geliefert wurde es dann von T002753 auf Port 8094 mit UD-IQ3_XXS. Loadout und
+# Backend-Zeile stimmen heute ueberein — aber nichts hat das geprueft, und genau die Art
+# Doppelquelle ist in dieser Codebasis schon mehrfach auseinandergelaufen. Der Test sichert
+# also bestehendes Verhalten ab; er ist kein RED-GREEN-Schritt fuer neues Verhalten.
+#
+# NICHT GEPRUEFT (bewusst, andernorts abgedeckt):
+#   - Existenz der Modelldatei  -> loadout-model-files-exist.bats (T002753)
+#   - kanonische JSON-Form      -> loadouts-format.bats (T002553)
+#   - Port-Literale im Gateway  -> gateway-consumer-lint.bats (T002582)
+#
+# KEINE EINDEUTIGKEITS-PRUEFUNG AUF PORTS: Port 8091 wird von gemma26-factory, gemma4-base
+# und gemma4-tuned geteilt. Das ist zulaessig, weil alle drei in exclusiveGroup "chat-gpu"
+# liegen und nie gleichzeitig laufen. Ein Guard "jeder Port genau einmal" waere also falsch.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  LOADOUTS="${REPO_ROOT}/scripts/llm/loadouts.json"
+  BACKEND_MIGRATION="${REPO_ROOT}/scripts/migrations/2026-08-04-llm-proxy-gemma-qwen-families.sql"
+  QWEN_SLUG="qwen3-coder-30b"
+  QWEN_BACKEND="llamacpp-qwen"
+}
+
+@test "T002645: das qwen3-coder-Loadout ist registriert und nennt einen Port (Anker)" {
+  [ -f "$LOADOUTS" ]
+
+  run jq -r --arg s "$QWEN_SLUG" '[.loadouts[] | select(.slug == $s)] | length' "$LOADOUTS"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+
+  run jq -r --arg s "$QWEN_SLUG" '.loadouts[] | select(.slug == $s) | .port' "$LOADOUTS"
+  [ "$status" -eq 0 ]
+  # Ein Port, kein null und keine leere Ausgabe — sonst waere jede Aussage darueber wertlos.
+  [[ "$output" =~ ^[0-9]+$ ]]
+
+  # Das Loadout teilt sich die GPU mit den uebrigen Chat-Loadouts; ohne diese Gruppe
+  # koennten zwei Modelle gleichzeitig starten und sich den VRAM streitig machen.
+  run jq -r --arg s "$QWEN_SLUG" '.loadouts[] | select(.slug == $s) | .exclusiveGroup' "$LOADOUTS"
+  [ "$output" = "chat-gpu" ]
+}
+
+@test "T002645: Loadout-Port und Proxy-Backend-Registrierung nennen denselben Port" {
+  [ -f "$BACKEND_MIGRATION" ]
+
+  loadout_port="$(jq -r --arg s "$QWEN_SLUG" '.loadouts[] | select(.slug == $s) | .port' "$LOADOUTS")"
+  [[ "$loadout_port" =~ ^[0-9]+$ ]]
+
+  # POSITIV-ANKER (T002356-M1) ZUERST: die Backend-Zeile muss ueberhaupt existieren und einen
+  # Port tragen. Ohne ihn bestuende der Vergleich vakuos — zwei leere Zeichenketten sind
+  # gleich, und der Test waere auch dann gruen, wenn die Registrierung ganz fehlte.
+  backend_port="$(grep -F "'${QWEN_BACKEND}'" "$BACKEND_MIGRATION" \
+    | grep -oE 'http://127\.0\.0\.1:[0-9]+' | grep -oE '[0-9]+$' | head -1)"
+  [ -n "$backend_port" ]
+  [[ "$backend_port" =~ ^[0-9]+$ ]]
+
+  # Eigentliche Aussage.
+  [ "$loadout_port" = "$backend_port" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2856,6 +2856,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/qwen3-coder-loadout",
+    "file": "tests/spec/local-llm-proxy/qwen3-coder-loadout.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/ui-config-seed",
     "file": "tests/spec/local-llm-proxy/ui-config-seed.bats",
     "category": "local-llm-proxy",


### PR DESCRIPTION
## Was

Schließt **T002645** ab — allerdings anders, als der Plan es vorsah.

## Der Plan war überholt und unbaubar

Der Plan vom 04.08. verlangt ein neues Loadout `qwen3-coder` auf **Port 8097** mit `Qwen3-Coder-30B-A3B-Instruct-UD-Q4_K_XL.gguf`. Diese Datei **existiert nicht** — unter `~/models/gguf/qwen3coder30/` liegen nur `Q3_K_M` und `UD-IQ3_XXS`. Der seit T002753 bestehende Guard `loadout-model-files-exist.bats` ließe so einen Eintrag sofort rot fallen.

Zwei der drei Deliverables waren bereits erfüllt, ohne dass dieser Plan je lief:

| Deliverable | Stand | geliefert von |
|---|---|---|
| Loadout in `loadouts.json` | ✅ `qwen3-coder-30b`, Port **8094**, UD-IQ3_XXS | T002753 (08.08.) |
| Proxy-Backend-Registrierung | ✅ `llamacpp-qwen` → `:8094`, `enabled=true` in der DB | `2026-08-04-llm-proxy-gemma-qwen-families.sql` |
| BATS-Guard | ❌ fehlte | **dieser PR** |

Den Loadout- und den Migrations-Step auszuführen würde ein Duplikat auf einem zweiten Port anlegen. Sie bleiben unausgeführt; der Plan trägt einen Nachtrag, der das festhält.

## Was stattdessen geliefert wird

Statt „Eintrag existiert und meldet Port 8097" prüft `tests/spec/local-llm-proxy/qwen3-coder-loadout.bats`, dass **Loadout und Proxy-Registrierung denselben Port nennen**. Das ist die Invariante, die zwischen zwei getrennt gepflegten Quellen real brechen kann: laufen sie auseinander, startet das Modell und der Proxy routet trotzdem ins Leere — ohne Fehlermeldung an der Stelle, an der man sucht.

**Mutationsprobe als Beleg gegen einen vakuosen Guard:** Port im Loadout auf 8097 verstellt (also auf den ursprünglich geplanten Wert) → Test 2 fällt rot, der Positiv-Anker bleibt grün. Datei danach wiederhergestellt (leerer Diff).

Die im Plan vorgesehene **Eindeutigkeitsprüfung auf Ports wurde verworfen**: Port 8091 teilen sich `gemma26-factory`, `gemma4-base` und `gemma4-tuned` — zulässig über die gemeinsame `exclusiveGroup "chat-gpu"`, weil nie zwei gleichzeitig laufen. Ein Guard „jeder Port genau einmal" wäre schlicht falsch.

## Kein RED-GREEN

Der Test sichert **bestehendes** Verhalten ab; ein RED war nicht herstellbar, weil das Loadout bereits existiert. Der Beleg, dass der Guard beißt, ist die Mutationsprobe oben statt eines künstlichen Fehlschlags.

## Verifikation

- `bats -r tests/spec/local-llm-proxy*` — 128 Tests, die beiden neuen grün
- `task test:spec:changed` — grün bis auf zwei vorbestehende Gruppen
- `task freshness:regenerate` + Inventar-Guard `test-inventory-coverage.bats` grün
- `plan-lint` auf den nachgetragenen Plan: PASS (0 hard, 0 warn)

**Vorbestehende Fehlschläge, gegen `main` gegengeprüft und nicht von diesem PR verursacht:** `ui-config-seed.bats` Task 8 (`llama-server failed to start`, umgebungsabhängig) und drei `backfill-id-sequence`-Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NAwFqXtsPZMPVWEx7U65j
