### PR TITLE
fix(infra): bge-embed -np 4->2 und limits.memory 3Gi->4Gi [T002835]

### DIFF
--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -106,8 +106,21 @@ spec:
             - "8192"
             - "-ub"
             - "8192"
+            # T002835: -np 4 -> 2. Der Speicherbedarf skaliert mit -np x -ub;
+            # vier Slots erzeugten die Peaks, die T002580 durch ein hoeheres
+            # Limit aufzufangen versuchte. Durchsatz kosten sie nichts: bei
+            # limits.cpu 2000m / -t 2 stehen hinter vier Slots nur zwei
+            # Threads. Gemessen am 2026-08-09: CPU 1977m von 2000m (99 %) —
+            # die Parallelitaet wartet auf Kerne, die es nicht gibt.
+            #
+            # -ub bleibt bei 8192 und ist KEIN Stellhebel: bge-m3 ist
+            # nicht-kausal (XLM-RoBERTa), llama.cpp kann eine solche Sequenz
+            # nicht ueber mehrere physische Batches aufteilen. Jeder Input
+            # laenger als -ub scheitert mit "input is too large to process"
+            # (T002260) — eine Senkung braeche lange Texte still, waehrend
+            # Kurztext-Smoke-Tests gruen blieben.
             - "-np"
-            - "4"
+            - "2"
             # T002661: -t MUSS zur CPU-Quota passen. Ohne das Flag waehlt
             # llama.cpp nproc — im Container 8 (der Node hat 8 Kerne, cgroup
             # maskiert nproc nicht), waehrend limits.cpu 2000m nur 2 Kerne
@@ -132,13 +145,16 @@ spec:
               memory: "1Gi"
               cpu: "1000m"
             limits:
-              # T002580: limits.memory 2Gi -> 3Gi. Gemessener Peak-RSS unter
-              # 64er-Embedding-Batch-Last: ~1.94Gi (kubectl top pod, 2026-08-03),
-              # stabil auch bei 96 Requests mit langen Texten. 2Gi liess nur
-              # ~60Mi Headroom -> OOMKilled-Restart-Schleife (9 Restarts in 6h).
-              # 3Gi = Peak + ~1Gi Headroom; -np 4 -ub 8192 bleibt erhalten
-              # (Durchsatz fuer den T002572-Benchmark). Guard: llm-pipeline.bats.
-              memory: "3Gi"
+              # T002835: limits.memory 3Gi -> 4Gi. T002580 hob 2Gi -> 3Gi auf
+              # Basis eines Peak-RSS von ~1.94Gi (2026-08-03) und liess -np 4
+              # -ub 8192 stehen. Das reichte nicht: gemessen am 2026-08-09
+              # 2647Mi von 3072Mi (86 %) und 6 OOMKills in 11h, letzter
+              # exitCode 137 am 2026-08-08 18:22. Der Fix hat zwei Haelften —
+              # das Limit gibt Kopfraum ueber dem realen Peak, die gesenkte
+              # Parallelitaet (-np 2, oben) nimmt den Peaks die Ursache.
+              # Ohne die zweite Haelfte verschoebe sich die Grenze nur.
+              # Guard: llm-pipeline.bats.
+              memory: "4Gi"
               cpu: "2000m"
           readinessProbe:
             httpGet:

--- a/tests/spec/llm-pipeline.bats
+++ b/tests/spec/llm-pipeline.bats
@@ -297,16 +297,20 @@ assert_var_not_declared() {
   [ "$output" -eq 4 ]
 }
 
-# ── bge-embed OOM-Guard (T002580) ─────────────────────────────────────
+# ── bge-embed OOM-Guard (T002580, verschaerft durch T002835) ──────────
 # bge-embed lief wiederholt in OOMKilled (limits.memory 2Gi, 9 Restarts in 6h).
-# Gemessener Peak-RSS unter 64er-Embedding-Batch-Last: ~1.94Gi (kubectl top pod,
-# 2026-08-03) — 2Gi liess nur ~60Mi Headroom. Fix: limits.memory auf 3Gi
-# angehoben, -np 4 -ub 8192 bleibt erhalten (Durchsatz fuer den T002572-
-# Benchmark). Dieser Guard sichert die gewaehlte Kombination statisch ab: eine
-# kuenftige Senkung des Limits unter den gemessenen Peak oder eine arglose
-# Aenderung der Batch-Parameter darf nicht unbemerkt durchrutschen.
+# T002580 hob das Limit auf 3Gi (Peak-RSS ~1.94Gi, gemessen 2026-08-03) und
+# liess -np 4 -ub 8192 stehen. Das reichte nicht: am 2026-08-09 lag der Pod bei
+# 2647Mi von 3072Mi (86 %) mit 6 weiteren OOMKills in 11h. T002835 zieht daher
+# beide Haelften — limits.memory 4Gi UND -np 2 — und dieser Guard sichert sie
+# gemeinsam ab. Ein Limit-Bump ohne die gesenkte Parallelitaet verschiebt die
+# Grenze nur; genau das war der Fehler von T002580.
+#
+# -ub bleibt bewusst bei 8192 und ist KEIN Stellhebel — siehe den Guard
+# "bge-K8s-Manifest setzt -b und -ub auf volle Kontextlaenge (T002260)" oben:
+# bge-m3 ist nicht-kausal, eine Senkung braeche jeden Input > -ub still.
 
-@test "bge-embed OOM-Guard: limits.memory >= 3Gi und dokumentiert (T002580)" {
+@test "bge-embed OOM-Guard: limits.memory >= 4Gi und dokumentiert (T002835)" {
   local f="$REPO/k3d/llm-gpu.yaml"
   # Das bge-embed-Deployment muss limits.memory auf mindestens 3Gi setzen.
   # Der Wert steht im bge-embed-Block (vor dem bge-rerank-Block); geprueft wird
@@ -316,24 +320,27 @@ assert_var_not_declared() {
   first_limit="$(awk '/limits:/{found=1} found && /memory:/{print; exit}' "$f" \
     | sed -E 's/.*memory:[[:space:]]*"?([0-9]+)Gi"?.*/\1/')"
   [ -n "$first_limit" ] || { echo "kein memory-Limit im bge-embed-Block gefunden"; false; }
-  [ "$first_limit" -ge 3 ] || { echo "bge-embed limits.memory=${first_limit}Gi < 3Gi — unter gemessenem Peak+Headroom"; false; }
-  # Die Begruendung (T002580) muss im Manifest stehen, damit die Wahl nicht
-  # stillschweigend zurueckgedreht wird.
-  run grep -q 'T002580' "$f"
+  [ "$first_limit" -ge 4 ] || { echo "bge-embed limits.memory=${first_limit}Gi < 4Gi — unter gemessenem Peak (2647Mi) plus Headroom"; false; }
+  # Die Begruendung muss im Manifest stehen, damit die Wahl nicht
+  # stillschweigend zurueckgedreht wird. Beide Ticket-Referenzen: T002580 haelt
+  # die Vorgeschichte, T002835 die geltende Entscheidung.
+  run grep -q 'T002835' "$f"
   [ "$status" -eq 0 ]
 }
 
-@test "bge-embed OOM-Guard: -np 4 -ub 8192 bleibt erhalten (T002580)" {
+@test "bge-embed OOM-Guard: -np im bge-embed-Block ist 2 (T002835)" {
   local f="$REPO/k3d/llm-gpu.yaml"
-  # Durchsatz fuer den T002572-Benchmark: -np 4 und -ub 8192 muessen im
-  # bge-embed-Block stehen bleiben. -np 4 kommt genau 2x vor (embed + rerank),
-  # -ub 8192 genau 2x.
+  # Positiv-Anker zuerst (T002356-M1): -np muss ueberhaupt in beiden
+  # bge-Deployments gesetzt sein, sonst prueft der Wert-Test unten ins Leere.
   run grep -cE '^[[:space:]]+- "-np"[[:space:]]*$' "$f"
-  [ "$output" -eq 2 ]
-  run grep -cE '^[[:space:]]+- "4"[[:space:]]*$' "$f"
-  [ "$output" -eq 2 ]
-  run grep -cE '^[[:space:]]+- "-ub"[[:space:]]*$' "$f"
-  [ "$output" -eq 2 ]
+  [ "$output" -eq 2 ] || { echo "-np steht nicht 2x im Manifest (embed + rerank) — Guard prueft ins Leere"; false; }
+
+  # Der Wert im bge-embed-Block: erster -np-Eintrag nach 'name: bge-embed'.
+  # llama.cpp nimmt den Wert als eigenen Listeneintrag direkt nach dem Flag.
+  local np
+  np="$(awk '/^  name: bge-embed$/{f=1} f && /- "-np"/{getline; gsub(/[^0-9]/,""); print; exit}' "$f")"
+  [ -n "$np" ] || { echo "kein -np-Wert im bge-embed-Block gefunden"; false; }
+  [ "$np" -le 2 ] || { echo "bge-embed -np=${np} > 2 — vier Slots ueber -t 2 Threads erzeugten die OOM-Peaks (T002835)"; false; }
 }
 
 # ── CPU-only im Cluster (T002337) ─────────────────────────────────────


### PR DESCRIPTION
## Problem

T002580 hob `limits.memory` 2Gi → 3Gi (PR #3732) auf Basis eines Peak-RSS von ~1.94Gi (gemessen 2026-08-03) und liess `-np 4` stehen. Das reichte nicht.

Messung am 2026-08-09 (`kubectl top pod -l app=bge-embed`, fleet/workspace, pk-hetzner-8):

| Ressource | Wert | Auslastung |
|---|---|---|
| Memory | 2647Mi / 3072Mi | 86 % |
| CPU | 1977m / 2000m | **99 %, gesättigt** |
| Restarts | 6 in 11h | letzter `exitCode 137 / OOMKilled` am 2026-08-08 18:22 |

Beobachtete Auswirkung: `POST /v1/embeddings` antwortete über 60s nicht (Client-Timeout), während `/health` weiter 200 lieferte — der Health-Check fasst die Inferenz-Queue nicht an. Betroffen waren `bge-mcp` (:13005) und damit Embedding in opencode sowie `scripts/openspec-embed-local.sh`.

## Fix

Beide Hälften, nicht nur eine:

- `limits.memory` 3Gi → **4Gi** — Kopfraum über dem realen Peak
- `-np` 4 → **2** — nimmt den Peaks die Ursache

Ein reiner Limit-Bump verschöbe die Grenze nur; genau das war der Fehler von T002580. `-np 4` über `-t 2` Threads brachte ohnehin keinen Durchsatz.

## Was bewusst NICHT geändert wurde

`-ub` bleibt bei 8192. Der Guard aus T002260 begründet warum: bge-m3 ist nicht-kausal (XLM-RoBERTa), llama.cpp kann eine solche Sequenz nicht über mehrere physische Batches aufteilen. Eine Senkung bräche jeden Input länger als `-ub` still, während Kurztext-Smoke-Tests grün blieben. Der erste Entwurf dieses PRs senkte `-ub` auf 2048 — der bestehende Guard hat das gefangen.

## Verifikation

- `bats -r tests/spec/llm-pipeline*` — 78/78 grün (beide Formen, Sammeldatei + Verzeichnis)
- `task workspace:validate` — Manifeste valide
- Guard `bge-embed OOM-Guard: -np im bge-embed-Block ist 2 (T002835)` mit Positiv-Anker nach T002356-M1

Closes T002835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYbeCbnqBfzvvVPwuKqAYM