### PR TITLE
chore(scripts): bge-mcp callUpstream bricht bei schweigendem Upstream ab [T002838]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 836,
+      "file_count": 837,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -472,6 +472,7 @@
         "tests/spec/local-llm-proxy.bats",
         "tests/spec/local-llm-proxy/bge-cpu-parallel-start.bats",
         "tests/spec/local-llm-proxy/bge-loadout-cpu-bound.bats",
+        "tests/spec/local-llm-proxy/bge-mcp-upstream-timeout.bats",
         "tests/spec/local-llm-proxy/bge-token-ssot.bats",
         "tests/spec/local-llm-proxy/embed-bge-fallback.bats",
         "tests/spec/local-llm-proxy/embed-probe-timeout.bats",

--- a/scripts/bge-mcp/server.mjs
+++ b/scripts/bge-mcp/server.mjs
@@ -101,7 +101,20 @@ function target(role) {
  * systemd-Unit) mehrere Schritte entfernt lag. Die Rolle und die aufgeloeste
  * Zieladresse gehoeren deshalb in die Meldung: sie zeigen sofort, ob der
  * Router falsch aufloest oder der Endpoint nicht antwortet.
+ *
+ * Der Aufruf ist zeitlich begrenzt (T002838). Ein *toter* Endpoint wirft
+ * sofort; ein *ueberlasteter* nahm die Verbindung an und antwortete dann nie —
+ * ohne Signal wartete `fetch` unbegrenzt. Am 2026-08-09 hing bge_embed so
+ * ueber 60s am Cluster-Endpoint, waehrend dessen /health weiter 200 lieferte:
+ * der MCP-Client sah ein blockiertes Werkzeug statt einer Fehlermeldung.
+ * Ein Timeout macht daraus einen Fehler, den der Aufrufer sehen und
+ * weiterreichen kann. Ueberschreibbar per BGE_MCP_UPSTREAM_TIMEOUT_MS.
  */
+const UPSTREAM_TIMEOUT_MS = Number.parseInt(
+  process.env.BGE_MCP_UPSTREAM_TIMEOUT_MS ?? '30000',
+  10,
+);
+
 async function callUpstream(role, url, path, payload) {
   let r;
   try {
@@ -109,8 +122,18 @@ async function callUpstream(role, url, path, payload) {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
   } catch (cause) {
+    // TimeoutError vom Abort getrennt melden: "nicht erreichbar" und "hat
+    // angenommen, aber nicht geantwortet" fuehren zu verschiedenen Diagnosen.
+    if (cause?.name === 'TimeoutError') {
+      throw new Error(
+        `bge_${role}: upstream at ${url}${path} did not answer within ${UPSTREAM_TIMEOUT_MS}ms `
+          + '(connection accepted — endpoint overloaded or queue saturated)',
+        { cause },
+      );
+    }
     throw new Error(
       `bge_${role}: upstream unreachable at ${url}${path} (${cause?.message ?? String(cause)})`,
       { cause },

--- a/tests/spec/local-llm-proxy/bge-mcp-upstream-timeout.bats
+++ b/tests/spec/local-llm-proxy/bge-mcp-upstream-timeout.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Pruefmodus: command output verification [T002448-M4] — der Test startet den
+# bge-MCP-Shim gegen einen Upstream, der die Verbindung annimmt und dann nie
+# antwortet, und prueft die tatsaechliche JSON-RPC-Antwort. Kein Source-Grep:
+# dass `AbortSignal` im Quelltext steht, belegt nicht, dass der Aufruf
+# abbricht.
+#
+# Hintergrund (T002838): callUpstream rief `fetch` ohne Signal auf. Ein toter
+# Endpoint warf sofort, ein ueberlasteter liess den Aufruf unbegrenzt haengen —
+# am 2026-08-09 ueber 60s, waehrend /health des Endpoints weiter 200 lieferte.
+# Der MCP-Client sah ein blockiertes Werkzeug statt einer Fehlermeldung.
+
+setup() {
+  REPO="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  PORT_HANG=$((20000 + RANDOM % 1000))
+  PORT_MCP=$((21000 + RANDOM % 1000))
+
+  # Upstream, der annimmt und schweigt — genau der Fall, den ein reines
+  # "unreachable" nicht abdeckt.
+  node -e "
+    require('http').createServer(() => {}).listen($PORT_HANG, '127.0.0.1');
+  " &
+  HANG_PID=$!
+
+  BGE_MCP_TOKEN=testtoken \
+  BGE_MCP_PORT="$PORT_MCP" \
+  BGE_MCP_UPSTREAM_TIMEOUT_MS=800 \
+  LLM_EMBED_URL="http://127.0.0.1:$PORT_HANG" \
+  LLM_RERANKER_URL="http://127.0.0.1:$PORT_HANG" \
+    node "$REPO/scripts/bge-mcp/server.mjs" >/dev/null 2>&1 &
+  MCP_PID=$!
+
+  # Warten per curl statt /dev/tcp: BATS belegt FD 3 selbst, ein `exec 3<>`
+  # hier bricht den Testlauf mit "Bad file descriptor" ab.
+  for _ in $(seq 1 30); do
+    curl -s --max-time 1 -o /dev/null "http://127.0.0.1:$PORT_MCP/mcp" && break
+    sleep 0.2
+  done
+}
+
+teardown() {
+  [ -n "${MCP_PID:-}" ] && kill "$MCP_PID" 2>/dev/null
+  [ -n "${HANG_PID:-}" ] && kill "$HANG_PID" 2>/dev/null
+  return 0
+}
+
+@test "bge_embed bricht bei schweigendem Upstream ab statt zu haengen (T002838)" {
+  # Positiv-Anker zuerst [T002356-M1]: der Shim muss ueberhaupt antworten.
+  # Ohne ihn koennte der Test auch bei einem gar nicht gestarteten Server
+  # gruen wirken, sobald die Fehlerpruefung unten leer ausginge.
+  run curl -s --max-time 10 -X POST "http://127.0.0.1:$PORT_MCP/mcp" \
+    -H "Authorization: Bearer testtoken" \
+    -H "Accept: application/json, text/event-stream" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"bats","version":"1"}}}'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"serverInfo"'* ]] || { echo "Shim antwortet nicht auf initialize: $output"; false; }
+
+  # Der eigentliche Vorgang: der Aufruf MUSS innerhalb der curl-Frist
+  # zurueckkehren. Vor dem Fix lief er in --max-time und $status waere 28.
+  run curl -s --max-time 10 -X POST "http://127.0.0.1:$PORT_MCP/mcp" \
+    -H "Authorization: Bearer testtoken" \
+    -H "Accept: application/json, text/event-stream" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"bge_embed","arguments":{"texts":["ping"]}}}'
+  [ "$status" -eq 0 ] || { echo "curl lief in den Timeout (status=$status) — der Shim haengt weiterhin"; false; }
+  [[ "$output" == *"did not answer within"* ]] || { echo "keine Timeout-Diagnose in der Antwort: $output"; false; }
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2760,6 +2760,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/bge-mcp-upstream-timeout",
+    "file": "tests/spec/local-llm-proxy/bge-mcp-upstream-timeout.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/bge-token-ssot",
     "file": "tests/spec/local-llm-proxy/bge-token-ssot.bats",
     "category": "local-llm-proxy",


### PR DESCRIPTION
## Problem

`callUpstream` in `scripts/bge-mcp/server.mjs` rief `fetch` ohne `AbortSignal` auf. Ein **toter** Endpoint warf sofort (die Diagnose aus T002604 griff), ein **überlasteter** liess den Aufruf unbegrenzt hängen.

Beobachtet am 2026-08-09: `bge_embed` hing über 60 s am Cluster-Endpoint `llm-gateway-embed`, während dessen `/health` weiter 200 lieferte — der Health-Check fasst die Inferenz-Queue nicht an. Der MCP-Client (opencode) sah ein blockiertes Werkzeug statt einer Fehlermeldung.

## Änderung

- `AbortSignal.timeout` mit 30 s Default, überschreibbar per `BGE_MCP_UPSTREAM_TIMEOUT_MS`
- `TimeoutError` wird **getrennt** von `unreachable` gemeldet — "nicht erreichbar" und "hat angenommen, aber nicht geantwortet" führen zu verschiedenen Diagnosen

## Test

`tests/spec/local-llm-proxy/bge-mcp-upstream-timeout.bats` startet den Shim gegen einen Upstream, der die Verbindung annimmt und dann schweigt, und prüft die tatsächliche JSON-RPC-Antwort (command output verification nach T002448-M4, kein Source-Grep).

Gegenprobe ohne den Fix: `curl` läuft in `--max-time`, `status=28` — der Test ist nicht vakuos. Positiv-Anker nach T002356-M1 vorhanden.

Nebenbefund im Bau: BATS belegt FD 3 selbst, ein `exec 3<>` im `setup()` bricht den Lauf mit "Bad file descriptor" ab; das Warten läuft daher über curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYbeCbnqBfzvvVPwuKqAYM