### PR TITLE
chore(agents): skills/MCPs auf lokale Ressourcen ausgerichtet, Registry-SSOT gehärtet [T002851]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ opencode reads its agents from `.opencode/agent-models.jsonc` — NOT `.agents/a
 Dispatch:
 - `task` for the local family subagents (`gptoss`, `devstral`, `gemma`, `qwen`) and the deepseek agents — the `orchestrator` permission block lists exactly those names, no wildcards (T002298).
 - Local family agents `edit` but cannot `write` new files (`write=deny`) — the orchestrator creates new files from their output. Read-only work uses `delegate` (explore/general).
-- SSOT is `.opencode/agent-models.jsonc`. `docs/agent-guide/registry/agents.yaml` mirrors it but LAGS the config — trust the jsonc. Global config sync: `bash scripts/opencode-sync-agents.sh`.
+- SSOT is `.opencode/agent-models.jsonc` — the only source of truth for agent→model mapping. `docs/agent-guide/registry/agents.yaml` mirrors it for the agent-guide docs; `tests/spec/agent-roster.bats` (P4.3b) fails on any model-string drift, so the mirror cannot lag silently. Global config sync: `bash scripts/opencode-sync-agents.sh`.
 - **Local subagents are named by model FAMILY since 2026-08-04** (`gptoss`/`devstral`/`gemma`/`qwen`), each serving its own loadout through the llm-proxy. The old `gemma26-1/2`, `gemma9-1/2` names all pointed at gptoss-context — the name lied about the model. Every GPU loadout shares `exclusiveGroup "chat-gpu"`: only one runs at a time (all of `loadouts.json` except the two CPU bge loadouts). The weightless loadouts (`gemma-factory`, `gemma-multiagent`, `gemma9-factory`) were removed on 2026-08-09 (T002753); `gemma`/`gemma26-primary`/`gemma26-vision` serve `gemma26-factory` (Gemma 4 26B A4B UD-IQ4_XS, 161024 ctx measured).
 
 ## Core Commands

--- a/docs/agent-guide/maps/agents-map.md
+++ b/docs/agent-guide/maps/agents-map.md
@@ -27,9 +27,9 @@ Die Registry ist die SSOT: `docs/agent-guide/registry/agents.yaml`.
 | deepseek-pro | all | opencode-go/deepseek-v4-pro | ja | DeepSeek-V4 Pro (1M ctx, max reasoning effort) for deep analysis and hard refactors; tab-selectable + task-dispatchable [T002632] |
 | deepseek-pro-direct | all | deepseek/deepseek-v4-pro | ja | Same model as deepseek-pro, but over the direct DeepSeek API instead of opencode-go — fallback when the gateway is unavailable; tab-selectable + task-dispatchable [T002633] |
 | devstral | subagent | llamacpp-local/devstral-quality | nein | devstral family: Devstral-Small-2 24B IQ4_XS [2026-08-04] |
-| gemma | subagent | llamacpp-local/gemma4 | nein | gemma family: Gemma 4 12B Q4_K_M, Loadout gemma4 auf Port 8090 [2026-08-04] |
-| gemma26-primary | primary | llamacpp-local/gptoss-context | nein | Tab-selectable primary local agent, 105472 ctx (measured, not n_ctx_train) [T002545/T002633] |
-| gemma26-vision | primary | llamacpp-local/gptoss-context | nein | Max context, no subagent dispatch. Text-only — gpt-oss-20b has no mmproj [T002633] |
+| gemma | subagent | llamacpp-local/gemma26-factory | nein | gemma family: Gemma 4 26B A4B IQ4_XS, Loadout gemma26-factory auf Port 8091 (exclusiveGroup chat-gpu) [2026-08-09 T002753] |
+| gemma26-primary | primary | llamacpp-local/gemma26-factory | nein | Tab-selectable primary local agent, 161024 ctx measured (np=3 -kvu q4_0 fitt 128) [T002753] |
+| gemma26-vision | primary | llamacpp-local/gemma26-factory | nein | Max context, no subagent dispatch. Vision IS available — gemma26-factory loads mmproj-F16.gguf since T002753 |
 | gptoss | subagent | llamacpp-local/gptoss-context | nein | gpt-oss family: gpt-oss-20b Q8_0, 105472 ctx (measured, not n_ctx_train) [T002545/T002633] |
 | orchestrator | primary | opencode-go/deepseek-v4-flash | ja | Primary orchestrator, dispatches the local family subagents (gptoss/devstral/gemma/qwen) sequentially |
 | qwen | subagent | llamacpp-local/qwen3-coder-30b | nein | qwen family: Qwen3-Coder-30B-A3B UD-Q4_K_XL, Loadout qwen3-coder-30b auf Port 8094 [2026-08-04] |

--- a/docs/agent-guide/registry/agents.yaml
+++ b/docs/agent-guide/registry/agents.yaml
@@ -61,9 +61,9 @@ runtimes:
     note: "devstral family: Devstral-Small-2 24B IQ4_XS [2026-08-04]"
   gemma:
     mode: subagent
-    model: llamacpp-local/gemma4
+    model: llamacpp-local/gemma26-factory
     write_capable: false
-    note: "gemma family: Gemma 4 12B Q4_K_M, Loadout gemma4 auf Port 8090 [2026-08-04]"
+    note: "gemma family: Gemma 4 26B A4B IQ4_XS, Loadout gemma26-factory auf Port 8091 (exclusiveGroup chat-gpu) [2026-08-09 T002753]"
   qwen:
     mode: subagent
     model: llamacpp-local/qwen3-coder-30b
@@ -71,14 +71,14 @@ runtimes:
     note: "qwen family: Qwen3-Coder-30B-A3B UD-Q4_K_XL, Loadout qwen3-coder-30b auf Port 8094 [2026-08-04]"
   gemma26-primary:
     mode: primary
-    model: llamacpp-local/gptoss-context
+    model: llamacpp-local/gemma26-factory
     write_capable: false
-    note: "Tab-selectable primary local agent, 105472 ctx (measured, not n_ctx_train) [T002545/T002633]"
+    note: "Tab-selectable primary local agent, 161024 ctx measured (np=3 -kvu q4_0 fitt 128) [T002753]"
   gemma26-vision:
     mode: primary
-    model: llamacpp-local/gptoss-context
+    model: llamacpp-local/gemma26-factory
     write_capable: false
-    note: "Max context, no subagent dispatch. Text-only — gpt-oss-20b has no mmproj [T002633]"
+    note: "Max context, no subagent dispatch. Vision IS available — gemma26-factory loads mmproj-F16.gguf since T002753"
   big-pickle:
     mode: primary
     model: opencode-zen/big-pickle

--- a/tests/spec/agent-roster.bats
+++ b/tests/spec/agent-roster.bats
@@ -1,12 +1,13 @@
 #!/usr/bin/env bats
 # tests/spec/agent-roster.bats — Drift-Gates für die Agenten-Registry
 #
-# Prüft fünf Zusicherungen:
+# Prüft sechs Zusicherungen:
 #   1. roles ↔ .claude/agents/*.md  (beidseitig)
 #   2. runtimes ↔ .opencode/agent-models.jsonc  (beidseitig)
-#   3. Agentennamen in CLAUDE.md ↔ Registry
-#   4. agents-map.md ist aktuell (task agent-guide:maps erzeugt keinen Diff)
-#   5. Keine .tmp-Reste aus abgebrochenen Emitter-Läufen (T002308)
+#   3. runtimes.model ↔ .opencode/agent-models.jsonc agent.model (Modell-Zuordnung)
+#   4. Agentennamen in CLAUDE.md ↔ Registry
+#   5. agents-map.md ist aktuell (task agent-guide:maps erzeugt keinen Diff)
+#   6. Keine .tmp-Reste aus abgebrochenen Emitter-Läufen (T002308)
 
 setup_file() {
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
@@ -81,6 +82,39 @@ setup_file() {
     " || extra="${extra}${key} "
   done
   [ -z "$extra" ] || { echo "agent-models.jsonc-Einträge ohne runtime: $extra"; return 1; }
+}
+
+@test "P4.3b: runtimes.model ↔ agent-models.jsonc agent.model (Modell-Zuordnung synchron)" {
+  cd "$REPO_ROOT"
+
+  # .opencode/agent-models.jsonc ist die SSOT für die Modell-Zuordnung. Jede
+  # runtime in agents.yaml muss denselben Modell-String tragen — Namens-Gleichheit
+  # allein (P4.3) hat den Drift nicht gefangen (gemma zeigte auf gemma4,
+  # gemma26-primary/-vision auf gptoss-context statt gemma26-factory, T002851).
+  local drift=""
+  while IFS='|' read -r rt reg_model; do
+    local json_model
+    json_model=$(node -e "
+      const fs = require('fs');
+      const j5 = require('json5');
+      const d = j5.parse(fs.readFileSync('.opencode/agent-models.jsonc','utf8'));
+      const m = d.agent && d.agent['${rt}'] && d.agent['${rt}'].model;
+      console.log(m || '');
+    ")
+    if [ -z "$json_model" ]; then
+      drift="${drift}${rt} (agent-models.jsonc ohne model) "
+    elif [ "$json_model" != "$reg_model" ]; then
+      drift="${drift}${rt} (registry=${reg_model}, jsonc=${json_model}) "
+    fi
+  done < <(node -e "
+    const y = require('yaml');
+    const fs = require('fs');
+    const d = y.parse(fs.readFileSync('docs/agent-guide/registry/agents.yaml','utf8'));
+    for (const [k, v] of Object.entries(d.runtimes || {})) {
+      if (v.model) console.log(k + '|' + v.model);
+    }
+  ")
+  [ -z "$drift" ] || { echo "Modell-Drift registry vs. agent-models.jsonc: $drift"; return 1; }
 }
 
 @test "P4.4: CLAUDE.md nennt nur Agenten aus der Registry" {


### PR DESCRIPTION
## Summary
- **Registry-Drift behoben:** `docs/agent-guide/registry/agents.yaml` und die generierte `agents-map.md` zeigten `gemma`/`gemma26-primary`/`gemma26-vision` auf `llamacpp-local/gemma4` bzw. `gptoss-context` statt `gemma26-factory` (Gemma 4 26B A4B IQ4_XS, Port 8091, 161024 ctx, mmproj seit T002753).
- **MCP-Seite verifiziert (kein Change nötig):** `mcp.yaml` ist SSOT, `scripts/mcp-sync.sh check` grün, alle Endpunkte lokal (localhost:13001–13005, :18080, :18235, lokale stdio-Commands). Skills enthalten keine veralteten Modell-/Port-Referenzen.
- **Single Source of Truth gehärtet:** `tests/spec/agent-roster.bats` prüfte nur Namens-Gleichheit (P4.3); neuer Test P4.3b gleicht zusätzlich die **Modell-Strings** jeder runtime gegen `.opencode/agent-models.jsonc` ab — der Namens-Check allein hatte den Drift nicht gefangen. Negativtest verifiziert: absichtlich eingebauter `gemma4`-Eintrag wird gemeldet.
- `AGENTS.md`: "mirrors but LAGS" durch Drift-Gate-Verweis ersetzt.

## Test Plan
- [x] `task test:agent-guide` grün
- [x] `bats tests/spec/agent-roster.bats` grün (inkl. neuem P4.3b)
- [x] `scripts/mcp-sync.sh check` grün
- [x] `task freshness:check` grün (nach Commit; nur "commit it"-Hinweis vor Commit)
- [x] CI grün
- Hinweis: 3 BATS-Suiten (backfill-id T002732, loadout-model-files T002753, ui-config-seed) schlagen auf origin/main vor — vorbestehend, nicht durch diesen PR verursacht (im main-Checkout reproduziert).

[T002851]