### PR TITLE
chore(db): enable llamacpp-gemma backend and update model_aliases [T002640]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -859,7 +859,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 56,
+      "file_count": 57,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -916,7 +916,8 @@
         "scripts/migrations/2026-08-03-retire-stale-model-ids.sql",
         "scripts/migrations/2026-08-04-llm-proxy-gemma-qwen-families.sql",
         "scripts/migrations/2026-08-04-provider-config-data-residency.sql",
-        "scripts/migrations/2026-08-09-customer-projects-copy.sql"
+        "scripts/migrations/2026-08-09-customer-projects-copy.sql",
+        "scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql"
       ]
     },
     {

--- a/scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql
+++ b/scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql
@@ -1,0 +1,20 @@
+-- 2026-08-09-enable-gemma-backend-proxy-T002640.sql
+-- Schaltet das llamacpp-gemma Backend (:8091) im llm-proxy nach Abschluss des
+-- Base-vs-Tuned-Gates scharf (T002640).
+--
+-- model_aliases wird von der veralteten 12B-Datei auf den aktiven Modell-Alias
+-- gemma26-factory (Port 8091, Gemma 4 26B A4B UD-IQ4_XS) korrigiert.
+--
+-- Idempotent & Reversibel.
+--
+-- Apply:
+--   BRAND=mentolder bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql'
+BEGIN;
+
+UPDATE tickets.llm_proxy_backends
+   SET enabled       = true,
+       model_aliases = '{"gemma-4-12b": "gemma26-factory", "gemma-4-26b": "gemma26-factory"}'::jsonb,
+       updated_at    = now()
+ WHERE name = 'llamacpp-gemma';
+
+COMMIT;


### PR DESCRIPTION
Enabled llamacpp-gemma backend in tickets.llm_proxy_backends table (enabled = true) and updated model_aliases mapping to gemma26-factory for port 8091.

Closes T002640.