### PR TITLE
fix(factory): strip markdown codefences from LLM JSON responses [T002621]

### DIFF
--- a/scripts/factory/auto-triage.sh
+++ b/scripts/factory/auto-triage.sh
@@ -338,6 +338,12 @@ PROMPT
     return 1
   fi
 
+  # Strip Markdown code fences in case the LLM wraps its JSON despite the prompt.
+  # Removes leading ```json / ``` and trailing ``` lines.
+  content=$(printf '%s' "$content" | sed -e '1s/^```[a-zA-Z]*[[:space:]]*//' -e '1s/^```//' -e '$s/[[:space:]]*```[[:space:]]*$//')
+  # Trim surrounding whitespace/newlines.
+  content=$(printf '%s' "$content" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
   echo "$content"
   return 0
 }

--- a/scripts/factory/ci-review.mjs
+++ b/scripts/factory/ci-review.mjs
@@ -40,6 +40,11 @@ const readPrompt = (lens) => readFileSync(PROMPT_DIR + LENS_FILE[lens], 'utf8')
 const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY, ...(ANTHROPIC_BASE_URL ? { baseURL: ANTHROPIC_BASE_URL } : {}) })
 
 function parseJson(text, fallback) {
+  // Strip Markdown code fences that LLMs wrap around JSON responses.
+  if (typeof text === 'string') {
+    const fenced = text.match(/^```(?:json|javascript|js)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/m)
+    if (fenced) text = fenced[1].trim()
+  }
   const m = text && text.match(/\{[\s\S]*\}/)
   if (!m) return fallback
   try { return JSON.parse(m[0]) } catch { return fallback }

--- a/scripts/factory/pipeline-runner.js
+++ b/scripts/factory/pipeline-runner.js
@@ -21,6 +21,22 @@ const evalCtxModule = await import('./eval-context.cjs');
 
 const REPO = '/home/patrick/Bachelorprojekt';
 
+/**
+ * Strip Markdown code fences from an LLM response before JSON.parse.
+ * Handles ```json … ```, ``` … ```, and leading/trailing whitespace.
+ * Returns the raw text unchanged if no fence is found, so callers can
+ * always do JSON.parse(stripCodefence(llmOutput)).
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function stripCodefence(text) {
+  if (typeof text !== 'string') return text;
+  const m = text.match(/^```(?:json|javascript|js)?\s*\r?\n?([\s\S]*?)\r?\n?```\s*$/m);
+  if (m) return m[1].trim();
+  return text.trim();
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const command = args[0];
@@ -81,7 +97,7 @@ async function main() {
       '--repo', REPO
     ], { encoding: 'utf8', timeout: 60000 });
 
-    let scout = JSON.parse(scoutJson);
+    let scout = JSON.parse(stripCodefence(scoutJson));
 
     try {
       execFileSync('bash', [


### PR DESCRIPTION
## Summary

Fixes T002621: `json.loads` / `JSON.parse` breaking when LLMs wrap JSON responses in Markdown code fences (```json...```).

## Changes

- **`pipeline-runner.js`**: Added `stripCodefence()` helper; applied to `scoutJson` before `JSON.parse`
- **`ci-review.mjs`**: Extended `parseJson()` to strip fences before regex extraction  
- **`auto-triage.sh`**: Added `sed`-based codefence stripping from LLM content before `validate_triage`

## Why

All three scripts called JSON.parse / jq directly on raw LLM output. When a model wraps its JSON in ```json...``` despite the prompt, parsing fails silently or throws. The helpers are idempotent (no-op on unfenced text).