### PR TITLE
fix(factory): wakeup.sh --help/-h prints usage, unknown args rejected [T002662]

### DIFF
--- a/openspec/changes/fix-wakeup-help-T002662/proposal.md
+++ b/openspec/changes/fix-wakeup-help-T002662/proposal.md
@@ -1,0 +1,19 @@
+# Proposal: fix-wakeup-help-T002662
+
+## Why
+
+`wakeup.sh` hat kein Argument-Handling. Ein Aufruf mit `--help` (etwa im Rahmen von
+repo-hygiene, um die Usage zu pruefen) wird stillschweigend ignoriert und loest einen
+echten Factory-Tick aus — inklusive Konsum des `force-tick-requested`-Flags und
+Dispatch von Backlog-Tickets. Ein harmloser Help-Aufruf hat also reale Seiteneffekte.
+Das Skript ist die "Inversion of Intelligence"-Waechterhuelle (spec §4): jede bewusste
+Handlung braucht einen expliziten, pruefbaren Weg — ein irrtuemlicher Tick ist genau
+der Zustand, den der Kill-Switch verhindern soll.
+
+## What
+
+`scripts/factory/wakeup.sh` weist unbekannte Argumente ab und beantwortet `--help`
+mit der Usage (Exit 0). Beides geschieht VOR jedem Seiteneffekt (env source,
+flock, git pull, force-tick-Flag, Tick-Loop).
+
+_Ticket: T002662_

--- a/openspec/changes/fix-wakeup-help-T002662/specs/fix-wakeup-help-T002662.md
+++ b/openspec/changes/fix-wakeup-help-T002662/specs/fix-wakeup-help-T002662.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: wakeup.sh beantwortet --help mit Usage ohne Seiteneffekte
+
+The system SHALL make `scripts/factory/wakeup.sh --help` (and `-h`) print the
+usage to stdout, exit 0, and perform NO factory side effect (no env sourcing,
+no flock, no git pull, no force-tick consumption, no dispatcher tick).
+
+#### Scenario: Help-Aufruf bleibt wirkungslos
+
+- **GIVEN** the factory wrapper `scripts/factory/wakeup.sh`
+- **WHEN** it is invoked as `bash scripts/factory/wakeup.sh --help`
+- **THEN** it prints the usage text and exits 0
+- **AND** the dispatcher-bridge stub is never invoked
+
+### Requirement: wakeup.sh weist unbekannte Argumente ab
+
+The system SHALL reject any argument other than `--help`/`-h` in
+`scripts/factory/wakeup.sh` with an error message on stderr and a non-zero exit
+code, WITHOUT performing any factory side effect.
+
+#### Scenario: Unbekanntes Argument wird abgewiesen
+
+- **GIVEN** the factory wrapper `scripts/factory/wakeup.sh`
+- **WHEN** it is invoked with an unknown argument (e.g. `--bogus`)
+- **THEN** it prints an error naming the argument to stderr and exits non-zero
+- **AND** the dispatcher-bridge stub is never invoked

--- a/openspec/changes/fix-wakeup-help-T002662/tasks.md
+++ b/openspec/changes/fix-wakeup-help-T002662/tasks.md
@@ -1,0 +1,63 @@
+---
+title: "fix-wakeup-help-T002662 — Implementation Plan"
+ticket_id: T002662
+domains: [plan-authoring]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# fix-wakeup-help-T002662 — Implementation Plan
+
+_Ticket: T002662_
+
+## File Structure
+
+```
+tests/spec/software-factory/wakeup.bats   (modify — add FA-SF-41 help/unknown-arg tests)
+scripts/factory/wakeup.sh                 (modify — arg handling before any side effect)
+openspec/specs/software-factory.md        (modify — ADDED Requirements merged via archive)
+```
+
+## Tasks
+
+### Task 1: Failing-Test (RED)
+
+Add two BATS tests to `tests/spec/software-factory/wakeup.bats` (section
+FA-SF-41, hermetic stub pattern like the existing single-flight test):
+
+1. `wakeup.sh --help prints usage and never invokes the dispatcher-bridge`
+   — stub bridge records invocation; assert exit 0, usage on stdout,
+   bridge-stub NOT invoked.
+2. `wakeup.sh rejects unknown arguments without side effects`
+   — stub bridge; assert non-zero exit, error on stderr, bridge-stub
+   NOT invoked.
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/software-factory/wakeup.bats
+# expected: FAIL (red — the fix is not yet implemented; --help currently runs a tick)
+```
+
+### Task 2: Fix (GREEN)
+
+In `scripts/factory/wakeup.sh`, directly after the header comment and BEFORE
+`FACTORY_ENV_FILE` sourcing (which can trigger the tick path):
+
+- `--help` / `-h` → print usage (the Env-knobs block) to stdout, `exit 0`
+- any other argument → error to stderr naming the argument, `exit 2`
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/software-factory/wakeup.bats
+# expected: PASS (green — help exits 0, unknown args exit 2, no side effects)
+```
+
+### Task 3: Final Verification
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -27,6 +27,28 @@
 #     FACTORY_IDLE_RETICK_DELAY     seconds to wait between reticks (default: 5)
 set -euo pipefail
 
+# ── Argument handling [T002662] ─────────────────────────────────────────────
+# wakeup.sh is fired by the systemd USER timer (factory.timer → factory.service)
+# and takes NO arguments in its operational path. Before any side effect (env
+# sourcing, flock, git pull, force-tick consumption, tick loop):
+#   --help / -h  → print usage, exit 0
+#   anything else → error on stderr, exit 2
+# Pre-fix, a --help call was silently ignored and ran a real dry-run tick. [T002662]
+_usage() {
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+case "${1:-}" in
+  '' ) : ;;
+  --help|-h )
+    _usage
+    exit 0
+    ;;
+  * )
+    echo "wakeup.sh: unknown argument '${1}' — this wrapper takes no arguments (see --help)" >&2
+    exit 2
+    ;;
+esac
+
 # Production config (real claude bin, DeepSeek creds, dry_run policy). Sourced
 # with set -a so it exports everything — which means it CLOBBERS pre-set env.
 # Tests point FACTORY_ENV_FILE at a non-existent path for full env isolation. [T000523]

--- a/tests/spec/software-factory/wakeup.bats
+++ b/tests/spec/software-factory/wakeup.bats
@@ -260,6 +260,44 @@ STUB
   [ "$status" -eq 0 ]   # confirms the break path exists when disabled
 }
 
+# ── FA-SF-41-wakeup-args [T002662] ─────────────────────────────#
+# wakeup.sh must answer --help / -h with usage and reject unknown args,
+# WITHOUT any factory side effect (no env source, no flock, no git pull,
+# no force-tick consumption, no dispatcher tick). The pre-fix behavior
+# silently ignored --help and ran a real dry-run tick. [T002662]
+
+@test "FA-SF-41: wakeup.sh --help prints usage and never invokes the dispatcher-bridge" {
+  tmp="$(mktemp -d)"
+  bridgefile="${tmp}/bridge-invoked"
+  cat > "${tmp}/bridge-stub" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${bridgefile}"
+STUB
+  chmod +x "${tmp}/bridge-stub"
+  FACTORY_REPO="${tmp}" FACTORY_DISPATCHER_BRIDGE="${tmp}/bridge-stub" \
+    FACTORY_TICK_LOCK="${tmp}/tick.lock" FACTORY_ENV_FILE="${tmp}/no-env" run bash "$WAKEUP" --help
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'Usage|usage|Env knobs'
+  [ ! -f "${bridgefile}" ]
+  rm -rf "${tmp}"
+}
+
+@test "FA-SF-41: wakeup.sh rejects unknown arguments without side effects" {
+  tmp="$(mktemp -d)"
+  bridgefile="${tmp}/bridge-invoked"
+  cat > "${tmp}/bridge-stub" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "${bridgefile}"
+STUB
+  chmod +x "${tmp}/bridge-stub"
+  FACTORY_REPO="${tmp}" FACTORY_DISPATCHER_BRIDGE="${tmp}/bridge-stub" \
+    FACTORY_TICK_LOCK="${tmp}/tick.lock" FACTORY_ENV_FILE="${tmp}/no-env" run bash "$WAKEUP" --bogus
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qi 'unknown'
+  [ ! -f "${bridgefile}" ]
+  rm -rf "${tmp}"
+}
+
 # ── FA-SF-47-wakeup-reasoning-effort ────────────────────────────#
 # FA-SF-47: wakeup.sh must NOT set reasoning_effort. [T000519]
 # The Workflow harness forces thinking.type=disabled for nested agent() spawns.


### PR DESCRIPTION
## [T002662] wakeup.sh: --help handling

### Problem
`wakeup.sh` hatte kein Argument-Handling. Ein `--help`-Aufruf (z.B. in repo-hygiene zur Usage-Prüfung) wurde still ignoriert und löste einen echten dry-run Factory-Tick aus — inkl. Konsum des force-tick-requested-Flags und Dispatch von T002622.

### Fix
- `--help`/`-h` → Usage auf stdout, Exit 0, **keine** Seiteneffekte
- beliebige andere Argumente → Fehler auf stderr, Exit 2
- Argument-Handling steht VOR env-sourcing/flock/git-pull/force-tick — kein Pfad erreicht den Tick

### Tests
- 2 neue BATS-Tests (FA-SF-41): `--help` invokiert dispatcher-bridge nicht; unbekanntes Argument wird abgewiesen
- RED→GREEN verifiziert; gesamte wakeup.bats 32/32 grün
- `task test:changed` 52/52, `task freshness:regenerate` + `freshness:check` grün