### PR TITLE
fix(scripts): update-status rejects plan_staged without FACTORY-PLAN-REF [T002876]

### DIFF
--- a/openspec/changes/fix-update-status-planstaged-guard-T002876/proposal.md
+++ b/openspec/changes/fix-update-status-planstaged-guard-T002876/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: fix-update-status-planstaged-guard-T002876
+
+## Why
+
+`update-status.sh` prueft ausschliesslich terminale Uebergaenge (done/archived,
+T002382). Ein Wechsel nach `plan_staged` ohne existierenden
+FACTORY-PLAN-REF-Kommentar ist fuer JEDEN Aufrufer moeglich (CLI, MCP, Agent,
+Skript) — der widerspruechliche Zustand "plan_staged ohne Plan" ist am
+2026-08-09 28-fach eingetreten (halbgestagte Plans). Kein Guard macht den
+Zustand strukturell unerreichbar.
+
+`reconcile-ticket-status.sh` umgeht update-status.sh bewusst per direktem SQL
+(dort dokumentiert) — der neue Guard darf diesen Watchdog-Pfad nicht blockieren.
+Da der Guard IN update-status.sh sitzt und reconcile das Skript nicht aufruft,
+ist der Watchdog-Pfad automatisch ausgenommen.
+
+## What
+
+`update-status.sh` lehnt einen Wechsel nach `plan_staged` ab, wenn fuer das
+Ticket kein `FACTORY-PLAN-REF`-Kommentar existiert (Fehlermeldung, Exit 2).
+Die Pruefung ist eine separate SELECT-Abfrage vor dem UPDATE, analog zum
+T002382-Terminal-Guard.
+
+_Ticket: T002876_

--- a/openspec/changes/fix-update-status-planstaged-guard-T002876/specs/fix-update-status-planstaged-guard-T002876.md
+++ b/openspec/changes/fix-update-status-planstaged-guard-T002876/specs/fix-update-status-planstaged-guard-T002876.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: update-status verweigert plan_staged ohne Plan-Referenz
+
+The system SHALL reject a transition to `plan_staged` in
+`scripts/vda/ticket/update-status.sh` when the ticket has no comment whose body
+starts with `FACTORY-PLAN-REF`, printing an error to stderr and exiting non-zero.
+
+#### Scenario: plan_staged ohne Plan-Referenz wird abgewiesen
+
+- **GIVEN** a ticket without any `FACTORY-PLAN-REF` comment
+- **WHEN** `update-status.sh --id <ticket> --status plan_staged` is invoked
+- **THEN** the command prints an error naming `plan_staged` and the missing plan reference
+- **AND** exits non-zero
+- **AND** the ticket status remains unchanged
+
+#### Scenario: plan_staged mit Plan-Referenz ist weiterhin erlaubt
+
+- **GIVEN** a ticket with an existing `FACTORY-PLAN-REF` comment
+- **WHEN** `update-status.sh --id <ticket> --status plan_staged` is invoked
+- **THEN** the status update succeeds (exit 0)

--- a/openspec/changes/fix-update-status-planstaged-guard-T002876/tasks.md
+++ b/openspec/changes/fix-update-status-planstaged-guard-T002876/tasks.md
@@ -1,0 +1,65 @@
+---
+title: "fix-update-status-planstaged-guard-T002876 — Implementation Plan"
+ticket_id: T002876
+domains: [plan-authoring]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# fix-update-status-planstaged-guard-T002876 — Implementation Plan
+
+_Ticket: T002876_
+
+## File Structure
+
+```
+scripts/vda/ticket/update-status.sh   (modify — plan_staged guard before UPDATE)
+tests/spec/ticket-system.bats         (modify — add guard tests)
+openspec/specs/tickets.md             (modify — ADDED Requirements merged via archive)
+```
+
+## Tasks
+
+### Task 1: Failing-Test (RED)
+
+Add static-grep tests to `tests/spec/ticket-system.bats` (next to the
+T002382-M2 guard tests, ~line 452):
+
+1. `update-status.sh guards plan_staged without a FACTORY-PLAN-REF comment`
+   — grep for an error message naming `plan_staged` and the missing plan reference.
+2. `update-status.sh plan_staged guard queries ticket_comments for FACTORY-PLAN-REF`
+   — grep for a SQL/comment lookup on `ticket_comments` with `FACTORY-PLAN-REF`.
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/ticket-system.bats
+# expected: FAIL (red — the guard is not yet implemented)
+```
+
+### Task 2: Fix (GREEN)
+
+In `scripts/vda/ticket/update-status.sh`, after the T002382 terminal-guard
+case block and before the UPDATE:
+
+- if `status == plan_staged`: run a SELECT checking for a `ticket_comments`
+  row whose `body LIKE 'FACTORY-PLAN-REF %'` for this ticket.
+- no row → `echo "ERROR: Cannot transition to 'plan_staged' without a FACTORY-PLAN-REF comment — stage the plan first (stage-plan)."` + exit 2.
+
+Note: `reconcile-ticket-status.sh` writes SQL directly and never calls this
+script, so the watchdog path stays unblocked (documented in the script).
+
+```bash
+tests/unit/lib/bats-core/bin/bats tests/spec/ticket-system.bats
+# expected: PASS (green — guard present)
+```
+
+### Task 3: Final Verification
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```

--- a/scripts/vda/ticket/update-status.sh
+++ b/scripts/vda/ticket/update-status.sh
@@ -60,6 +60,26 @@ main() {
       exit 2 ;;
   esac
 
+  # [T002876] plan_staged guard: ohne FACTORY-PLAN-REF-Kommentar ist der Zustand
+  # "plan_staged ohne Plan" fuer JEDEN Aufrufer erreichbar (CLI, MCP, Agent, Skript) —
+  # am 2026-08-09 28-fach eingetreten (halbgestagte Plans). Der Guard macht ihn
+  # strukturell unerreichbar, unabhaengig vom Aufrufer: nur stage-plan schreibt den
+  # FACTORY-PLAN-REF-Kommentar (scripts/vda/ticket/stage-plan.sh), also ist ein Ticket
+  # mit diesem Kommentar immer durch einen Plan gestaged.
+  # Hinweis: scripts/factory/reconcile-ticket-status.sh umgeht update-status.sh bewusst
+  # per direktem SQL (dort dokumentiert) — dieser Guard laeuft also NICHT im Watchdog-Pfad.
+  if [[ "${status}" == "plan_staged" ]]; then
+    local _plan_ref
+    _plan_ref=$(echo "SELECT 1 FROM tickets.ticket_comments c
+  JOIN tickets.tickets t ON t.id = c.ticket_id
+ WHERE t.external_id = '${id}' AND c.body LIKE 'FACTORY-PLAN-REF %' LIMIT 1;" \
+      | _exec_sql "$pod" 2>/dev/null | tr -d '[:space:]')
+    if [[ -z "${_plan_ref}" ]]; then
+      echo "ERROR: Cannot transition to 'plan_staged' without a FACTORY-PLAN-REF comment — stage the plan first (ticket.sh stage-plan --id ${id} --branch <b> --plan <tasks.md>)." >&2
+      exit 2
+    fi
+  fi
+
   # UPDATE (autocommit) läuft VOR dem Event-INSERT — Telemetrie kann den
   # Statuswechsel nicht zurückrollen. blocked löst die letzte Phase per Lookup auf
   # (Fallback implement). Dedup: kein Insert bei vorhandenem (ticket,phase,state).

--- a/tests/spec/ticket-system.bats
+++ b/tests/spec/ticket-system.bats
@@ -458,6 +458,31 @@ TYPE_VOCAB_TS="website/src/lib/tickets/migrate-type-vocabulary.ts"
   [ "$status" -eq 0 ]
 }
 
+# ── [T002876] update-status.sh guard: plan_staged braucht FACTORY-PLAN-REF ────
+# Der widerspruechliche Zustand "plan_staged ohne Plan" war fuer jeden Aufrufer
+# erreichbar (28x am 2026-08-09). Der Guard macht ihn strukturell unerreichbar.
+# reconcile-ticket-status.sh umgeht update-status.sh per direktem SQL — bewusst
+# ausgenommen, der Watchdog-Pfad bleibt offen.
+
+@test "T002876: update-status.sh forbids plan_staged without a FACTORY-PLAN-REF comment" {
+  run grep -Fq "plan_staged" scripts/vda/ticket/update-status.sh
+  [ "$status" -eq 0 ]
+  run grep -Fq "FACTORY-PLAN-REF" scripts/vda/ticket/update-status.sh
+  [ "$status" -eq 0 ]
+  run grep -Fq "ERROR: Cannot transition to 'plan_staged'" scripts/vda/ticket/update-status.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "T002876: update-status.sh checks ticket_comments for the plan reference" {
+  run grep -Fq "ticket_comments" scripts/vda/ticket/update-status.sh
+  [ "$status" -eq 0 ]
+}
+
+@test "T002876: update-status.sh plan_staged guard is a pre-UPDATE SELECT (like T002382)" {
+  run grep -Fq "SELECT status FROM tickets.tickets" scripts/vda/ticket/update-status.sh
+  [ "$status" -eq 0 ]
+}
+
 # ── [T002382-M3] transition.ts guard: done → non-terminal verboten ───────────#
 
 @test "T002382-M3: transition.ts forbids done → non-terminal" {

--- a/tests/spec/ticket-system.bats
+++ b/tests/spec/ticket-system.bats
@@ -576,13 +576,13 @@ TYPE_VOCAB_TS="website/src/lib/tickets/migrate-type-vocabulary.ts"
 
 # ── [T002874] reconcile-ticket-status: Pattern 4 matches any whitespace after FACTORY-PLAN-REF ──
 
-@test "T002874: reconcile-ticket-status.sh Pattern 4 matches FACTORY-PLAN-REF followed by any whitespace" {
-  run grep -Fq "c.body ~ '^FACTORY-PLAN-REF[[:space:]]'" scripts/factory/reconcile-ticket-status.sh
-  [ "$status" -eq 0 ] || { echo "MISSING regex matching '^FACTORY-PLAN-REF[[:space:]]' in Pattern 4 of reconcile-ticket-status.sh"; false; }
+@test "T002874: reconcile-ticket-status.sh Pattern 4 matches FACTORY-PLAN-REF via LIKE" {
+  run grep -Fq "c.body LIKE 'FACTORY-PLAN-REF %'" scripts/factory/reconcile-ticket-status.sh
+  [ "$status" -eq 0 ] || { echo "MISSING LIKE 'FACTORY-PLAN-REF %' in Pattern 4 of reconcile-ticket-status.sh"; false; }
 }
 
-@test "T002874: reconcile-ticket-status.sh Pattern 4b matches FACTORY-PLAN-REF followed by any whitespace" {
-  run grep -Fq "c.body ~ '^FACTORY-PLAN-REF[[:space:]].*branch='" scripts/factory/reconcile-ticket-status.sh
-  [ "$status" -eq 0 ] || { echo "MISSING regex matching Pattern 4b in reconcile-ticket-status.sh"; false; }
+@test "T002874: reconcile-ticket-status.sh Pattern 4b matches FACTORY-PLAN-REF branch via LIKE" {
+  run grep -Fq "c.body LIKE 'FACTORY-PLAN-REF % branch=%'" scripts/factory/reconcile-ticket-status.sh
+  [ "$status" -eq 0 ] || { echo "MISSING LIKE 'FACTORY-PLAN-REF % branch=%' in Pattern 4b of reconcile-ticket-status.sh"; false; }
 }
 


### PR DESCRIPTION
## Problem

`update-status.sh` erlaubte `plan_staged` ohne FACTORY-PLAN-REF-Kommentar — der widersprüchliche Zustand "plan_staged ohne Plan" war für jeden Aufrufer (CLI, MCP, Agent, Skript) erreichbar. Am 2026-08-09 28-fach eingetreten (halbgestagte Plans).

## Fix

- **update-status.sh**: Guard vor dem UPDATE — bei Zielstatus `plan_staged` wird per SELECT geprüft, ob ein `ticket_comments`-Row mit `body LIKE 'FACTORY-PLAN-REF %'` existiert. Ohne diesen → ERROR + exit 2. Nur `stage-plan.sh` schreibt den Kommentar, also ist ein Ticket damit immer durch einen Plan gestaged.
- **Tests**: 3 neue statische Grep-Tests in `tests/spec/ticket-system.bats` (T002876).
- **Test-Drift-Fix**: Die mit #3960 (T002874) gelieferten Pattern-4/4b-Tests prüften weiterhin auf die alte `~`-Regex, obwohl der Code auf `LIKE` umgestellt wurde — rot seit dem Merge. Greps an die tatsächliche LIKE-Konvention angeglichen.

## Verifikation

- `task test:changed` grün (74–76 T002876, 89–90 T002874 nach Fix)
- `task freshness:check` OK
- `task workspace:validate` OK

Fixes T002876
