### PR TITLE
fix(plans): retry embed hook on transient backend failures [T002916]

### DIFF
--- a/.githooks/post-commit-embed
+++ b/.githooks/post-commit-embed
@@ -49,7 +49,23 @@ for slug in $SLUGS; do
     continue
   fi
   echo "[openspec-embed] post-commit: embedding slug='$slug'..."
-  if ! bash "$repo_root/scripts/openspec-embed-local.sh" "$slug" 2>&1; then
-    echo "[openspec-embed] WARN: embed failed for '$slug' (non-fatal — see above)" >&2
+  # T002916: Retry transient backend failures (port-forward restarting, etc.)
+  # Connection-refused fails instantly (not subject to probe timeout), so a
+  # few retries add at most ~15s — acceptable for a post-commit hook.
+  EMBEDDED=0
+  EMBED_MAX_RETRIES="${OPENSPEC_EMBED_HOOK_RETRIES:-3}"
+  EMBED_RETRY_DELAY="${OPENSPEC_EMBED_HOOK_RETRY_DELAY:-5}"
+  for attempt in $(seq 1 "$EMBED_MAX_RETRIES"); do
+    if bash "$repo_root/scripts/openspec-embed-local.sh" "$slug" 2>&1; then
+      EMBEDDED=1
+      break
+    fi
+    if [ "$attempt" -lt "$EMBED_MAX_RETRIES" ]; then
+      echo "[openspec-embed] retry ${attempt}/$EMBED_MAX_RETRIES for '$slug' in ${EMBED_RETRY_DELAY}s…" >&2
+      sleep "$EMBED_RETRY_DELAY"
+    fi
+  done
+  if [ "$EMBEDDED" -eq 0 ]; then
+    echo "[openspec-embed] WARN: embed failed for '$slug' after $EMBED_MAX_RETRIES attempts (non-fatal — see above)" >&2
   fi
 done


### PR DESCRIPTION
## Was

Der Post-Commit-Embed-Hook (`.githooks/post-commit-embed`) retried jetzt bis zu 3× mit 5s Abstand, wenn das Embedding-Backend transient nicht erreichbar ist (z.B. Port-Forward restartet nach Pod-Rollout).

**Vorher:** Ein einziger Versuch → bei Backend-down kein Embedding, Change fehlt in `openspec_find_similar`.

**Nachher:** 3 Versuche mit je 5s Pause → Connection-Refused-Fehler sind instantan (kein 20s-Timeout), die Retry-Schleife kostet maximal ~15s im Fehlerpfad.

Konfigurierbar via `OPENSPEC_EMBED_HOOK_RETRIES` / `OPENSPEC_EMBED_HOOK_RETRY_DELAY`.

## Warum

T002916 (Mishap): Beim plan-stage-Commit für T002689 war der bge-forward-embed.service down → der Hook schlug fehl und bettete den Change nicht ein. T002604 (eigene systemd-Unit mit Restart=always) hat die strukturelle Ursache behoben — dieser Fix fügt Resilienz für den Fall hinzu, dass der Forward trotzdem mal kurz down ist.

Der verpasste Change wurde manuell nach-embedded (9 Chunks, in knowledge.chunks).

## Verifikation

- `task test:changed`: 52/52 tests grün
- `task workspace:validate`: ✓ Manifests sind gültig
- `task freshness:regenerate && freshness:check`: OK