### PR TITLE
fix(security): bind external_id as psql variable + allowlist guard in update-status [T002906]

### DIFF
--- a/scripts/vda/ticket/update-status.sh
+++ b/scripts/vda/ticket/update-status.sh
@@ -18,6 +18,28 @@ main() {
     exit 2
   fi
 
+  # [T002906] Strikte Allowlist auf external_id. Zwei Gruende, in dieser Reihenfolge:
+  #
+  # 1) SQL-Injection. Beide Guard-Queries unten binden $id per psql-Variable (:'tid'),
+  #    aber diese Allowlist ist die Schicht davor: sie stellt sicher, dass gar kein
+  #    fremdes Byte in die Naehe der Query kommt, egal was ein spaeterer Umbau an der
+  #    Bindung aendert. Vor T002906 wurde $id an zwei Stellen roh interpoliert; die
+  #    zweite kam am 2026-08-09 per #3964 (T002876) dazu, ohne dass CI es bemerkte —
+  #    der security-scan-Job prueft Image-Pinning und Secrets in k3d/*.yaml, nicht
+  #    Shell-SQL. Der Aufrufer ist scripts/ticket.sh, das in der Factory-Pipeline von
+  #    LLM-Agenten mit IDs aus Modellausgaben und Ticketinhalten gerufen wird — die
+  #    Eingabe ist also nicht per Konstruktion vertrauenswuerdig.
+  # 2) Tippfehler. Ein vertipptes --id lief bisher bis zum UPDATE durch und traf
+  #    schlicht keine Zeile. Jetzt scheitert es sofort mit klarer Meldung.
+  #
+  # Das Format ist eng und belegt: alle 2190 Zeilen in tickets.tickets matchen
+  # ^T[0-9]{6}$ (Stand 2026-08-09, null Abweichler). {6,} laesst Raum fuer den
+  # Uebergang auf siebenstellige Nummern, ohne den Guard erneut anfassen zu muessen.
+  if [[ ! "$id" =~ ^T[0-9]{6,}$ ]]; then
+    echo "ERROR: --id '$id' ist keine gueltige external_id (erwartet: T gefolgt von mindestens 6 Ziffern, z.B. T002906)." >&2
+    exit 2
+  fi
+
   # Status → auto-emitted phase event (T001444). Leere auto_phase = keine Emission.
   local auto_phase="" auto_state=""
   case "$status" in
@@ -45,8 +67,10 @@ main() {
   # Note: scripts/factory/reconcile-ticket-status.sh bypasses this guard by writing
   # SQL directly via kubectl exec — that's intentional for its watchdog patterns.
   local _cur_status
-  local _sql="SELECT status FROM tickets.tickets WHERE external_id = '${id}' LIMIT 1;"
-  _cur_status=$(echo "$_sql" | _exec_sql "$pod" 2>/dev/null | tr -d '[:space:]')
+  # [T002906] $id per psql-Variable binden statt in den String zu interpolieren.
+  # :'tid' quotet und escapet serverseitig — der Wert kann den String nicht verlassen.
+  local _sql="SELECT status FROM tickets.tickets WHERE external_id = :'tid' LIMIT 1;"
+  _cur_status=$(echo "$_sql" | _exec_sql "$pod" -v tid="$id" 2>/dev/null | tr -d '[:space:]')
   case "${_cur_status}:${status}" in
     done:done|archived:archived)
       ;; # idempotent — always allowed
@@ -70,10 +94,11 @@ main() {
   # per direktem SQL (dort dokumentiert) — dieser Guard laeuft also NICHT im Watchdog-Pfad.
   if [[ "${status}" == "plan_staged" ]]; then
     local _plan_ref
+    # [T002906] wie oben: :'tid' statt Interpolation von $id.
     _plan_ref=$(echo "SELECT 1 FROM tickets.ticket_comments c
   JOIN tickets.tickets t ON t.id = c.ticket_id
- WHERE t.external_id = '${id}' AND c.body LIKE 'FACTORY-PLAN-REF %' LIMIT 1;" \
-      | _exec_sql "$pod" 2>/dev/null | tr -d '[:space:]')
+ WHERE t.external_id = :'tid' AND c.body LIKE 'FACTORY-PLAN-REF %' LIMIT 1;" \
+      | _exec_sql "$pod" -v tid="$id" 2>/dev/null | tr -d '[:space:]')
     if [[ -z "${_plan_ref}" ]]; then
       echo "ERROR: Cannot transition to 'plan_staged' without a FACTORY-PLAN-REF comment — stage the plan first (ticket.sh stage-plan --id ${id} --branch <b> --plan <tasks.md>)." >&2
       exit 2

--- a/tests/spec/software-factory/update-status-id-allowlist-T002906.bats
+++ b/tests/spec/software-factory/update-status-id-allowlist-T002906.bats
@@ -1,0 +1,82 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/update-status-id-allowlist-T002906.bats
+# SSOT: openspec/specs/software-factory.md
+#
+# PRUEFMODUS: command output verification [T002448-M4]. Die Tests RUFEN
+# scripts/ticket.sh update-status auf und pruefen $status und $output — kein grep
+# auf die Skriptquelle. Der Allowlist-Guard liegt bewusst VOR _ticket_lock_guard
+# und _pgpod, deshalb laufen alle Faelle hier OHNE Cluster.
+#
+# [T002906] Hintergrund: --id wurde an zwei Stellen roh in SQL interpoliert
+# (Guard-SELECT fuer den Terminal-Status-Uebergang und Guard-SELECT fuer
+# FACTORY-PLAN-REF). Der Aufrufer ist in der Factory-Pipeline ein LLM-Agent, die
+# Eingabe also nicht per Konstruktion vertrauenswuerdig.
+
+load '_sf_common'
+
+setup()    { _sf_setup; }
+teardown() { _sf_teardown; }
+
+FORMAT_ERR='keine gueltige external_id'
+
+# ── Positiv-Anker ───────────────────────────────────────────────#
+# Pflicht bei Negativtests [T002356-M1]: ohne ihn bestuenden die Faelle unten
+# vakuos, sobald der Guard versehentlich JEDE Eingabe ablehnt — "Fehler kam" ist
+# dann trivial wahr. Dieser Test wird rot, wenn die Regex zu streng wird.
+@test "T002906: gueltige external_id passiert den Allowlist-Guard" {
+  run bash scripts/ticket.sh update-status --id T002906 --status triage
+  # Der Aufruf darf hier aus jedem anderen Grund scheitern (kein Cluster, Lock,
+  # Statusregel) — nur NICHT am Formatguard.
+  [[ "$output" != *"$FORMAT_ERR"* ]]
+}
+
+@test "T002906: siebenstellige ID passiert den Guard (Wachstumsraum)" {
+  run bash scripts/ticket.sh update-status --id T1234567 --status triage
+  [[ "$output" != *"$FORMAT_ERR"* ]]
+}
+
+# ── Negativfaelle ───────────────────────────────────────────────#
+@test "T002906: SQL-Injection-Payload wird abgelehnt (exit 2, kein DB-Kontakt)" {
+  run bash scripts/ticket.sh update-status --id "T000001' OR '1'='1" --status triage
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"$FORMAT_ERR"* ]]
+}
+
+@test "T002906: Payload mit Statement-Terminator wird abgelehnt" {
+  run bash scripts/ticket.sh update-status --id "T000001'; DROP TABLE tickets.tickets; --" --status triage
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"$FORMAT_ERR"* ]]
+}
+
+@test "T002906: Kleinschreibung und Praefixfehler werden abgelehnt" {
+  run bash scripts/ticket.sh update-status --id t002906 --status triage
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"$FORMAT_ERR"* ]]
+
+  run bash scripts/ticket.sh update-status --id 002906 --status triage
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"$FORMAT_ERR"* ]]
+}
+
+@test "T002906: zu kurze Nummer wird abgelehnt" {
+  run bash scripts/ticket.sh update-status --id T123 --status triage
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"$FORMAT_ERR"* ]]
+}
+
+# ── Parametrisierung der beiden Guard-Queries ───────────────────#
+# Ausnahme vom Output-Prinzip: dass die Queries per psql-Variable binden statt zu
+# interpolieren, laesst sich ohne Cluster nicht am Laufzeitverhalten ablesen — der
+# Allowlist-Guard oben schneidet jede Eingabe vorher ab. Die Bindung ist die zweite
+# Verteidigungslinie und soll bestehen bleiben, auch wenn jemand den Guard lockert;
+# deshalb wird sie hier strukturell festgeschrieben.
+@test "T002906: beide Guard-SELECTs binden external_id als psql-Variable" {
+  local f='scripts/vda/ticket/update-status.sh'
+  # Positiv-Anker: die Bindungen sind ueberhaupt vorhanden.
+  run bash -c "grep -c \"external_id = :'tid'\" '$f'"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 2 ]
+  # Negativ: keine rohe Interpolation von \$id in einem SQL-Vergleich mehr.
+  run bash -c "grep -cE \"external_id *= *'\\\\\\\$\\{?id\\}?'\" '$f' || true"
+  [ "$output" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3732,6 +3732,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/update-status-id-allowlist-T002906",
+    "file": "tests/spec/software-factory/update-status-id-allowlist-T002906.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "studio-sessions-reorganize",
     "file": "tests/spec/studio-sessions-reorganize.bats",
     "category": "studio-sessions-reorganize",


### PR DESCRIPTION
## Befund

`scripts/vda/ticket/update-status.sh` interpolierte `--id` an **zwei** Stellen roh in SQL:

- Zeile 48 — Guard-SELECT für den Terminal-Status-Übergang (seit T002371, 28.07.)
- Zeile 75 — Guard-SELECT für `FACTORY-PLAN-REF` (seit `c9c869ad6`, **09.08. 13:58**, via #3964 / T002876)

Der automatische Sicherheits-Review meldete nur die zweite. Beide sind behoben.

Der eigentliche `UPDATE` (Zeile 112) war mit `-v ext_id=` bereits parametrisiert — nur die beiden Guard-Queries waren offen.

## Warum das kein rein theoretischer Fund ist

Das übliche „wer das Skript aufruft, hat ohnehin Shell" greift hier nur halb. Einziger Aufrufer ist `scripts/ticket.sh` (Zeile 124, per `source`), und der wird in der Factory-Pipeline von LLM-Agenten mit IDs aufgerufen, die aus Modellausgaben und Ticketinhalten stammen. `_exec_sql` verbindet mit Schreibrechten auf `tickets.*` — dem SSOT für alle Issues dieses Repos. Das Risiko ist Datenintegrität, nicht Netzexposition.

CI hat es nicht gefunden: der `security-scan`-Job prüft Image-Pinning und hartkodierte Secrets in `k3d/*.yaml`; Shell-SQL-Interpolation liegt außerhalb seines Musters.

## Fix — zwei Schichten

**1. Allowlist `^T[0-9]{6,}$`** direkt nach der Argumentprüfung, also **vor** `_ticket_lock_guard` und `_pgpod`. Damit kommt gar kein fremdes Byte in die Nähe der Queries, unabhängig davon, was ein späterer Umbau an der Bindung ändert.

Belegt: alle **2190** Zeilen in `tickets.tickets` matchen `^T[0-9]{6}$`, null Abweichler. `{6,}` lässt Raum für siebenstellige Nummern. Nebeneffekt: ein vertipptes `--id` scheitert jetzt sofort mit klarer Meldung, statt bis zum wirkungslosen `UPDATE` durchzulaufen.

**2. Parametrisierung** — beide SELECTs binden per psql-Variable (`:'tid'`) statt zu interpolieren.

## Tests

`tests/spec/software-factory/update-status-id-allowlist-T002906.bats` — 7 Fälle, command-output-verifiziert (`run` + `$status` + `$output`, kein grep auf die Skriptquelle), läuft **ohne Cluster**, weil der Guard vor jedem DB-Kontakt greift.

RED gegen `origin/main` belegt:

```
ok 1     gueltige external_id passiert den Allowlist-Guard      ← Positiv-Anker
ok 2     siebenstellige ID passiert den Guard                   ← Positiv-Anker
not ok 3 SQL-Injection-Payload wird abgelehnt
not ok 4 Payload mit Statement-Terminator wird abgelehnt
not ok 5 Kleinschreibung und Praefixfehler werden abgelehnt
not ok 6 zu kurze Nummer wird abgelehnt
not ok 7 beide Guard-SELECTs binden external_id als psql-Variable
```

Die beiden Positiv-Anker bleiben in **beiden** Zuständen grün — das ist Absicht: sie sichern gegen einen zu strengen Guard ab (Pflicht nach T002356-M1, sonst bestünden die Negativfälle vakuos, sobald der Guard versehentlich jede Eingabe ablehnt).

Regression: `bats -r tests/spec/software-factory/` grün.

Closes T002906
