### PR TITLE
docs: drei Doku-Korrekturen aus Sammel-Chore T002923 [T002667][T002873][T002875]

### DIFF
--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -20,7 +20,8 @@ branch="chore/mishap-incident-rollup"   # persistenter Branch, kein Ticket-Suffi
 ```
 
 Der Branch wird nie gelöscht, das Ticket (`"Mishap Rollup — fortlaufende Sammlung"`,
-`type=chore`, `status=plan_staged`) bleibt dauerhaft offen. `worktree-create.sh --unattended`
+`type=chore`, `status=plan_staged` — **nur der Rollup-Container**, nicht die einzelnen
+Mishap-Tickets) bleibt dauerhaft offen. `worktree-create.sh --unattended`
 überspringt den Namens-Guard für diesen Branch (Allowlist). Die gemeinsame Auflösung
 erfolgt über `ticket.sh rollup-container --brand <brand>`.
 
@@ -134,10 +135,13 @@ An den Rollup-Container angehängt wird auf zwei Wegen, beide ohne Session-Bezug
 | Schwelle | `report_mishap` hängt ab **10** Einträgen an den Rollup-Container an |
 | Alters-Schnitt | Der Factory-Tick (`scripts/factory/wakeup.sh`) ruft periodisch `ticket-mcp-go --flush-stale-mishaps` auf und hängt an, sobald der älteste Eintrag ≥ 7 Tage alt ist |
 
-**Zum Rollup-Container:** Ein persistentes Ticket (`type=chore`, `status=plan_staged`) mit dem Titel
-"Mishap Rollup — fortlaufende Sammlung". Es wird niemals geschlossen — nicht-kritische Mishaps
-werden als Kommentar-Batches an dieses Ticket gehängt. Der Rollup-Treiber
-(`scripts/factory/mishap-rollup.sh`) extrahiert daraus periodisch einen Plan und staged ihn.
+**Zum Rollup-Container:** Ein persistentes Ticket (`type=chore`, `status=plan_staged` — nur
+der Rollup-Container selbst) mit dem Titel "Mishap Rollup — fortlaufende Sammlung". Es wird
+niemals geschlossen — nicht-kritische Mishaps werden als Kommentar-Batches an dieses Ticket
+gehängt. Der Rollup-Treiber (`scripts/factory/mishap-rollup.sh`) extrahiert daraus periodisch
+einen Plan und staged ihn. Die einzelnen Mishap-Tickets selbst entstehen immer mit
+`status=triage` (`scripts/ticket-mcp/go/internal/tools/mishap.go` setzt konsequent
+`--status triage`) — nie direkt als `plan_staged`.
 
 `flush_mishap_buffer` bleibt als **bewusster manueller Schnitt** verfügbar — z. B. wenn ein
 Befund sofort ein Ticket braucht. Es ist kein Pflichtschritt dieses Skills mehr:
@@ -152,7 +156,8 @@ mcp__ticket-mcp__flush_mishap_buffer({ brand: "<brand>" })
 
 Nicht-kritische Mishaps, die den Buffer-Schwellwert erreicht oder den Alters-Schnitt
 ausgelöst haben, liegen als Kommentar-Batches am Rollup-Container-Ticket
-("Mishap Rollup — fortlaufende Sammlung", `type=chore`, `status=plan_staged`).
+("Mishap Rollup — fortlaufende Sammlung", `type=chore`, `status=plan_staged` — auch hier
+nur der Rollup-Container, nicht die angehängten Einzel-Mishaps).
 
 **Ausgeführt wird das Extrahieren von `scripts/factory/mishap-rollup.sh` [T002407]** — nicht von Hand:
 
@@ -213,8 +218,9 @@ Report:
 - Ob ein Bundle-Ticket ausgelöst wurde (und welches `T000xxx`)
 - Wie viele Einträge im Buffer liegen bleiben (Normalfall — kein Flush)
 - Bei nicht-kritischem Bundle zusätzlich: ob ein Auto-Chore-Plan gestaged wurde
-  (Branch `$branch` = `chore/mishap-<ext-id>`, `status=plan_staged`) oder übersprungen wurde
-  (Lint-Fehler → `status=triage`)
+  (Branch `$branch` = `chore/mishap-<ext-id>`, `status=plan_staged` — der aus dem
+  Rollup-Container extrahierte Bundle-Plan, nicht ein rohes Einzel-Mishap-Ticket) oder
+  übersprungen wurde (Lint-Fehler → `status=triage`)
 
 ---
 

--- a/.claude/skills/references/ticket-ops-procedures.md
+++ b/.claude/skills/references/ticket-ops-procedures.md
@@ -31,6 +31,13 @@ Helper voraus.
 
 The triaging agent **autonomously decides** severity, component, areas, and readiness flags using the rubrics below. Only **significant decisions** that genuinely need human judgement are escalated via `attention_mode='needs_human'`. Use all available subagents (`bachelorprojekt-test`, `bachelorprojekt-infra`, `bachelorprojekt-security`, `bachelorprojekt-website`, etc.) to validate and complete ticket data in parallel up until plans are staged.
 
+**Prüfkriterium "Ticket hat einen Plan" [T002873]:** Nicht `tickets.ticket_plans` abfragen —
+`scripts/vda/ticket/stage-plan.sh` legt dort **keine** Zeile an; die entsteht erst beim
+Archivieren. Maßgeblich ist der `FACTORY-PLAN-REF branch=… plan=…`-Kommentar, den `stage-plan.sh`
+beim regulären Staging schreibt (so wie `reconcile-ticket-status.sh` Pattern 4 es bereits prüft).
+Ein frisch gestagtes Ticket zeigt `status=plan_staged`, `ticket_plans`-Zeilenzahl `0` und
+`branch=null` — das ist der Normalfall, kein Defekt.
+
 ### Decision Rubric (AI-Autonomous)
 
 | Field | Autonomous Default Values | Escalate to Human When... |

--- a/docs/dev-stack/README.md
+++ b/docs/dev-stack/README.md
@@ -3,8 +3,11 @@
 > **⚠️ Veraltet (Stand 2026-05-31).** Der hier beschriebene standalone k3d-in-k3s-Stack
 > auf `k3s-1` ist Legacy: `k3s-1` wurde dauerhaft **DECOMMISSIONED** (Speicherfehler 2026-05-31).
 > Das geplante `devc`-3-Knoten-k3s-HA-Cluster wurde nie gebaut (shelved 2026-05-30).
-> Die aktuelle Dev-Umgebung läuft als lokales k3d auf dem WSL-Host (Proxmox VM 10.0.0.26,
-> context: `k3d-mentolder-dev`). Die k3d-Schritte unten bleiben als historische Referenz erhalten.
+> Die aktuelle Dev-Umgebung ist der Flux-Kustomization `flux-dev` (`flux/clusters/fleet/ks-dev.yaml`,
+> `path: ./dev`) unterworfen: sie reconciled `prod-fleet/dev` → `k3d/dev-stack` in den Namespace
+> `workspace-dev` auf dem **`fleet`**-Cluster (Produktionsknoten) — nicht lokal auf dem WSL-Host.
+> Details und offene Frage zum Zielbild: ADR-006, Abschnitt "Umsetzungsstand" (Abweichung 1).
+> Die k3d-Schritte unten bleiben als historische Referenz erhalten.
 
 Persistent staging stack hosted as a k3d-in-k3s sibling on
 `k3s-1` (10.0.3.1, wg-mesh 192.168.100.20). Mirrors the website + Brett


### PR DESCRIPTION
## Summary

Sammel-Chore fuer T002923 — drei der fuenf Kind-Befunde behandelt (reine Prosa-/Kommentar-Korrekturen):

- **T002667**: `docs/dev-stack/README.md` — das Korrektur-Banner nannte selbst das falsche Ziel (WSL-Host/`k3d-mentolder-dev`). Tatsaechlich reconciled die Flux-Kustomization `flux-dev` (`flux/clusters/fleet/ks-dev.yaml`, path `./dev`) `prod-fleet/dev` -> `k3d/dev-stack` in den Namespace `workspace-dev` auf dem **fleet**-Cluster (Produktionsknoten), nicht lokal. Verifiziert gegen `flux/clusters/fleet/ks-dev.yaml` und ADR-006 ("Umsetzungsstand", Abweichung 1).
- **T002873**: `.claude/skills/references/ticket-ops-procedures.md` — Phase 1 nannte kein Pruefkriterium fuer "Ticket hat einen Plan". Ergaenzt: massgeblich ist der `FACTORY-PLAN-REF`-Kommentar von `stage-plan.sh` (nicht `tickets.ticket_plans`, das erst beim Archivieren befuellt wird).
- **T002875**: `.claude/skills/mishap-tracker/SKILL.md` — an den vier genannten Stellen (Rollup-Container-Branch, Rollup-Container-Ticket ×2, Bundle-Plan) praezisiert, dass `status=plan_staged` nur den Rollup-Container bzw. den daraus extrahierten Bundle-Plan meint. Plus expliziter Hinweis, dass einzelne Mishap-Tickets immer mit `status=triage` entstehen (belegt gegen `scripts/ticket-mcp/go/internal/tools/mishap.go`).

## Bereits behoben — nicht in diesem PR

Bei der Vorpruefung gegen `origin/main` stellten sich zwei der fuenf Kind-Befunde als bereits erledigt heraus:

- **T002695** (`.gitattributes` merge=ours praezisieren) — behoben via PR #3832 (commit `3d472770a`, "chore(docs): vier Mishap-Befunde dokumentieren [T002694][T002695][T002696][T002698]"). Der Kommentarblock in `.gitattributes` enthaelt bereits den GRENZE-Hinweis fuer serverseitige GitHub-Konflikte.
- **T002715** (skip-worktree-Gotcha in `gotchas-footguns.md`) — inhaltlich deckungsgleich mit T002712, behoben via PR #3927 (commit `0325c33ef`, "docs: document skip-worktree silent pull blocker [T002712]"). Der Abschnitt "skip-worktree: git status schweigt, pull scheitert" deckt `git ls-files -v`, `--no-skip-worktree` vs. `--no-assume-unchanged` und die Datei-Verschiebungs-Fussnote bereits ab.

Bitte T002695 und T002715 mit diesen Belegen schliessen; kein weiterer Code-Fix noetig.

## Test plan

- [x] `task test:unit` grün (727 BATS-Tests inkl. Coverage-Guard)
- [x] Reine Prosa-/Kommentaraenderungen in drei Markdown/Doku-Dateien, kein Verhalten geaendert
- [x] CI abwarten

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>