### PR TITLE
fix(ci): Fork-Guard fuer arbitration.yml + cron-Trigger entfernen [T002927]

### DIFF
--- a/.github/workflows/arbitration.yml
+++ b/.github/workflows/arbitration.yml
@@ -8,12 +8,19 @@ name: Merge Arbitration
 # Strikt fail-open: kein Required Check, kein Force-Push, keine fremden
 # Branches. continue-on-error auf jedem Schritt — ein Ausfall (GPU-Runner
 # down, LLM antwortet nicht) darf niemals gegen einen PR zählen.
+#
+# [T002927] Das obige fail-open galt nur für LAUFENDE Schritte. Startet der
+# Job gar nicht — weil kein Runner mit dem Label online ist —, greift kein
+# continue-on-error: der Run bleibt unbegrenzt in `queued`. Mit cron */30
+# waren das 48 Zombie-Runs pro Tag; am 2026-08-09 mussten 100 hängende Runs
+# abgebrochen werden, der älteste knapp zwei Stunden alt. Deshalb ist der
+# schedule-Trigger entfernt — Arbitration läuft jetzt ereignisgetrieben am
+# PR und auf Zuruf. Ein Ausfall des Runners kostet damit höchstens einen
+# übersprungenen PR-Lauf statt einer wachsenden Warteschlange.
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
-  schedule:
-    - cron: '*/30 * * * *'
   workflow_dispatch: {}
 
 env:
@@ -21,6 +28,16 @@ env:
 
 jobs:
   arbitrate:
+    # [T002927] Fork-Guard — Pflicht, weil dieser Job auf einem SELF-HOSTED
+    # Runner läuft und das Repo PUBLIC ist. `actions/checkout` holt bei einem
+    # pull_request-Event den PR-HEAD; die Schritte darunter führen daraus
+    # scripts/arbitration/detect.sh und apply.sh aus. Ohne diesen Guard könnte
+    # ein beliebiger Fork-PR fremden Code auf dem Runner-Host ausführen.
+    # opencode.yml (derselbe fleet-gpu-Pool) trägt den gleichen Guard; hier
+    # fehlte er. Folgenlos blieb das nur, solange gar kein Runner online war.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, fleet-gpu]
     permissions:
       contents: read
@@ -33,6 +50,11 @@ jobs:
         continue-on-error: true
         with:
           fetch-depth: 0
+          # persist-credentials bleibt bewusst true: scripts/arbitration/apply.sh
+          # pusht den Arbitrations-Branch (`git push -q origin "$branch"`) und
+          # braucht dafür die Credentials im Checkout. Vertretbar ist das erst
+          # durch den Fork-Guard oben — der ausgecheckte Code stammt dann
+          # ausschließlich aus diesem Repo. [T002927]
           persist-credentials: true
 
       - name: Fetch all open PR branches

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 851,
+      "file_count": 852,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -390,6 +390,7 @@
         "tests/spec/ci-cd/mishap-t002425.bats",
         "tests/spec/ci-cd/pr-refresh-batch.bats",
         "tests/spec/ci-cd/pre-push-artifact-guard.bats",
+        "tests/spec/ci-cd/self-hosted-fork-guard.bats",
         "tests/spec/ci-cd/skip-ci-marker-guard.bats",
         "tests/spec/ci-cd/spec-dir-convention.bats",
         "tests/spec/ci-cd/spec-shard-partition.bats",

--- a/tests/spec/ci-cd/self-hosted-fork-guard.bats
+++ b/tests/spec/ci-cd/self-hosted-fork-guard.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+#
+# T002927 — Fork-Guard-Pflicht fuer self-hosted Runner.
+#
+# Pruefmodus: YAML-Auswertung der Workflow-Dateien via yq (nicht Source-Grep auf
+# einen bestimmten String). Ausnahme nach der Test-Resultats-Konvention
+# [T002448-M4]: die geschuetzte Eigenschaft manifestiert sich ausschliesslich in
+# der Workflow-Konfiguration; sie zur Laufzeit zu messen hiesse, einen Fork-PR
+# gegen einen echten Runner zu fahren.
+#
+# Die Eigenschaft, nicht der Wortlaut: JEDER Job, der auf einem self-hosted
+# Runner laeuft UND dessen Workflow auf pull_request triggert, muss eine
+# if-Bedingung tragen, die den PR gegen github.repository prueft. Ohne das
+# fuehrt ein beliebiger Fork-PR seinen eigenen Code auf fremder Hardware aus:
+# actions/checkout holt bei pull_request den PR-HEAD.
+#
+# Formuliert als Invariante ueber ALLE Workflows statt als Pin auf eine Datei,
+# weil genau die Luecke real auftrat — opencode.yml hatte den Guard,
+# arbitration.yml nicht, und niemandem fiel der Unterschied auf, solange kein
+# Runner online war.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  cd "$REPO" || return 1
+}
+
+# Gibt alle Workflow-Dateien aus, die (a) mindestens einen self-hosted Job haben
+# und (b) auf pull_request triggern.
+_self_hosted_pr_workflows() {
+  local f
+  for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [ -f "$f" ] || continue
+    yq -e '.on | has("pull_request")' "$f" >/dev/null 2>&1 || continue
+    yq -e '[.jobs[] | select(.["runs-on"] | tostring | test("self-hosted"))] | length > 0' \
+      "$f" >/dev/null 2>&1 || continue
+    printf '%s\n' "$f"
+  done
+}
+
+@test "T002927: es gibt ueberhaupt self-hosted pull_request-Workflows (Positiv-Anker)" {
+  # Positiv-Anker [T002356-M1]: ohne ihn ist die Negativ-Aussage im naechsten
+  # Test vakuos — bei leerer Kandidatenliste gilt sie trivial, auch wenn yq
+  # kaputt ist, das Glob nicht matcht oder der Filter falsch liegt.
+  run _self_hosted_pr_workflows
+  [ "$status" -eq 0 ]
+  [ -n "$output" ] || {
+    echo "Kandidatenliste leer — Filter oder yq defekt, kein gueltiges Urteil moeglich" >&2
+    false
+  }
+}
+
+@test "T002927: jeder self-hosted Job in einem pull_request-Workflow hat einen Fork-Guard" {
+  local f job cond missing=0
+  while IFS= read -r f; do
+    while IFS= read -r job; do
+      cond="$(yq -r ".jobs.\"$job\".if // \"\"" "$f")"
+      case "$cond" in
+        *github.repository*) ;;
+        *)
+          echo "FEHLT: $f job '$job' laeuft self-hosted, prueft aber nicht gegen github.repository" >&2
+          echo "  if: ${cond:-<keine if-Bedingung>}" >&2
+          missing=$((missing + 1))
+          ;;
+      esac
+    done < <(yq -r '.jobs | to_entries[] | select(.value["runs-on"] | tostring | test("self-hosted")) | .key' "$f")
+  done < <(_self_hosted_pr_workflows)
+
+  [ "$missing" -eq 0 ] || {
+    echo "$missing self-hosted Job(s) ohne Fork-Guard" >&2
+    false
+  }
+}
+
+@test "T002927: arbitration.yml triggert nicht mehr per cron" {
+  # Der schedule-Trigger erzeugte 48 Runs/Tag, die ohne online Runner
+  # unbegrenzt in 'queued' haengen blieben — continue-on-error greift nur fuer
+  # Schritte eines GESTARTETEN Jobs, nicht fuer einen, der nie anlaeuft.
+  [ -f .github/workflows/arbitration.yml ]
+  run yq -e '.on | has("pull_request")' .github/workflows/arbitration.yml
+  [ "$status" -eq 0 ] || { echo "pull_request-Trigger fehlt — Datei unerwartet umgebaut"; false; }
+
+  run yq -e '.on | has("schedule")' .github/workflows/arbitration.yml
+  [ "$status" -ne 0 ] || {
+    echo "schedule-Trigger ist zurueck — Zombie-Queue ohne online Runner" >&2
+    false
+  }
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2274,6 +2274,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/self-hosted-fork-guard",
+    "file": "tests/spec/ci-cd/self-hosted-fork-guard.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/skip-ci-marker-guard",
     "file": "tests/spec/ci-cd/skip-ci-marker-guard.bats",
     "category": "ci-cd",


### PR DESCRIPTION
## Warum

Beim repo-hygiene-Lauf fiel auf, dass `arbitrate` auf allen PRs dauerhaft in `queued` steht. Die Ursache war eine verwaiste Runner-Registrierung (`k3d-dev`, id=21) ohne jeden Daemon. Beim Versuch, den Runner wieder in Betrieb zu nehmen, kamen zwei gekoppelte Defekte zum Vorschein.

## 1) Sicherheit — fehlender Fork-Guard

Das Repo ist **public**. `arbitration.yml` triggert auf `pull_request`, checkt per `actions/checkout` den PR-HEAD aus (also Fork-Code) und führt daraus `scripts/arbitration/detect.sh` und `apply.sh` aus — auf `runs-on: [self-hosted, fleet-gpu]`.

Damit hätte ein beliebiger Fork-PR fremden Code auf dem Runner-Host ausgeführt. `opencode.yml` (derselbe Runner-Pool) trägt den Guard `head.repo.full_name == github.repository` seit jeher; `arbitration.yml` nicht. Folgenlos blieb das nur, solange gar kein Runner online war — bei Wiederinbetriebnahme wird es akut.

`persist-credentials` bleibt bewusst `true`: `apply.sh` pusht den Arbitrations-Branch (`git push -q origin "$branch"`) und braucht die Credentials im Checkout. Vertretbar ist das erst durch den Guard, der den ausgecheckten Code auf dieses Repo begrenzt. Das ist im Workflow kommentiert.

## 2) Zombie-Queue

`schedule: cron '*/30 * * * *'` erzeugte 48 Runs/Tag. Ohne online Runner hängen die unbegrenzt in `queued`: der Header verspricht „strikt fail-open", aber `continue-on-error` greift nur für Schritte eines **gestarteten** Jobs. Startet er nie, greift es nicht. 100 hängende Runs wurden abgebrochen, der älteste knapp zwei Stunden alt.

Arbitration läuft jetzt ereignisgetrieben am PR und per `workflow_dispatch`.

## Test

`tests/spec/ci-cd/self-hosted-fork-guard.bats` formuliert die **Invariante über alle Workflows** statt einen String zu pinnen: jeder Job auf einem self-hosted Runner in einem `pull_request`-Workflow muss gegen `github.repository` prüfen. Dieser Test hätte die Lücke ursprünglich gefunden.

Mutationsprobe lokal:
- Fork-Guard entfernt → Test 2 rot (`FEHLT: … job 'arbitrate' laeuft self-hosted, prueft aber nicht gegen github.repository`)
- cron wieder eingeführt → Test 3 rot (`schedule-Trigger ist zurueck`)

Positiv-Anker nach T002356-M1 vorhanden: ohne ihn wäre die Negativ-Aussage bei leerer Kandidatenliste vakuos.

Ticket: T002927