### PR TITLE
fix(ci): Arbitration bekommt scoped Kubeconfig als Secret [T002944]

### DIFF
--- a/.github/workflows/arbitration.yml
+++ b/.github/workflows/arbitration.yml
@@ -44,6 +44,10 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
+      # Auf JOB-Ebene gebunden, nicht am Schritt: `steps.*.if` kann weder den
+      # `secrets`-Kontext lesen noch das step-eigene `env`. Nur so laesst sich
+      # unten auf "Secret gesetzt?" pruefen. [T002944]
+      ARBITRATION_KUBECONFIG: ${{ secrets.ARBITRATION_KUBECONFIG }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -72,6 +76,32 @@ jobs:
           echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
           echo "Found ${COUNT} cluster(s) at/above threshold"
 
+      # [T002944] Der Runner laeuft als unprivilegierter Dienst-User (ghrunner)
+      # ohne Zugriff auf ein Entwickler-Home — vorher lief er als der
+      # Desktop-User mit NOPASSWD-root, dessen SSH-Keys fuer die Prod-Nodes und
+      # dessen Fleet-Kubeconfig. Damit hat er auch keine Kubeconfig mehr, und
+      # apply.sh braucht eine: bei Eskalation ruft es `ticket.sh create`, das
+      # ueber `kubectl exec … psql` in den shared-db-Pod geht.
+      #
+      # Statt der Admin-Kubeconfig eine eng geschnittene ServiceAccount-
+      # Credential aus dem Secret ARBITRATION_KUBECONFIG. Sie kann genau zwei
+      # Dinge im Namespace workspace des DEV-Clusters: Pods auflisten und
+      # `pods --subresource=exec` erzeugen. Kein Secret-Lesezugriff, kein
+      # anderer Namespace, nichts cluster-weit, und insbesondere kein Zugang
+      # zum prod-Cluster `fleet`.
+      #
+      # Fehlt das Secret, bleibt KUBECONFIG leer und `ticket.sh` scheitert wie
+      # bisher still (apply.sh ruft es mit `|| true`) — der Guard degradiert
+      # also, statt den Lauf zu brechen.
+      - name: Provide scoped kubeconfig for ticket escalation
+        if: steps.detect.outputs.count != '0' && env.ARBITRATION_KUBECONFIG != ''
+        continue-on-error: true
+        run: |
+          install -m 600 /dev/null "${RUNNER_TEMP}/arbitration.kubeconfig"
+          printf '%s' "$ARBITRATION_KUBECONFIG" > "${RUNNER_TEMP}/arbitration.kubeconfig"
+          echo "KUBECONFIG=${RUNNER_TEMP}/arbitration.kubeconfig" >> "$GITHUB_ENV"
+          echo "TICKET_CTX=k3d-mentolder-dev" >> "$GITHUB_ENV"
+
       - name: Apply arbitration (per Cluster)
         if: steps.detect.outputs.count != '0'
         continue-on-error: true
@@ -79,3 +109,14 @@ jobs:
           jq -c '.[]' /tmp/arbitration-clusters.json | while IFS= read -r cluster; do
             echo "$cluster" | bash scripts/arbitration/apply.sh || true
           done
+
+      # Die Credential darf den Lauf nicht ueberleben: _work wird zwischen Jobs
+      # nicht zuverlaessig geleert, und RUNNER_TEMP liegt im Home des
+      # Dienst-Users. `if: always()`, damit auch ein Abbruch aufraeumt.
+      - name: Shred scoped kubeconfig
+        if: always()
+        continue-on-error: true
+        run: |
+          shred -u "${RUNNER_TEMP}/arbitration.kubeconfig" 2>/dev/null \
+            || rm -f "${RUNNER_TEMP}/arbitration.kubeconfig" \
+            || true

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 852,
+      "file_count": 853,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -377,6 +377,7 @@
         "tests/spec/centralized-logging.bats",
         "tests/spec/chat-inbox.bats",
         "tests/spec/ci-cd.bats",
+        "tests/spec/ci-cd/arbitration-scoped-kubeconfig.bats",
         "tests/spec/ci-cd/automerge-run-scope.bats",
         "tests/spec/ci-cd/branch-allowlist-ssot.bats",
         "tests/spec/ci-cd/branch-reaper.bats",

--- a/tests/spec/ci-cd/arbitration-scoped-kubeconfig.bats
+++ b/tests/spec/ci-cd/arbitration-scoped-kubeconfig.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+#
+# T002944 — die Arbitration bekommt ihre Cluster-Credential als Secret, nicht
+# aus dem Home des Runner-Users.
+#
+# Pruefmodus: YAML-Auswertung via yq. Ausnahme nach der Test-Resultats-
+# Konvention [T002448-M4]: die Eigenschaft manifestiert sich ausschliesslich in
+# der Workflow-Konfiguration. Sie zur Laufzeit zu messen hiesse, einen echten
+# Arbitrations-Cluster zu erzeugen und den Runner zu beobachten.
+#
+# Vorgeschichte: der Runner lief als Desktop-User mit NOPASSWD-root; damit hatte
+# jeder Workflow-Lauf beilaeufig die SSH-Keys der Prod-Nodes und die
+# Fleet-Kubeconfig. Nach dem Umbau auf den unprivilegierten Dienst-User
+# (ghrunner) gibt es kein Home mehr, aus dem sich eine Kubeconfig "ergibt" —
+# `ticket.sh` braucht aber eine, weil es ueber `kubectl exec … psql` geht.
+#
+# Der zweite Test pinnt eine Falle, in die diese Aenderung selbst gelaufen ist:
+# `steps.*.if` kann WEDER den `secrets`-Kontext lesen NOCH das step-eigene
+# `env:`. Beide Varianten sehen richtig aus, die Bedingung ist aber immer
+# falsch und der Schritt laeuft nie — lautlos. Deshalb muss das Secret auf
+# JOB-Ebene gebunden sein.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  cd "$REPO" || return 1
+  WF=".github/workflows/arbitration.yml"
+}
+
+@test "T002944: arbitration.yml ist lesbar und hat den arbitrate-Job (Positiv-Anker)" {
+  # Positiv-Anker [T002356-M1]: ohne ihn liefen alle folgenden yq-Abfragen auf
+  # einer fehlenden oder umbenannten Datei ins Leere und lieferten "null",
+  # was sich von einem echten Befund nicht unterscheiden liesse.
+  [ -f "$WF" ] || { echo "$WF fehlt"; return 1; }
+  run yq -e '.jobs.arbitrate | has("steps")' "$WF"
+  [ "$status" -eq 0 ] || { echo "arbitrate-Job oder seine steps fehlen"; false; }
+}
+
+@test "T002944: das Kubeconfig-Secret ist auf JOB-Ebene gebunden" {
+  # Auf Step-Ebene waere es fuer das `if:` desselben Schritts unsichtbar.
+  run yq -r '.jobs.arbitrate.env.ARBITRATION_KUBECONFIG // ""' "$WF"
+  [ -n "$output" ] || {
+    echo "ARBITRATION_KUBECONFIG nicht im job-level env — steps.*.if kann es dann nicht lesen" >&2
+    false
+  }
+  case "$output" in
+    *secrets.ARBITRATION_KUBECONFIG*) ;;
+    *) echo "job-env liest nicht aus secrets: $output" >&2; false ;;
+  esac
+}
+
+@test "T002944: die if-Bedingung des Kubeconfig-Schritts nutzt env, nicht secrets" {
+  local cond
+  cond="$(yq -r '.jobs.arbitrate.steps[] | select(.name == "Provide scoped kubeconfig for ticket escalation") | .if // ""' "$WF")"
+  [ -n "$cond" ] || { echo "Kubeconfig-Schritt oder seine if-Bedingung fehlt" >&2; false; }
+
+  case "$cond" in
+    *env.ARBITRATION_KUBECONFIG*) ;;
+    *) echo "if-Bedingung prueft nicht auf env.ARBITRATION_KUBECONFIG: $cond" >&2; false ;;
+  esac
+  case "$cond" in
+    *secrets.*)
+      echo "if-Bedingung liest den secrets-Kontext — in steps.*.if nicht verfuegbar, Schritt laeuft nie: $cond" >&2
+      false ;;
+  esac
+}
+
+@test "T002944: die Kubeconfig wird am Ende geschreddert, auch bei Abbruch" {
+  # RUNNER_TEMP liegt im Home des Dienst-Users und wird zwischen Jobs nicht
+  # zuverlaessig geleert — ohne diesen Schritt ueberlebt die Credential den Lauf.
+  local cond
+  cond="$(yq -r '.jobs.arbitrate.steps[] | select(.name == "Shred scoped kubeconfig") | .if // ""' "$WF")"
+  [ -n "$cond" ] || { echo "Aufraeum-Schritt fehlt" >&2; false; }
+  case "$cond" in
+    *always*) ;;
+    *) echo "Aufraeum-Schritt laeuft nicht bei always(): $cond" >&2; false ;;
+  esac
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2196,6 +2196,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/arbitration-scoped-kubeconfig",
+    "file": "tests/spec/ci-cd/arbitration-scoped-kubeconfig.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/automerge-run-scope",
     "file": "tests/spec/ci-cd/automerge-run-scope.bats",
     "category": "ci-cd",


### PR DESCRIPTION
Folgearbeit zu T002927 (PR #3975). Der Fork-Guard dort schloss den **externen** Pfad; dieser PR schließt den internen.

## Ausgangslage

Der `fleet-gpu`-Runner lief als Desktop-User `patrick` mit `NOPASSWD: ALL`. In demselben Home liegen die SSH-Keys der Hetzner-Prod-Nodes, die Fleet-Kubeconfig und die git-crypt-Schlüssel. Jeder Repo-Kollaborator hätte über einen PR root auf dem Entwicklungsrechner und darüber Prod-Zugang gehabt. Das Design (`2026-07-10-opencode-local-model-runner-design.md`) fordert ausdrücklich „kein root, kein Kubeconfig-Zugriff im Runner-User-Kontext" — `svc.sh install` nimmt per Default den aufrufenden User, daher die Abweichung.

## Umbau am Host (nicht in diesem Diff)

- Unprivilegierter Dienst-User `ghrunner` (`--system`, `nologin`, kein sudo, nur die eigene Gruppe, **nicht** in der docker-Gruppe — die ist root-äquivalent).
- Runner nach `/opt/actions-runner` verschoben, `chmod 700`, Credentials auf `600` (waren `644`, also weltlesbar).
- `/home/patrick` ist `drwxr-x---`: `ghrunner` kann das Verzeichnis nicht einmal betreten. Gegenprobe als `ghrunner` ausgeführt — SSH-Key, SSH-Config und Kubeconfig alle gesperrt.
- `.path` bereinigt: `svc.sh install` hatte 18 Einträge aus dem Desktop-Home in den Runner-PATH übernommen.

## Was dieser Diff ändert

Ohne Home gibt es keine Kubeconfig mehr — `apply.sh` braucht aber eine, weil es bei Eskalation `ticket.sh create` ruft, und das geht über `kubectl exec … psql` in den `shared-db`-Pod. Ein direkter DB-Pfad existiert in `ticket.sh` nicht.

Statt der Admin-Kubeconfig liefert das Secret `ARBITRATION_KUBECONFIG` eine ServiceAccount-Credential (`arbitration-ticket`, ns `workspace`, **Dev**-Cluster). Verifiziert:

| Prüfung | Ergebnis |
|---|---|
| `create pods --subresource=exec` | **yes** |
| `list pods` | **yes** |
| `create pods` | no |
| `get secrets` | no |
| `list pods -n kube-system` | no |
| `'*' '*' --all-namespaces` | no |
| psql im DB-Pod real ausgeführt | `SCOPED-OK` |

Kein Zugang zum Prod-Cluster `fleet`. Fehlt das Secret, bleibt `KUBECONFIG` leer und `ticket.sh` scheitert still wie bisher (`apply.sh` ruft es mit `|| true`) — der Lauf bricht nicht.

Die Credential wird mit `if: always()` geschreddert; `RUNNER_TEMP` liegt im Home des Dienst-Users und wird zwischen Jobs nicht zuverlässig geleert.

## Eine Falle, in die dieser PR selbst lief

`steps.*.if` kann **weder** den `secrets`-Kontext lesen **noch** das step-eigene `env:`. Beide Varianten sehen richtig aus, die Bedingung ist aber immer falsch und der Schritt läuft **lautlos nie**. Deshalb ist das Secret auf **Job**-Ebene gebunden.

Gefunden hat das `actionlint`:

```
context "secrets" is not allowed here. available contexts are "env", "github", ...
```

`actionlint` läuft derzeit **nirgends** im Repo — weder in CI noch als Task. Das ist eine eigene Lücke und wäre eine sinnvolle Folgearbeit; hier nicht mitgemacht, um den PR schmal zu halten.

## Test

`tests/spec/ci-cd/arbitration-scoped-kubeconfig.bats` (yq-basiert, kein Zusatz-Binary nötig). Mutationsprobe:

- Secret auf Step- statt Job-Ebene → Test 2 rot
- `if:` auf `secrets.` umgestellt → Test 3 rot
- Shred-Schritt entfernt → Test 4 rot

Positiv-Anker nach T002356-M1 vorhanden.

Ticket: T002944