### PR TITLE
fix(db): Knowledge-Ingest liest Live-Ticket-Quellen statt leerer Legacy-Tabellen [T002605]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 857,
+      "file_count": 858,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -480,6 +480,7 @@
         "tests/spec/llm-pipeline/bge-usecase-reachability.bats",
         "tests/spec/llm-pipeline/gemma-thinking-budget.bats",
         "tests/spec/llm-pipeline/index-repo-embed-port.bats",
+        "tests/spec/llm-pipeline/knowledge-ingest-live-sources.bats",
         "tests/spec/llm-pipeline/kv-offload.bats",
         "tests/spec/local-llm-proxy.bats",
         "tests/spec/local-llm-proxy/bge-cpu-parallel-start.bats",

--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -140,15 +140,31 @@ data:
         const collectionId = await ensureCollection(pool, {
           name: COLLECTION_NAME,
           source: COLLECTION_SOURCE,
-          description: 'Merged pull requests from bachelorprojekt.features',
+          description: 'Merged pull requests (live source: tickets.ticket_links)',
         });
 
         const { rows } = await pool.query(
-          `SELECT pr_number, title, description, merged_at
-             FROM bachelorprojekt.features
-            WHERE merged_at IS NOT NULL
-            ORDER BY merged_at DESC`,
+          `SELECT DISTINCT l.pr_number, t.title, t.description
+             FROM tickets.ticket_links l
+             JOIN tickets.tickets t ON t.id = l.from_id
+            WHERE l.pr_number IS NOT NULL
+            ORDER BY l.pr_number DESC`,
         );
+
+        if (rows.length === 0) {
+          // [T002605] Zero-Item-Guard: leere Quelle ist verdaechtig, wenn der
+          // Live-Store befuellt ist (die Legacy-Quelle ist leer — die
+          // Quelle ist tickets.ticket_links).
+          const { rows: live } = await pool.query(
+            `SELECT COUNT(DISTINCT pr_number) AS n FROM tickets.ticket_links WHERE pr_number IS NOT NULL`,
+          );
+          const liveCount = Number(live[0]?.n ?? 0);
+          if (liveCount > 0) {
+            console.error(`0 PRs, but live store has $${liveCount} — source misconfiguration?`);
+            process.exit(1);
+          }
+          console.log('0 PRs (live store empty — nothing to ingest)');
+        }
 
         console.log(`Found $${rows.length} PRs to ingest`);
 
@@ -173,8 +189,6 @@ data:
             hash,
             metadata: {
               pr_number: row.pr_number,
-              merged_at: row.merged_at,
-              labels: row.labels ?? [],
             },
             chunks: chunksWithEmbed,
           });
@@ -192,6 +206,8 @@ data:
     main().catch(err => { console.error(err); process.exit(1); });
 
   ingest-markdown.mjs: |
+    // [T002605] Suspended: Markdown-Ingest laeuft bewusst lokal-only —
+    // task knowledge:reindex SOURCE=markdown (Repo-Mount noetig).
     // Markdown ingestion requires the repository to be mounted at /repo.
     // In-cluster CronJob pods do not have repo access — skipping.
     // Trigger manually via: task knowledge:reindex SOURCE=markdown
@@ -216,18 +232,37 @@ data:
         });
 
         const { rows } = await pool.query(
-          `SELECT ticket_id, description, status, brand, created_at, fixed_in_pr
-             FROM bugs.bug_tickets
-            WHERE brand = $1
-            ORDER BY created_at DESC`,
+          `SELECT t.external_id AS ticket_id, t.title, t.description, t.status, t.brand, t.created_at,
+                  (SELECT l.pr_number FROM tickets.ticket_links l
+                    WHERE l.from_id = t.id AND l.kind = 'fixes' AND l.pr_number IS NOT NULL
+                    ORDER BY l.created_at DESC LIMIT 1) AS fixed_in_pr
+             FROM tickets.tickets t
+            WHERE t.brand = $1 AND t.type IN ('bug','fix')
+            ORDER BY t.created_at DESC`,
           [BRAND],
         );
+
+        if (rows.length === 0) {
+          // [T002605] Zero-Item-Guard: leere Quelle ist verdaechtig, wenn der
+          // Live-Store befuellt ist (die Legacy-Quelle ist leer — die Quelle
+          // ist tickets.tickets).
+          const { rows: live } = await pool.query(
+            `SELECT COUNT(*) AS n FROM tickets.tickets WHERE brand = $1 AND type IN ('bug','fix')`,
+            [BRAND],
+          );
+          const liveCount = Number(live[0]?.n ?? 0);
+          if (liveCount > 0) {
+            console.error(`0 bug tickets, but live store has $${liveCount} — source misconfiguration?`);
+            process.exit(1);
+          }
+          console.log('0 bug tickets (live store empty — nothing to ingest)');
+        }
 
         console.log(`Found $${rows.length} bug tickets for brand "$${BRAND}"`);
 
         for (const row of rows) {
           const text = [
-            `$${row.ticket_id}: $${row.description.slice(0, 100)}...`,
+            `$${row.ticket_id}: $${row.title}`,
             `Status: $${row.status}`,
             row.fixed_in_pr ? `Fixed in PR #$${row.fixed_in_pr}` : '',
             row.description ?? '',
@@ -241,7 +276,7 @@ data:
 
           await upsertDocumentAndChunks(pool, {
             collectionId,
-            title: `$${row.ticket_id}: $${row.description.slice(0, 100)}...`,
+            title: `$${row.ticket_id}: $${row.title}`,
             sourceUri,
             rawText: text,
             hash,
@@ -357,6 +392,9 @@ metadata:
     app: knowledge
 spec:
   schedule: "30 2 * * *"
+  # [T002605] Suspended: Markdown-Ingest laeuft bewusst lokal-only —
+  # task knowledge:reindex SOURCE=markdown (Repo-Mount noetig, Cluster hat keinen).
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3

--- a/scripts/knowledge/ingest-bug-tickets.mjs
+++ b/scripts/knowledge/ingest-bug-tickets.mjs
@@ -16,37 +16,56 @@ async function main() {
     });
 
     const { rows } = await pool.query(
-      `SELECT id, title, description, status, brand, created_at, fixed_in_pr
-         FROM bugs.bug_tickets
-        WHERE brand = $1
-        ORDER BY created_at DESC`,
+      `SELECT t.external_id AS ticket_id, t.title, t.description, t.status, t.brand, t.created_at,
+              (SELECT l.pr_number FROM tickets.ticket_links l
+                WHERE l.from_id = t.id AND l.kind = 'fixes' AND l.pr_number IS NOT NULL
+                ORDER BY l.created_at DESC LIMIT 1) AS fixed_in_pr
+         FROM tickets.tickets t
+        WHERE t.brand = $1 AND t.type IN ('bug','fix')
+        ORDER BY t.created_at DESC`,
       [BRAND],
     );
+
+    if (rows.length === 0) {
+      // [T002605] Zero-Item-Guard: leere Quelle ist verdaechtig, wenn der
+      // Live-Store befuellt ist — vorher meldete der CronJob "Found 0 bug
+      // tickets" mit Exit 0, obwohl die Legacy-Tabellen schon lange leer waren.
+      const { rows: live } = await pool.query(
+        `SELECT COUNT(*) AS n FROM tickets.tickets WHERE brand = $1 AND type IN ('bug','fix')`,
+        [BRAND],
+      );
+      const liveCount = Number(live[0]?.n ?? 0);
+      if (liveCount > 0) {
+        console.error(`0 bug tickets, but live store has ${liveCount} — source misconfiguration?`);
+        process.exit(1);
+      }
+      console.log('0 bug tickets (live store empty — nothing to ingest)');
+    }
 
     console.log(`Found ${rows.length} bug tickets for brand "${BRAND}"`);
 
     for (const row of rows) {
       const text = [
-        `${row.id}: ${row.title}`,
+        `${row.ticket_id}: ${row.title}`,
         `Status: ${row.status}`,
         row.fixed_in_pr ? `Fixed in PR #${row.fixed_in_pr}` : '',
         row.description ?? '',
       ].filter(Boolean).join('\n\n');
 
       const hash = sha256(text);
-      const sourceUri = `bug:${row.id}`;
+      const sourceUri = `bug:${row.ticket_id}`;
       const rawChunks = chunkPlain(text);
       const embeddings = await embedAll(rawChunks.map(c => c.text));
       const chunks = rawChunks.map((c, i) => ({ ...c, embedding: embeddings[i] }));
 
       await upsertDocumentAndChunks(pool, {
         collectionId,
-        title: `${row.id}: ${row.title}`,
+        title: `${row.ticket_id}: ${row.title}`,
         sourceUri,
         rawText: text,
         hash,
         metadata: {
-          ticket_id: row.id,
+          ticket_id: row.ticket_id,
           status: row.status,
           brand: row.brand,
           fixed_in_pr: row.fixed_in_pr,

--- a/scripts/knowledge/ingest-prs.mjs
+++ b/scripts/knowledge/ingest-prs.mjs
@@ -10,15 +10,30 @@ async function main() {
     const collectionId = await ensureCollection(pool, {
       name: COLLECTION_NAME,
       source: COLLECTION_SOURCE,
-      description: 'Merged pull requests from bachelorprojekt.features',
+      description: 'Merged pull requests (live source: tickets.ticket_links)',
     });
 
     const { rows } = await pool.query(
-      `SELECT pr_number, title, description, body, merged_at, labels
-         FROM bachelorprojekt.features
-        WHERE merged_at IS NOT NULL
-        ORDER BY merged_at DESC`,
+      `SELECT DISTINCT l.pr_number, t.title, t.description
+         FROM tickets.ticket_links l
+         JOIN tickets.tickets t ON t.id = l.from_id
+        WHERE l.pr_number IS NOT NULL
+        ORDER BY l.pr_number DESC`,
     );
+
+    if (rows.length === 0) {
+      // [T002605] Zero-Item-Guard: siehe ingest-bug-tickets.mjs — stille-gruene
+      // Fehlerklasse beheben, bevor der Live-Store uebersehen bleibt.
+      const { rows: live } = await pool.query(
+        `SELECT COUNT(DISTINCT pr_number) AS n FROM tickets.ticket_links WHERE pr_number IS NOT NULL`,
+      );
+      const liveCount = Number(live[0]?.n ?? 0);
+      if (liveCount > 0) {
+        console.error(`0 PRs, but live store has ${liveCount} — source misconfiguration?`);
+        process.exit(1);
+      }
+      console.log('0 PRs (live store empty — nothing to ingest)');
+    }
 
     console.log(`Found ${rows.length} PRs to ingest`);
 
@@ -26,8 +41,6 @@ async function main() {
       const text = [
         `PR #${row.pr_number}: ${row.title}`,
         row.description ?? '',
-        row.body ?? '',
-        row.labels?.length ? `Labels: ${row.labels.join(', ')}` : '',
       ].filter(Boolean).join('\n\n');
 
       const hash = sha256(text);
@@ -46,8 +59,6 @@ async function main() {
         hash,
         metadata: {
           pr_number: row.pr_number,
-          merged_at: row.merged_at,
-          labels: row.labels ?? [],
         },
         chunks: chunksWithEmbed,
       });

--- a/tests/spec/llm-pipeline/knowledge-ingest-live-sources.bats
+++ b/tests/spec/llm-pipeline/knowledge-ingest-live-sources.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# tests/spec/llm-pipeline/knowledge-ingest-live-sources.bats
+# SSOT: openspec/specs/llm-pipeline.md (fix-knowledge-ingest-zero-items-T002605)
+# Stellt sicher, dass die Knowledge-Ingest-CronJobs aus dem lebenden
+# Ticket-Store lesen (tickets.tickets / tickets.ticket_links) statt aus
+# leeren Legacy-Tabellen, den Zero-Item-Guard tragen und der Markdown-
+# CronJob suspendiert ist.
+#
+# PRUEFMODUS: Output-Verifikation (T002448-M4). Die Assertions laufen gegen
+# den gerenderten Kustomize-Build von k3d/ — das Artefakt, das Flux
+# tatsaechlich anwendet — nicht per grep gegen den Manifest-Quelltext.
+
+REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+
+setup_file() {
+  export RENDERED="${BATS_FILE_TMPDIR}/rendered-knowledge-live-sources.yaml"
+  kubectl kustomize "${REPO}/k3d" --load-restrictor=LoadRestrictionsNone > "$RENDERED" 2>&1
+}
+
+@test "ingest-bug-tickets.mjs (ConfigMap) liest tickets.tickets, nicht bugs.bug_tickets" {
+  run grep -A 45 "ingest-bug-tickets.mjs" "$RENDERED"
+  [ "$status" -eq 0 ] || { echo "ConfigMap-Block nicht gefunden"; false; }
+  [[ "$output" == *"FROM tickets.tickets"* ]] || { echo "kein tickets.tickets-SELECT: $output"; false; }
+  [[ "$output" != *"FROM bugs.bug_tickets"* ]] || { echo "Legacy-SELECT noch vorhanden: $output"; false; }
+}
+
+@test "ingest-prs.mjs (ConfigMap) liest tickets.ticket_links, nicht bachelorprojekt.features" {
+  run grep -A 45 "ingest-prs.mjs" "$RENDERED"
+  [ "$status" -eq 0 ] || { echo "ConfigMap-Block nicht gefunden"; false; }
+  [[ "$output" == *"FROM tickets.ticket_links"* ]] || { echo "kein ticket_links-Join: $output"; false; }
+  [[ "$output" != *"bachelorprojekt.features"* ]] || { echo "Legacy-Tabelle noch referenziert"; false; }
+}
+
+@test "Zero-Item-Guard vorhanden (stille-gruene Fehlerklasse)" {
+  run grep -A 45 "ingest-bug-tickets.mjs" "$RENDERED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"live store"* ]] || { echo "Guard-Meldung fehlt: $output"; false; }
+}
+
+@test "knowledge-ingest-markdown CronJob ist suspendiert" {
+  # awk: ab der Markdown-CronJob-Zeile bis zum naechsten apiVersion-Ressourcen-
+  # trenner (Kustomize-Ausgabe ist alphabetisch sortiert — suspend: true liegt
+  # mehrere Dutzend Zeilen nach dem Namen, ein festes -A-Fenster waere bruchig).
+  run awk '/name: knowledge-ingest-markdown/{f=1} f{print} f&&/^apiVersion:/{exit}' "$RENDERED"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"suspend: true"* ]] || { echo "kein suspend: true am Markdown-CronJob"; false; }
+}
+
+@test "Lokale Kopie ingest-bug-tickets.mjs liest ebenfalls tickets.tickets" {
+  run grep -A 20 "FROM tickets.tickets" "${REPO}/scripts/knowledge/ingest-bug-tickets.mjs"
+  [ "$status" -eq 0 ] || { echo "lokale Kopie liest nicht tickets.tickets"; false; }
+}
+
+@test "Lokale Kopie ingest-prs.mjs liest ebenfalls tickets.ticket_links" {
+  run grep -A 20 "FROM tickets.ticket_links" "${REPO}/scripts/knowledge/ingest-prs.mjs"
+  [ "$status" -eq 0 ] || { echo "lokale Kopie liest nicht ticket_links"; false; }
+}

--- a/tests/unit/knowledge-ingest-schema.bats
+++ b/tests/unit/knowledge-ingest-schema.bats
@@ -9,8 +9,10 @@ setup_file() {
 }
 
 @test "ingest-prs.mjs does NOT query non-existent columns (body, labels)" {
-  # The broken columns should NOT be found in the SELECT query
-  run grep -A 10 "SELECT pr_number" "$RENDERED"
+  # The broken columns should NOT be found in the SELECT query.
+  # [T002605] Quelle ist jetzt tickets.ticket_links — der SELECT beginnt mit
+  # 'SELECT DISTINCT l.pr_number' (Live-Quelle statt bachelorprojekt.features).
+  run grep -A 10 "SELECT DISTINCT l.pr_number" "$RENDERED"
   assert_success
   
   refute_line --partial "body,"

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2808,6 +2808,12 @@
     "kind": "shell"
   },
   {
+    "id": "llm-pipeline/knowledge-ingest-live-sources",
+    "file": "tests/spec/llm-pipeline/knowledge-ingest-live-sources.bats",
+    "category": "llm-pipeline",
+    "kind": "shell"
+  },
+  {
     "id": "llm-pipeline/kv-offload",
     "file": "tests/spec/llm-pipeline/kv-offload.bats",
     "category": "llm-pipeline",


### PR DESCRIPTION
T002605 — Knowledge-Ingest-CronJobs liefen gruen, embeddeten aber 0 Items.

## p1 Diagnose (Evidenz, fleet-Produktions-DB, 2026-08-09)
- `bachelorprojekt.features`=0, `bugs.bug_tickets`=0, `tickets.pr_events`=0; pg_stat n_tup_ins=0 — die Legacy-Quellen wurden nie beschrieben
- Live: `tickets.tickets` (mentolder fix=694, korczewski fix=18), `tickets.ticket_links` (376 distinkte PRs)
- Entscheidungen D2 (Filter `type IN ('bug','fix')`), D3 (PR-Quelle = ticket_links-Join), D4 (Markdown suspendieren) als Ticket-Kommentar protokolliert (Diagnose-Gate)

## Fix (p2+p3)
- `scripts/knowledge/ingest-bug-tickets.mjs` + ConfigMap-Kopie in `k3d/knowledge-ingest-cronjob.yaml`: liest `tickets.tickets` (mit `fixed_in_pr`-Subquery) statt `bugs.bug_tickets`
- `ingest-prs.mjs` + ConfigMap-Kopie: liest `tickets.ticket_links` JOIN `tickets.tickets` statt `bachelorprojekt.features`; kein `body`/`labels`/-`merged_at` mehr (existieren dort nicht)
- **Zero-Item-Guard** in beiden: leere Quelle + befuellter Live-Store → stderr + exit 1 (CronJob wird rot statt still gruen)
- `knowledge-ingest-markdown` CronJob: `spec.suspend: true` + Doku-Kommentar (laueft bewusst lokal-only, Repo-Mount noetig)
- Neue Suite `tests/spec/llm-pipeline/knowledge-ingest-live-sources.bats` (6 Tests, Output-Verifikation gegen kustomize-Render); `tests/unit/knowledge-ingest-schema.bats` an neuen SELECT angepasst

## Verifikation
- Neue Suite: 6/6 gruen (2x stabil); bestehende knowledge-ingest-Unit-Suiten: gruen
- `kubectl kustomize k3d` OK; `task workspace:validate` OK; `node --check` beide Scripts OK; keine Legacy-Tabellen-Referenzen mehr in k3d/
- freshness:check: gruen