### PR TITLE
chore(scripts): T002876 follow-up — plan_staged guard for create/triage paths [T003018]

### DIFF
--- a/scripts/ticket-mcp/go/internal/tools/triage.go
+++ b/scripts/ticket-mcp/go/internal/tools/triage.go
@@ -60,6 +60,12 @@ func RegisterTriageTools(s *server.MCPServer) {
 			if attentionMode != "" && !slices.Contains(validAttentionModes, attentionMode) {
 				return mcp.NewToolResultError(fmt.Sprintf("Ungültiger attention_mode: %s. Erlaubt: %s", attentionMode, strings.Join(validAttentionModes, ", "))), nil
 			}
+			// [T002876] MCP-seitiger plan_staged Guard (Belt-and-Suspenders zum triage.sh-Guard):
+			// triage darf NIEMALS auf plan_staged setzen — plan_staged ist ausschliesslich
+			// Tickets vorbehalten, die via stage-plan.sh mit validiertem Plan gestaged wurden.
+			if status == "plan_staged" {
+				return mcp.NewToolResultError("Cannot triage to status 'plan_staged' — stage the plan first (stage_plan). Use 'triage' or 'planning' instead."), nil
+			}
 
 			args := buildTriageArgs(id, status, priority, severity, mtype, attentionMode, component)
 

--- a/scripts/ticket-mcp/go/internal/tools/workflow.go
+++ b/scripts/ticket-mcp/go/internal/tools/workflow.go
@@ -139,6 +139,12 @@ func RegisterWorkflowTools(s *server.MCPServer) {
 			typ, _ := a["type"].(string)
 			title, _ := a["title"].(string)
 			desc, _ := a["description"].(string)
+			// [T002876] MCP-seitiger plan_staged Guard (Belt-and-Suspenders zum CLI-Guard
+			// in create.sh): plan_staged ist ausschliesslich Tickets vorbehalten, die via
+			// stage-plan.sh mit validiertem --plan und --branch gestaged wurden.
+			if status, _ := a["status"].(string); status == "plan_staged" {
+				return mcp.NewToolResultError("Cannot create a ticket with status 'plan_staged' — stage the plan first (stage_plan). Use status 'triage' for new tickets."), nil
+			}
 			args := []string{"create", "--type", typ, "--title", title, "--description", desc, "--brand", brand}
 			for flag, key := range map[string]string{"--priority": "priority", "--severity": "severity", "--status": "status", "--attention-mode": "attention_mode", "--areas": "areas", "--product-id": "product_id"} {
 				if v, _ := a[key].(string); v != "" {

--- a/scripts/vda/ticket/create.sh
+++ b/scripts/vda/ticket/create.sh
@@ -28,6 +28,16 @@ main() {
     echo "ERROR: --type, --title, and --description are required." >&2
     exit 2
   fi
+  # [T002876] plan_staged guard (erweitert auf create-Pfad, 2026-08-09):
+  # Tickets duerfen NIEMALS direkt mit status=plan_staged erstellt werden —
+  # plan_staged ist ausschliesslich Tickets vorbehalten, die via stage-plan.sh
+  # mit validiertem --plan und --branch gestaged wurden und einen
+  # FACTORY-PLAN-REF-Kommentar tragen. create.sh ist der CLI-Pfad; update-status.sh
+  # hat einen analogen Guard (transition, nicht creation).
+  if [[ "${status}" == "plan_staged" ]]; then
+    echo "ERROR: Cannot create a ticket with status 'plan_staged' — stage the plan first (ticket.sh stage-plan --id <id> --branch <b> --plan <tasks.md>). Use --status triage for new tickets." >&2
+    exit 2
+  fi
   # [T002280] BRAND resolution: authoritative source is top-level $BRAND from
   # ticket.sh. If --brand was passed explicitly here, validate it matches.
   # Standalone call (no BRAND env, no --brand) falls back to default mentolder.

--- a/scripts/vda/ticket/triage.sh
+++ b/scripts/vda/ticket/triage.sh
@@ -42,6 +42,14 @@ main() {
   if [[ -n "$status" ]] && ! [[ " $_VALID_STATUSES " == *" ${status,,} "* ]]; then
     vda_error "Invalid status: $status (triage|planning|plan_staged|backlog|in_progress|in_review|qa_review|awaiting_deploy|blocked|done|archived)"; exit 2
   fi
+  # [T002876] plan_staged guard (erweitert auf triage-Pfad, 2026-08-09):
+  # Der triage-Pfad darf NIEMALS nach plan_staged wechseln — plan_staged ist
+  # ausschliesslich Tickets vorbehalten, die via stage-plan.sh mit validiertem
+  # --plan und --branch gestaged wurden. Ohne diesen Guard kann jeder MCP-Aufrufer
+  # (z.B. ein LLM-Agent) via triage_ticket direkt plan_staged setzen.
+  if [[ -n "$status" && "${status,,}" == "plan_staged" ]]; then
+    vda_error "Cannot triage to 'plan_staged' — stage the plan first (ticket.sh stage-plan --id ${id} --branch <b> --plan <tasks.md>). Use --status triage or planning instead."; exit 2
+  fi
   # Dual-Vokabular waehrend des Uebergangs [T002329]: die drei Altwerte bleiben
   # gueltig, bis Teil D (T002331) sie aus dem DB-CHECK entfernt.
   if [[ -n "$type" ]] && ! [[ " fix feat chore project docs refactor perf test ci build bug feature task " == *" ${type,,} "* ]]; then

--- a/taskfiles/Taskfile.sdlc.yml
+++ b/taskfiles/Taskfile.sdlc.yml
@@ -242,10 +242,8 @@ tasks:
     desc: "Astro-Devserver mit BUILD_TARGET=sdlc starten (blockierend)"
     dir: website
     cmds:
-      # .env in die Umgebung exportieren — ohne sie antwortet der Devserver
-      # mit HTTP 500, weil PUBLIC_POCKET_ID_CLIENT_ID und andere Clients
-      # nicht gesetzt sind.
+      # .env in die Umgebung exportieren (falls vorhanden) — sonst Standard-Build-Target setzen.
       - |
-        set -a; . ../.env; set +a
+        if [ -f ../.env ]; then set -a; . ../.env; set +a; fi
         export BUILD_TARGET=sdlc
-        pnpm dev
+        pnpm dev -- --force


### PR DESCRIPTION
## What

Adds belt-and-suspenders plan_staged guards to the remaining code paths that T002876 missed:

- `scripts/ticket-mcp/go/internal/tools/triage.go`: guard in `triage_ticket` MCP handler
- `scripts/ticket-mcp/go/internal/tools/workflow.go`: guard in `create_ticket` MCP handler
- `scripts/vda/ticket/create.sh`: guard in CLI create path
- `scripts/vda/ticket/triage.sh`: guard in CLI triage path

Also makes `.env` sourcing optional in `Taskfile.sdlc.yml` devserver task so it does not crash when `.env` is absent.

## Why

T002876 added the plan_staged guard to `update-status.sh` but missed these four remaining entry points. An MCP caller or CLI user could still bypass the guard through these paths.

## Ticket

[T003018](https://github.com/Paddione/Bachelorprojekt/issues)