### PR TITLE
fix(factory): post-commit-embed hang blockiert Factory-Tick — hooksPath + Timeout [T002913]

### DIFF
--- a/scripts/factory/mishap-rollup.sh
+++ b/scripts/factory/mishap-rollup.sh
@@ -110,10 +110,15 @@ cd "$WT"
 # ── Branch auf Remote → rebasen ─────────────────────────────────────────────
 # Wenn der Branch auf origin existiert, rebasen wir auf origin/main, damit der
 # Plan den aktuellen Stand des main-Branches reflektiert.
+# [T002913] Der post-commit-embed-Hook feuert bei JEDEM rebasierten Commit und
+# kann am Embedding-Backend haengen (readiness=true bei totem Endpoint). Genau so
+# hing der Factory-Tick stundenlang im Rebase, hielt den Flock und blockierte
+# jeden weiteren Tick. Ein Factory-interner Rollup-Rebase braucht den Hook nicht
+# (der Embed laeuft ohnehin nach dem stage-plan) — also deaktivieren.
 if git rev-parse --verify --quiet "origin/${BRANCH}" >/dev/null 2>&1; then
-  echo "mishap-rollup: rebase ${BRANCH} auf origin/main"
+  echo "mishap-rollup: rebase ${BRANCH} auf origin/main (post-commit-embed deaktiviert)"
   git fetch origin main 2>/dev/null || true
-  git rebase origin/main 2>/dev/null || {
+  git -c core.hooksPath=/dev/null rebase origin/main 2>/dev/null || {
     echo "mishap-rollup: rebase fehlgeschlagen — breche ab" >&2
     exit 1
   }
@@ -253,7 +258,7 @@ else
   git push -q -u origin "$BRANCH" 2>/dev/null || {
     echo "mishap-rollup: push fehlgeschlagen — rebase + retry"
     git fetch origin main 2>/dev/null || true
-    git rebase origin/main 2>/dev/null || true
+    git -c core.hooksPath=/dev/null rebase origin/main 2>/dev/null || true
     git push -q -u origin "$BRANCH" || {
       echo "mishap-rollup: FEHLER — push auf '${BRANCH}' auch nach rebase fehlgeschlagen." >&2
       echo "  Der Plan ist lokal committet, aber nicht auf origin: ${CHANGE_DIR}" >&2

--- a/scripts/openspec-embed.mjs
+++ b/scripts/openspec-embed.mjs
@@ -181,12 +181,21 @@ function vecLiteral(v) {
 const DEFAULT_EMBED_URL = () =>
   process.env.LLM_EMBED_URL ?? 'http://llm-gateway-embed.workspace.svc.cluster.local:8081';
 
-async function defaultEmbed(texts) {
+// T002913: ohne hartes Timeout haengt defaultEmbed fuer immer, wenn das Backend
+// TCP akzeptiert aber nie antwortet (readiness=true bei totem Endpoint). Genau so
+// blockierte der post-commit-embed-Hook den `git rebase` im Factory-Tick und damit
+// den gesamten Dispatcher (flock gehalten, keine weiteren Ticks). Konfigurierbar,
+// Default 60s — fuer den Hook-Kontext reicht das, ein laengeres Embedding duerfte
+// ohnehin ein Symptom sein.
+const embedFetchTimeoutMs = () => Number(process.env.OPENSPEC_EMBED_FETCH_TIMEOUT_MS ?? 60_000);
+
+export async function defaultEmbed(texts) {
   const model = resolveEmbeddingModel();
   const r = await fetch(`${DEFAULT_EMBED_URL()}/v1/embeddings`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'X-LLM-Purpose': 'index' },
     body: JSON.stringify({ model, input: texts }),
+    signal: AbortSignal.timeout(embedFetchTimeoutMs()),
   });
   if (!r.ok) throw new Error(`embed ${r.status} ${await r.text().catch(() => '')}`);
   const j = await r.json();

--- a/scripts/openspec-embed.test.mjs
+++ b/scripts/openspec-embed.test.mjs
@@ -1,3 +1,4 @@
+import http from 'node:http';
 import { describe, it, expect } from 'vitest';
 import {
   stripFrontmatter,
@@ -7,6 +8,7 @@ import {
   buildChunks,
   embedSlug,
   resolveEmbeddingModel,
+  defaultEmbed,
 } from './openspec-embed.mjs';
 
 describe('stripFrontmatter', () => {
@@ -119,5 +121,32 @@ describe('embedSlug', () => {
     const res = await embedSlug({ slug: 'demo', repoRoot: '/nonexistent', dryRun: true, deps: fake });
     expect(res.dryRun).toBe(true);
     expect(queries.some((q) => /INSERT/i.test(q.sql))).toBe(false);
+  });
+});
+
+describe('defaultEmbed', () => {
+  // T002913: a backend that accepts TCP but never answers must NOT hang the
+  // embed call forever — the post-commit hook ran inside the factory tick's
+  // `git rebase` and wedged the whole dispatcher (flock held, no further ticks).
+  it('aborts after the fetch timeout when the backend never responds', async () => {
+    const server = http.createServer((_req, _res) => {
+      // Accept the connection, never send a response (dead-but-accepting).
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+
+    const prevUrl = process.env.LLM_EMBED_URL;
+    const prevTimeout = process.env.OPENSPEC_EMBED_FETCH_TIMEOUT_MS;
+    process.env.LLM_EMBED_URL = `http://127.0.0.1:${port}`;
+    process.env.OPENSPEC_EMBED_FETCH_TIMEOUT_MS = '300';
+
+    try {
+      await expect(defaultEmbed(['ping'])).rejects.toThrow(/aborted|timed out/i);
+    } finally {
+      process.env.LLM_EMBED_URL = prevUrl;
+      if (prevTimeout === undefined) delete process.env.OPENSPEC_EMBED_FETCH_TIMEOUT_MS;
+      else process.env.OPENSPEC_EMBED_FETCH_TIMEOUT_MS = prevTimeout;
+      await new Promise((resolve) => server.close(resolve));
+    }
   });
 });

--- a/tests/spec/software-factory/ticket-lifecycle.bats
+++ b/tests/spec/software-factory/ticket-lifecycle.bats
@@ -655,8 +655,22 @@ SH
 @test "T002407-M7c: mishap-rollup.sh verwendet branch-exists-Pfad (rebase statt Neu-Anlage)" {
   local script="$REPO/scripts/factory/mishap-rollup.sh"
   # Der Branch lebt dauerhaft auf dem Remote. Statt neu anlegen: checkout + rebase.
-  run grep -Eq "BRANCH_EXISTS|git checkout.*BRANCH|git rebase" "$script"
+  # [T002913] rebase laeuft mit deaktivierten Hooks (`-c core.hooksPath=/dev/null`),
+  # damit der post-commit-embed-Hook den Factory-Tick nicht haengen laesst.
+  run grep -Eq "BRANCH_EXISTS|git checkout.*BRANCH|rebase origin/main" "$script"
   [ "$status" -eq 0 ] || { echo "Branch-Existenz-Pfad fehlt in mishap-rollup.sh"; false; }
+}
+
+@test "T002913-M8a: mishap-rollup.sh rebased mit deaktiviertem post-commit-Hook (hooksPath=/dev/null)" {
+  # Der post-commit-embed-Hook feuert bei JEDEM rebasierten Commit und kann am
+  # Embedding-Backend haengen (readiness=true bei totem Endpoint). Genau so hing der
+  # Factory-Tick stundenlang im Rollup-Rebase, hielt den Flock und blockierte alle
+  # weiteren Ticks. Beide Rebase-Aufrufe muessen den Hook deaktivieren.
+  local script="$REPO/scripts/factory/mishap-rollup.sh"
+  [ -f "$script" ]
+  local count
+  count=$(grep -c 'git -c core.hooksPath=/dev/null rebase' "$script")
+  [ "$count" -eq 2 ] || { echo "erwarte 2 hooksPath-rebase-Aufrufe in mishap-rollup.sh, gefunden: $count"; false; }
 }
 
 @test "T002407-M7d: mishap-rollup.sh hat plan-lint als Hard Gate" {


### PR DESCRIPTION
## What

Fixes the root cause of the dormant Factory since 2026-07-22:

1. **mishap-rollup.sh**: Both `git rebase` calls now use `-c core.hooksPath=/dev/null` to prevent the post-commit-embed hook from hanging the rebase (and thus the entire factory tick, holding the flock).

2. **openspec-embed.mjs**: `defaultEmbed()` now has a configurable fetch timeout via `AbortSignal.timeout()` (default 60s, env `OPENSPEC_EMBED_FETCH_TIMEOUT_MS`). Previously, a backend that accepted TCP but never responded would hang forever.

## Why

The post-commit-embed hook runs during every `git rebase` in the factory tick. When the embedding backend is unreachable (readiness=true, dead endpoint), the hook hangs indefinitely. With the flock held, no further factory ticks could run — leaving 33 backlog + 2 plan_staged tickets waiting since July 22.

## Tests

- `scripts/openspec-embed.test.mjs`: Timeout abort test (dead-but-accepting server)
- `tests/spec/software-factory/ticket-lifecycle.bats`: T002913-M8a asserts 2 hooksPath-rebase calls, T002407-M7c pattern updated

## Ticket

[T002913](https://github.com/Paddione/Bachelorprojekt/issues)