### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -2853,6 +2853,12 @@
       "status": "plan_staged"
     }
   ],
+  "T002839": [
+    {
+      "slug": "fix-openspec-embed-token-limit-T002839",
+      "status": "plan_staged"
+    }
+  ],
   "T002868": [
     {
       "slug": "2026-08-09-workflow-self-trigger",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31321248898).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
