### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -2861,8 +2861,8 @@
   ],
   "T002839": [
     {
-      "slug": "fix-openspec-embed-token-limit-T002839",
-      "status": "plan_staged"
+      "slug": "2026-08-09-fix-openspec-embed-token-limit-T002839",
+      "status": "archived"
     }
   ],
   "T002868": [


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31321455367).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
