### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -2699,8 +2699,8 @@
   ],
   "T002710": [
     {
-      "slug": "tcc-fixture-cleanup",
-      "status": "plan_staged"
+      "slug": "2026-08-09-tcc-fixture-cleanup",
+      "status": "archived"
     }
   ],
   "T002714": [
@@ -2831,8 +2831,8 @@
   ],
   "T002785": [
     {
-      "slug": "mishap-t002785",
-      "status": "plan_staged"
+      "slug": "2026-08-09-mishap-t002785",
+      "status": "archived"
     }
   ],
   "T002809": [


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31322445975).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
