### PR TITLE
fix: rollup-container creates as triage instead of plan_staged, complying with the update-status plan_staged guard [T003027]

### DIFF
--- a/scripts/factory/mishap-rollup.sh
+++ b/scripts/factory/mishap-rollup.sh
@@ -276,8 +276,8 @@ bash "$WT/scripts/ticket.sh" stage-plan \
   --partials 1 >/dev/null
 
 # ── execution_released=true explizit setzen (idempotent) ────────────────────
-# Der Container wurde von mishap.go mit status=plan_staged angelegt, aber
-# ohne execution_released. Der stage-plan-Schritt aktualisiert den Plan-Ref.
+# Der Container startet als triage und bekommt hier plan_staged + FACTORY-PLAN-REF.
+# Der stage-plan-Schritt setzt Status und Plan-Ref in einem Schritt.
 # Mit release-hold stellen wir sicher, dass execution_released=true gesetzt
 # UND die Factory aufgeweckt wird.
 echo "mishap-rollup: release-hold (execution_released=true) ..."

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -1012,7 +1012,7 @@ cmd_rollup_container() {
     --type chore --brand "$brand" \
     --title "$ROLLUP_TITLE" \
     --description "Fortlaufende Sammlung nicht-kritischer Mishaps. Dieses Ticket bleibt dauerhaft offen." \
-    --status plan_staged --severity minor 2>&1)
+    --status triage --severity minor 2>&1)
   echo "$ext_id"
 }
 


### PR DESCRIPTION
## Why

`cmd_rollup_container` in `scripts/ticket.sh` passed `--status plan_staged` when creating new rollup container tickets. `create.sh` now rejects this via the T002876 guard (plan_staged requires FACTORY-PLAN-REF). The error was silently swallowed by `2>&1` capture, producing a bogus ticket ID.

## What

1. **`scripts/ticket.sh:1015`**: Changed `--status plan_staged` to `--status triage` — the container gets properly staged later by `mishap-rollup.sh` via `stage-plan.sh`, which sets `plan_staged` AND writes `FACTORY-PLAN-REF` atomically.
2. **`scripts/factory/mishap-rollup.sh:279-280`**: Updated stale comment that claimed the container was created as `plan_staged`.

## Context

- T002876 added guards preventing `plan_staged` without `FACTORY-PLAN-REF` in `create.sh`, `update-status.sh`, `triage.sh`, and MCP tools — but `cmd_rollup_container` was never updated to comply.
- BGE outages (OOM-kills, TCP-hangs) caused the factory to be stuck since 2026-07-22 (T002913), which prevented `mishap-rollup.sh` from completing the staging cycle — leaving 13 rollup containers stranded in `plan_staged` without plan_ref.
- This is the last remaining bypass of the T002876 guard.