### PR TITLE
fix(factory): Rollup-Rebase gegen origin/\<BRANCH\> statt origin/main [T002914]

### DIFF
--- a/scripts/factory/mishap-rollup.sh
+++ b/scripts/factory/mishap-rollup.sh
@@ -38,6 +38,31 @@ if [[ "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
+# [T002914] Rebase gegen den REMOTE-BRANCH statt gegen origin/main.
+# Ein divergierter Rollup-Branch (Remote hat eigene Commits — z.B. den Anker
+# ee4b350c1 oder parallele Rollup-Runs, die die lokale Chain nicht kennt) wird
+# durch ein Rebase auf origin/main NIE zusammenfuehrbar: die lokale Kette bleibt
+# gegenueber origin/<BRANCH> divergiert und jeder Push bleibt non-fast-forward
+# (abgelehnt) — der Rollup-Branch deadlockt dauerhaft. Erst das Rebase auf
+# origin/${BRANCH} (nach fetch) integriert die Remote-Chain und macht den naechsten
+# Push wieder fast-forward. Da der Plan pro Lauf idempotent aus den Container-
+# Kommentaren regeneriert wird, ist die Remote-Chain die saubere Basis.
+#
+# [T002913] core.hooksPath=/dev/null ist hier NICHT optional: der
+# post-commit-embed-Hook feuert bei JEDEM rebasierten Commit und kann am
+# Embedding-Backend haengen (readiness=true bei totem Endpoint). Genau so hing der
+# Factory-Tick stundenlang im Rebase, hielt den Flock und blockierte jeden
+# weiteren Tick. Ein Factory-interner Rollup-Rebase braucht den Hook nicht — der
+# Embed laeuft ohnehin nach dem stage-plan.
+rollup_rebase_onto_remote() {
+  git fetch -q origin "$BRANCH" 2>/dev/null || true
+  if git -c core.hooksPath=/dev/null rebase "origin/${BRANCH}" 2>/dev/null; then
+    return 0
+  fi
+  echo "mishap-rollup: rebase auf origin/${BRANCH} fehlgeschlagen (Konflikt?) — breche ab" >&2
+  return 1
+}
+
 # ── Load factory lib ────────────────────────────────────────────────────────
 source "$HERE/lib.sh"
 
@@ -108,20 +133,14 @@ fi
 cd "$WT"
 
 # ── Branch auf Remote → rebasen ─────────────────────────────────────────────
-# Wenn der Branch auf origin existiert, rebasen wir auf origin/main, damit der
-# Plan den aktuellen Stand des main-Branches reflektiert.
-# [T002913] Der post-commit-embed-Hook feuert bei JEDEM rebasierten Commit und
-# kann am Embedding-Backend haengen (readiness=true bei totem Endpoint). Genau so
-# hing der Factory-Tick stundenlang im Rebase, hielt den Flock und blockierte
-# jeden weiteren Tick. Ein Factory-interner Rollup-Rebase braucht den Hook nicht
-# (der Embed laeuft ohnehin nach dem stage-plan) — also deaktivieren.
+# Wenn der Branch auf origin existiert, rebasen wir auf origin/${BRANCH} (statt
+# auf origin/main), damit die lokale Kette die Remote-Commits integriert und der
+# Push fast-forward bleibt. [T002914]
+# Der Hook-Guard aus [T002913] steckt in rollup_rebase_onto_remote — beide Fixes
+# betreffen denselben Rebase und schliessen sich nicht aus.
 if git rev-parse --verify --quiet "origin/${BRANCH}" >/dev/null 2>&1; then
-  echo "mishap-rollup: rebase ${BRANCH} auf origin/main (post-commit-embed deaktiviert)"
-  git fetch origin main 2>/dev/null || true
-  git -c core.hooksPath=/dev/null rebase origin/main 2>/dev/null || {
-    echo "mishap-rollup: rebase fehlgeschlagen — breche ab" >&2
-    exit 1
-  }
+  echo "mishap-rollup: rebase ${BRANCH} auf origin/${BRANCH} (post-commit-embed deaktiviert)"
+  rollup_rebase_onto_remote || exit 1
 fi
 
 # ── Plan-Erzeugung / -Update ────────────────────────────────────────────────
@@ -254,16 +273,22 @@ else
     exit 1
   fi
   # Push scheitert, wenn der Branch remote bereits weiter ist (z.B. durch
-  # einen parallelen merge). Dann holen wir neu und rebasen.
+  # einen parallelen merge). Dann holen wir neu und rebasen — gegen die
+  # REMOTE-BRANCH-Kette, nicht gegen origin/main (sonst bleibt ein divergierter
+  # Branch dauerhaft non-fast-forward, siehe T002914).
   git push -q -u origin "$BRANCH" 2>/dev/null || {
-    echo "mishap-rollup: push fehlgeschlagen — rebase + retry"
-    git fetch origin main 2>/dev/null || true
-    git -c core.hooksPath=/dev/null rebase origin/main 2>/dev/null || true
-    git push -q -u origin "$BRANCH" || {
-      echo "mishap-rollup: FEHLER — push auf '${BRANCH}' auch nach rebase fehlgeschlagen." >&2
+    echo "mishap-rollup: push fehlgeschlagen — rebase auf origin/${BRANCH} + retry"
+    if rollup_rebase_onto_remote; then
+      git push -q -u origin "$BRANCH" || {
+        echo "mishap-rollup: FEHLER — push auf '${BRANCH}' auch nach rebase fehlgeschlagen." >&2
+        echo "  Der Plan ist lokal committet, aber nicht auf origin: ${CHANGE_DIR}" >&2
+        exit 1
+      }
+    else
+      echo "mishap-rollup: FEHLER — rebase nach push-Fehlschlag nicht aufloesbar." >&2
       echo "  Der Plan ist lokal committet, aber nicht auf origin: ${CHANGE_DIR}" >&2
       exit 1
-    }
+    fi
   }
 fi
 

--- a/tests/spec/mishap-rollup/container-resolution-and-unattended-worktree.bats
+++ b/tests/spec/mishap-rollup/container-resolution-and-unattended-worktree.bats
@@ -57,3 +57,18 @@ setup() {
   # Eigentliche Aussage: der unbeaufsichtigte Modus ist dokumentiert und damit vorhanden.
   [ "$(printf '%s\n' "$output" | grep -c -- '--unattended')" -ge 1 ]
 }
+
+# ── [T002914] Rollup-Rebase gegen origin/<BRANCH>, nicht origin/main ─────────
+# Ein divergierter Rollup-Branch (Remote hat eigene Commits, die die lokale
+# Chain nicht kennt) bleibt bei einem Rebase auf origin/main dauerhaft
+# non-fast-forward — jeder Push wird abgelehnt. Das Skript muss deshalb gegen
+# origin/${BRANCH} rebasen (nach fetch), damit die Remote-Chain integriert wird.
+
+@test "T002914: mishap-rollup.sh rebased gegen origin/<BRANCH> statt origin/main" {
+  run grep -n "rollup_rebase_onto_remote\|origin/\${BRANCH}" "$REPO_ROOT/scripts/factory/mishap-rollup.sh"
+  [ "$status" -eq 0 ] || { echo "MISSING rebase-onto-origin-branch in mishap-rollup.sh"; false; }
+
+  # Negativ-Anker: der alte, toedliche Pfad darf nicht mehr aktiv sein.
+  run grep -n "git rebase origin/main" "$REPO_ROOT/scripts/factory/mishap-rollup.sh"
+  [ "$status" -eq 1 ] || { echo "STILL rebasing onto origin/main in mishap-rollup.sh"; false; }
+}

--- a/tests/spec/software-factory/ticket-lifecycle.bats
+++ b/tests/spec/software-factory/ticket-lifecycle.bats
@@ -655,22 +655,45 @@ SH
 @test "T002407-M7c: mishap-rollup.sh verwendet branch-exists-Pfad (rebase statt Neu-Anlage)" {
   local script="$REPO/scripts/factory/mishap-rollup.sh"
   # Der Branch lebt dauerhaft auf dem Remote. Statt neu anlegen: checkout + rebase.
-  # [T002913] rebase laeuft mit deaktivierten Hooks (`-c core.hooksPath=/dev/null`),
-  # damit der post-commit-embed-Hook den Factory-Tick nicht haengen laesst.
-  run grep -Eq "BRANCH_EXISTS|git checkout.*BRANCH|rebase origin/main" "$script"
+  # Das Rebase-ZIEL ist seit T002914 origin/${BRANCH} statt origin/main — geprueft
+  # wird hier nur, DASS ueber einen Rebase-Pfad gearbeitet wird, nicht wohin; das
+  # Ziel sichert der eigene T002914-Guard. Die Alternation nennt deshalb beide
+  # Formen: sie an eine einzelne festzuschreiben liess diesen Test rot werden,
+  # obwohl der branch-exists-Pfad unveraendert vorhanden war.
+  run grep -Eq 'BRANCH_EXISTS|git checkout.*BRANCH|rebase .*origin/|rollup_rebase_onto_remote' "$script"
   [ "$status" -eq 0 ] || { echo "Branch-Existenz-Pfad fehlt in mishap-rollup.sh"; false; }
 }
 
-@test "T002913-M8a: mishap-rollup.sh rebased mit deaktiviertem post-commit-Hook (hooksPath=/dev/null)" {
+@test "T002913-M8a: kein Rebase in mishap-rollup.sh laeuft mit aktiven Hooks" {
   # Der post-commit-embed-Hook feuert bei JEDEM rebasierten Commit und kann am
   # Embedding-Backend haengen (readiness=true bei totem Endpoint). Genau so hing der
   # Factory-Tick stundenlang im Rollup-Rebase, hielt den Flock und blockierte alle
-  # weiteren Ticks. Beide Rebase-Aufrufe muessen den Hook deaktivieren.
+  # weiteren Ticks.
+  #
+  # Geprueft wird die EIGENSCHAFT ("kein ungesicherter Rebase"), nicht die Anzahl
+  # der Aufrufe. Die Vorgaengerfassung verlangte exakt zwei Vorkommen von
+  # `git -c core.hooksPath=/dev/null rebase`; als T002914 beide Aufrufstellen auf
+  # eine gemeinsame Funktion zusammenzog, sank die Zahl auf eins — der Guard
+  # meldete eine Verschlechterung, wo der Schutz tatsaechlich zentraler und damit
+  # schwerer zu umgehen wurde. Eine Zaehlung schreibt die Form der Implementierung
+  # fest, nicht ihre Zusicherung.
   local script="$REPO/scripts/factory/mishap-rollup.sh"
   [ -f "$script" ]
-  local count
-  count=$(grep -c 'git -c core.hooksPath=/dev/null rebase' "$script")
-  [ "$count" -eq 2 ] || { echo "erwarte 2 hooksPath-rebase-Aufrufe in mishap-rollup.sh, gefunden: $count"; false; }
+
+  # Positiv-Anker: es muss ueberhaupt einen Rebase-Aufruf geben, sonst waere die
+  # Aussage unten leer erfuellt. Das Muster MUSS die ungesicherte Form
+  # `git rebase ...` mitfinden — ein Muster, das Inhalt zwischen `git` und
+  # `rebase` verlangt, traefe nur die bereits abgesicherte Form, und beim Wegfall
+  # des Guards fiele der ANKER statt der Zusicherung (Defektbild aus T002878).
+  local rebase_calls
+  rebase_calls=$(grep -E '\bgit\b.*\brebase\b' "$script" | grep -vE '^[[:space:]]*#' || true)
+  [ -n "$rebase_calls" ] \
+    || { echo "kein git-rebase-Aufruf in mishap-rollup.sh gefunden — Anker verfehlt"; false; }
+
+  local unguarded
+  unguarded=$(printf '%s\n' "$rebase_calls" | grep -v 'core.hooksPath=/dev/null' || true)
+  [ -z "$unguarded" ] \
+    || { echo "Rebase ohne core.hooksPath=/dev/null:"; printf '%s\n' "$unguarded"; false; }
 }
 
 @test "T002407-M7d: mishap-rollup.sh hat plan-lint als Hard Gate" {


### PR DESCRIPTION
## Why

`mishap-rollup.sh` rebased `chore/mishap-incident-rollup` gegen `origin/main` statt `origin/\<BRANCH\>`. Das funktionierte, solange der Branch auf main basierte — nachdem er aber einen älteren Stand hatte, divergierte er und der Rebase erzeugte Konflikte, die den Rollup-Flow blockierten.

## What

- Rebase-Ziel von `origin/main` auf `origin/$BRANCH` geändert
- Unattended-Worktree-Test hinzugefügt

## Ticket

T002914