### PR TITLE
fix(test): Guard T002407-M6b auf triage umstellen [T003027]

### DIFF
--- a/.claude/skills/mishap-tracker/SKILL.md
+++ b/.claude/skills/mishap-tracker/SKILL.md
@@ -135,13 +135,19 @@ An den Rollup-Container angehängt wird auf zwei Wegen, beide ohne Session-Bezug
 | Schwelle | `report_mishap` hängt ab **10** Einträgen an den Rollup-Container an |
 | Alters-Schnitt | Der Factory-Tick (`scripts/factory/wakeup.sh`) ruft periodisch `ticket-mcp-go --flush-stale-mishaps` auf und hängt an, sobald der älteste Eintrag ≥ 7 Tage alt ist |
 
-**Zum Rollup-Container:** Ein persistentes Ticket (`type=chore`, `status=plan_staged` — nur
-der Rollup-Container selbst) mit dem Titel "Mishap Rollup — fortlaufende Sammlung". Es wird
-niemals geschlossen — nicht-kritische Mishaps werden als Kommentar-Batches an dieses Ticket
-gehängt. Der Rollup-Treiber (`scripts/factory/mishap-rollup.sh`) extrahiert daraus periodisch
-einen Plan und staged ihn. Die einzelnen Mishap-Tickets selbst entstehen immer mit
-`status=triage` (`scripts/ticket-mcp/go/internal/tools/mishap.go` setzt konsequent
-`--status triage`) — nie direkt als `plan_staged`.
+**Zum Rollup-Container:** Ein persistentes Ticket (`type=chore`) mit dem Titel "Mishap Rollup —
+fortlaufende Sammlung". Es wird niemals geschlossen — nicht-kritische Mishaps werden als
+Kommentar-Batches an dieses Ticket gehängt. Der Rollup-Treiber
+(`scripts/factory/mishap-rollup.sh`) extrahiert daraus periodisch einen Plan und staged ihn.
+
+**Nichts entsteht direkt als `plan_staged` [T003027].** Sowohl die einzelnen Mishap-Tickets
+(`scripts/ticket-mcp/go/internal/tools/mishap.go`) als auch der Container selbst
+(`ticket.sh rollup-container`) werden mit `status=triage` angelegt. Der Grund ist der Guard aus
+T002876: `update-status.sh` lehnt `plan_staged` ohne `FACTORY-PLAN-REF` fail-closed ab — ein
+Ticket, das den gestagten Zustand behauptet, ohne einen Plan zu haben, ist widersprüchlich.
+Der Unterschied zwischen beiden liegt also **nicht** in der Anlage, sondern danach: nur der
+Container durchläuft `stage-plan` und erreicht dabei `plan_staged` **zusammen mit** seinem
+Plan-Ref. Im eingeschwungenen Zustand steht er deshalb auf `plan_staged`.
 
 `flush_mishap_buffer` bleibt als **bewusster manueller Schnitt** verfügbar — z. B. wenn ein
 Befund sofort ein Ticket braucht. Es ist kein Pflichtschritt dieses Skills mehr:

--- a/tests/spec/mcp-skill-integration.bats
+++ b/tests/spec/mcp-skill-integration.bats
@@ -221,14 +221,37 @@ setup() {
   [ "$output" = "0" ] || { echo "buildRollupContainerArgs darf keinen --status hartcodieren — ticket.sh managed das"; false; }
 }
 
-@test "T002407-M6b: ticket.sh rollup-container dokumentiert status=plan_staged (T002783)" {
-  # T002783: plan_staged lebt jetzt in ticket.sh, nicht in mishap.go.
-  run bash -c "grep -c 'plan_staged' \
-    '$REPO/scripts/ticket.sh' 2>/dev/null"
-  [ "$output" != "0" ]
-  # Der Container wird als plan_staged angelegt (create... --status plan_staged)
-  run bash -c "grep -B2 -A10 'ROLLUP_TITLE' '$REPO/scripts/ticket.sh' 2>/dev/null | grep -c 'plan_staged'"
-  [ "$output" != "0" ] || { echo "rollup-container muss den Container mit status=plan_staged anlegen"; false; }
+@test "T002407-M6b: rollup-container legt den Container als triage an [T003027]" {
+  # Pruefmodus: Quelltext-Pruefung. cmd_rollup_container loest seinen Pod ueber
+  # _pgpod auf und braucht damit eine lebende DB — in der Offline-CI nicht
+  # ausfuehrbar. Das ist die in CLAUDE.md (T002448-M4) dokumentierte Ausnahme fuer
+  # Querschnittstests, nicht die bequeme Abkuerzung: eine Output-Verifikation waere
+  # hier schlicht nicht lauffaehig.
+  #
+  # Sachlage (T003027): Bis T002876 legte rollup-container den Container direkt als
+  # plan_staged an. Seit T002876 lehnt update-status.sh genau das fail-closed ab —
+  # plan_staged ohne FACTORY-PLAN-REF ist ein widerspruechlicher Zustand. Der
+  # Container entsteht deshalb als triage; stage-plan hebt ihn spaeter zusammen mit
+  # dem Plan-Ref auf plan_staged.
+  local block
+  block=$(awk '/^cmd_rollup_container\(\)/,/^\}/' "$REPO/scripts/ticket.sh")
+
+  # Positiv-Anker 1 — ohne ihn liefe alles Folgende auf leerem Text vakuos durch.
+  [ -n "$block" ] || { echo "cmd_rollup_container nicht in scripts/ticket.sh gefunden"; false; }
+
+  # Positiv-Anker 2: der Anlage-Pfad setzt ueberhaupt einen expliziten Status.
+  local status_flag
+  status_flag=$(printf '%s\n' "$block" | grep -oE '\-\-status[[:space:]]+[a-z_]+' | head -1)
+  [ -n "$status_flag" ] || { echo "cmd_rollup_container legt den Container ohne explizites --status an"; false; }
+
+  # Zusicherung: dieser Status ist triage (und damit nicht plan_staged).
+  printf '%s' "$status_flag" | grep -q 'triage' \
+    || { echo "rollup-container muss den Container als triage anlegen, gefunden: $status_flag"; false; }
+
+  # Der Wiederfinde-Pfad muss plan_staged weiterhin als offenen Status fuehren —
+  # sonst legt jeder Lauf neben dem bereits gestagten Container einen neuen an.
+  printf '%s\n' "$block" | grep -q "status IN.*plan_staged" \
+    || { echo "SELECT im Wiederfinde-Pfad fuehrt plan_staged nicht mehr als offenen Status"; false; }
 }
 
 @test "T002407-M6c: ROLLUP_TICKET_TITLE ist definiert" {


### PR DESCRIPTION
Behebt einen **auf `main` roten Guard**. `main` ist seit dem Merge von #4006 (Commit `e5bbafc33`) auf `Factory spec shard 4` rot.

## Warum

`ticket.sh rollup-container` legte den Mishap-Rollup-Container als `plan_staged` an. Seit T002876 (PR #3964) lehnt `update-status.sh` genau das fail-closed ab — `plan_staged` ohne `FACTORY-PLAN-REF` ist ein widersprüchlicher Zustand. #4006 stellte die Anlage deshalb korrekt auf `triage` um, **ohne den Guard mitzuziehen**, der die alte Regel festschrieb.

## Was der Test jetzt prüft

Das `--status`-Flag im Anlage-Pfad von `cmd_rollup_container` statt eines Wortvorkommens in der Datei.

Ein Detail, das die Zusicherung fast falsch gemacht hätte: `plan_staged` kommt in derselben Funktion **legitim** vor — im `SELECT`, das einen bereits gestagten Container wiederfindet. Ein pauschales „kein `plan_staged` in dieser Funktion" wäre ein Fehlalarm gewesen. Die Zusicherung hängt deshalb am Flag, nicht am Wort. Zusätzlich abgesichert: der Wiederfinde-Pfad **muss** `plan_staged` weiter als offenen Status führen, sonst legt jeder Lauf neben dem gestagten Container einen neuen an.

## Prüfmodus

Bleibt Quelltext-Prüfung — die in CLAUDE.md (T002448-M4) dokumentierte Ausnahme, nicht die bequeme Abkürzung: `cmd_rollup_container` löst seinen Pod über `_pgpod` auf und ist in der Offline-CI schlicht nicht lauffähig. Der Header-Kommentar sagt das explizit.

## Verifikation

- Grün gegen heutiges `main`: `bats -f T002407-M6 tests/spec/mcp-skill-integration.bats` → 4/4
- **Gegenprobe**: mit auf `plan_staged` zurückgedrehtem `ticket.sh` fällt der Test mit `gefunden: --status plan_staged`
- Zwei Positiv-Anker gegen vakuoses Durchlaufen (Funktion gefunden, expliziter Status gesetzt)
- Beide BATS-Konventionsformen erfasst (`-r tests/spec/mcp-skill-integration*`)

## Doku

`mishap-tracker/SKILL.md` stellte „Container = `plan_staged`" gegen „Einzel-Mishaps entstehen als `triage`". Nach der Änderung entsteht **beides** als `triage`; der Unterschied liegt erst danach, im `stage-plan`-Schritt. Ohne diese Korrektur widerspräche die Doku dem Verhalten.