### PR TITLE
fix(test): Guard T002500 misst Balance nach Laufzeit statt @test-Anzahl [T003026]

### DIFF
--- a/tests/spec/ci-cd/spec-shard-partition.bats
+++ b/tests/spec/ci-cd/spec-shard-partition.bats
@@ -84,27 +84,42 @@ _all_spec_files() {
   [ "$sorted" = "$shuffled" ]
 }
 
-@test "T002500: die Shards sind nach @test-Anzahl balanciert (schwerster <= 1.5x leichtester)" {
-  input="$(_all_spec_files)"
-  weights=()
-  for s in 1 2 3 4; do
-    files=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard "$s" --of 4)
-    w=0
-    while IFS= read -r f; do
-      [ -n "$f" ] || continue
-      n=$(grep -c '^[[:space:]]*@test' "$REPO_ROOT/$f" 2>/dev/null || echo 0)
-      w=$((w + n))
-    done <<< "$files"
-    weights+=("$w")
-  done
-  min=${weights[0]}; max=${weights[0]}
-  for w in "${weights[@]}"; do
-    [ "$w" -lt "$min" ] && min=$w
-    [ "$w" -gt "$max" ] && max=$w
-  done
-  # Positiv-Anker: es muss ueberhaupt Gewicht geben.
-  [ "$min" -gt 0 ]
-  [ $((max * 2)) -le $((min * 3)) ]
+@test "T002500: die Shards sind nach gemessener Laufzeit balanciert (schwerster <= 1.5x leichtester) [T003026]" {
+  # Gewichtet wird seit T003026 nach gemessener Laufzeit aus
+  # tests/spec/.spec-runtime.tsv, nicht nach @test-Anzahl. Die Anzahl ist ein
+  # unzuverlaessiger Proxy: wenige lange Tests koennen mehr Zeit kosten als viele
+  # kurze. Der Vorgaenger dieses Tests mass die Anzahl und wurde durch die
+  # Umstellung rot, obwohl die Verteilung sich VERBESSERT hatte — gemessen am
+  # 2026-08-09: Laufzeit-Balance 100 %, @test-Anzahl 652..1049 (Faktor 1.61).
+  # Ein Guard, der die ersetzte Regel weiter festschreibt, meldet einen Defekt,
+  # den es nicht gibt.
+  #
+  # Geprueft wird der von --verify SELBST gemeldete Wert, nicht eine im Test
+  # nachgebaute Gewichtung: eine zweite Implementierung derselben Rechnung wuerde
+  # bei der naechsten Aenderung erneut auseinanderlaufen. Gegriffen wird ohne
+  # Zeilenanker (T002716), damit eine umformulierte Meldung den Test nicht kippt.
+  run bash -c "cd '$REPO_ROOT' && find tests/spec -name '*.bats' -type f | bash '$SHARD_SH' --verify --of 4"
+  [ "$status" -eq 0 ] || { echo "--verify schlug fehl (status=$status): $output"; false; }
+
+  # Positiv-Anker 1: es wurde ueberhaupt Gewicht verteilt. Ohne diese Pruefung
+  # liefe ein Lauf mit lauter Nullgewichten als perfekt balanciert durch.
+  local shard1_weight
+  shard1_weight=$(printf '%s\n' "$output" | grep -F 'shard 1:' | grep -oE 'Gewicht[[:space:]]+[0-9.]+' | grep -oE '[0-9.]+$')
+  [ -n "$shard1_weight" ] \
+    || { echo "--verify meldet kein Shard-Gewicht; Output: $output"; false; }
+  awk -v w="$shard1_weight" 'BEGIN { exit !(w + 0 > 0) }' \
+    || { echo "Shard 1 traegt Gewicht $shard1_weight, erwartet > 0"; false; }
+
+  # Positiv-Anker 2: die Balance-Zeile existiert. Fehlt sie, waere $balance leer
+  # und der Vergleich unten wuerde nicht messen, sondern nur nicht scheitern.
+  local balance
+  balance=$(printf '%s\n' "$output" | grep -F 'Balance' | grep -oE '[0-9]+' | head -1)
+  [ -n "$balance" ] \
+    || { echo "--verify meldet keine Balance-Zeile; Output: $output"; false; }
+
+  # Zusicherung: min/max >= 67 % ist gleichbedeutend mit schwerster <= 1.5x leichtester.
+  [ "$balance" -ge 67 ] \
+    || { echo "Laufzeit-Balance nur ${balance}% (min/max), erwartet >= 67%"; false; }
 }
 
 @test "T002500: ungueltige --shard/--of-Werte werden abgewiesen" {


### PR DESCRIPTION
Behebt einen **auf `main` roten Guard**. `main` ist seit dem Merge von #4004 auf `Factory spec shard 3` rot.

## Warum

#4004 stellte die Shard-Gewichtung auf gemessene Laufzeit um (junit-Timing + LPT). Der Guard verglich weiter die Anzahl der `@test`-Blöcke und wurde dadurch rot.

Bemerkenswert ist die **Richtung** des Fehlalarms: die Umstellung hat die Verteilung *verbessert*. Gemessen am 2026-08-09:

| Metrik | Wert |
|---|---|
| Laufzeit-Balance (min/max) | **100 %** |
| `@test`-Anzahl je Shard | 786 / 1049 / 831 / 652 → Faktor **1,61** |

Der Guard meldete also einen Defekt, den es nicht gab — und zwar genau deshalb, weil die Verteilung der ersetzten Metrik nicht mehr folgt.

## Was der Test jetzt prüft

Den von `--verify` **selbst** gemeldeten Balance-Wert, statt die Gewichtung im Test nachzubauen. Eine zweite Implementierung derselben Rechnung liefe bei der nächsten Änderung erneut auseinander — genau das ist gerade passiert. Gegriffen wird ohne Zeilenanker (T002716), damit eine umformulierte Meldung den Test nicht kippt.

Zwei Positiv-Anker gegen vakuoses Durchlaufen:
1. es muss überhaupt Gewicht verteilt worden sein — sonst wäre ein Lauf mit lauter Nullgewichten „perfekt balanciert"
2. die Balance-Zeile muss existieren — sonst vergliche der Test gegen einen leeren Wert und würde nicht messen, sondern nur nicht scheitern

## Verifikation

- Grün gegen heutiges `main`: `bats tests/spec/ci-cd/spec-shard-partition.bats` → 12/12
- **Gegenprobe**: mit einer künstlich dominierenden Datei in `.spec-runtime.tsv` fällt der Test mit `Laufzeit-Balance nur 0% (min/max), erwartet >= 67%`
- Wichtig für spätere Leser: der bloße **Entzug** der Laufzeit-Tabelle taugt *nicht* als Gegenprobe — LPT balanciert dann die `@test`-Anzahl auf 99 %, der Test bliebe grün. Nur eine echte Unwucht macht ihn rot.

## Nicht in diesem PR

Der zweite Fehlschlag aus #4004, `T002721 Daemon raeumt PID- und Token-Datei beim Beenden auf` (31,5 s), läuft lokal **3/3 grün**. `tests/spec/sdlc-cockpit/daemon-test-no-leak.bats` wartet mit festem `sleep 1` / `sleep 0.5` — dasselbe Muster wie T002850, das bereits in T002925 (Sammel-Bündel BATS-Hygiene) steckt. Dort vermerkt, hier nicht mitbehandelt.