### PR TITLE
chore(ci): disable go cache in setup-go to fix restore cache warning [T003052]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+          cache: false
 
       - uses: arduino/setup-task@bfe25a35f5c1f609e1d6153197b3b42a04ae054c  # v5.0.0
         with:


### PR DESCRIPTION
Fixes the warning `Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/Bachelorprojekt/Bachelorprojekt. Supported file pattern: go.sum` on CI matrix shards by setting `cache: false` on `actions/setup-go@v5`.