### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3239,7 +3239,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 686,
+      "file_count": 687,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3510,6 +3510,7 @@
         "scripts/factory/mcp-go/factory-mcp.service",
         "scripts/factory/mcp-go/go.mod",
         "scripts/factory/mcp-go/main.go",
+        "scripts/factory/mcp-go/main_test.go",
         "scripts/factory/mcp-server.mjs",
         "scripts/factory/merge-hooks.sh",
         "scripts/factory/metrics.sh",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31329499173).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
