### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 870,
+      "file_count": 871,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -649,6 +649,7 @@
         "tests/spec/sidekick-assistant.bats",
         "tests/spec/software-factory/_sf_common.bash",
         "tests/spec/software-factory/agent-lock-scope-argument.bats",
+        "tests/spec/software-factory/brand-is-row-filter-not-namespace.bats",
         "tests/spec/software-factory/canary-and-cleanup.bats",
         "tests/spec/software-factory/catalog-eval-telemetry.bats",
         "tests/spec/software-factory/conflict-db-triage.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31329739314).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
