### PR TITLE
chore(deps): @types/three-Patchbump und factory-floor-Import auf db-pool [T003066]

### DIFF
--- a/brett/package-lock.json
+++ b/brett/package-lock.json
@@ -25,7 +25,7 @@
         "@types/multer": "^2.2.0",
         "@types/node": "^26.1.1",
         "@types/pg": "^8.20.0",
-        "@types/three": "^0.185.1",
+        "@types/three": "^0.185.4",
         "@types/ws": "^8.18.1",
         "concurrently": "^10.0.3",
         "eslint": "^10.5.0",
@@ -1193,9 +1193,9 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.185.1",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.1.tgz",
-      "integrity": "sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==",
+      "version": "0.185.4",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.4.tgz",
+      "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/brett/package.json
+++ b/brett/package.json
@@ -35,7 +35,7 @@
     "@types/multer": "^2.2.0",
     "@types/node": "^26.1.1",
     "@types/pg": "^8.20.0",
-    "@types/three": "^0.185.1",
+    "@types/three": "^0.185.4",
     "@types/ws": "^8.18.1",
     "concurrently": "^10.0.3",
     "eslint": "^10.5.0",

--- a/website/src/lib/sdlc/factory-floor.ts
+++ b/website/src/lib/sdlc/factory-floor.ts
@@ -2,7 +2,7 @@
 // Reads tickets.factory_phase_events (current phase per ticket) joined with the
 // existing tickets/factory_control tables. PER-BRAND pool, same-namespace only.
 // factory-metrics.ts is intentionally left untouched; this is a separate module.
-import { pool } from '../website-db';
+import { pool } from '../db-pool';
 import { officeCount } from '../planning-office.ts';
 import { mapShippedRow, mapAwaitingRow, isAwaitingDeployLaneVisible } from '../factory-floor-lanes.ts';
 import type { ShippedItem, AwaitingDeployItem } from '../factory-floor-lanes.ts';


### PR DESCRIPTION
## Summary

Zwei zusammenhanglose, **verhaltensneutrale** Änderungen, die unkommittiert im Haupt-Checkout lagen. Sie werden hier geordnet nachgereicht statt weiter herumzuliegen — zwei Commits, damit die Scopes getrennt bleiben.

1. **`chore(deps)`** — `brett`: devDependency `@types/three` 0.185.1 → 0.185.4. Patchbump, `package.json` und Lock konsistent.
2. **`chore(website)`** — `factory-floor.ts`: `import { pool } from '../website-db'` → `'../db-pool'`.

Zu (2), weil es wie eine willkürliche Umstellung aussieht: funktional äquivalent. `website-db.ts:52` re-exportiert genau dieselbe Instanz, die `db-pool.ts:47` als `export const pool = new Pool(poolConfig)` anlegt. Es ist eine Normalisierung auf die direkte Quelle; das Repo ist hier gemischt (`cockpit-listen-hub.ts`, `factory-model-slots.ts` importieren schon aus `db-pool`).

## Offen gelegt

Die **Herkunft** von (2) ist nicht geklärt. Ich hatte zunächst `task freshness:regenerate` verdächtigt — das war falsch: kein Skript im Repo referenziert `db-pool`, ein Codemod war es also nicht. Plausibel ein IDE-Quick-Fix. Geprüft habe ich die *Korrektheit* gegen beide Dateien, nicht die Autorschaft.

## Test Plan

- `task freshness:check` → `rc=0`
- `preflight-pr-scope.sh` → `scope 'deps' ✓`
- Typprüfung und Website-Tests deckt CI ab (`Brett TypeScript`, `Vitest (website)`) — beide berühren genau die geänderten Pfade.

Ticket: T003066