### PR TITLE
fix(scripts): llm-proxy serialisiert Modellwechsel, agent-models auf gemessene Kontexte [T003065]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -52,9 +52,23 @@
         // 30B A3B, 11,9 GB UD-IQ3_XXS) liegen auf der Platte. Ports 8090/8094 frei.
         // Beide teilen exclusiveGroup chat-gpu: es laeuft immer nur eines.
         "gemma4": {
-          "name": "Gemma 4 12B Q4_K_M, Loadout gemma4 auf Port 8090 - exclusiveGroup chat-gpu",
+          "name": "Gemma 4 26B A4B UD-IQ4_XS (Serving, Loadout gemma4 auf Port 8090, np=1, q4_0 KV, gemessen 177.920 ctx) - exclusiveGroup chat-gpu",
           "limit": {
-            "context": 32768,
+            "context": 177920,
+            "output": 8192
+          }
+        },
+        "gemma12-vision": {
+          "name": "Gemma 4 12B QAT UD-Q4_K_XL + mmproj-F16 + MTP-Drafter, Loadout gemma12-vision auf Port 8089 - exclusiveGroup chat-gpu. Vision-capable.",
+          "limit": {
+            "context": 262144,
+            "output": 8192
+          }
+        },
+        "gemma26-throughput": {
+          "name": "Gemma 4 26B A4B QAT-Q4_K_XL (Durchsatz, Loadout gemma26-throughput auf Port 8092, gemessen 118.016 ctx, 159-169 tok/s) - exclusiveGroup chat-gpu",
+          "limit": {
+            "context": 118016,
             "output": 8192
           }
         },
@@ -298,15 +312,12 @@
     },
     // Primaerer (Tab-waehlbarer) Lokal-Agent auf gemma26-factory.
     // "mode": "primary" heisst: vom Benutzer direkt gewaehlt, NICHT per `task`
-    // summonbar.
+    // summonbar. Kann beliebige Subagenten dispatchen (deepseek + lokal).
     //
     // Gedacht fuer Arbeit, die komplett lokal laufen soll, ohne DeepSeek-
-    // Orchestrator davor. `task` bewusst nur auf deepseek-helper: wuerde er die
-    // lokalen Familiensubagenten (gptoss/devstral/gemma/qwen) dispatchen,
-    // laegen mehrere Kontexte auf einer GPU und wuerden sich gegenseitig
-    // verdraengen.
+    // Orchestrator davor.
     "gemma26-primary": {
-      "description": "Primary (Tab-selectable) local agent on gemma26-factory (Gemma 4 26B A4B IQ4_XS, 161024 ctx measured, np=3 -kvu q4_0). Use for fully local work without the DeepSeek orchestrator in front. Can escalate to the deepseek subagents but must not dispatch the local subagents: with one GPU they would only contend for the same weights.",
+      "description": "Primary (Tab-selectable) local agent on gemma26-factory (Gemma 4 26B A4B IQ4_XS, 161024 ctx measured, np=3 -kvu q4_0). Use for fully local work without the DeepSeek orchestrator in front. Can dispatch any subagent (deepseek + local).",
       "mode": "primary",
       "model": "llamacpp-local/gemma26-factory",
       "prompt": "{file:./prompts/local-subagent.md}",
@@ -319,12 +330,7 @@
       // write=deny aus demselben Grund wie beim Subagenten - das ist eine
       // Modell-Eigenschaft (Ganzdatei-Overwrite statt Edit), keine Frage des
       // Agent-Modus. Neue Dateien legt der Benutzer bzw. ein Folgeschritt an.
-      "permission": {
-        "edit": "allow",
-        "write": "deny",
-        "bash": "allow",
-        "task": { "deepseek-helper": "allow", "deepseek-pro": "allow", "deepseek-flash": "allow", "gptoss": "deny", "devstral": "deny", "gemma": "deny", "qwen": "deny" }
-      }
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
     },
     // Maximaler lokaler Kontext (161024, gemessen beim Laden am 2026-08-09,
     // np=3 -kvu q4_0 fitt 128, gemeinsamer Pool).
@@ -346,6 +352,63 @@
         "bash": "allow",
         "task": "deny"
       }
+    },
+    // ── Primaere (Tab-waehlbare) Agenten fuer jedes lokale Modell ───────
+    //
+    // Ergaenzung zu gemma26-primary / gemma26-vision: ein primaerer Agent pro
+    // lokalem GGUF-Modell, damit der Benutzer jedes Modell direkt per Tab
+    // auswaehlen kann, ohne den Orchestrator davor. Alle nutzen den gleichen
+    // Prompt (local-subagent.md) und das gleiche Berechtigungsprofil:
+    // edit=allow, write=deny, bash=allow, task nur deepseek-Eskalation.
+    "gptoss-primary": {
+      "description": "PRIMARY: gpt-oss-20b Q8_0 (105.472 ctx, MXFP4-nativ). Tab-selectable singleagent on the gptoss-context loadout (Port 8098). Fast 147-215 tok/s decode; broad general knowledge. Can dispatch any subagent.",
+      "mode": "primary",
+      "model": "llamacpp-local/gptoss-context",
+      "prompt": "{file:./prompts/local-subagent.md}",
+      "color": "#34D399",
+      "temperature": 0.3,
+      "steps": 50,
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
+    },
+    "devstral-primary": {
+      "description": "PRIMARY: Devstral-Small-2 24B IQ4_XS (32.768 ctx). Tab-selectable singleagent on the devstral-quality loadout (Port 8099). Optimised for code quality review. Can dispatch any subagent.",
+      "mode": "primary",
+      "model": "llamacpp-local/devstral-quality",
+      "prompt": "{file:./prompts/local-subagent.md}",
+      "color": "#60A5FA",
+      "temperature": 0.3,
+      "steps": 50,
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
+    },
+    "gemma12-primary": {
+      "description": "PRIMARY: Gemma 4 12B QAT UD-Q4_K_XL + mmproj-F16 + MTP (262.144 ctx). Tab-selectable singleagent on the gemma12-vision loadout (Port 8089). Vision-capable (mmproj loaded), speculative decoding via MTP drafter. Can dispatch any subagent.",
+      "mode": "primary",
+      "model": "llamacpp-local/gemma12-vision",
+      "prompt": "{file:./prompts/local-subagent.md}",
+      "color": "#F472B6",
+      "temperature": 0.3,
+      "steps": 50,
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
+    },
+    "gemma26-throughput-primary": {
+      "description": "PRIMARY: Gemma 4 26B A4B QAT-Q4_K_XL (118.016 ctx, 159-169 tok/s). Tab-selectable singleagent on the gemma26-throughput loadout (Port 8092). Fastest 26B option — QAT quant trades some quality for 30% higher throughput. Can dispatch any subagent.",
+      "mode": "primary",
+      "model": "llamacpp-local/gemma26-throughput",
+      "prompt": "{file:./prompts/local-subagent.md}",
+      "color": "#FBBF24",
+      "temperature": 0.3,
+      "steps": 50,
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
+    },
+    "qwen-primary": {
+      "description": "PRIMARY: Qwen3-Coder-30B-A3B UD-IQ3_XXS (96.000 ctx measured). Tab-selectable singleagent on the qwen3-coder-30b loadout (Port 8094). MoE architecture, strong coding performance per parameter. Can dispatch any subagent.",
+      "mode": "primary",
+      "model": "llamacpp-local/qwen3-coder-30b",
+      "prompt": "{file:./prompts/local-subagent.md}",
+      "color": "#A78BFA",
+      "temperature": 0.3,
+      "steps": 50,
+      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
     },
     // Eskalationsstufe fuer Parallel-Agenten, NACH lokaler Kontext-
     // Kompaktierung/Retry und opencodes eigener Kompaktierung - erst wenn

--- a/scripts/llm-proxy/server.mjs
+++ b/scripts/llm-proxy/server.mjs
@@ -123,10 +123,19 @@ async function forwardToBackend(backend, servedModel, subpath, budgetedBody) {
 
 async function proxyV1(req, res, subpath) {
   const body = await readBody(req);
-  const auto = await ensureLoadoutForModel(body.model);
+  const requestedModel = body.model;
+
+  // T002753 — Auto-Switch mit Preemptions-Schutz.
+  //
+  // ensureLoadoutForModel startet das angeforderte Modell und stoppt ggf.
+  // Konflikt-Loadouts. Danach kann das Modell von einem anderen Request
+  // wieder gestoppt werden (Preemption), bevor wir es benutzen. Wir pruefen
+  // nach dem Routing, ob das angeforderte Modell noch lebt — wenn nicht,
+  // retryen wir den Switch einmal.
+  let auto = await ensureLoadoutForModel(requestedModel);
   if (auto?.conflict) {
     return sendJson(res, 409, { error: { code: 'exclusive_conflict', message:
-      `${body.model} teilt exclusiveGroup mit dem laufenden Loadout ${auto.conflict}. `
+      `${requestedModel} teilt exclusiveGroup mit dem laufenden Loadout ${auto.conflict}. `
       + `Zuerst 'curl -XPOST http://127.0.0.1:${PORT}/admin/loadouts/${auto.conflict}/stop' `
       + `ausfuehren, dann die Anfrage wiederholen — der Proxy stoppt nichts von selbst.` } });
   }
@@ -134,6 +143,7 @@ async function proxyV1(req, res, subpath) {
     const e = auto.failed;
     return sendJson(res, e.status ?? 502, { error: { code: e.code ?? 'start_error', message: e.message } });
   }
+
   // [T002657] Lokal-only-Anforderung: der Aufrufer verlangt, dass die Inhalte
   // die eigene Infrastruktur nicht verlassen. Ohne diesen Weg faellt eine
   // korrekt auf on-premises umgestellte Coaching-Konfiguration beim naechsten
@@ -141,8 +151,23 @@ async function proxyV1(req, res, subpath) {
   // zurueck — der Guard in der Website waere dann umgangen, ohne dass jemand
   // etwas falsch gemacht haette.
   const localOnly = String(req.headers['x-llm-local-only'] ?? '') === '1';
-  const routed = resolveModel(body.model, getBackends, { localOnly });
+  let routed = resolveModel(requestedModel, getBackends, { localOnly });
+  // T002753: Wenn das Modell nach dem Switch nicht mehr gefunden wird (von
+  // einem anderen Request gestoppt), genau einen Retry.
+  if (!routed && auto?.started) {
+    console.log(`[switch] ${auto.started} wurde vor Routing gestoppt — retry (resolveModel ergab null)`);
+    auto = await ensureLoadoutForModel(requestedModel);
+    if (auto?.failed) {
+      const e = auto.failed;
+      return sendJson(res, e.status ?? 502, { error: { code: e.code ?? 'start_error', message: e.message } });
+    }
+    // auto ist null oder { started } — bei null ist das Modell schon da, bei
+    // started hat der Retry es neu gestartet. Ein erneuter resolveModel-Versuch.
+    routed = resolveModel(requestedModel, getBackends, { localOnly });
+  }
+
   if (!routed) {
+    console.log(`[route] ${requestedModel}: resolveModel ergab null (localOnly=${localOnly}, auto=${auto ? JSON.stringify(Object.keys(auto)) : 'null'})`);
     // Bewusst KEINE Substitution auf ein remote-Backend: bei lokal-only ist
     // Fehlschlagen das richtige Ergebnis, Ausweichen waere der Schaden.
     return localOnly
@@ -360,6 +385,11 @@ async function startLoadout(slug) {
 }
 
 const startsInFlight = new Map();
+/** T002753 — Grace-Period: ein gerade gestarteter Loadout darf fuer diese Zeitspanne
+ *  nicht von einem anderen Request gestoppt werden (Preemptions-Schutz). Der
+ *  ausloesende Request hat so Zeit, zu routen und das Modell zu benutzen. */
+const SWITCH_GRACE_MS = 3_000;
+const loadoutStartedAt = new Map(); // slug -> timestamp (Date.now())
 
 async function ensureLoadoutForModel(model) {
   let doc;
@@ -397,6 +427,18 @@ async function ensureLoadoutForModel(model) {
         const l = findLoadout(doc, slug);
         return l && l.exclusiveGroup === group && l.slug !== reDecide.slug && l.managed !== 'external';
       });
+      // T002753 — Grace-Period: ein gerade gestarteter Loadout darf nicht sofort
+      // wieder gestoppt werden. Der ausloesende Request braucht Zeit zum Routen.
+      const inGrace = toStop.filter((slug) => {
+        const at = loadoutStartedAt.get(slug);
+        return at && (Date.now() - at) < SWITCH_GRACE_MS;
+      });
+      if (inGrace.length > 0) {
+        console.log(`[switch] ${reDecide.slug}: Konflikt-Loadout(s) ${inGrace.join(',')} in Grace-Period — switch abgelehnt`);
+        return { failed: new LoadoutStartError(503, 'grace_period',
+          `${inGrace.join(', ')} wurde gerade erst gestartet (Grace-Period ${SWITCH_GRACE_MS}ms). `
+          + `Bitte in ${Math.ceil(SWITCH_GRACE_MS / 1000)}s erneut versuchen.`) };
+      }
       for (const slug of toStop) {
         console.log(`[switch] ${reDecide.slug}: stoppe Konflikt-Loadout ${slug} (Gruppe '${group}')`);
         try { stopUnit(slug); } catch (err) {
@@ -422,7 +464,7 @@ async function startRequestedLoadout(doc, slug) {
   const pending = startsInFlight.get(slug);
   if (pending) return pending;
   const p = startLoadout(slug)
-    .then(() => ({ started: slug }))
+    .then((r) => { loadoutStartedAt.set(slug, Date.now()); return { started: slug, ...r }; })
     .catch((err) => ({ failed: err }))
     .finally(() => startsInFlight.delete(slug));
   startsInFlight.set(slug, p);

--- a/scripts/llm-proxy/server.mjs
+++ b/scripts/llm-proxy/server.mjs
@@ -238,6 +238,31 @@ async function waitHealthy(port, timeoutMs) {
   return false;
 }
 
+/** Wartet, bis eine systemd-Unit gestoppt ist (active !== 'active'). Timeout in ms. */
+async function waitUntilStopped(slug, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const s = unitStatus(slug);
+    if (s.active !== 'active') return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+/**
+ * T002753 — Auto-Switch-Semaphor: serialisiert Modellwechsel (stop alt + start neu)
+ * damit nicht zwei Requests gleichzeitig verschiedene Loadouts starten.
+ * Der Aufrufer (proxyV1) serialisiert bereits ueber den per-Backend-Semaphor;
+ * dieser Lock schuetzt den Switch VOR dem Routing, also bevor der Backend bekannt ist.
+ */
+let switchLock = Promise.resolve();
+function withSwitchLock(fn) {
+  const p = switchLock.then(() => fn()).finally(() => {});
+  // next waiter gets this promise, even if it rejects — we never want to deadlock
+  switchLock = p.catch(() => {});
+  return p;
+}
+
 // Ein Server kann auf /health antworten und trotzdem unfaehig sein, ein
 // tool_calls-Objekt zu erzeugen -- fuer tool-basiertes Coding wertlos.
 async function smokeTestToolCall(port) {
@@ -339,19 +364,68 @@ const startsInFlight = new Map();
 async function ensureLoadoutForModel(model) {
   let doc;
   try { ({ doc } = readLoadouts(DEFAULT_PATH)); } catch { return null; }
+
+  // T002753 — Auto-Switch mit Re-Evaluation unter dem Lock.
+  //
+  // Der erste Blick auf planAutoStart entscheidet, OB ueberhaupt ein Switch
+  // noetig ist (none: Modell laeuft schon; conflict/start: etwas muss passieren).
+  // Bei none kehren wir sofort ohne Lock zurueck. Bei conflict/start betreten
+  // wir den Lock und lesen activeSlugs ERNEUT: ein anderer Request koennte
+  // zwischenzeitlich den Konflikt schon geloest haben — dann starten wir nicht
+  // doppelt.
   const activeSlugs = doc.loadouts
     .filter((l) => isLoadoutActive(l, unitStatus(l.slug)))
     .map((l) => l.slug);
   const decision = planAutoStart({ doc, model, activeSlugs });
   if (decision.action === 'none') return null;
-  if (decision.action === 'conflict') return { conflict: decision.conflictSlug };
-  const pending = startsInFlight.get(decision.slug);
+
+  return withSwitchLock(async () => {
+    // Re-read active slugs under the lock — another switch may have resolved
+    // the conflict while we were waiting.
+    const currentActive = doc.loadouts
+      .filter((l) => isLoadoutActive(l, unitStatus(l.slug)))
+      .map((l) => l.slug);
+    const reDecide = planAutoStart({ doc, model, activeSlugs: currentActive });
+    if (reDecide.action === 'none') return null;
+
+    // Nur wenn das angeforderte Modell WIRKLICH noch nicht laeuft, stoppen wir.
+    // `reDecide` kann `start` sein (kein Konflikt, Modell nicht aktiv)
+    // oder `conflict` (Konflikt mit einem laufenden Loadout).
+    if (reDecide.action === 'conflict') {
+      const group = reDecide.group;
+      const toStop = currentActive.filter((slug) => {
+        const l = findLoadout(doc, slug);
+        return l && l.exclusiveGroup === group && l.slug !== reDecide.slug && l.managed !== 'external';
+      });
+      for (const slug of toStop) {
+        console.log(`[switch] ${reDecide.slug}: stoppe Konflikt-Loadout ${slug} (Gruppe '${group}')`);
+        try { stopUnit(slug); } catch (err) {
+          return { failed: new LoadoutStartError(502, 'stop_error',
+            `Konnte ${slug} nicht stoppen: ${err.message}`) };
+        }
+        const stopped = await waitUntilStopped(slug, 30_000);
+        if (!stopped) {
+          return { failed: new LoadoutStartError(502, 'stop_timeout',
+            `${slug} wurde nach 30s nicht inaktiv`) };
+        }
+        console.log(`[switch] ${slug} gestoppt`);
+      }
+      await discovery.probeNow();
+    }
+
+    console.log(`[switch] starte ${reDecide.slug}`);
+    return startRequestedLoadout(doc, reDecide.slug);
+  });
+}
+
+async function startRequestedLoadout(doc, slug) {
+  const pending = startsInFlight.get(slug);
   if (pending) return pending;
-  const p = startLoadout(decision.slug)
-    .then(() => ({ started: decision.slug }))
+  const p = startLoadout(slug)
+    .then(() => ({ started: slug }))
     .catch((err) => ({ failed: err }))
-    .finally(() => startsInFlight.delete(decision.slug));
-  startsInFlight.set(decision.slug, p);
+    .finally(() => startsInFlight.delete(slug));
+  startsInFlight.set(slug, p);
   return p;
 }
 

--- a/tests/spec/local-llm-proxy/opencode-agent-model-drift.bats
+++ b/tests/spec/local-llm-proxy/opencode-agent-model-drift.bats
@@ -76,14 +76,40 @@ setup() {
 }
 
 @test "T002545: keine handgepflegte Kontextzahl widerspricht dem Loadout" {
-  # 262144 war der Wert des abgeloesten 12B-Servers. Er steht fuer die Drift-
-  # Klasse, die T002300 fuer die MCP-Configs geloest hat: eine Zahl, die von
-  # Hand gepflegt wird und niemandem auffaellt, wenn sich die Quelle aendert.
+  # Die Zusicherung ist "keine handgepflegte Zahl WIDERSPRICHT dem Loadout" —
+  # geprueft wird sie als Abgleich gegen loadouts.json, nicht als Schwarze
+  # Liste eines Integers.
+  #
+  # [T003065] Vorher stand hier `grep -c '262144'` mit der Erwartung 0: 262144
+  # war der Wert des abgeloesten 12B-Servers und stand fuer die Drift-Klasse,
+  # die T002300 fuer die MCP-Configs geloest hat. Inzwischen MISST das Loadout
+  # gemma12-vision genau diesen Wert ("Gemessen: 262.144 Kontext" in
+  # loadouts.json), und der Guard meldete einen Defekt, den es nicht gibt —
+  # Darstellung statt Semantik [T002716]. Eine Zahl ist nicht falsch, weil sie
+  # frueher falsch war; falsch ist sie, wenn die SSOT sie nicht deckt.
   [ -f "${AGENTS}" ]
-  # Nur in den wirksamen limit.context-Werten, nicht im Fliesstext: ein
-  # Kommentar darf festhalten, dass dort frueher 262144 stand.
-  run bash -c "grep -A2 '\"limit\"' '${AGENTS}' | grep -c '262144' || true"
-  [ "${output}" = "0" ]
+  [ -f "${LOADOUTS}" ]
+
+  # Nur limit.context-Werte, deren Eintrag ein "Loadout <slug>" nennt, sind an
+  # loadouts.json gebunden. API-Modelle (deepseek u.a.) tragen legitim Kontexte,
+  # die dort nicht vorkommen, und bleiben ausgeklammert.
+  run bash -c "grep -A3 '\"name\": \".*Loadout ' '${AGENTS}' | grep -oE '\"context\": [0-9]+' | grep -oE '[0-9]+' | sort -u"
+  [ "${status}" -eq 0 ]
+  # Positiv-Anker zuerst [T002356-M1]: ohne mindestens einen Kandidaten wuerde
+  # die Negativ-Aussage unten vakuos gelten.
+  [ -n "${output}" ]
+
+  local unbacked=0 n dotted
+  for n in ${output}; do
+    # loadouts.json notiert die Messwerte mit deutschem Tausenderpunkt
+    # ("Gemessen: 262.144 Kontext"), deshalb beide Schreibweisen akzeptieren.
+    dotted="$(printf '%s' "${n}" | sed ':a;s/\B[0-9]\{3\}\>/.&/;ta')"
+    if ! grep -qF "${n}" "${LOADOUTS}" && ! grep -qF "${dotted}" "${LOADOUTS}"; then
+      echo "FAIL: limit.context ${n} (auch nicht als ${dotted}) ist in loadouts.json nicht belegt"
+      unbacked=$((unbacked + 1))
+    fi
+  done
+  [ "${unbacked}" -eq 0 ]
 }
 
 @test "T002545: der Providername behauptet kein Draft-Modell, das nicht laedt" {


### PR DESCRIPTION
## Summary

Unkommittierte Folgearbeit nach **T002753** (`done`/`shipped`), im Arbeitsbaum des Haupt-Checkouts vorgefunden und hier geordnet nachgereicht. Drei Commits, weil es drei Anliegen sind — sie hängen aber kausal zusammen.

**1. `fix(scripts)` — Auto-Switch-Semaphor in `scripts/llm-proxy/server.mjs`**

`ensureLoadoutForModel` löste einen `exclusiveGroup`-Konflikt bisher **nicht** auf, sondern meldete ihn: der Aufrufer antwortete mit `409 exclusive_conflict` und verwies den Benutzer auf ein manuelles `/admin/loadouts/<slug>/stop`.

Neu serialisiert `withSwitchLock` den Wechsel: Konflikt-Loadouts derselben Gruppe (`managed !== 'external'`) werden gestoppt, `waitUntilStopped` wartet bis die Unit inaktiv ist (30 s, sonst `502 stop_timeout`), die Discovery wird neu geprobt, dann startet das angeforderte Loadout. **Unter dem Lock wird `planAutoStart` erneut ausgewertet** — ein paralleler Request kann den Konflikt zwischenzeitlich gelöst haben, dann wird nicht doppelt gestartet.

Der `409`-Zweig in Zeile 127 wird damit toter Code. Das ist beabsichtigt, aber bewusst benannt.

**2. `fix(agents)` — `.opencode/agent-models.jsonc` auf die belegten Messwerte**

| Eintrag | vorher | nachher | Belegstelle in `scripts/llm/loadouts.json` |
|---|---|---|---|
| `gemma4` | 32768 | 177920 | „Gemessen … 177.920 Kontext" |
| `gemma12-vision` | *fehlte* | 262144 | „Gemessen: 262.144 Kontext" |
| `gemma26-throughput` | *fehlte* | 118016 | „Gemessen … 118.016 Kontext" |

Beide neuen Slugs existieren auf `main` bereits in `loadouts.json` — nur die Agent-Config hinkte nach.

Zusätzlich fällt bei `gemma26-primary` die `task`-Sperre für die lokalen Subagenten (`gptoss`/`devstral`/`gemma`/`qwen`). Ihre Begründung war GPU-Kontention bei gleichzeitig laufenden Loadouts — genau das verhindert (1) jetzt. Die Reihenfolge ist also nicht beliebig: ohne den Semaphor wäre diese Lockerung nicht vertretbar.

**3. `fix(test)` — Kontext-Guard prüft Semantik statt einer Zahl**

`opencode-agent-model-drift.bats` verbot die **Zahl** 262144 als wirksamen `limit.context` (`grep -c '262144'`, erwartet 0). Sie stand für die Drift eines abgelösten 12B-Servers. Inzwischen *misst* `gemma12-vision` genau diesen Wert — der Guard meldete einen Defekt, den es nicht gibt. Dieselbe Klasse wie T002716/T002700/T002701: geprüft wurde die Darstellung.

Der Guard gleicht jetzt jeden `limit.context`-Wert, dessen Eintrag ein „Loadout &lt;slug&gt;" nennt, gegen `loadouts.json` ab (beide Schreibweisen, weil dort der deutsche Tausenderpunkt steht). API-Modelle bleiben ausgeklammert, sie sind nicht an Loadouts gebunden.

## Test Plan

- `tests/unit/lib/bats-core/bin/bats -r tests/spec/local-llm-proxy*` → **133 ok, 0 not ok** (beide Formen erfasst, T002696)
- **Mutationstest des neuen Guards**: `limit.context` auf eine in `loadouts.json` unbelegte Zahl gesetzt → rot mit `FAIL: limit.context 999424 … nicht belegt`; wiederhergestellt → grün. Der Guard ist strenger, nicht nachsichtiger.
- Positiv-Anker im Guard (T002356-M1): ohne mindestens einen Kandidaten würde die Negativ-Aussage vakuos gelten.
- `node --check scripts/llm-proxy/server.mjs` → OK; `stopUnit`, `discovery`, `findLoadout` und `reDecide.group` sind alle auflösbar (geprüft gegen Imports und `findExclusiveConflict`).
- `task freshness:check` → `rc=0`

## Nicht geprüft

Der Wechselpfad selbst ist **nicht** unter Last gefahren worden — dafür braucht es einen laufenden `llama-server` und zwei konkurrierende Requests, was in CI nicht herstellbar ist. Die Re-Evaluation unter dem Lock ist gegen den Code begründet, nicht gemessen.

Ticket: T003065

---

## Nachtrag (4. Commit) — Grace-Period und Preemptions-Retry

Während der Bearbeitung ist `scripts/llm-proxy/server.mjs` im Haupt-Checkout **weitergewachsen** (575 → 609 Zeilen): eine parallel laufende Session hat den Semaphor um zwei Dinge ergänzt. Ich habe den neueren Stand in den Branch geholt, damit dieser PR kein veralteter Schnappschuss ist:

- **Grace-Period** (`SWITCH_GRACE_MS = 3000`): ein gerade gestartetes Loadout darf nicht sofort von einem anderen Request gestoppt werden — sonst stirbt das Modell, bevor der auslösende Request routen konnte. Verletzung → `503 grace_period`.
- **Preemptions-Retry**: liefert `resolveModel` nach einem erfolgreichen Switch `null`, wird der Switch **genau einmal** wiederholt.
- Zusätzliche `console.log`-Diagnostik auf den Switch- und Routing-Pfaden.

**Zwei Kommentare wiederhergestellt.** Der Nachtrag hatte den `[T002657]`-Block zur Lokal-only-Anforderung und die Zeile „Bewusst KEINE Substitution auf ein remote-Backend" gelöscht und durch `console.log` ersetzt. Das **Verhalten** ist unverändert (`503 no_local_backend`, kein Ausweichen), aber die Begründung einer sicherheitsrelevanten Entscheidung war weg. Kein Guard hing daran — ich habe beide Kommentare zurückgeholt und die neue Diagnostik behalten.

Erneut verifiziert nach dem Nachtrag: `node --check` OK, `bats -r tests/spec/local-llm-proxy*` → **133 ok / 0 not ok**, `task freshness:check` → `rc=0`.

> **Hinweis zur Gleichzeitigkeit:** Der Haupt-Checkout wird parallel bearbeitet (HEAD wanderte während der Sitzung auf `7d8f8c51c`/#4037). Sein Arbeitsbaum ist **absichtlich unangetastet** geblieben — er hält dieselben Änderungen weiter als uncommittete Datei. Wer dort aufräumt, sollte vorher gegen diesen Branch abgleichen.