### PR TITLE
fix(agents): Primaeragenten in agents.yaml registrieren, Kontext-Guard auf ctx<=gemessen [T003079]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ opencode reads its agents from `.opencode/agent-models.jsonc` — NOT `.agents/a
 | `qwen` | `llamacpp-local/qwen3-coder-30b` (Qwen3-Coder-30B UD-IQ3_XXS, :8094) | Local work, qwen family |
 | `gemma26-primary` | `llamacpp-local/gemma26-factory`, `mode: primary` | Fully-local tab-selectable agent; NOT summonable via `task` |
 | `gemma26-vision` | `llamacpp-local/gemma26-factory`, `mode: primary` | Max local context (161024, measured), no subagent dispatch. **Vision-capable**: gemma26-factory loads mmproj-F16.gguf since T002753 |
+| `gptoss-primary` | `llamacpp-local/gptoss-context`, `mode: primary` | Tab-selectable primary, 105472 ctx measured (:8098) |
+| `devstral-primary` | `llamacpp-local/devstral-quality`, `mode: primary` | Tab-selectable primary, 32768 ctx, code-quality review (:8099) |
+| `gemma12-primary` | `llamacpp-local/gemma12-vision`, `mode: primary` | Tab-selectable primary, 262144 ctx measured. **Vision-capable** via mmproj-F16 (:8089) |
+| `gemma26-throughput-primary` | `llamacpp-local/gemma26-throughput`, `mode: primary` | Tab-selectable primary, 118016 ctx measured, 159-169 tok/s (:8092) |
+| `qwen-primary` | `llamacpp-local/qwen3-coder-30b`, `mode: primary` | Tab-selectable primary, 96000 ctx measured (:8094) |
 | `big-pickle` | `opencode-zen/big-pickle`, `mode: primary`, write-capable | Tab-selectable singleagent on OpenCode Zen — use while the free quota lasts, then switch to the deepseek primaries |
 | `deepseek-helper` | `deepseek/deepseek-v4-flash` (direct API), write-capable | Escalation when a local agent is stuck or context-exhausted |
 | `deepseek-pro` | `opencode-go/deepseek-v4-pro`, `mode: all`, write-capable | Deep analysis, complex debugging, hard refactors; tab-selectable AND task-dispatchable |

--- a/docs/agent-guide/maps/agents-map.md
+++ b/docs/agent-guide/maps/agents-map.md
@@ -27,9 +27,14 @@ Die Registry ist die SSOT: `docs/agent-guide/registry/agents.yaml`.
 | deepseek-pro | all | opencode-go/deepseek-v4-pro | ja | DeepSeek-V4 Pro (1M ctx, max reasoning effort) for deep analysis and hard refactors; tab-selectable + task-dispatchable [T002632] |
 | deepseek-pro-direct | all | deepseek/deepseek-v4-pro | ja | Same model as deepseek-pro, but over the direct DeepSeek API instead of opencode-go — fallback when the gateway is unavailable; tab-selectable + task-dispatchable [T002633] |
 | devstral | subagent | llamacpp-local/devstral-quality | nein | devstral family: Devstral-Small-2 24B IQ4_XS [2026-08-04] |
+| devstral-primary | primary | llamacpp-local/devstral-quality | nein | Tab-selectable primary on devstral-quality (Port 8099), 32768 ctx, code-quality review [T003065] |
 | gemma | subagent | llamacpp-local/gemma26-factory | nein | gemma family: Gemma 4 26B A4B IQ4_XS, Loadout gemma26-factory auf Port 8091 (exclusiveGroup chat-gpu) [2026-08-09 T002753] |
+| gemma12-primary | primary | llamacpp-local/gemma12-vision | nein | Tab-selectable primary on gemma12-vision (Port 8089), 262144 ctx measured, vision-capable via mmproj-F16 [T003065] |
 | gemma26-primary | primary | llamacpp-local/gemma26-factory | nein | Tab-selectable primary local agent, 161024 ctx measured (np=3 -kvu q4_0 fitt 128) [T002753] |
+| gemma26-throughput-primary | primary | llamacpp-local/gemma26-throughput | nein | Tab-selectable primary on gemma26-throughput (Port 8092), 118016 ctx measured, 159-169 tok/s [T003065] |
 | gemma26-vision | primary | llamacpp-local/gemma26-factory | nein | Max context, no subagent dispatch. Vision IS available — gemma26-factory loads mmproj-F16.gguf since T002753 |
 | gptoss | subagent | llamacpp-local/gptoss-context | nein | gpt-oss family: gpt-oss-20b Q8_0, 105472 ctx (measured, not n_ctx_train) [T002545/T002633] |
+| gptoss-primary | primary | llamacpp-local/gptoss-context | nein | Tab-selectable primary on gptoss-context (Port 8098), 105472 ctx measured [T003065] |
 | orchestrator | primary | opencode-go/deepseek-v4-flash | ja | Primary orchestrator, dispatches the local family subagents (gptoss/devstral/gemma/qwen) sequentially |
 | qwen | subagent | llamacpp-local/qwen3-coder-30b | nein | qwen family: Qwen3-Coder-30B-A3B UD-Q4_K_XL, Loadout qwen3-coder-30b auf Port 8094 [2026-08-04] |
+| qwen-primary | primary | llamacpp-local/qwen3-coder-30b | nein | Tab-selectable primary on qwen3-coder-30b (Port 8094), 96000 ctx measured [T003065] |

--- a/docs/agent-guide/registry/agents.yaml
+++ b/docs/agent-guide/registry/agents.yaml
@@ -79,6 +79,35 @@ runtimes:
     model: llamacpp-local/gemma26-factory
     write_capable: false
     note: "Max context, no subagent dispatch. Vision IS available — gemma26-factory loads mmproj-F16.gguf since T002753"
+  # [T003065] Ein tab-waehlbarer Primaeragent pro lokalem GGUF-Modell. Alle
+  # Kontextwerte sind in scripts/llm/loadouts.json als Messwert belegt — keine
+  # n_ctx_train-Zahlen. Der Semaphor in scripts/llm-proxy/server.mjs serialisiert
+  # den Modellwechsel, deshalb duerfen diese Agenten Subagenten dispatchen.
+  gptoss-primary:
+    mode: primary
+    model: llamacpp-local/gptoss-context
+    write_capable: false
+    note: "Tab-selectable primary on gptoss-context (Port 8098), 105472 ctx measured [T003065]"
+  devstral-primary:
+    mode: primary
+    model: llamacpp-local/devstral-quality
+    write_capable: false
+    note: "Tab-selectable primary on devstral-quality (Port 8099), 32768 ctx, code-quality review [T003065]"
+  gemma12-primary:
+    mode: primary
+    model: llamacpp-local/gemma12-vision
+    write_capable: false
+    note: "Tab-selectable primary on gemma12-vision (Port 8089), 262144 ctx measured, vision-capable via mmproj-F16 [T003065]"
+  gemma26-throughput-primary:
+    mode: primary
+    model: llamacpp-local/gemma26-throughput
+    write_capable: false
+    note: "Tab-selectable primary on gemma26-throughput (Port 8092), 118016 ctx measured, 159-169 tok/s [T003065]"
+  qwen-primary:
+    mode: primary
+    model: llamacpp-local/qwen3-coder-30b
+    write_capable: false
+    note: "Tab-selectable primary on qwen3-coder-30b (Port 8094), 96000 ctx measured [T003065]"
   big-pickle:
     mode: primary
     model: opencode-zen/big-pickle

--- a/tests/spec/llm-local-dev.bats
+++ b/tests/spec/llm-local-dev.bats
@@ -168,11 +168,41 @@ EOF"
 }
 
 @test "agent-models.jsonc provides a primary gemma agent with measured context (T002545)" {
-  # T002545: mode:primary, ~99840 ctx gemessen, kein 262144.
+  # T002545: mode:primary, und der genannte Kontext ist ein GEMESSENER Wert,
+  # kein n_ctx_train.
+  #
+  # [T003065] Vorher lautete die Bedingung
+  #   ctx === 262144 || ctx <= 50000 || ctx >= 200000  ->  implausible
+  # 262144 war der n_ctx_train-Wert des abgeloesten 12B-Servers, die Obergrenze
+  # 200000 eine daraus abgeleitete Faustzahl. Beides bricht, sobald ein Loadout
+  # legitim mehr misst: gemma12-vision belegt genau 262144 in
+  # scripts/llm/loadouts.json ("Gemessen: 262.144 Kontext"). Geprueft wird jetzt
+  # die Zahl gegen das im Loadout DOKUMENTIERTE Maximum: ctx <= gemessen.
+  # Semantik statt Darstellung [T002716].
+  #
+  # Warum <= und nicht ==: gemma26-factory nennt 161024 (gemessen bei fitt 128),
+  # loadouts.json fuer dasselbe Loadout 166.912 (andere Messgelegenheit). Beide
+  # Zahlen sind echt. Ein niedrigerer Wert ist konservativ und harmlos — etwa
+  # weil np=3 mit -kvu einen GETEILTEN Pool fahren. Schaden entsteht nur in der
+  # anderen Richtung: wenn die Config MEHR verspricht als gemessen wurde, und
+  # genau das war der Ursprungsfall (262144 behauptet, 99840 gemessen).
   run node -e "
-    const s = require('fs').readFileSync('$REPO/.opencode/agent-models.jsonc','utf8');
+    const fs = require('fs');
+    const s = fs.readFileSync('$REPO/.opencode/agent-models.jsonc','utf8');
     const j = s.replace(/^\s*\/\/.*\$/gm,'').replace(/\/\*[\s\S]*?\*\//g,'');
     const o = JSON.parse(j);
+    const ld = JSON.parse(fs.readFileSync('$REPO/scripts/llm/loadouts.json','utf8'));
+    // Messwerte stehen im notes-Feld des Loadouts, mit deutschem Tausenderpunkt
+    // und in wechselnder Formulierung ('Gemessen: 262.144 Kontext',
+    // 'gemessen 118.016 ctx'). Das groesste genannte Maximum gilt.
+    const measuredFor = (slug) => {
+      const l = (ld.loadouts || []).find((x) => x.slug === slug);
+      const notes = (l && l.notes) || '';
+      const ms = [...notes.matchAll(/([0-9][0-9.]*)\s*(?:Kontext|ctx)/gi)]
+        .map((m) => parseInt(m[1].replace(/\./g, ''), 10))
+        .filter((n) => Number.isInteger(n) && n > 0);
+      return ms.length ? Math.max(...ms) : null;
+    };
     const prim = Object.entries(o.agent || {})
       .filter(([n,v]) => n.startsWith('gemma') && v.mode === 'primary');
     if (prim.length < 1) { console.error('no primary gemma agents found'); process.exit(1); }
@@ -180,8 +210,19 @@ EOF"
       const model = agent.model;
       const [prov, mid] = model.split('/');
       const ctx = o.provider[prov].models[mid].limit.context;
-      if (!Number.isInteger(ctx) || ctx === 262144 || ctx <= 50000 || ctx >= 200000) {
-        console.error(name + ' ctx ' + ctx + ' implausible (expected a measured value, not n_ctx_train)');
+      if (!Number.isInteger(ctx) || ctx <= 0) {
+        console.error(name + ' ctx ' + ctx + ' is not a positive integer');
+        process.exit(1);
+      }
+      const max = measuredFor(mid);
+      if (max === null) {
+        console.error(name + ': loadout ' + mid + ' dokumentiert keinen gemessenen Kontext in loadouts.json');
+        process.exit(1);
+      }
+      // Kleiner als gemessen ist zulaessig (konservativ, z.B. geteilter -kvu-Pool).
+      // Schaden entsteht nur, wenn die Config MEHR verspricht als gemessen wurde.
+      if (ctx > max) {
+        console.error(name + ' ctx ' + ctx + ' > gemessenes Maximum ' + max + ' des Loadouts ' + mid);
         process.exit(1);
       }
     }


### PR DESCRIPTION
## Summary

**`main` ist rot** (Run auf `24061ced`). PR #4039 hat fünf tab-wählbare Primäragenten in `.opencode/agent-models.jsonc` eingeführt; zwei Guards **außerhalb der von jenem PR berührten Pfade** fallen dadurch. Dieser PR reicht den Fix nach.

1. **`P4.3: runtimes ↔ agent-models.jsonc`** (`tests/spec/agent-roster.bats`) — die fünf Einträge hatten keinen `runtimes`-Eintrag in `docs/agent-guide/registry/agents.yaml`:
   `gptoss-primary devstral-primary gemma12-primary gemma26-throughput-primary qwen-primary`.
   → Registriert, `docs/agent-guide/maps/agents-map.md` regeneriert.

2. **`provides a primary gemma agent with measured context (T002545)`** (`tests/spec/llm-local-dev.bats`) — die Bedingung lautete `ctx === 262144 || ctx <= 50000 || ctx >= 200000 → implausible`. 262144 war der `n_ctx_train`-Wert des abgelösten 12B-Servers, 200000 eine daraus abgeleitete Faustzahl. `gemma12-vision` **misst** 262144 belegt (`"Gemessen: 262.144 Kontext"` in `scripts/llm/loadouts.json`).
   → Umgestellt auf **`ctx ≤ im Loadout dokumentiertes Maximum`**, aus dem `notes`-Feld geparst (deutscher Tausenderpunkt toleriert).

### Warum `≤` und nicht `==`

`gemma26-factory` nennt 161024 (gemessen bei `fitt 128`), `loadouts.json` für dasselbe Loadout 166.912 (andere Messgelegenheit). **Beide Zahlen sind echt.** Ein niedrigerer Wert ist konservativ und harmlos — bei `np=3` mit `-kvu` teilen sich drei Agenten einen Pool. Schaden entsteht nur in der anderen Richtung: wenn die Config *mehr* verspricht als gemessen wurde. Genau das war der Ursprungsfall (262144 behauptet, 99840 gemessen), und den fängt `≤` weiterhin.

## Warum es erst nach dem Merge auffiel

Der CI-Automerge fährt seit **T002780** nur das Merge-Delta. Beide Guards liegen außerhalb der von #4039 geänderten Pfade, wurden für die Merge-Entscheidung also nicht ausgewertet — der PR galt als grün und mergte, der Post-Merge-Lauf auf `main` wurde rot. Das ist eine Eigenschaft des Delta-Scopings, kein Bedienfehler, aber sie verlagert diese Fehlerklasse hinter den Merge. Festgehalten in T003079.

## Test Plan

- `tests/spec/agent-roster.bats` → **6 ok / 0 not-ok** (vorher 1 rot)
- `tests/spec/llm-local-dev.bats` → **21 ok / 0 not-ok** (vorher 1 rot)
- `bats -r tests/spec/local-llm-proxy*` → 133 ok (unverändert)
- **Mutationstest** des neuen Guards: `limit.context` von 118016 auf 300000 (> gemessene 118.016) → rot mit `ctx 300000 > gemessenes Maximum 118016`; Rücknahme → grün.
- `task test:agent-guide` → `rc=0`; `task freshness:check` → `rc=0`

Ticket: T003079 (Fix stammt aus Commit `3aecb4d9`, der #4039 um Minuten verpasste)