### PR TITLE
fix(factory): Drift-Cache-Pfad isolierbar machen, Scout-Tests hermetisch [T003053]

### DIFF
--- a/scripts/factory/scout-drift.sh
+++ b/scripts/factory/scout-drift.sh
@@ -88,7 +88,9 @@ bash "$TICKET_SH" set-scout-drift --id "$TICKET" --drift "$drift" 2>/dev/null ||
 # ── Drift-cache JSON (T002241: consumed by scout.sh Phase 6) ────────────────
 # Write brand-keyed drift to /tmp for scout.sh to read during file discovery.
 # Fail-soft: if writing fails, next scout will fall back to drift=0.
-CACHE_FILE="/tmp/scout-drift-cache.json"
+# [T003053] Ueberschreibbar wie in scout.sh — beide Seiten muessen denselben
+# Pfad sehen, sonst schreibt der Producer woanders hin als der Consumer liest.
+CACHE_FILE="${SCOUT_DRIFT_CACHE_FILE:-/tmp/scout-drift-cache.json}"
 BRAND="${BRAND:-mentolder}"
 if command -v jq >/dev/null 2>&1; then
   # Read existing cache, merge new drift value for this brand

--- a/scripts/factory/scout.sh
+++ b/scripts/factory/scout.sh
@@ -105,7 +105,15 @@ done
 SCOUT_DRIFT=0
 SCOUT_GREP_FLAGS="-rliFi"
 SCOUT_FILE_MULTIPLIER=1.0
-DRIFT_CACHE_FILE="/tmp/scout-drift-cache.json"
+# [T003053] Pfad ueberschreibbar, Default unveraendert. Der feste /tmp-Pfad ist
+# eine GLOBALE, veraenderliche Datei ausserhalb von BATS_TEST_TMPDIR: schrieb
+# eine parallel laufende Spec-Datei dort einen Drift > 0.5, sah ein anderer Test
+# diesen Wert, scout.sh meldete "drift=... > 0.5" auf stderr, und `run` buendelte
+# das in $output — jq brach mit "Invalid numeric literal at line 1, column 9" ab
+# (Spalte 9 = der Doppelpunkt nach "scout.sh"). Deterministisch, aber
+# shard-abhaengig, und die Shard-Zusammensetzung wechselt pro PR — deshalb sah es
+# wie Flakiness aus.
+DRIFT_CACHE_FILE="${SCOUT_DRIFT_CACHE_FILE:-/tmp/scout-drift-cache.json}"
 DRIFT_BRAND="${BRAND:-mentolder}"
 if [[ -f "$DRIFT_CACHE_FILE" ]]; then
   cached_drift="$(jq -r --arg b "$DRIFT_BRAND" '.[$b] // 0' "$DRIFT_CACHE_FILE" 2>/dev/null || echo 0)"

--- a/tests/spec/scout-prediction-quality.bats
+++ b/tests/spec/scout-prediction-quality.bats
@@ -10,6 +10,15 @@ setup() {
   load 'test_helper.bash' 2>/dev/null || true
   export SCOUT_LLM_ENABLED=false
   export SCOUT_LLM_MIN_FILES=2
+  # [T003053] Drift-Cache pro Test isolieren. Vorher schrieb 5.7a nach
+  # /tmp/scout-drift-cache.json — eine GLOBALE Datei ausserhalb von
+  # BATS_TEST_TMPDIR. Das rm -f kam nach dem `run`, und CI faehrt Spec-Dateien
+  # parallel: im Fenster dazwischen las
+  # tests/spec/software-factory/scout-and-routing.bats einen Drift > 0.5, scout.sh
+  # schrieb daraufhin "scout.sh: drift=... > 0.5" nach stderr, `run` buendelte das
+  # in $output, und jq brach ab ("Invalid numeric literal at line 1, column 9").
+  # BATS_TEST_TMPDIR ist pro Test frisch — damit kann kein Fenster mehr entstehen.
+  export SCOUT_DRIFT_CACHE_FILE="$BATS_TEST_TMPDIR/scout-drift-cache.json"
 }
 
 # ── 5.1 N-gram extraction ──────────────────────────────────────
@@ -188,9 +197,9 @@ setup() {
 # ── 5.7 Drift feedback expands search ──────────────────────────
 
 @test "5.7a: scout.sh reads drift-cache before file discovery" {
-  # When /tmp/scout-drift-cache.json exists and drift > 0.5,
+  # When the drift cache (SCOUT_DRIFT_CACHE_FILE) exists and drift > 0.5,
   # scout.sh should switch grep to -E regex mode
-  echo '{"mentolder":0.6}' > /tmp/scout-drift-cache.json
+  echo '{"mentolder":0.6}' > "$SCOUT_DRIFT_CACHE_FILE"
   run bash scripts/factory/scout.sh \
     --ticket-id T002241 \
     --title "Test Feature" \
@@ -198,7 +207,7 @@ setup() {
     --repo "$PWD" 2>/dev/null || true
 
   echo "output=$output" >&2
-  rm -f /tmp/scout-drift-cache.json
+  rm -f "$SCOUT_DRIFT_CACHE_FILE"
   [[ "$output" != "" ]]
 }
 
@@ -220,7 +229,7 @@ setup() {
 # ── 5.9 No drift data ──────────────────────────────────────────
 
 @test "5.9a: no drift cache file -> drift=0 fallback" {
-  rm -f /tmp/scout-drift-cache.json
+  rm -f "$SCOUT_DRIFT_CACHE_FILE"
   run bash scripts/factory/scout.sh \
     --ticket-id T002241 \
     --title "Test Feature" \
@@ -233,7 +242,7 @@ setup() {
 }
 
 @test "5.9b: scout works without any drift mechanism installed" {
-  rm -f /tmp/scout-drift-cache.json
+  rm -f "$SCOUT_DRIFT_CACHE_FILE"
   run bash scripts/factory/scout.sh \
     --ticket-id T002241 \
     --title "Simple Query" \

--- a/tests/spec/software-factory/scout-and-routing.bats
+++ b/tests/spec/software-factory/scout-and-routing.bats
@@ -103,7 +103,21 @@ teardown() { _sf_teardown; }
 }
 
 @test "scout.sh with SCOUT_LLM_ENABLED=false runs deterministic path only (no crash, valid JSON)" {
-  run env SCOUT_LLM_ENABLED=false bash "$SCOUT" --title "zzzxqq fffvvv" --slug "" --repo "$REPO_ROOT"
+  # [T003053] Zwei Absicherungen, beide gegen dieselbe Ursache:
+  #
+  # 1. SCOUT_DRIFT_CACHE_FILE auf einen frischen, NICHT existierenden Pfad in
+  #    BATS_TEST_TMPDIR. Vorher las scout.sh den festen /tmp/scout-drift-cache.json;
+  #    schrieb tests/spec/scout-prediction-quality.bats dort parallel einen Drift
+  #    > 0.5, meldete scout.sh das auf stderr.
+  # 2. --separate-stderr: $output enthaelt dann nur stdout. scout.sh DARF auf
+  #    stderr diagnostizieren — der Vertrag ist "stdout ist reines JSON". Ohne
+  #    das Flag buendelt `run` beide Stroeme und jq brach ab mit
+  #    "Invalid numeric literal at line 1, column 9" (Spalte 9 = der Doppelpunkt
+  #    nach "scout.sh"). Damit ist die Zusicherung unabhaengig davon, ob scout.sh
+  #    kuenftig weitere Diagnosen ausgibt.
+  run --separate-stderr env SCOUT_LLM_ENABLED=false \
+    SCOUT_DRIFT_CACHE_FILE="$BATS_TEST_TMPDIR/no-drift-cache.json" \
+    bash "$SCOUT" --title "zzzxqq fffvvv" --slug "" --repo "$REPO_ROOT"
   [ "$status" -eq 0 ]
   echo "$output" | jq -e . >/dev/null
   c="$(echo "$output" | jq -r '.complexity')"


### PR DESCRIPTION
## Summary

`scripts/factory/scout.sh` las den Drift-Cache aus dem **festen** Pfad `/tmp/scout-drift-cache.json` — einer globalen, veränderlichen Datei außerhalb von `BATS_TEST_TMPDIR`.

`tests/spec/scout-prediction-quality.bats` (5.7a) schrieb dort `{"mentolder":0.6}` und räumte erst **nach** dem `run` auf. CI fährt Spec-Dateien parallel: im Fenster dazwischen las `tests/spec/software-factory/scout-and-routing.bats` diesen Wert, `scout.sh` meldete `scout.sh: drift=… > 0.5` auf stderr, `run` bündelte das in `$output`, und `jq` brach ab:

```
jq: parse error: Invalid numeric literal at line 1, column 9
```

Spalte 9 ist der Doppelpunkt nach `scout.sh` — ein sicheres Erkennungszeichen dieser Klasse.

**Deterministisch, aber shard-abhängig.** Die Shard-Zusammensetzung wechselt pro PR, deshalb sah es wie Flakiness aus und traf PR #4021, der `scout.sh` gar nicht anfasste.

## Änderung

| Datei | Änderung |
|---|---|
| `scripts/factory/scout.sh` | `DRIFT_CACHE_FILE="${SCOUT_DRIFT_CACHE_FILE:-/tmp/scout-drift-cache.json}"` — Default unverändert |
| `scripts/factory/scout-drift.sh` | dito für `CACHE_FILE`; Producer und Consumer müssen denselben Pfad sehen |
| `tests/spec/scout-prediction-quality.bats` | `setup()` exportiert `SCOUT_DRIFT_CACHE_FILE="$BATS_TEST_TMPDIR/…"` — pro Test frisch, kein Fenster mehr |
| `tests/spec/software-factory/scout-and-routing.bats` | frischer, nicht existierender Cache-Pfad **plus** `--separate-stderr` |

Zum letzten Punkt: `scout.sh` **darf** auf stderr diagnostizieren — der Vertrag ist „stdout ist reines JSON". `--separate-stderr` macht die Zusicherung unabhängig davon, ob künftig weitere Diagnosen hinzukommen. Defense in Depth: selbst wenn wieder jemand einen globalen Cache vergiftet, hält der Test.

## Test Plan

Beides **gemessen**, nicht abgeleitet:

- **Consumer, gegen einen vergifteten globalen Cache** (`echo '{"mentolder":0.8}' > /tmp/scout-drift-cache.json`):
  - mit der Isolation → **ok**
  - mit der alten Fassung (per `git stash`) → **not ok**, mit genau der CI-Meldung `jq: parse error: Invalid numeric literal at line 1, column 9`
- **Producer**: `tests/spec/scout-prediction-quality.bats` → **21 ok / 0 not-ok**, und `/tmp/scout-drift-cache.json` existiert vorher *und* nachher **nicht** — die Datei wird gar nicht mehr angelegt.
- `tests/spec/software-factory/scout-and-routing.bats` → **33 ok / 0 not-ok**
- Kein weiterer Guard schreibt den `/tmp`-Pfad fest (repo-weit geprüft) — sonst wäre der Fix der nächste T002716-Fall geworden.
- `bash -n` auf beide Skripte OK; `task freshness:check` → `rc=0`

Ticket: T003053