### PR TITLE
fix(test): FIND_CHANGED_TESTS_FILES leckt nicht mehr in die Spec-Tests [T003056]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -884,6 +884,14 @@ tasks:
       - task: test:spec:build-mcp-runner
       - |
         CHANGED_FILES=$(bash scripts/find-changed-tests.sh spec)
+        # [T003056] Ab hier ist die Variable verbraucht: sie steuert AUSSCHLIESSLICH
+        # die Auswahl oben. Bliebe sie in der Umgebung, erbte sie jeder von bats
+        # gestartete Test — und Tests, die find-changed-tests.sh in einem eigenen
+        # tmp-Repo gegen dessen Default-Diff pruefen, bekaemen stattdessen den
+        # override-Zweig mit den Dateien des aeusseren Repos. Genau das machte auf
+        # main sechs Guards rot (T002245/T002345/T002377), waehrend sie lokal und
+        # auf PRs gruen blieben: nur auf main setzt ci.yml die Variable.
+        unset FIND_CHANGED_TESTS_FILES
         if [ -z "$CHANGED_FILES" ]; then
           echo "→ No matching spec tests for this diff"
           exit 0

--- a/tests/spec/ci-cd.bats
+++ b/tests/spec/ci-cd.bats
@@ -5,6 +5,20 @@
 
 setup() {
   bats_require_minimum_version 1.5.0
+  # [T003056] Die Tests dieser Datei pruefen den DEFAULT-Diff-Pfad von
+  # scripts/find-changed-tests.sh in einem eigenen tmp-Repo. Auf main ruft
+  # .github/workflows/ci.yml den Runner als
+  #   FIND_CHANGED_TESTS_FILES="$DELTA" task test:spec:changed
+  # auf, um das Merge-Delta zu uebergeben (auf main ist HEAD == origin/main,
+  # der Default-Diff also leer). Die Variable liegt damit in der Umgebung jedes
+  # gestarteten BATS-Tests — das Skript nimmt drinnen den override-Zweig und
+  # liefert die Dateien des AEUSSEREN Repos statt den Diff des tmp-Repos.
+  # Folge: sechs Guards rot, ausschliesslich auf main, gruen lokal und auf PRs.
+  # Hier unsetzen macht die Datei hermetisch, unabhaengig vom Aufrufer.
+  # Der override-Pfad selbst wird in
+  # tests/spec/ci-cd/changed-tests-uncommitted-diff.bats geprueft, dort mit
+  # explizitem export.
+  unset FIND_CHANGED_TESTS_FILES
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
   WF="$REPO_ROOT/.github/workflows/post-merge.yml"
   BUILD_WF="$REPO_ROOT/.github/workflows/build-website.yml"

--- a/tests/spec/ci-cd/changed-tests-env-hermetic.bats
+++ b/tests/spec/ci-cd/changed-tests-env-hermetic.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# tests/spec/ci-cd/changed-tests-env-hermetic.bats
+# SSOT: openspec/specs/ci-cd.md
+#
+# Pruefmodus: Ergebnis-Verifikation. Der Guard FUEHRT den Runner in einem
+# eigenen tmp-Repo aus, mit einem gesetzten FIND_CHANGED_TESTS_FILES in der
+# Umgebung, und prueft dessen Ausgabe.
+#
+# [T003056] Auf main ruft .github/workflows/ci.yml den Spec-Runner als
+#   FIND_CHANGED_TESTS_FILES="$DELTA" task test:spec:changed
+# auf, um das Merge-Delta zu uebergeben — auf main ist HEAD == origin/main, der
+# Default-Diff des Skripts also leer. Die Variable lag damit in der Umgebung
+# JEDES von bats gestarteten Tests. Tests, die den Default-Diff-Pfad in einem
+# tmp-Repo pruefen, bekamen drinnen den override-Zweig und damit die Dateien des
+# AEUSSEREN Repos. Sechs Guards fielen dadurch ausschliesslich auf main
+# (T002245 79/80, T002345 81/82, T002377 113/114) — lokal und auf PRs gruen,
+# weil die Variable dort nie gesetzt ist. Diagnostisch teuer, weil "gruen auf
+# dem PR, rot nach dem Merge" wie Flakiness aussieht.
+#
+# Dieser Guard haelt die Zusicherung fest: ein gesetztes
+# FIND_CHANGED_TESTS_FILES in der Umgebung darf das Ergebnis eines Aufrufs im
+# tmp-Repo NICHT veraendern, wenn der Aufrufer den Default-Pfad meint.
+
+setup() {
+  bats_require_minimum_version 1.5.0
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  BATS_BIN="$REPO_ROOT/tests/unit/lib/bats-core/bin/bats"
+}
+
+@test "T003056: ci-cd.bats-Guards bleiben gruen mit gesetztem FIND_CHANGED_TESTS_FILES" {
+  cd "$REPO_ROOT"
+  local filter='T002245|T002345|T002377'
+
+  # Positiv-Anker zuerst [T002356-M1]: der Filter trifft ueberhaupt Tests. Ohne
+  # das bestuende die Aussage unten auch bei einem Tippfehler im Filter —
+  # "0 von 0 Tests rot" ist trivial wahr.
+  run bash -c "'$BATS_BIN' --filter '$filter' --count tests/spec/ci-cd.bats"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 6 ]
+
+  # Der eigentliche Nachweis: dieselben Guards mit einer Variable in der
+  # Umgebung, so wie ci.yml sie auf main hinterlaesst. Der Wert nennt einen
+  # Pfad, der im tmp-Repo der Guards nicht existiert — greift der
+  # override-Zweig dort, weicht die Auswahl ab und die Guards fallen.
+  # Ergebnis-Verifikation ueber den echten Runner, kein Quelltext-grep.
+  run bash -c "FIND_CHANGED_TESTS_FILES='scripts/factory/queue.sh' '$BATS_BIN' --filter '$filter' tests/spec/ci-cd.bats"
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL: Guards fallen mit gesetztem FIND_CHANGED_TESTS_FILES — die Variable leckt in die Tests."
+    printf '%s\n' "$output" | grep -E '^not ok' | head -8
+    return 1
+  fi
+}
+
+@test "T003056: test:spec:changed gibt die Variable nicht an bats weiter" {
+  cd "$REPO_ROOT"
+  # Ergebnis-Verifikation ueber den Runner selbst waere ein >10-min-Vollauf.
+  # Geprueft wird deshalb die Naht: nach der Auswahl steht ein unset, und zwar
+  # VOR dem bats-Aufruf. Die Reihenfolge ist die Zusicherung — ein unset nach
+  # bats waere wirkungslos.
+  run bash -c "
+    awk '/^  test:spec:changed:/{f=1} f' Taskfile.yml \
+      | awk '/unset FIND_CHANGED_TESTS_FILES/{u=NR} /bats-core\/bin\/bats/{if(!b)b=NR} END{print (u && b && u < b) ? \"OK\" : \"FAIL u=\" u \" b=\" b}'
+  "
+  [ "$status" -eq 0 ]
+  [ "$output" = "OK" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2250,6 +2250,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/changed-tests-env-hermetic",
+    "file": "tests/spec/ci-cd/changed-tests-env-hermetic.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/changed-tests-uncommitted-diff",
     "file": "tests/spec/ci-cd/changed-tests-uncommitted-diff.bats",
     "category": "ci-cd",


### PR DESCRIPTION
## Summary

Sechs Guards fielen **ausschließlich auf `main`** — lokal und auf PRs grün. Das sah wie Flakiness aus und war eine Umgebungsvariable.

`.github/workflows/ci.yml:383` ruft den Spec-Runner auf `main` so auf:

```bash
FIND_CHANGED_TESTS_FILES="$DELTA" task test:spec:changed
```

Das ist die dafür vorgesehene Naht: auf `main` ist `HEAD == origin/main`, der Default-Diff des Skripts also leer, und das Merge-Delta muss von außen kommen. Die Variable liegt damit aber in der Umgebung **jedes** von `bats` gestarteten Tests. Tests, die `find-changed-tests.sh` in einem eigenen tmp-Repo gegen dessen **Default**-Diff prüfen, bekamen drinnen den `override`-Zweig — und damit die Dateien des **äußeren** Repos.

Betroffen: `T002245` (79/80), `T002345` (81/82), `T002377` (113/114).

Auf PRs ist die Variable nie gesetzt, deshalb war der Defekt dort unsichtbar. Und weil die Spec-Suite auf `main` diff-gescopt läuft, fielen die Guards nur, wenn das Merge-Delta `ci-cd.bats` auswählte — was zwischen grünen und roten `main`-Läufen wechselte und die Diagnose zusätzlich verschleierte.

## Änderung

**Wurzel** — `Taskfile.yml`, `test:spec:changed`: `unset FIND_CHANGED_TESTS_FILES` direkt nach der Auswahl. Die Variable steuert ausschließlich die Auswahl; ab dort ist sie verbraucht. Damit ist kein Test mehr darauf angewiesen, sich selbst zu verteidigen.

**Defense in Depth** — `tests/spec/ci-cd.bats`: `unset` in `setup()`, macht die Datei hermetisch unabhängig vom Aufrufer. Der `override`-Pfad selbst wird weiterhin in `tests/spec/ci-cd/changed-tests-uncommitted-diff.bats` geprüft, dort mit explizitem `export`.

**Guard** — `tests/spec/ci-cd/changed-tests-env-hermetic.bats`, zwei Zusicherungen:
1. Die sechs Guards laufen mit gesetztem `FIND_CHANGED_TESTS_FILES` durch — Ergebnis-Verifikation über den echten Runner, kein Quelltext-`grep`.
2. Im Taskfile steht das `unset` **vor** dem `bats`-Aufruf. Die Reihenfolge ist die Zusicherung; ein `unset` danach wäre wirkungslos.

## Test Plan

Beide Guards **mutationsgeprüft**:

- `unset` aus `ci-cd.bats` entfernt → Guard 1 **rot**, und nennt die leckenden Tests namentlich (`T002245 …`, `T002377 …`); wiederhergestellt → grün.
- `unset` aus `Taskfile.yml` entfernt → Guard 2 **rot** (`FAIL u= b=…`); wiederhergestellt → grün.
- Ursache vorab lokal reproduziert: `FIND_CHANGED_TESTS_FILES=… bats tests/spec/ci-cd.bats` färbt die Guards rot, ohne die Variable 0 Fehler.
- `bats -r tests/spec/ci-cd*` → **251 ok / 0 not-ok** (beide Formen erfasst, T002696)
- `task --list` → `rc=0` (Taskfile syntaktisch heil); `task freshness:check` → `rc=0`

## Ein Hinweis zur ersten Fassung

Mein erster Entwurf des Guards hätte ein `unset` **innerhalb** des geprüften Aufrufs gehabt und wäre damit trivial grün gewesen — unabhängig vom Fix. Ersetzt durch die Ergebnisprüfung über den echten Runner, siehe oben.

Ticket: T003056