### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 873,
+      "file_count": 874,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -386,6 +386,7 @@
         "tests/spec/ci-cd/branch-allowlist-ssot.bats",
         "tests/spec/ci-cd/branch-reaper.bats",
         "tests/spec/ci-cd/changed-tests-collection-parity.bats",
+        "tests/spec/ci-cd/changed-tests-env-hermetic.bats",
         "tests/spec/ci-cd/changed-tests-uncommitted-diff.bats",
         "tests/spec/ci-cd/devflow-ci-watch-merged-exit.bats",
         "tests/spec/ci-cd/devflow-execute-hardening-t002365.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31334472410).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
