### PR TITLE
chore(skills): Signallücken-Regel im Repo-Hygiene-Runbook [T002821]

### DIFF
--- a/.claude/skills/references/repo-hygiene-ops.md
+++ b/.claude/skills/references/repo-hygiene-ops.md
@@ -45,8 +45,8 @@ Stashes ansehen — sie sind die Quelle von Arbeit, die nirgendwo sonst auftauch
    angekommen, ihr eigener Diff zeigte das nicht.
 
 5. **Fail-Closed-Regel.** Lässt sich ein Marker nicht bilden oder die Prüfung nicht abschließen
-   (leere Antwort, Fehler): Stash **behalten**. Eine leere Antwort ist kein Urteil — dasselbe
-   Muster, das §3 bereits für `mergedAt` festhält.
+   (leere Antwort, Fehler): Stash **behalten**. Eine leere Antwort ist kein Urteil — Instanz
+   der Grundregel, die §3 einleitend für alle Signale dieses Runbooks festhält.
 
 ## 1. Stale Git Worktrees
 
@@ -138,6 +138,28 @@ allein hätte auch die einzige Kopie eines nie gemergten Deliverables gelöscht 
 
 ## 3. PR-Triage → verknüpftes Ticket schließen
 
+### Grundregel: ein leeres Signal ist kein Urteil
+
+Alle Fehldiagnosen, die dieser Abschnitt sammelt, sind Instanzen **einer** Fehlerklasse: ein
+Signal meldet Gesundheit, ohne das Attestierte geprüft zu haben. Es entsteht immer gleich —
+eine Abfrage liefert nichts zurück, und die auswertende Logik liest „nichts" als „nichts
+Schlechtes". Deshalb gilt für jede Prüfung in diesem Abschnitt:
+
+> **Eine leere Antwort muss von einer negativen unterscheidbar sein.** Erst prüfen, dass die
+> Messung überhaupt stattgefunden hat (Antwort da? Aufruf erfolgreich?), dann auf das
+> **positive** Signal prüfen — nie auf die Abwesenheit des negativen. Lässt sich das erste
+> nicht belegen, ist das Ergebnis kein Messwert, sondern ein Fehler.
+
+Belegte Fundstellen, jede mit ihrer Gegenprobe unten im Detail:
+
+| Signal | Trügerisch leer, weil … | Gegenprobe |
+|--------|-------------------------|------------|
+| `mergedAt` [T002498-M5] | `gh` konnte nicht antworten | Rohantwort auf Nichtleere prüfen, dann Feld |
+| `statusCheckRollup` / `gh pr checks` [T002821] | GitHub liefert leeres Rollup trotz existierender Runs | `gh run list --branch <b>` |
+| leere Checkliste bei CONFLICTING PR [T002822] | Konflikt unterdrückt CI — Symptom identisch mit „noch nicht gestartet" | `mergeStateStatus` + lokaler Probe-Merge |
+| Probe-Schleife mit `2>/dev/null` [T002847] | harter Fehler wurde zu stiller Leerzeile | stderr sichtbar lassen, Exit-Code getrennt messen |
+| Title-Dedupe-Guard (§4) [T002844] | prüft nur Tickets, nicht den Mishap-Buffer | zweite Quelle abfragen |
+
 ```bash
 gh pr list --state open --json number,title,headRefName,statusCheckRollup,reviewDecision,isDraft,mergeStateStatus
 ```
@@ -201,6 +223,36 @@ TICKET_ID=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oiE 'T[0-9]{6}' | head -1 
 * **CI-Failures:** `gh pr checks <number>` diagnostizieren. Rote PRs nie mergen. Bekannter Flake →
   re-run; sonst PR offen lassen und (falls Ticket vorhanden) auf `in_progress` belassen.
 
+  > **„no checks reported" ist kein CI-Zustand [T002821]:** `gh pr checks <n>` antwortete an
+  > PR #3916 mit „no checks reported on the branch", `gh pr view --json statusCheckRollup`
+  > lieferte ein **leeres Array** — während `gh run list --branch <b>` fünf abgeschlossene
+  > Runs zeigte, darunter einen CI-Run mit `conclusion=failure`. Der PR-HEAD war identisch mit
+  > dem Remote-Branch-Tip, es lag also kein nachträglicher Push vor. Die Meldung liest sich als
+  > „Workflows noch nicht gestartet" und lenkt auf die Actions-Infrastruktur, obwohl der PR
+  > schlicht an zwei BATS-Tests scheiterte. Bei leerem Rollup deshalb **immer** gegenprüfen:
+  > ```bash
+  > gh run list --branch "$BRANCH" --limit 10 \
+  >   --json databaseId,name,headSha,status,conclusion
+  > ```
+  > und die Runs auf den PR-HEAD (`gh pr view <n> --json headRefOid`) filtern.
+
+  > **Leere Checkliste kann auch Konflikt heißen [T002822]:** An PR #3915 existierten **null**
+  > Workflow-Runs, weil der PR mit `main` konfligierte — dass ein CONFLICTING PR die CI
+  > unterdrückt, steht in
+  > [`gotchas-footguns.md`](../../../docs/superpowers/references/gotchas-footguns.md), sein
+  > **Symptom** war bisher nirgends notiert: `gh pr checks` liefert exakt dieselbe Meldung wie
+  > bei einem nicht gestarteten Lauf, und `mergeStateStatus` stand auf `UNKNOWN`. Reihenfolge
+  > bei leerer Checkliste deshalb: erst `mergeStateStatus` lesen, und bei `UNKNOWN` oder
+  > `DIRTY` lokal probe-mergen — das trennt „Konflikt" von „noch nicht gestartet" eindeutig:
+  > ```bash
+  > gh pr view <n> --json mergeStateStatus -q '.mergeStateStatus'
+  > git fetch origin main
+  > git merge origin/main --no-commit --no-ff   # danach: git merge --abort
+  > git diff --name-only --diff-filter=U        # nicht leer = echter Konflikt
+  > ```
+  > `UNKNOWN` bedeutet dabei nur, dass GitHub die Mergebarkeit noch nicht berechnet hat — auch
+  > das ist eine fehlende Messung, kein Befund.
+
 ### PR-Branch auf `main` nachziehen
 
 Nötig bei `mergeStateStatus=BEHIND` und bei den Phantom-Konflikten aus `merge=ours`
@@ -208,7 +260,28 @@ Nötig bei `mergeStateStatus=BEHIND` und bei den Phantom-Konflikten aus `merge=o
 GitHub führt keine Custom-Merge-Driver aus; Details in
 [`gotchas-footguns.md`](../../../docs/superpowers/references/gotchas-footguns.md#mergeours-erzeugt-github-only-phantom-konflikte)).
 
-1. **Wenn die `gh`-Version es kann:**
+> **Erst den Fall bestimmen — die beiden Fälle haben verschiedene Wege [T002823]:**
+> Bei **`BEHIND`** ist `update-branch` (Schritt 1/2) der Weg. Bei einem
+> **`merge=ours`-Phantomkonflikt** ist er es **nicht**: er scheitert an genau demselben
+> Phantomkonflikt. Real beobachtet an PR #3915: `mergeStateStatus=DIRTY`,
+> `gh api --method PUT …/update-branch` antwortete **HTTP 422 „merge conflict between base and
+> head"** — während lokal `git merge origin/main` glatt durchlief und
+> `git diff --name-only --diff-filter=U` **leer** blieb. Ursache sind die Freshness-Generate
+> (`website/src/data/openspec-status.json`, `test-inventory.json`), die in `.gitattributes`
+> einen Custom-Merge-Driver tragen, den GitHub nicht ausführt.
+>
+> Unterscheiden mit dem lokalen Probe-Merge aus §3 („Leere Checkliste kann auch Konflikt
+> heißen"): bleibt `--diff-filter=U` leer, ist es der Phantomkonflikt. Dann ist der **lokale
+> Merge der einzige Weg** — Schritt 1/2 überspringen und direkt so vorgehen:
+> ```bash
+> git fetch origin main && git merge origin/main    # läuft lokal konfliktfrei durch
+> task freshness:regenerate                          # Generate gegen den neuen Stand neu bauen
+> git add -- website/src/data/openspec-status.json website/src/data/test-inventory.json
+> git commit --amend --no-edit || git commit -m "chore: regenerate freshness artifacts"
+> git push origin HEAD                               # Merge-Commit pushen — danach ist der PR sauber
+> ```
+
+1. **Wenn die `gh`-Version es kann** (nur bei `BEHIND`):
    ```bash
    gh pr update-branch <number>
    ```
@@ -230,12 +303,60 @@ GitHub führt keine Custom-Merge-Driver aus; Details in
    Den SHA deshalb per `gh pr view` frisch holen und **nicht** aus einem lokalen
    `git rev-parse HEAD` nehmen — lokal kann der Branch veraltet sein.
 
+   > **422 ist nicht immer das Rennen [T002823]:** Lautet der Fehlertext „merge conflict
+   > between base and head" (statt eines SHA-Mismatch), ist es der Phantomkonflikt von oben,
+   > und ein Retry hilft nie — auf den lokalen Merge wechseln.
+
 3. Danach die generierten Artefakte gegen den neuen Stand neu bauen und committen:
    ```bash
    git fetch origin <branch> && git reset --hard origin/<branch>
    task freshness:regenerate
    ```
    [T002347]
+
+### Probe-Schleifen: stderr nicht unterdrücken [T002847]
+
+Dieselbe Fehlerklasse trifft nicht nur GitHub-Antworten, sondern jede Schleife, die einen
+Zustand über mehrere IDs abfragt. Real beobachtet beim Abfragen von acht Ticketstatus:
+
+```bash
+# FALSCH — acht leere Zeilen, gelesen als "Tickets existieren nicht"
+for t in T00…; do
+  s=$(bash scripts/ticket.sh show "$t" 2>/dev/null | grep -iE '^(status|title)')
+  echo "$t: $s"
+done
+```
+
+Tatsächlich kennt `ticket.sh` **kein** Subkommando `show`; es schrieb „Unknown command: show"
+nach stderr und beendete mit Exit 1 — beides durch `2>/dev/null` und die Pipe unsichtbar. Der
+Fehlerfall war von acht leeren Messwerten nicht zu unterscheiden.
+
+Auch die naheliegende Gegenprobe misst das Falsche:
+
+```bash
+bash scripts/ticket.sh show T00… 2>&1 | head -5; echo "exit=$?"   # FALSCH: Exit von head
+```
+
+Regeln:
+
+1. In Probe-Schleifen stderr **nicht** unterdrücken.
+2. Den Exit-Code **getrennt von der Pipeline** auswerten (Aufruf zuerst in eine Variable oder
+   Datei, `$?` direkt danach; alternativ `set -o pipefail` bzw. `${PIPESTATUS[0]}`).
+3. Ein leeres Ergebnis ist erst dann ein Messwert, wenn der Aufruf **nachweislich erfolgreich**
+   war — sonst gilt die Fail-Closed-Regel aus §0 Punkt 5: kein Urteil.
+
+```bash
+for t in T00…; do
+  if ! out=$(bash scripts/ticket.sh <subkommando> "$t" 2>&1); then
+    echo "$t: FEHLER — $(printf '%s' "$out" | head -1)"; continue
+  fi
+  echo "$t: $(printf '%s' "$out" | grep -iE '^(status|title)')"
+done
+```
+
+Für Ticketstatus ist der kanonische Weg ohnehin `mcp__ticket-mcp__get_ticket` /
+`mcp__ticket-mcp__list_tickets`, nicht ein geratenes CLI-Subkommando (siehe
+[`mcp-tool-guide.md`](mcp-tool-guide.md)).
 
 ## 4. GitHub-Issue-Intake (selten)
 
@@ -248,6 +369,27 @@ Issues leben in Postgres, nicht auf GitHub. Falls `gh issue list --state open` e
    `gh issue close <n> --comment "Duplicate of <external_id>."`. (Die 4 Duplikate
    T001196/T001197/T001201/T001202 entstanden 2026-06-27 genau, weil dieser Guard fehlte.)
    Dieselbe Dedupe-Vorbedingung gilt bei der Completeness-Triage vor Auto-Intake-Zeilen.
+
+   > **Der Guard braucht eine zweite Quelle: den Mishap-Buffer [T002844].** Die Ticket-Suche
+   > allein ist dieselbe Signallücke wie in §3 — sie meldet „kein Duplikat", ohne alle Orte
+   > geprüft zu haben, an denen ein Befund liegen kann. Am 2026-08-09 wurde derselbe Befund
+   > zweimal erfasst: 05:04 UTC als Mishap-Buffer-Eintrag, 05:35 UTC als Ticket T002830. Der
+   > Guard war korrekt angewandt und lieferte trotzdem grün, weil der frühere Befund als
+   > Eintrag in `.git/mishap-buffer.json` lag (Buffer-Stand 5/10) — **Buffer-Einträge tauchen
+   > in keiner Ticket-Query auf**. Zwischen „Befund erfasst" und „Befund als Ticket sichtbar"
+   > liegt ein Fenster von bis zu 10 Buffer-Einträgen bzw. 7 Tagen.
+   >
+   > Vor dem Anlegen deshalb **beide** Quellen prüfen:
+   > ```
+   > mcp__ticket-mcp__list_tickets({ … })      # offene Tickets, wie gehabt
+   > mcp__ticket-mcp__get_mishap_buffer({})    # ungeflushte Befunde
+   > ```
+   > Fallback ohne MCP: `jq -r '.[].title' .git/mishap-buffer.json` (Datei fehlt = Buffer leer;
+   > ein Lesefehler ist **kein** „leer" — dann gilt Fail-Closed, siehe §3-Grundregel).
+   >
+   > Das bleibt vorerst eine Merkregel, ist aber ein Kandidat fürs Werkzeug: eine Regel, die
+   > zwei getrennte Quellen von Hand zusammenführt, ist genau die Form, die hier versagt hat.
+   > Der belastbare Zuschnitt wäre ein Dedupe, das beide Quellen in **einem** Aufruf abfragt.
 2. `tickets.tickets`-Zeile aus dem Issue anlegen (`type`, `brand`, `title`, `description`, `status='triage'`).
 3. `gh issue close <n> --comment "Tracked internally as <external_id>."`
 

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 873,
+      "file_count": 874,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -595,6 +595,7 @@
         "tests/spec/release-notes-erden.bats",
         "tests/spec/repo-health-goals.bats",
         "tests/spec/repo-hygiene/dead-path-references.bats",
+        "tests/spec/repo-hygiene/signal-gaps.bats",
         "tests/spec/repo-hygiene/worktree-stash-inspection.bats",
         "tests/spec/rustdesk-server.bats",
         "tests/spec/s1-violations-batch2.bats",

--- a/tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
+++ b/tests/spec/dev-flow-chore-ticket-ops-mishaps.bats
@@ -93,7 +93,12 @@ setup() {
   local step4 keyword
   step4="$(grep -nE '^##[[:space:]]+4\.[[:space:]]' "$REPO_HYGIENE_OPS" | head -1 | cut -d: -f1)"
   [ -n "$step4" ]
-  keyword="$(grep -nEi 'dedup|deduplicate|duplicate ticket|same title' "$REPO_HYGIENE_OPS" | head -1 | cut -d: -f1)"
+  # Die Suche ist auf den Bereich AB "## 4." beschränkt statt "erster Treffer in der
+  # ganzen Datei, muss hinter §4 liegen" [T002844]: §3 verweist inzwischen selbst auf
+  # den Dedupe-Guard, und dieser Verweis wäre als erster Treffer aufgetaucht — der
+  # Guard wäre rot geworden, obwohl der Wortlaut in §4 unverändert dort steht.
+  keyword="$(awk 'NR > start && tolower($0) ~ /dedup|deduplicate|duplicate ticket|same title/ { print NR; exit }' \
+    start="$step4" "$REPO_HYGIENE_OPS")"
   [ -n "$keyword" ]
   [ "$keyword" -gt "$step4" ]
 }

--- a/tests/spec/repo-hygiene/signal-gaps.bats
+++ b/tests/spec/repo-hygiene/signal-gaps.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# tests/spec/repo-hygiene/signal-gaps.bats
+# SSOT: openspec/specs/agent-skills.md — repo-hygiene-Runbook
+#
+# Tickets T002821, T002822, T002823, T002844, T002847. Alle fünf sind Instanzen EINER
+# Fehlerklasse: ein Signal meldet Gesundheit, ohne das Attestierte geprüft zu haben.
+# Der Guard sichert, dass das Runbook diese Klasse als Regel führt — nicht als fünf
+# unverbundene Sonderfälle.
+#
+# Prüfmodus: **Quelltext-Prüfung (grep)** — ausdrückliche Ausnahme der Konvention
+# T002448-M4 für Querschnittstests, deren Ergebnis sich ausschliesslich im Quelltext
+# manifestiert. Der Gegenstand IST hier der Text: eine Doku-Regel hat kein Laufzeit-
+# verhalten, das sich ausführen liesse. Geprüft werden Vorkommen und Reihenfolge im
+# Runbook, nicht das Ausgabeformat irgendeines Werkzeugs (T002716).
+#
+# Jeder Block belegt ZUERST, dass sein Bezugspunkt existiert (Positiv-Anker, T002356-M1),
+# und prüft DANN die eigentliche Aussage.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  OPS="${REPO_ROOT}/.claude/skills/references/repo-hygiene-ops.md"
+}
+
+# Schneidet einen `## `-Abschnitt aus dem Runbook heraus, damit Aussagen im richtigen
+# Abschnitt landen statt irgendwo in der Datei.
+_section() {
+  awk -v pat="$1" '
+    $0 ~ pat { inside = 1; next }
+    inside && /^## / { inside = 0 }
+    inside { print }
+  ' "$OPS"
+}
+
+@test "T002821: §3 führt die Signallücken als Regel, nicht als Einzelfälle" {
+  [ -f "$OPS" ]
+
+  # Positiv-Anker: §3 existiert überhaupt und hat Inhalt. Ohne ihn wären alle
+  # Aussagen unten über einem leeren Ausschnitt vakuos wahr.
+  local sec
+  sec="$(_section '^## 3[.]')"
+  [ -n "$sec" ]
+
+  # Die Regel selbst ist benannt.
+  printf '%s' "$sec" | grep -qF 'kein Urteil'
+
+  # Und sie ist mit allen fünf Fundstellen belegt — nicht nur mit der ältesten.
+  local t
+  for t in T002821 T002822 T002823 T002847 T002844; do
+    printf '%s' "$sec" | grep -qF "$t" || {
+      echo "Fundstelle $t fehlt in §3" >&2
+      return 1
+    }
+  done
+}
+
+@test "T002821: leeres statusCheckRollup verlangt die Gegenprobe über gh run list" {
+  local sec
+  sec="$(_section '^## 3[.]')"
+  [ -n "$sec" ]
+
+  # Positiv-Anker: §3 spricht überhaupt über die Checkliste.
+  printf '%s' "$sec" | grep -qF 'statusCheckRollup'
+
+  # Aussage: die Gegenprobe gegen die tatsächlich gelaufenen Runs ist dokumentiert.
+  printf '%s' "$sec" | grep -qF 'gh run list'
+}
+
+@test "T002822: leere Checkliste wird gegen den Konfliktfall abgegrenzt" {
+  local sec
+  sec="$(_section '^## 3[.]')"
+  [ -n "$sec" ]
+
+  # Positiv-Anker: der Befund ist verortet.
+  printf '%s' "$sec" | grep -qF 'T002822'
+
+  # Aussage: beide Trennschritte stehen da — Zustand lesen UND lokal probe-mergen.
+  printf '%s' "$sec" | grep -qF 'mergeStateStatus'
+  printf '%s' "$sec" | grep -qF -e '--diff-filter=U'
+}
+
+@test "T002823: der Phantomkonflikt-Hinweis steht VOR dem update-branch-Rezept" {
+  # Positiv-Anker: das Nachzieh-Rezept existiert überhaupt.
+  local update_ln
+  update_ln="$(grep -n 'update-branch' "$OPS" | head -1 | cut -d: -f1)"
+  [ -n "$update_ln" ]
+
+  # Aussage: die Einschränkung kommt vor dem Rezept. Stünde sie danach, läse sich
+  # update-branch weiter als der Weg — genau die Fehldiagnose aus T002823.
+  local warn_ln
+  warn_ln="$(grep -n 'T002823' "$OPS" | head -1 | cut -d: -f1)"
+  [ -n "$warn_ln" ]
+  [ "$warn_ln" -lt "$update_ln" ]
+}
+
+@test "T002847: Probe-Schleifen dürfen stderr nicht unterdrücken" {
+  local sec
+  sec="$(_section '^## 3[.]')"
+  [ -n "$sec" ]
+
+  # Positiv-Anker: der Befund ist verortet.
+  printf '%s' "$sec" | grep -qF 'T002847'
+
+  # Aussage: beide Teilregeln sind benannt — stderr sichtbar UND Exit-Code getrennt
+  # von der Pipeline. Nur eine von beiden liesse die Fehlmessung bestehen.
+  printf '%s' "$sec" | grep -qF 'stderr'
+  printf '%s' "$sec" | grep -qiE 'exit-code|PIPESTATUS|pipefail'
+}
+
+@test "T002844: der Dedupe-Guard in §4 nennt den Mishap-Buffer als zweite Quelle" {
+  local sec
+  sec="$(_section '^## 4[.]')"
+  [ -n "$sec" ]
+
+  # Positiv-Anker: der Guard aus T001210 steht weiterhin in §4.
+  printf '%s' "$sec" | grep -qF 'T001210'
+
+  # Aussage: die zweite Quelle ist benannt, samt Fundstelle.
+  printf '%s' "$sec" | grep -qF 'mishap-buffer'
+  printf '%s' "$sec" | grep -qF 'T002844'
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3486,6 +3486,12 @@
     "kind": "shell"
   },
   {
+    "id": "repo-hygiene/signal-gaps",
+    "file": "tests/spec/repo-hygiene/signal-gaps.bats",
+    "category": "repo-hygiene",
+    "kind": "shell"
+  },
+  {
     "id": "repo-hygiene/worktree-stash-inspection",
     "file": "tests/spec/repo-hygiene/worktree-stash-inspection.bats",
     "category": "repo-hygiene",


### PR DESCRIPTION
## Was

Fünf Mishap-Befunde betreffen dieselbe Datei `.claude/skills/references/repo-hygiene-ops.md` und sind Instanzen **einer** Fehlerklasse: ein Signal meldet Gesundheit, ohne das Attestierte zu prüfen. §3 führte diese Regel bisher nur für `mergedAt` — sie wird jetzt als allgemeine Regel des Abschnitts formuliert, mit den fünf Fundstellen als Belege.

| Ticket | Befund | Ergänzung |
|--------|--------|-----------|
| T002821 | `gh pr checks` meldet „no checks reported", `statusCheckRollup` leer — obwohl fünf Runs für denselben HEAD-SHA existierten (PR #3916, CI `conclusion=failure`) | Gegenprobe via `gh run list --branch` |
| T002822 | CONFLICTING PR unterdrückt CI; Symptom identisch mit „noch nicht gestartet", `mergeStateStatus=UNKNOWN` (PR #3915) | erst `mergeStateStatus`, dann lokaler Probe-Merge mit `--diff-filter=U` |
| T002823 | `merge=ours`-Phantomkonflikt: `update-branch` antwortet 422, lokaler Merge läuft konfliktfrei (PR #3915) | **update-branch hilft hier nicht** — lokaler Merge ist der einzige Weg; Hinweis steht jetzt VOR dem Rezept |
| T002847 | Probe-Schleife mit `2>/dev/null` machte harten Fehler (Exit 1, „Unknown command") zu acht stillen Leerzeilen | stderr sichtbar lassen, Exit-Code getrennt von der Pipeline auswerten |
| T002844 | Title-Dedupe-Guard prüft nur offene Tickets, nicht den Mishap-Buffer — derselbe Befund zweimal erfasst (05:04 Buffer, 05:35 T002830) | §4 um zweite Quelle erweitert (`get_mishap_buffer` / `.git/mishap-buffer.json`) |

## Guard

`tests/spec/repo-hygiene/signal-gaps.bats` — 6 Blöcke, eigene Datei nach der Verzeichnis-Konvention (T002416), jeder mit Positiv-Anker (T002356-M1). Prüfmodus **Quelltext-grep**, im Header-Kommentar als die dokumentierte Ausnahme von T002448-M4 begründet (Doku-Regel hat kein ausführbares Laufzeitverhalten). Keine Format-Assertionen gegen Werkzeug-Output (T002716).

RED/GREEN belegt: alle 6 Blöcke laufen gegen die `origin/main`-Fassung des Runbooks rot, gegen die neue grün.

## Nebenbefund

Der bestehende Guard `T001210: ticket-ops Phase 4 … title-dedupe guard` suchte den **ersten** Treffer auf `dedup` in der ganzen Datei und verlangte ihn hinter `## 4.`. Der neue §3-Verweis auf den Dedupe-Guard wäre ihm zuvorgekommen und hätte ihn rot gefärbt, obwohl §4 unverändert ist. Die Suche ist jetzt auf den Bereich ab `## 4.` beschränkt — das ist genau die Aussage, die der Guard treffen will.

## Verifikation

- `task test:spec:changed` grün (14 Blöcke)
- `task freshness:check` grün (Artefakte committet)
- Restbudget-Check (S1) für alle geänderten Dateien: kein Befund

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw3QJnppGdVoqQ6PJc9gH