### PR TITLE
chore(skills): dev-flow-plan Rotphasen- und Handoff-Konventionen praezisieren [T002816]

### DIFF
--- a/.claude/skills/dev-flow-plan/SKILL.md
+++ b/.claude/skills/dev-flow-plan/SKILL.md
@@ -71,6 +71,38 @@ Die feature/fix/chore-Wahl oben ist die *Pfad*-Wahl durch diese Skill; davor ste
 *Artefakt*-Wahl (PRD vs. ADR vs. Change-Proposal vs. Chore-Ticket). Entscheidungstabelle +
 PRD-Checkliste: [plan-artifact-level](file:///home/patrick/Bachelorprojekt/.claude/skills/references/plan-artifact-level.md).
 
+## Schritt 0.7: Prior-Art-Suche vor der ersten Architekturfrage [T002829]
+
+Bevor dem User eine **Architekturfrage** gestellt wird („gemeinsame Quelle oder duplizieren?",
+„Bibliothek oder Inline?", „Hook oder Helper?"), MUSS geprüft sein, ob dieselbe Frage im Repo
+schon einmal entschieden wurde. Das gilt für **beide** Pfade und liegt **vor** dem Brainstorming:
+eine Antwort, die eine dokumentierte Entscheidung unbemerkt umkehrt, fällt sonst erst im Review
+auf — oder gar nicht.
+
+Die Suche geht über die **Requirements**, nicht nur über den Code. Eine bewusst verworfene
+Lösungsrichtung hinterlässt im Code definitionsgemäß keine Spur; sie steht nur im Spec:
+
+```bash
+# 1) Requirements zum betroffenen Gegenstand — über die Dateipfade, nicht nur Stichworte
+grep -rn -e '<pfad/der/betroffenen/datei>' -e '<zweiter-pfad>' openspec/specs/
+# 2) Die Guards, die diese Entscheidung absichern (Drift-/Konventionstests)
+grep -rln '<pfad/der/betroffenen/datei>' tests/spec/
+```
+
+Liefert die Suche ein Requirement zum selben Gegenstand, wird es **zitiert** (Datei + Zeilen) und
+die Frage an den User lautet nicht mehr „welche Richtung?", sondern „bestehende Entscheidung
+beibehalten oder ersetzen?". Fällt die Wahl auf Ersetzen, geht das über ein `RENAMED`/`MODIFIED`-
+Delta auf den SSOT-Spec — nicht durch stilles Danebenschreiben.
+
+> Beobachtet an T002817: Die Frage „gemeinsame Quelle vs. Allowlist spiegeln" war in
+> `openspec/specs/divergence-guard.md` (aus T002470) bereits zugunsten der Duplikation entschieden
+> und mit drei Drift-Tests abgesichert. Gefunden wurde das erst beim Schreiben des failing Tests —
+> also nach der Nutzerfrage, die daraufhin ein zweites Mal beantwortet werden musste.
+>
+> Verwandt, aber nicht dasselbe: T002448-M5 (Fix-Pfad) verlangt, dass die **Ursache** vor dem
+> Lösungsdesign belegt ist. Dieser Schritt verlangt zusätzlich, dass die **Lösungsrichtung** nicht
+> schon einmal bewusst verworfen wurde.
+
 ## Feature-Pfad
 > **Proposal-Konvention:** Die gesamte Proposal-Phase (Brainstorming + `openspec:propose`) läuft
 > auf dem `main`-Branch — erst danach wird der Worktree angelegt. So sieht OpenSpec beim
@@ -212,6 +244,20 @@ Ein Fix braucht **zwingend einen failing Test**, bevor der Plan geschrieben wird
 hier harte Voraussetzung, nicht Stilfrage. Der Test gehört nach `tests/spec/<spec-slug>.bats`
 (die Spec aus `openspec/specs/`), nicht in eine neue ticket-nummerierte Datei.
 
+> **Externe Abhängigkeiten schon in der Rotphase absichern [T002820]:** Setzt der failing Test ein
+> externes Binary oder einen externen Dienst voraus (Drittanbieter-CLI, erreichbarer Cluster,
+> laufende DB), gehört der Verfügbarkeits-Guard **in die Rotphase** — nicht erst in die Grünphase:
+> ```bash
+> command -v <binary> >/dev/null 2>&1 || skip "<binary> binary not installed"
+> ```
+> Etabliertes Muster im Repo: `tests/spec/sealed-secret-cluster-drift.bats`. Vor dem Schreiben des
+> Tests prüfen, ob CI die Abhängigkeit überhaupt einrichtet — `grep -rn '<binary>'
+> .github/workflows/`; **0 Treffer heißt: in CI nicht vorhanden**. Ohne Guard ist der Test in CI
+> dauerhaft rot und misst die Ausstattung des Runners statt den Zustand des Codes. Genau das
+> zerstört den Zweck der Rotphase: „rot, weil Implementierung fehlt" und „rot, weil das Binary
+> fehlt" sind in der CI-Ausgabe nicht zu unterscheiden. Beide Richtungen verifizieren — mit dem
+> Binary im PATH läuft der Test, mit `PATH=/usr/bin:/bin` skippt er sauber.
+
 Schritte 1–5 im Detail (Ticket anlegen, Worktree, Claims, Lavish-Board, Brainstorming mit
 Root-Cause-Fokus, failing Test, Plan, `stage-plan`, Commit):
 [dev-flow-plan-phases](file:///home/patrick/Bachelorprojekt/.claude/skills/references/dev-flow-plan-phases.md) §Fix-Pfad.
@@ -242,6 +288,18 @@ und gemergt. In Schritt 0 für Chores sofort `dev-flow-chore` aufrufen und hier 
 - Plan `openspec/changes/<slug>/tasks.md` committed
 - Ticket status = `plan_staged`
 - Branch-Lock aktiv (andere Sessions sehen diesen Branch als belegt)
+- **Kein PR** — der Plan-Stand ist ein gepushter Branch, nichts weiter
+
+> **Kein fertig aussehender PR aus dem Plan-Stand [T002816]:** Ein offener PR, dessen Titel einen
+> fertigen Fix ankündigt, während der Branch nur `chore: anchor branch` und `chore(plans): add
+> failing test + stage plan` trägt, liest sich von außen als „kaputter Fix, Diagnose nötig" statt
+> als „Plan gestagt, Implementierung ausstehend". Die roten Checks stammen dann aus der schlicht
+> nicht committeten Implementierung — untracked `specs/`-Delta („missing specs/ delta dir") und
+> uncommittete SSOT-Ergänzung, auf die ein BATS-Guard greppt — und in einer Queue mit mehreren PRs
+> kostet das gezielt Zeit an der falschen Stelle (beobachtet an PR #3918/T002719).
+> Wird aus anderem Grund dennoch früh ein PR gebraucht, dann **als Draft**
+> (`gh pr create --draft`) und mit erkennbarem Titel-Präfix `[plan-only]`, damit der Zustand aus
+> der PR-Liste ablesbar ist. Den regulären PR eröffnet `dev-flow-execute` nach der Implementierung.
 **Nächster Schritt im Kreislauf:** `dev-flow-execute` aufrufen.  
 Der Skill liest den Plan automatisch aus der DB (`FACTORY-PLAN-REF` Kommentar) — kein manuelle Pfad-Übergabe nötig.
 ## Verwandte Skills

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 875,
+      "file_count": 876,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -429,6 +429,7 @@
         "tests/spec/dev-flow-plan/plan-lint-task-count.bats",
         "tests/spec/dev-flow-plan/plan-qa-livez-probe.bats",
         "tests/spec/dev-flow-plan/plan-qa-payload.bats",
+        "tests/spec/dev-flow-plan/red-phase-and-handoff-conventions.bats",
         "tests/spec/dev-flow-plan/task-context.bats",
         "tests/spec/dev-flow-plan/tcc-fixture-orphan-reap.bats",
         "tests/spec/devflow-selection-archive-hardening.bats",

--- a/tests/spec/dev-flow-plan/red-phase-and-handoff-conventions.bats
+++ b/tests/spec/dev-flow-plan/red-phase-and-handoff-conventions.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# tests/spec/dev-flow-plan/red-phase-and-handoff-conventions.bats
+# T002816 / T002820 / T002829 — drei Runbook-Konventionen in .claude/skills/dev-flow-plan/SKILL.md
+#
+# PRUEFMODUS: Source-Grep auf die Skill-Datei.
+# Das ist die ausdrueckliche Ausnahme der Test-Resultats-Konvention [T002448-M4]: die
+# geprueften Gegenstaende sind Dokumentationskonventionen eines Runbooks, deren Ergebnis
+# sich ausschliesslich im Quelltext manifestiert — es gibt kein Kommando, dessen Output
+# sie belegen koennte.
+#
+# Die Zusicherungen haengen an der Semantik (Ticket-Referenz, Schluesselbegriff,
+# relative Position im Ablauf), nicht an der Formulierung: keine Zeilenanker auf Prosa,
+# keine festgeschriebenen Satzbauten [T002716].
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SKILL="$REPO/.claude/skills/dev-flow-plan/SKILL.md"
+}
+
+@test "dev-flow-plan SKILL.md ist lesbar und traegt seinen Frontmatter-Namen (Positiv-Anker)" {
+  [ -r "$SKILL" ]
+  run grep -cF 'name: dev-flow-plan' "$SKILL"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "T002829: Prior-Art-Suche ueber openspec/specs vor der Architekturfrage ist dokumentiert" {
+  run grep -F 'T002829' "$SKILL"
+  [ "$status" -eq 0 ]
+  # Der Kern der Ableitung: gesucht wird ueber die Requirements, nicht nur ueber den Code.
+  echo "$output" | grep -qiF 'architekturfrage'
+  grep -qF 'openspec/specs/' "$SKILL"
+}
+
+@test "T002829: die Prior-Art-Suche steht VOR den Pfad-Abschnitten, nicht am Dateiende" {
+  local prior feature fix
+  prior="$(grep -nF 'T002829' "$SKILL" | head -1 | cut -d: -f1)"
+  feature="$(grep -n '^## Feature-Pfad' "$SKILL" | head -1 | cut -d: -f1)"
+  fix="$(grep -n '^## Fix-Pfad' "$SKILL" | head -1 | cut -d: -f1)"
+  # Positiv-Anker: beide Pfad-Ueberschriften existieren ueberhaupt.
+  [ -n "$feature" ]
+  [ -n "$fix" ]
+  [ -n "$prior" ]
+  # Recherche ist Eingang: sie liegt vor beiden Pfaden.
+  [ "$prior" -lt "$feature" ]
+  [ "$prior" -lt "$fix" ]
+}
+
+@test "T002820: Verfuegbarkeits-Guard fuer externe Binaries gehoert in die Rotphase" {
+  run grep -F 'T002820' "$SKILL"
+  [ "$status" -eq 0 ]
+  # Das konkrete Muster muss im Runbook stehen, nicht nur die Absicht.
+  grep -qF 'command -v' "$SKILL"
+  grep -qF 'skip' "$SKILL"
+  # Und der Hinweis, wie man CI-Verfuegbarkeit ueberhaupt prueft.
+  grep -qF '.github/workflows/' "$SKILL"
+}
+
+@test "T002820: die Rotphasen-Konvention steht im Fix-Pfad, nicht in der Uebergabe" {
+  local guard fix handoff
+  guard="$(grep -nF 'T002820' "$SKILL" | head -1 | cut -d: -f1)"
+  fix="$(grep -n '^## Fix-Pfad' "$SKILL" | head -1 | cut -d: -f1)"
+  handoff="$(grep -n '^## Uebergabe an dev-flow-execute\|^## Übergabe an dev-flow-execute' "$SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$fix" ]
+  [ -n "$handoff" ]
+  [ -n "$guard" ]
+  [ "$guard" -gt "$fix" ]
+  [ "$guard" -lt "$handoff" ]
+}
+
+@test "T002816: Plan-Stand oeffnet keinen fertig aussehenden PR" {
+  run grep -F 'T002816' "$SKILL"
+  [ "$status" -eq 0 ]
+  # Der Ausweg, falls doch frueh ein PR gebraucht wird, ist benannt.
+  grep -qF -e '--draft' "$SKILL"
+  grep -qF '[plan-only]' "$SKILL"
+}
+
+@test "T002816: die PR-Konvention steht in der Uebergabe, also am Ausgang" {
+  local guard handoff
+  guard="$(grep -nF 'T002816' "$SKILL" | head -1 | cut -d: -f1)"
+  handoff="$(grep -n '^## Uebergabe an dev-flow-execute\|^## Übergabe an dev-flow-execute' "$SKILL" | head -1 | cut -d: -f1)"
+  [ -n "$handoff" ]
+  [ -n "$guard" ]
+  [ "$guard" -gt "$handoff" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2508,6 +2508,12 @@
     "kind": "shell"
   },
   {
+    "id": "dev-flow-plan/red-phase-and-handoff-conventions",
+    "file": "tests/spec/dev-flow-plan/red-phase-and-handoff-conventions.bats",
+    "category": "dev-flow-plan",
+    "kind": "shell"
+  },
+  {
     "id": "dev-flow-plan/task-context",
     "file": "tests/spec/dev-flow-plan/task-context.bats",
     "category": "dev-flow-plan",


### PR DESCRIPTION
## Was

Drei Mishap-Befunde am selben Runbook (`.claude/skills/dev-flow-plan/SKILL.md`), als eine Arbeitseinheit. Reine Runbook-Aenderung, kein Softwareverhalten betroffen.

| Ticket | Stelle im Ablauf | Ergaenzung |
|---|---|---|
| **T002829** | Eingang (vor beiden Pfaden) | Neuer **Schritt 0.7**: vor einer Architekturfrage an den User wird ueber `openspec/specs/` nach bestehenden Requirements zum selben Gegenstand gesucht — ueber die Dateipfade, nicht nur ueber den Code. Eine bewusst verworfene Loesungsrichtung hinterlaesst im Code definitionsgemaess keine Spur. |
| **T002820** | Ausgang der Rotphase (Fix-Pfad) | Setzt der failing Test ein externes Binary oder einen Dienst voraus, gehoert der `command -v … \|\| skip`-Guard **schon in die Rotphase**. Sonst ist „rot mangels Implementierung" von „rot mangels Runner-Ausstattung" in der CI-Ausgabe nicht unterscheidbar — und genau diese Unterscheidung ist der einzige Zweck der Rotphase. |
| **T002816** | Ausgang / Handoff | Der Plan-Stand ist ein gepushter Branch, **kein PR**. Ein roter PR mit Fix-Titel liest sich von aussen als „kaputter Fix, Diagnose noetig" statt „Plan gestagt, Implementierung ausstehend". Falls doch frueh ein PR gebraucht wird: `--draft` + Titel-Praefix `[plan-only]`. |

## Guard

`tests/spec/dev-flow-plan/red-phase-and-handoff-conventions.bats` (7 Tests) prueft Vorhandensein **und relative Position** der drei Bloecke — Recherche vor beiden Pfad-Ueberschriften, Rotphasen-Konvention innerhalb des Fix-Pfads, PR-Konvention in der Uebergabe.

- **Pruefmodus Source-Grep**, die ausdrueckliche Doku-Ausnahme von T002448-M4, im Dateikopf vermerkt.
- Zusicherungen haengen an der Semantik (Ticket-Referenz, Schluesselbegriff, Zeilenordnung), nicht an Formulierungen — keine Zeilenanker auf Prosa [T002716].
- Positiv-Anker vorhanden (Test 1 + Existenzpruefungen der Ueberschriften in den Ordnungstests).

## Verifikation

- Rot vor der Aenderung belegt: `git show origin/main:.claude/skills/dev-flow-plan/SKILL.md | grep -cF T002816|T002820|T002829` → jeweils **0**.
- Gruen nach der Aenderung: `tests/unit/lib/bats-core/bin/bats -r tests/spec/dev-flow-plan*` → 114/114 ok.
- `task test:inventory` + `task freshness:regenerate` regeneriert und mitcommittet (`test-inventory.json`, `repo-index.json`).
- `task test:changed`: ein Fehlschlag, **vorbestehend und sachfremd** — `tests/spec/e2e-test-infrastructure/purge-test-data-missing-table.bats` (T002894, lokale DB-Drift; dieser Diff beruehrt keinen DB-Code).

Refs: T002816, T002820, T002829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYw3QJnppGdVoqQ6PJc9gH