### PR TITLE
fix(ci): --prune aus den origin/main-Fetches entfernen [T003095]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-tags: false
 
       - name: Fetch origin/main for diffing (shallow)
-        run: git fetch --no-tags --prune --depth=1 origin +main:refs/remotes/origin/main
+        run: git fetch --no-tags --depth=1 origin +main:refs/remotes/origin/main
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           fetch-tags: false
 
       - name: Fetch origin/main for diffing (shallow)
-        run: git fetch --no-tags --prune --depth=1 origin +main:refs/remotes/origin/main
+        run: git fetch --no-tags --depth=1 origin +main:refs/remotes/origin/main
 
       - uses: actions/setup-node@v7
         with:
@@ -216,7 +216,7 @@ jobs:
           fetch-tags: false
 
       - name: Fetch origin/main for diffing (shallow)
-        run: git fetch --no-tags --prune --depth=1 origin +main:refs/remotes/origin/main
+        run: git fetch --no-tags --depth=1 origin +main:refs/remotes/origin/main
 
       - uses: actions/setup-node@v7
         with:
@@ -262,7 +262,7 @@ jobs:
           fetch-tags: false
 
       - name: Fetch origin/main for diffing (shallow)
-        run: git fetch --no-tags --prune --depth=1 origin +main:refs/remotes/origin/main
+        run: git fetch --no-tags --depth=1 origin +main:refs/remotes/origin/main
 
       - uses: actions/setup-node@v7
         with:
@@ -578,7 +578,7 @@ jobs:
         run: cd website && pnpm install --frozen-lockfile
 
       - name: Fetch origin/main for --changed diffing
-        run: git fetch --no-tags --prune --depth=1 origin +main:refs/remotes/origin/main
+        run: git fetch --no-tags --depth=1 origin +main:refs/remotes/origin/main
 
       - name: Check coverage relevance
         id: check-cov

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-tags: false
 
       - name: Fetch origin/main for diffing (shallow)
-        run: git fetch --no-tags --prune --depth=1 origin +main:refs/remotes/origin/main
+        run: git fetch --no-tags --depth=1 origin +main:refs/remotes/origin/main
 
       - name: Check if E2E-relevant files changed
         id: filter

--- a/tests/spec/ci-cd/fetch-refspec-forced.bats
+++ b/tests/spec/ci-cd/fetch-refspec-forced.bats
@@ -35,3 +35,28 @@ WF_DIR="${BATS_TEST_DIRNAME}/../../../.github/workflows"
   run bash -c "grep -rhoE '.main:refs/remotes/origin/main' '$WF_DIR' | grep -cv '^\\+'"
   [ "$output" -eq 0 ]
 }
+
+@test "T003095: kein --prune auf den origin/main-Fetch-Zeilen" {
+  # [T003095] TEILKORREKTUR zu T003054: das fuehrende + allein genuegt nicht.
+  # --prune loescht refs/remotes/origin/main, BEVOR derselbe Fetch sie
+  # aktualisiert. actions/checkout setzt refs/remotes/origin/HEAD auf
+  # refs/remotes/origin/main; nach dem Prune haengt HEAD in der Luft und die
+  # Aktualisierung kann die Ref nicht mehr sperren:
+  #   - [deleted]  (none)  -> origin/main
+  #     (refs/remotes/origin/HEAD has become dangling)
+  #   error: cannot lock ref 'refs/remotes/origin/main': unable to resolve reference
+  #   ! d224ed0...06cc3d9 main -> origin/main  (unable to update local ref)
+  # Das + hat die Meldung veraendert (vorher '[rejected] non-fast-forward'), nicht
+  # die Ursache. --prune ist hier ohnehin zwecklos: geholt wird genau EINE Ref per
+  # explizitem Refspec. Lokal zeichengleich reproduziert (mit --prune rc=1, ohne
+  # rc=0). Belegt an Run 31334724203.
+  #
+  # Positiv-Anker zuerst [T002356-M1]: die Fetch-Zeilen existieren ueberhaupt.
+  run bash -c "grep -rhc 'git fetch .*main:refs/remotes/origin/main' '$WF_DIR' | paste -sd+ | bc"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+
+  # Und keine davon traegt --prune.
+  run bash -c "grep -rh 'git fetch .*main:refs/remotes/origin/main' '$WF_DIR' | grep -c -- '--prune' || true"
+  [ "$output" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

**Teilkorrektur zu T003054.** Der Fetch-Schritt fällt auf `main` weiter in jedem Job — obwohl das dort eingeführte führende `+` vorhanden ist (4× in `ci.yml` auf `main`, im Kommando sichtbar).

Belegt an Run `31334724203` (Commit `d224ed08`):

```
- [deleted]  (none)  -> origin/main
  (refs/remotes/origin/HEAD has become dangling)
error: cannot lock ref 'refs/remotes/origin/main': unable to resolve reference 'refs/remotes/origin/main'
! d224ed0...06cc3d9 main -> origin/main  (unable to update local ref)
```

`--prune` **löscht** `refs/remotes/origin/main`, bevor derselbe Fetch sie aktualisiert. `actions/checkout` setzt `refs/remotes/origin/HEAD` auf `refs/remotes/origin/main`; nach dem Prune hängt HEAD in der Luft, und die anschließende Aktualisierung kann die Ref nicht mehr sperren. `--prune` ist hier ohnehin zwecklos: geholt wird genau **eine** Ref per explizitem Refspec.

## Was ich in T003054 falsch eingeordnet habe

Das `+` war nicht die Wurzel — es hat nur die **Fehlermeldung** verändert: vorher `! [rejected] non-fast-forward`, jetzt `cannot lock ref`. Die Zeile `- [deleted] (none) -> origin/main` stand bereits im damaligen Log und war der eigentliche Hinweis; ich habe sie als Nebenbefund gelesen. Der beobachtete Fortschritt (main-Lauf `0730d8c3`: von 7 fehlgeschlagenen Jobs auf 1) war echt, der Kausalschluss aber unvollständig. Das `+` bleibt richtig und notwendig — es genügt nur nicht.

Meine damalige lokale Reproduktion traf den Fall nicht, weil `refs/remotes/origin/HEAD` in jenem Wegwerf-Klon nicht auf `origin/main` zeigte. Mit dieser Bedingung reproduziert er sofort.

## Änderung

`--prune` aus allen sechs Fetch-Zeilen entfernt (`ci.yml` 4×, `ai-review.yml`, `e2e-pr.yml`), `+` beibehalten.

## Test Plan

- **Lokal zeichengleich reproduziert** (shallow clone mit `origin/HEAD → origin/main`, danach neuer Upstream-Commit):
  - mit `--prune` → `rc=1`, identische Meldungen inklusive `HEAD has become dangling` und `cannot lock ref`
  - ohne `--prune` → `rc=0`, `+ … (forced update)`
- **Guard erweitert** (`tests/spec/ci-cd/fetch-refspec-forced.bats`), mutationsgeprüft: `--prune` wieder eingefügt → **not ok**; entfernt → **ok**. Positiv-Anker sichert, dass die Fetch-Zeilen überhaupt existieren.
- `task freshness:check` → `rc=0`

## Verifikationsgrenze

Wie bei T003054: **auf diesem PR nicht verifizierbar**, der Defekt tritt nur beim Push auf `main` auf. Nachweis ist der erste `main`-Lauf nach dem Merge. Die lokale Reproduktion und der Guard sind die vorab mögliche Evidenz.

Ticket: T003095