### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -2905,6 +2905,10 @@
     {
       "slug": "agent-lock-liveness-t002849",
       "status": "plan_staged"
+    },
+    {
+      "slug": "2026-08-09-agent-lock-liveness-t002849",
+      "status": "archived"
     }
   ],
   "T002868": [


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31336849397).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
