### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -2967,8 +2967,8 @@
   ],
   "T002896": [
     {
-      "slug": "factory-worktree-reaper-lock-guard",
-      "status": "plan_staged"
+      "slug": "2026-08-10-factory-worktree-reaper-lock-guard",
+      "status": "archived"
     }
   ],
   "T002925": [


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31338477311).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
