### PR TITLE
fix(scripts): ticket-mcp cmd.Dir guard gegen geloeschte Worktree-CWD [T002999-M10]

### DIFF
--- a/scripts/ticket-mcp/go/internal/runner/run_ticket.go
+++ b/scripts/ticket-mcp/go/internal/runner/run_ticket.go
@@ -58,6 +58,11 @@ func RunTicket(args []string, extraEnv map[string]string) (string, error) {
 		return "", fmt.Errorf("ticket.sh path %s is outside repo root %s", cleaned, repoRoot)
 	}
 	cmd := exec.Command("bash", append([]string{ticketSh}, args...)...)
+	// [T002999-M10] Worktree kann nach Merge geloescht sein — die CWD des
+	// MCP-Servers existiert dann nicht mehr und exec.Command scheitert mit
+	// "FileSystem.access" bevor bash startet. cmd.Dir explizit auf repoRoot
+	// setzen entkoppelt den Kindprozess von der (moeglicherweise toten) CWD.
+	cmd.Dir = repoRoot
 	env := os.Environ()
 	for k, v := range extraEnv {
 		env = append(env, k+"="+v)


### PR DESCRIPTION
## Was

One-line fix: Add `cmd.Dir = repoRoot` to `RunTicket()` in `scripts/ticket-mcp/go/internal/runner/run_ticket.go`.

## Problem

`exec.Command` inherits the parent process CWD. When the MCP server's CWD is a worktree that got deleted after PR merge (branch deleted → git worktree prune), the exec call fails in the kernel with `FileSystem.access` before bash even starts.

## Fix

`cmd.Dir = repoRoot` decouples the child process from the possibly-dead CWD.

## Workaround (no rebuild needed)

`export TICKET_MCP_REPO_ROOT=/home/patrick/Bachelorprojekt` — already honored at line 15 of `findRepoRoot()`.