### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 885,
+      "file_count": 886,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -566,6 +566,7 @@
         "tests/spec/observability.bats",
         "tests/spec/opencode-local-model-runner.bats",
         "tests/spec/openspec-embedding.bats",
+        "tests/spec/openspec-embedding/dynamic-port-T003077.bats",
         "tests/spec/openspec-embedding/port-forward-identity-T002870.bats",
         "tests/spec/openspec-pgvector.bats",
         "tests/spec/openspec-ticket-links-evaluation.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31340524822).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
