### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 886,
+      "file_count": 887,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -558,6 +558,7 @@
         "tests/spec/mishap-categorize-erden.bats",
         "tests/spec/mishap-docker-wsl-T002250.bats",
         "tests/spec/mishap-rollup/container-resolution-and-unattended-worktree.bats",
+        "tests/spec/mishap-rollup/rollup-container-empty-list-selfheal.bats",
         "tests/spec/mishap-t002422.bats",
         "tests/spec/mishap-t002424.bats",
         "tests/spec/monitoring-alerts.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31340843716).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
