### PR TITLE
docs: repo-hygiene-Rollup T002637 — Massenverschiebung + cherry-pick --abort Lehren [T002637]

### DIFF
--- a/.claude/skills/references/dev-flow-gotchas.md
+++ b/.claude/skills/references/dev-flow-gotchas.md
@@ -118,3 +118,8 @@ Use the correct project name in `playwright.config.ts` depending on the targeted
 ### [T001393] Lavish reload can discard in-flight form input
 **Context**: Re-running `npx -y lavish-axi <html-file>` (e.g. to fix a layout warning) reloads the existing browser tab.
 **Rule**: See `.claude/skills/lavish/SKILL.md#reload-safety` for the full lavish reload-safety protocol — never reload while a poll is outstanding, and check the last poll status before reloading.
+
+### [T002637-M5] Massenverschiebung: Referenzliste zuerst erheben, nicht aus CI ernten
+**Context**: Nach der sdlc/-Verschiebung (T002624) waren Testpfade in `tests/` nicht nachgezogen. Das kam über DREI CI-Runden einzeln hoch (dashboard.bats; dann G-CQ02 in zwei Kopien; dann pipeline-interface/openspec-pgvector/brain-link-derivation), weil jeweils nur der gemeldete Fehler behoben wurde — statt einmal die Gesamtliste zu erheben. Ein Teil zeigte sogar auf eine ZWISCHENFORM der Verschiebung (`website/src/sdlc/components/`), die nie existierte.
+**Rule**: Bei einer Massenverschiebung VOR dem ersten Commit systematisch alle Referenzen auf die alten Pfade suchen (git grep über den ganzen Baum, inkl. tests/), NICHT CI-Runde für CI-Runde die gemeldeten Fehler abarbeiten. Erwartete Fehlerliste einmal vollständig erheben und abhaken.
+

--- a/.claude/skills/references/git-workflow-procedures.md
+++ b/.claude/skills/references/git-workflow-procedures.md
@@ -129,3 +129,23 @@ git fetch origin main && git rebase origin/main && task freshness:regenerate \
 ```
 
 Details: [dev-flow-gotchas T001395](dev-flow-gotchas.md).
+
+## cherry-pick --abort verwirft die GANZE Sequenz [T002637-M6]
+
+Bei `git cherry-pick A B` mit einem Konflikt in B setzt `--abort` auf den Zustand VOR der
+gesamten Sequenz zurück — der bereits erfolgreich gepickte Commit A ist damit ebenfalls weg.
+Nicht offensichtlich; kostete eine Wiederholungsrunde (verifiziert am 2026-08-04).
+
+**Regel:** Bei Mehr-Commit-Sequenzen entweder einzeln picken (jeder Commit separat,
+Konflikt löst nur diesen ab) oder `--quit` statt `--abort` verwenden: `--quit` belässt die
+bereits angewendeten Commits im Arbeitsbaum und verwirft nur den Sequenzer-Zustand
+(HEAD bleibt auf dem zuletzt gepickten Commit). `--abort` nur, wenn wirklich ALLE Commits
+der Sequenz verworfen werden sollen.
+
+```bash
+git cherry-pick A B          # Konflikt in B
+git cherry-pick --quit       # A bleibt angewendet; Sequenz beenden
+# vs.
+git cherry-pick --abort      # verwirft AUCH A — Zustand vor der Sequenz
+```
+


### PR DESCRIPTION
## T002637 — Mishap-Rollup repo-hygiene-Lauf 2026-08-04

5 verifizierte Befunde evaluiert — Stand auf origin/main:

### Bereits behoben durch spätere Tickets (kein Handlungsbedarf)
1. **G-CQ02-Duplikat** — aufgelöst: Test nur noch in `tests/spec/g-cq02-any-types.bats` (T002624-Nachlauf-Kommentar in code-quality.bats).
2. **merge=ours-Staleness** — adressiert: repo-index.json aus dem PR-Weg genommen (T002687), freshness:check regeneriert vor dem Diff (T002252) + origin/main-Divergenz-Warnung (T002561).
3. **Paralleler Checkout-Branch-Switch** — adressiert: guard-precommit hard-blockt fremde deliberat-Locks (T001383), guard-postcheckout revertt automatisch (live verifiziert).
4. **Warte-/Prüfschleifen aus leeren Antworten** — beide neuen Formen (a: `grep -c OPEN`-Warteschleife, b: Run-vs-Job) durch T002339/T002821/T002822/T002498-M5/T002523-M7 in repo-hygiene-ops.md abgedeckt.

### In diesem PR ergänzt (die beiden fehlenden Lehren)
5. **Massenverschiebung: Referenzliste zuerst** → `dev-flow-gotchas.md` [T002637-M5] — bei Massenverschiebungen die Gesamt-Referenzliste per git grep erheben, nicht CI-Runde für CI-Runde ernten (T002624-Beispiel, 3 CI-Runden).
6. **cherry-pick --abort verwirft die ganze Sequenz** → `git-workflow-procedures.md` [T002637-M6] — `--quit` statt `--abort` bei Mehr-Commit-Sequenzen.

Verifikation: `task test:changed` grün, `task freshness:check` grün.