### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 893,
+      "file_count": 896,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -3268,7 +3268,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 690,
+      "file_count": 691,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31349849099).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
