### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 898,
+      "file_count": 899,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -565,6 +565,7 @@
         "tests/spec/mishap-categorize-erden.bats",
         "tests/spec/mishap-docker-wsl-T002250.bats",
         "tests/spec/mishap-rollup/container-resolution-and-unattended-worktree.bats",
+        "tests/spec/mishap-rollup/rollup-branch-progress.bats",
         "tests/spec/mishap-rollup/rollup-container-empty-list-selfheal.bats",
         "tests/spec/mishap-t002422.bats",
         "tests/spec/mishap-t002424.bats",
@@ -3270,7 +3271,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 692,
+      "file_count": 693,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3584,6 +3585,7 @@
         "scripts/factory/review-pattern-enforcer.prompt.md",
         "scripts/factory/review-perf-reviewer.prompt.md",
         "scripts/factory/review-security-auditor.prompt.md",
+        "scripts/factory/rollup-publish.sh",
         "scripts/factory/route-provider.sh",
         "scripts/factory/run-dispatcher-prep.sh",
         "scripts/factory/run-dispatcher.sh",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31350732095).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
