### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 900,
+      "file_count": 901,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -354,6 +354,7 @@
         "tests/spec/agent-skills/dev-flow-chore-step0-foreign-guard.bats",
         "tests/spec/agent-skills/plugin-activation.bats",
         "tests/spec/agent-skills/skill-path-references.bats",
+        "tests/spec/agent-skills/worktree-mid-rebase-guard.bats",
         "tests/spec/agentic-review.bats",
         "tests/spec/agentic-tooling-quality-goals.bats",
         "tests/spec/agentic-tooling-quality-goals/g-agentic01-unresolved-tools.bats",
@@ -3273,7 +3274,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 693,
+      "file_count": 694,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3966,6 +3967,7 @@
         "scripts/weekly-dep-schema-audit.sh",
         "scripts/whiteboard-setup.sh",
         "scripts/worktree-create.sh",
+        "scripts/worktree-git-op-guard.sh",
         "scripts/wsl-dns-fix.sh",
         "scripts/wsl-open.sh"
       ]


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31355620172).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
