### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 901,
+      "file_count": 902,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -586,6 +586,7 @@
         "tests/spec/openspec-upstream-cli.bats",
         "tests/spec/openspec-workflow.bats",
         "tests/spec/openspec-workflow/archive-atomic-guards.bats",
+        "tests/spec/openspec-workflow/archive-deliverable-guard.bats",
         "tests/spec/openspec-workflow/archive-no-merge.bats",
         "tests/spec/openspec-workflow/archive-terminal-ticket-status.bats",
         "tests/spec/openspec-workflow/delta-scenario-guard.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31357020538).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
