### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 897,
+      "file_count": 902,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -351,8 +351,10 @@
         "tests/spec/agent-lock-session-identity.bats",
         "tests/spec/agent-roster.bats",
         "tests/spec/agent-skills.bats",
+        "tests/spec/agent-skills/dev-flow-chore-step0-foreign-guard.bats",
         "tests/spec/agent-skills/plugin-activation.bats",
         "tests/spec/agent-skills/skill-path-references.bats",
+        "tests/spec/agent-skills/worktree-mid-rebase-guard.bats",
         "tests/spec/agentic-review.bats",
         "tests/spec/agentic-tooling-quality-goals.bats",
         "tests/spec/agentic-tooling-quality-goals/g-agentic01-unresolved-tools.bats",
@@ -444,6 +446,7 @@
         "tests/spec/devflow-selection-archive-hardening.bats",
         "tests/spec/divergence-guard.bats",
         "tests/spec/divergence-guard/branch-name-guard.bats",
+        "tests/spec/divergence-guard/main-checkout-foreign-guard.bats",
         "tests/spec/docker-build-speedup.bats",
         "tests/spec/dora-dashboard.bats",
         "tests/spec/e2e-test-infrastructure.bats",
@@ -510,6 +513,7 @@
         "tests/spec/local-llm-proxy/bge-loadout-cpu-bound.bats",
         "tests/spec/local-llm-proxy/bge-mcp-upstream-timeout.bats",
         "tests/spec/local-llm-proxy/bge-token-ssot.bats",
+        "tests/spec/local-llm-proxy/brain-ingest-port.bats",
         "tests/spec/local-llm-proxy/embed-bge-fallback.bats",
         "tests/spec/local-llm-proxy/embed-probe-timeout.bats",
         "tests/spec/local-llm-proxy/embed-skip-visibility.bats",
@@ -582,6 +586,7 @@
         "tests/spec/openspec-upstream-cli.bats",
         "tests/spec/openspec-workflow.bats",
         "tests/spec/openspec-workflow/archive-atomic-guards.bats",
+        "tests/spec/openspec-workflow/archive-deliverable-guard.bats",
         "tests/spec/openspec-workflow/archive-no-merge.bats",
         "tests/spec/openspec-workflow/archive-terminal-ticket-status.bats",
         "tests/spec/openspec-workflow/delta-scenario-guard.bats",
@@ -910,7 +915,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 57,
+      "file_count": 58,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -968,7 +973,8 @@
         "scripts/migrations/2026-08-04-llm-proxy-gemma-qwen-families.sql",
         "scripts/migrations/2026-08-04-provider-config-data-residency.sql",
         "scripts/migrations/2026-08-09-customer-projects-copy.sql",
-        "scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql"
+        "scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql",
+        "scripts/migrations/2026-08-10-brain-ingest-port.sql"
       ]
     },
     {
@@ -3269,7 +3275,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 692,
+      "file_count": 694,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3687,6 +3693,7 @@
         "scripts/lib/google-import.sh",
         "scripts/lib/kubelet-cert-hint.sh",
         "scripts/lib/llm-stack-measure.sh",
+        "scripts/lib/main-checkout-foreign-guard.sh",
         "scripts/lib/mcp-endpoint-probe.py",
         "scripts/lib/nextcloud-api.sh",
         "scripts/lib/notify.sh",
@@ -3961,6 +3968,7 @@
         "scripts/weekly-dep-schema-audit.sh",
         "scripts/whiteboard-setup.sh",
         "scripts/worktree-create.sh",
+        "scripts/worktree-git-op-guard.sh",
         "scripts/wsl-dns-fix.sh",
         "scripts/wsl-open.sh"
       ]


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31357219610).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
