### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 902,
+      "file_count": 903,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -592,6 +592,7 @@
         "tests/spec/openspec-workflow/delta-scenario-guard.bats",
         "tests/spec/openspec-workflow/design-location-guard.bats",
         "tests/spec/openspec-workflow/half-archive-guard.bats",
+        "tests/spec/openspec-workflow/half-archive-uncommitted.bats",
         "tests/spec/openspec-workflow/t002573-backlog-slugs.txt",
         "tests/spec/openspec-workflow/ticket-file-required.bats",
         "tests/spec/openspec-worktree-anchor.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31358185766).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
