### PR TITLE
fix(docs): jq-Ausdruck in ticket-ops-procedures.md — .result[] → .[0].result [T003175]

### DIFF
--- a/.claude/skills/references/ticket-ops-procedures.md
+++ b/.claude/skills/references/ticket-ops-procedures.md
@@ -76,7 +76,7 @@ unverändert (der Blocker wurde bereits formal erfasst).
 > `psql -t`-Spalten mit `-A -F '|'`. Lange Titel verschoben die Spalten, sodass
 > `desc_len` Titelfragmente und `priority` den `created_at`-Wert enthielt. Die
 > JSON-Ausgabe unten ist spaltenausrichtungsinvariant — das Ergebnis wird mit
-> `jq -r '.result[]'` verarbeitet, nicht mit Split-by-Pipe.
+> `jq -r '.[0].result'` verarbeitet (mcp-postgres liefert `[{"result":"<json-string>"}]` — ein Array mit einem Objekt, dessen `result`-Feld den JSON-String enthält; der zweite Parse-Schritt ist explizit nötig), nicht mit Split-by-Pipe.
 
 > **Das `ORDER BY` steht INNERHALB des Aggregats [T002481].** Mit einem äußeren
 > `ORDER BY` scheitert die Query an einem GROUP-BY-Fehler: `json_agg` aggregiert

--- a/openspec/changes/fix-jq-expression-ticket-ops-T003175/proposal.md
+++ b/openspec/changes/fix-jq-expression-ticket-ops-T003175/proposal.md
@@ -1,0 +1,14 @@
+# Fix jq expression in ticket-ops-procedures.md Step 1.1
+
+## Purpose
+
+Der in ticket-ops-procedures.md §Step 1.1 dokumentierte jq-Ausdruck `jq -r '.result[]'` scheitert am tatsächlichen mcp-postgres-Ausgabeformat `[{"result":"<json-string>"}]`. Der korrekte Ausdruck ist `jq -r '.[0].result'`.
+
+## Scope
+
+- `.claude/skills/references/ticket-ops-procedures.md` Zeile 79: jq-Ausdruck korrigieren und den doppelten Parse-Schritt dokumentieren
+
+## Out of scope
+
+- T003174 (Query-Token-Limit) — separat
+- Das mcp-postgres-Ausgabeformat selbst — das ist korrekt, nur die Dokumentation weicht ab

--- a/openspec/changes/fix-jq-expression-ticket-ops-T003175/specs/ticket-ops.md
+++ b/openspec/changes/fix-jq-expression-ticket-ops-T003175/specs/ticket-ops.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Step-1.1-Triage-Query dokumentiert den korrekten jq-Parse-Schritt
+
+Die Prozedur in ticket-ops-procedures.md §Step 1.1 MUSS den jq-Ausdruck dokumentieren,
+der das tatsächliche mcp-postgres-Ausgabeformat `[{"result":"<json-string>"}]` korrekt
+verarbeitet. Der dokumentierte Ausdruck ist `jq -r '.[0].result'`, nicht
+`jq -r '.result[]'`.
+
+Der zweite Parse-Schritt (die Ausgabe von `jq -r '.[0].result'` ist ein JSON-String, der
+erneut geparst werden muss) MUSS explizit benannt sein.
+
+#### Scenario: Dokumentierter jq-Ausdruck matcht das mcp-postgres-Format
+
+- **GIVEN** die ticket-ops-procedures.md §Step 1.1
+- **WHEN** ein Agent die dokumentierte jq-Anweisung befolgt
+- **THEN** der Ausdruck verarbeitet das Format `[{"result":"<json-string>"}]` ohne Fehler

--- a/openspec/changes/fix-jq-expression-ticket-ops-T003175/tasks.md
+++ b/openspec/changes/fix-jq-expression-ticket-ops-T003175/tasks.md
@@ -1,0 +1,4 @@
+# Tasks: Fix jq expression in ticket-ops-procedures.md
+
+- [x] Zeile 79: `jq -r '.result[]'` → `jq -r '.[0].result'` mit Erklärung des doppelten Parse-Schritts
+- [ ] Verifikation: `task freshness:check` + manuelle Sichtung der geänderten Zeile


### PR DESCRIPTION
## Was

Korrigiert den dokumentierten jq-Ausdruck in ticket-ops-procedures.md §Step 1.1. Der alte Ausdruck `jq -r '.result[]'` scheitert am tatsächlichen mcp-postgres-Ausgabeformat `[{"result":"<json-string>"}]`.

**Fix:** `jq -r '.[0].result'` mit explizitem Hinweis auf den nötigen zweiten Parse-Schritt.

## Verifikation
- [x] Zeile 79 korrigiert
- [ ] `task freshness:check`