### PR TITLE
fix(factory): opencode-exec prueft das Ergebnis statt nur den Exit-Code [T003335]

### DIFF
--- a/scripts/factory/opencode-exec.sh
+++ b/scripts/factory/opencode-exec.sh
@@ -54,8 +54,20 @@ PROMPT="$(printf '%s\n' \
   "## Partials" \
   "${partials_manifest}" \
   "" \
+  "## Required end state (T003335)" \
+  "The run counts as done ONLY if all of these hold when you finish:" \
+  "1. The plan is implemented in this worktree." \
+  "2. The plan's failing test is green." \
+  "3. The work is COMMITTED on ${BRANCH:-the feature branch} with a conventional" \
+  "   commit whose subject carries [${EXT_ID}]." \
+  "4. The commit is PUSHED to origin." \
+  "Do NOT stop after analysing the plan. A run that ends without a commit is a" \
+  "failed run, not a finished one — the executor verifies this and will mark the" \
+  "phase blocked." \
+  "" \
   "Guardrails (opt-in trial, D3):" \
   "- Do NOT merge the PR and do NOT enable auto-merge — stop at the pr-ready gate." \
+  "- Do NOT open a PR either; the caller does that after verifying the result." \
   "- Respect the existing pr-ready / CI gate; never bypass it." \
   "- Empty-return rule (M2/M3): if a dispatched subagent returns an empty/blank" \
   "  final message, switch model on the FIRST empty return — deepseek-flash-direct" \
@@ -68,10 +80,44 @@ PROMPT="$(printf '%s\n' \
 # --- run opencode in the launch worktree, measure duration ---------------------------
 start=$(date +%s)
 run_log="$(mktemp)"
+
+# Stand VOR dem Lauf festhalten — er ist der Bezugspunkt des Ergebnis-Checks unten.
+# `git rev-parse HEAD` schlaegt in einem Verzeichnis ohne Repo fehl; dann bleibt
+# head_before leer und der Check faellt auf den Arbeitsbaum-Vergleich zurueck.
+head_before="$(git -C "$LAUNCH_DIR" rev-parse HEAD 2>/dev/null || true)"
+
 ( cd "$LAUNCH_DIR" && opencode run --agent orchestrator --format json "$PROMPT" ) \
   >"$run_log" 2>&1
 ex=$?
 dur=$(( $(date +%s) - start ))
+
+# --- Ergebnis-Check (T003335) --------------------------------------------------------
+# Bis T003335 stammte `state` ALLEIN aus dem Exit-Code. Ein Orchestrator, der lief und
+# nichts tat, endete mit 0 und wurde als `implement/done` verbucht — beobachtet an
+# T002843 (duration_s=157, exit=0, kein Diff). Der Exit-Code sagt "der Prozess ist
+# sauber zurueckgekehrt", nicht "es ist Arbeit entstanden". Das sind zwei Aussagen.
+#
+# Geprueft wird deshalb das Ergebnis: ein neuer Commit gegenueber head_before, oder
+# — falls der Orchestrator absichtlich uncommittet uebergibt — ein nicht leerer
+# Arbeitsbaum. Beides fehlt => der Lauf hat nichts geleistet.
+#
+# Fail-closed ist hier richtig: ein faelschlich als `done` verbuchtes Ticket verlaesst
+# die Queue und kehrt nie zurueck, waehrend ein faelschlich `blocked` gemeldetes im
+# naechsten Tick erneut dispatcht wird. Der teurere Fehler ist das stille `done`.
+produced_work=false
+if [[ $ex -eq 0 ]]; then
+  head_after="$(git -C "$LAUNCH_DIR" rev-parse HEAD 2>/dev/null || true)"
+  if [[ -n "$head_after" && "$head_after" != "$head_before" ]]; then
+    produced_work=true
+  elif [[ -n "$(git -C "$LAUNCH_DIR" status --porcelain 2>/dev/null)" ]]; then
+    produced_work=true
+  fi
+  if [[ "$produced_work" != true ]]; then
+    ex=6   # kollisionsfrei: 2 Bedienfehler, 127 Kommando fehlt
+    echo "opencode-exec: orchestrator run for $EXT_ID exited 0 but produced NO commit and NO working-tree change — treating as blocked [T003335]" >&2
+  fi
+fi
+
 state=done; [[ $ex -ne 0 ]] && state=blocked
 
 # --- terminal telemetry: one event per partial (deterministic gang-slot mapping) -----
@@ -87,6 +133,9 @@ fi
 
 if [[ $ex -ne 0 ]]; then
   echo "opencode-exec: orchestrator run for $EXT_ID exited $ex (blocked; NO claude fallback)" >&2
+  # Das Run-Log ist die einzige Spur, WARUM der Orchestrator nichts getan hat. Bis
+  # T003335 wurde es bei Exit 0 ungelesen geloescht — und weil ein leerer Lauf damals
+  # als Exit 0 galt, war genau der interessante Fall der einzige ohne Beweismittel.
   tail -n 40 "$run_log" | sed "s/^/[opencode-exec:${EXT_ID}] /" >&2
 fi
 rm -f "$run_log"

--- a/tests/spec/software-factory/opencode-exec-result-check.bats
+++ b/tests/spec/software-factory/opencode-exec-result-check.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# T003335 — opencode-exec darf `implement/done` nicht allein aus dem Exit-Code ableiten.
+#
+# Pruefmodus: Output-Verifikation (T002448-M4). Der Test FUEHRT
+# scripts/factory/opencode-exec.sh AUS und prueft dessen Exit-Code und Meldung —
+# er greppt nicht die Quelldatei.
+#
+# Die Zusicherung haengt an der Semantik (entsteht ein Commit oder nicht), nicht am
+# Wortlaut einer Meldung (T002716). Jeder Negativfall traegt einen Positiv-Anker
+# (T002356-M1): ohne ihn bestuende "leerer Lauf wird abgelehnt" vakuos, sobald das
+# Skript aus beliebigem Grund alles ablehnt.
+#
+# Der Orchestrator wird gestubbt — kein echter `opencode`-Aufruf, kein Modell, kein Netz.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  EXEC="$REPO_ROOT/scripts/factory/opencode-exec.sh"
+
+  # Wegwerf-Worktree als LAUNCH_DIR: eigenes git-Repo, ein Basis-Commit.
+  LAUNCH="$BATS_TEST_TMPDIR/launch"
+  mkdir -p "$LAUNCH"
+  git -C "$LAUNCH" init -q -b main
+  git -C "$LAUNCH" config user.email t@example.invalid
+  git -C "$LAUNCH" config user.name Test
+  echo base > "$LAUNCH/file.txt"
+  git -C "$LAUNCH" add -A
+  git -C "$LAUNCH" commit -qm "base"
+
+  # Stub-Verzeichnis vor den PATH — der echte Orchestrator darf nie laufen.
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+  export PATH="$STUB_BIN:$PATH"
+
+  # phase_event schreibt in die Ticket-DB; offline halten, es ist ohnehin `|| true`.
+  export TICKET_OFFLINE=1
+}
+
+# Stub, der laeuft und mit 0 endet, aber KEINEN Commit erzeugt.
+_stub_noop() {
+  cat > "$STUB_BIN/opencode" <<'EOF'
+#!/usr/bin/env bash
+echo '{"type":"step_start"}'
+exit 0
+EOF
+  chmod +x "$STUB_BIN/opencode"
+}
+
+# Stub, der einen echten Commit im cwd erzeugt und mit 0 endet.
+_stub_commits() {
+  cat > "$STUB_BIN/opencode" <<'EOF'
+#!/usr/bin/env bash
+echo '{"type":"step_start"}'
+echo implemented >> file.txt
+git add -A
+git commit -qm "fix(scripts): implementiert [T003335]"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/opencode"
+}
+
+@test "T003335: Positiv-Anker — ein Lauf MIT Commit gilt weiterhin als erfolgreich" {
+  _stub_commits
+  run bash "$EXEC" T003335 "$LAUNCH" fix/stub-T003335 openspec/changes/stub/tasks.md
+  [ "$status" -eq 0 ]
+  # Der Commit ist wirklich entstanden — sonst prueft der Anker nichts.
+  run git -C "$LAUNCH" log --oneline -1
+  [[ "$output" == *"implementiert"* ]]
+}
+
+@test "T003335: ein Lauf OHNE Commit gilt NICHT als erfolgreich" {
+  _stub_noop
+  run bash "$EXEC" T003335 "$LAUNCH" fix/stub-T003335 openspec/changes/stub/tasks.md
+  # Gegenprobe zuerst: der Stub hat tatsaechlich nichts committet.
+  run git -C "$LAUNCH" log --oneline
+  [ "$(printf '%s\n' "$output" | wc -l)" -eq 1 ]
+  # Und der Executor darf das nicht als Erfolg melden.
+  run bash "$EXEC" T003335 "$LAUNCH" fix/stub-T003335 openspec/changes/stub/tasks.md
+  [ "$status" -ne 0 ]
+}
+
+@test "T003335: der leere Lauf wird diagnostiziert, das Run-Log nicht verschluckt" {
+  _stub_noop
+  run bash "$EXEC" T003335 "$LAUNCH" fix/stub-T003335 openspec/changes/stub/tasks.md
+  [ "$status" -ne 0 ]
+  # Formatfreie Probe: irgendeine Diagnose muss den Ticketbezug tragen.
+  # Kein Zeilenanker, kein festgeschriebener Wortlaut (T002716).
+  [[ "$output" == *"T003335"* ]]
+  # Und die Ausgabe des Orchestrators muss erhalten bleiben, statt geloescht zu werden.
+  [[ "$output" == *"step_start"* ]]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -4032,6 +4032,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/opencode-exec-result-check",
+    "file": "tests/spec/software-factory/opencode-exec-result-check.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/orphan-slot-reap",
     "file": "tests/spec/software-factory/orphan-slot-reap.bats",
     "category": "software-factory",


### PR DESCRIPTION
Behebt **T003335**. Der Executor der Software Factory leitete `implement/done` allein aus dem Exit-Code des Orchestrators ab und löschte das Run-Log bei Erfolg ungelesen.

## Warum das zählt

Beobachtet an T002843 — Produktionslauf über den Dispatcher:

```
implement|done|{"executor":"opencode","subagent":"orchestrator","duration_s":157,"exit":0}
```

Der Worktree trug danach keinerlei Implementierung. Das Ticket galt trotzdem als gebaut. Der Exit-Code sagt „der Prozess ist sauber zurückgekehrt", nicht „es ist Arbeit entstanden" — das sind zwei verschiedene Aussagen, und die Factory hat sie gleichgesetzt.

Gegenprobe im selben Worktree, identischer Orchestrator, identisches Modell (`gemma26-factory`), einziger Unterschied im Prompt — die ausdrückliche Aufforderung zu committen und zu pushen: **458 Zeilen Code, Test von 5/7 rot auf 7/7 grün, PR #4133 gemergt.** Der lokale Stack konnte also die ganze Zeit bauen; es fehlte die Aufforderung und jede Prüfung des Ergebnisses.

## Änderung

- **Ergebnis-Check:** nach dem Lauf wird gegen den Stand davor geprüft, ob ein neuer Commit entstanden ist — hilfsweise, ob der Arbeitsbaum nicht leer ist. Fehlt beides, ist der Zustand `blocked` (Exit 6) statt `done`.
- **Fail-closed, begründet:** ein fälschlich `done` verbuchtes Ticket verlässt die Queue und kehrt nie zurück; ein fälschlich `blocked` gemeldetes wird im nächsten Tick erneut dispatcht. Der teurere Fehler ist das stille `done`.
- **Run-Log bleibt erhalten**, wenn es gebraucht wird. Bisher war ausgerechnet der leere Lauf der einzige Fall ohne Beweismittel.
- **Prompt benennt den Endzustand** (implementiert, Test grün, committet, gepusht, kein PR) und weist ausdrücklich darauf hin, dass ein Lauf ohne Commit als gescheitert gilt.

## Verifikation

`tests/spec/software-factory/opencode-exec-result-check.bats` — vorher 2 von 3 rot, jetzt 3/3:

```
1..3
ok 1 Positiv-Anker — ein Lauf MIT Commit gilt weiterhin als erfolgreich
ok 2 ein Lauf OHNE Commit gilt NICHT als erfolgreich
ok 3 der leere Lauf wird diagnostiziert, das Run-Log nicht verschluckt
```

Der Orchestrator ist gestubbt — kein `opencode`-Aufruf, kein Modell, kein Netz. Jede Negativ-Aussage trägt einen Positiv-Anker davor (T002356-M1); ohne ihn bestünde „leerer Lauf wird abgelehnt" vakuos, sobald der Check alles ablehnt. Die Zusicherung hängt an der Semantik (entsteht ein Commit), nicht am Wortlaut einer Meldung (T002716).

## Einordnung

Achte belegte Instanz derselben Klasse in dieser Codebasis — eine Prüfung, die bei fehlender Substanz still besteht. Verwandt: T003109 (vakuoses `all()`), T003278 (`bats` Exit 0 auf fehlender Datei), T002932 (gepipedes `git status` auf totem Pfad), T003112 (`plan-qa-check` fail-open). Diese hier saß im Kern der Fertigung und hat die Factory über Wochen als arbeitend erscheinen lassen.