### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 910,
+      "file_count": 911,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -694,6 +694,7 @@
         "tests/spec/software-factory/db-pod-phase-guard.bats",
         "tests/spec/software-factory/dispatcher.bats",
         "tests/spec/software-factory/factory-prep-stdout-json.bats",
+        "tests/spec/software-factory/opencode-exec-result-check.bats",
         "tests/spec/software-factory/orphan-slot-reap.bats",
         "tests/spec/software-factory/partial-deploy-gang.bats",
         "tests/spec/software-factory/pipeline-and-ticket-cli.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31383298158).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
