### PR TITLE
fix(test): e2-local-stack skip guard checks reachability instead of context name [T002723]

### DIFF
--- a/tests/spec/sdlc-isolation/e2-local-stack.bats
+++ b/tests/spec/sdlc-isolation/e2-local-stack.bats
@@ -16,7 +16,10 @@ setup() {
 }
 
 cluster_running() {
-  kubectl config current-context 2>/dev/null | grep -q k3d-mentolder-dev
+  # Prüft echte Cluster-Erreichbarkeit statt nur des Kontextnamens.
+  # kubectl config current-context kann auf einen nicht erreichbaren Cluster zeigen
+  # (anderer Rechner, Docker-Reset) — die Tests würden dann rot statt skip.
+  kubectl get nodes --request-timeout=3s &>/dev/null
 }
 
 # ── Struktur-Anker ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes T002723: The `cluster_running()` function in `tests/spec/sdlc-isolation/e2-local-stack.bats` checked `kubectl config current-context` which can point to a non-reachable cluster. Changed to `kubectl get nodes --request-timeout=3s` which probes actual cluster reachability.