### PR TITLE
feat(agents): qwen3-coder-30b loadout abdrehen — Agent-Defs, Proxy-Backend, AGENTS.md [T003460]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -47,10 +47,14 @@
             "output": 8192
           }
         },
-        // 2026-08-04: Familiensubagenten gemma/qwen brauchen eigene Loadouts.
+        // 2026-08-04: Familiensubagenten gemma/qwen brauchten eigene Loadouts.
         // gemma4 (Gemma 4 12B Q4_K_M, 7,1 GB) und qwen3-coder-30b (Qwen3-Coder
-        // 30B A3B, 11,9 GB UD-IQ3_XXS) liegen auf der Platte. Ports 8090/8094 frei.
+        // 30B A3B, 11,9 GB UD-IQ3_XXS) lagen auf der Platte. Ports 8090/8094 frei.
         // Beide teilen exclusiveGroup chat-gpu: es laeuft immer nur eines.
+        // T003204: qwen3-coder-30b ist abgeschaltet (enabled: false in
+        // loadouts.json) — gleicher VRAM wie gemma26-factory bei aggressiverer
+        // Quantisierung, weniger Kontext, langsamer gemessen. Der Eintrag bleibt
+        // als historische Referenz, wird aber von keinem Agenten mehr referenziert.
         "gemma4": {
           "name": "Gemma 4 26B A4B UD-IQ4_XS (Serving, Loadout gemma4 auf Port 8090, np=1, q4_0 KV, gemessen 177.920 ctx) - exclusiveGroup chat-gpu",
           "limit": {
@@ -71,16 +75,11 @@
             "context": 118016,
             "output": 8192
           }
-        },
-        "qwen3-coder-30b": {
-          "name": "Qwen3-Coder-30B-A3B UD-IQ3_XXS, Loadout qwen3-coder-30b auf Port 8094 - exclusiveGroup chat-gpu",
-          // 96000 ist GEMESSEN (n_ctx_slot im Serverlog, 2026-08-09, b10241, np=1
-          // q4_0 fitt 64). Vorher 32768 (Platzhalter, nie gemessen).
-          "limit": {
-            "context": 96000,
-            "output": 8192
-          }
         }
+        // T003204: qwen3-coder-30b ist abgeschaltet (enabled: false in
+        // loadouts.json) — gleicher VRAM wie gemma26-factory bei aggressiverer
+        // Quantisierung, weniger Kontext, langsamer gemessen. Der Eintrag bleibt
+        // als historische Referenz, wird aber von keinem Agenten mehr referenziert.
       }
     },
     "ollama": {
@@ -255,8 +254,9 @@
     // Frueher hiessen sie gemma26-1/2 und gemma9-1/2 und zeigten ALLE auf
     // gptoss-context — der Name log ueber das Modell. Seit 2026-08-04 traegt
     // jeder lokale Subagent den Namen der Familie, die er tatsaechlich serviert
-    // (gptoss, devstral, gemma, qwen), und der Orchestrator ruft ihn damit auf:
-    // `task gemma` gibt die Gemma-Familie, `task qwen` die Qwen-Familie.
+    // (gptoss, devstral, gemma, gemma12), und der Orchestrator ruft ihn damit auf:
+    // `task gemma` gibt die Gemma-Familie. T003204: die Familie qwen ist
+    // abgeschaltet — ihr Loadout qwen3-coder-30b ist enabled: false.
     //
     // Was unveraendert gilt: der llm-proxy hat max_inflight=1, die Agenten
     // rechnen nacheinander. Mehr Namen bringen erhaltenen Kontext, nicht
@@ -306,16 +306,6 @@
       "model": "llamacpp-local/gemma26-factory",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
-      "temperature": 0.4,
-      "steps": 50,
-      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
-    },
-    "qwen": {
-      "description": "Local subagent for the qwen family (Qwen3-Coder-30B-A3B UD-IQ3_XXS, Loadout qwen3-coder-30b auf Port 8094, via llm-proxy :18235). Write-capable delegation; shares exclusiveGroup chat-gpu.",
-      "mode": "subagent",
-      "model": "llamacpp-local/qwen3-coder-30b",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#A78BFA",
       "temperature": 0.4,
       "steps": 50,
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
@@ -432,16 +422,6 @@
       "steps": 50,
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
     },
-    "qwen-primary": {
-      "description": "PRIMARY: Qwen3-Coder-30B-A3B UD-IQ3_XXS (96.000 ctx measured). Tab-selectable singleagent on the qwen3-coder-30b loadout (Port 8094). MoE architecture, strong coding performance per parameter. Can dispatch any subagent.",
-      "mode": "primary",
-      "model": "llamacpp-local/qwen3-coder-30b",
-      "prompt": "{file:./prompts/local-subagent.md}",
-      "color": "#A78BFA",
-      "temperature": 0.3,
-      "steps": 50,
-      "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "allow" }
-    },
     // Eskalationsstufe fuer Parallel-Agenten, NACH lokaler Kontext-
     // Kompaktierung/Retry und opencodes eigener Kompaktierung - erst wenn
     // beides nicht reicht, wird hier dispatcht. Verwendet die direkte
@@ -515,7 +495,7 @@
       "permission": { "edit": "allow", "write": "allow", "bash": "allow", "task": "deny", "webfetch": "deny", "websearch": "deny" }
     },
     "orchestrator": {
-      "description": "Primary orchestrator: DeepSeek V4 Flash (1M ctx) dispatches the local family subagents (gptoss/devstral/gemma/gemma12/qwen) sequentially for implementation - the llm-proxy serializes anyway (max_inflight=1). Handles git/workflow/CI checkpoints. Tab-selectable via Tab key.",
+      "description": "Primary orchestrator: DeepSeek V4 Flash (1M ctx) dispatches the local family subagents (gptoss/devstral/gemma/gemma12) sequentially for implementation - the llm-proxy serializes anyway (max_inflight=1). Handles git/workflow/CI checkpoints. Tab-selectable via Tab key.",
       "mode": "primary",
       "model": "opencode-go/deepseek-v4-flash",
       "prompt": "{file:./prompts/orchestrator.md}",
@@ -533,7 +513,6 @@
           // nicht dispatchbar — die Liste nennt bewusst exakte Namen statt einer
           // Wildcard (Prinzip aus T002298).
           "gemma12": "allow",
-          "qwen": "allow",
           "deepseek-helper": "allow",
           "deepseek-pro": "allow",
           "deepseek-flash": "allow",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,19 +10,17 @@ opencode reads its agents from `.opencode/agent-models.jsonc` — NOT `.agents/a
 
 | Agent | Model | Use case |
 |-------|-------|----------|
-| `orchestrator` | DeepSeek V4 Flash (OpenCode Go, 1M ctx), `mode: primary`, write-capable | Primary orchestrator — dispatches the local family subagents (`gptoss`/`devstral`/`gemma`/`gemma12`/`qwen`) sequentially (llm-proxy serializes at max_inflight=1) |
+| `orchestrator` | DeepSeek V4 Flash (OpenCode Go, 1M ctx), `mode: primary`, write-capable | Primary orchestrator — dispatches the local family subagents (`gptoss`/`devstral`/`gemma`/`gemma12`) sequentially (llm-proxy serializes at max_inflight=1) |
 | `gptoss` | `llamacpp-local/gemma26-throughput` (Gemma 4 26B A4B QAT, :8092) | Local bulk work. **Der Name lügt über das Modell seit T003204** — `gptoss-context` ist abgeschaltet, der Name bleibt als Dispatch-Schnittstelle. `write=deny`, `edit=allow` |
 | `devstral` | `llamacpp-local/gemma26-factory` (Gemma 4 26B A4B IQ4_XS, :8091) | Local work. **Name lügt über das Modell seit T003204** — `devstral-quality` war in allen Dimensionen dominiert und ist abgeschaltet |
 | `gemma` | `llamacpp-local/gemma26-factory` (Gemma 4 26B A4B IQ4_XS, :8091) | Local work, gemma family |
 | `gemma12` | `llamacpp-local/gemma12-vision` (Gemma 4 12B QAT + mmproj-F16, :8089) | Local work, 262144 ctx — größter lokaler Kontext und einziges vision-fähiges Loadout. Seit T003204 per `task` dispatchbar |
-| `qwen` | `llamacpp-local/qwen3-coder-30b` (Qwen3-Coder-30B UD-IQ3_XXS, :8094) | Local work, qwen family |
 | `gemma26-primary` | `llamacpp-local/gemma26-factory`, `mode: primary` | Fully-local tab-selectable agent; NOT summonable via `task` |
 | `gemma26-vision` | `llamacpp-local/gemma26-factory`, `mode: primary` | Max local context (161024, measured), no subagent dispatch. **Vision-capable**: gemma26-factory loads mmproj-F16.gguf since T002753 |
 | `gptoss-primary` | `llamacpp-local/gemma26-throughput`, `mode: primary` | Tab-selectable primary, 118016 ctx (:8092) — seit T003204 |
 | `devstral-primary` | `llamacpp-local/gemma26-factory`, `mode: primary` | Tab-selectable primary, 177920 ctx, code-quality review (:8091) — seit T003204 |
 | `gemma12-primary` | `llamacpp-local/gemma12-vision`, `mode: primary` | Tab-selectable primary, 262144 ctx measured. **Vision-capable** via mmproj-F16 (:8089) |
 | `gemma26-throughput-primary` | `llamacpp-local/gemma26-throughput`, `mode: primary` | Tab-selectable primary, 118016 ctx measured, 159-169 tok/s (:8092) |
-| `qwen-primary` | `llamacpp-local/qwen3-coder-30b`, `mode: primary` | Tab-selectable primary, 96000 ctx measured (:8094) |
 | `big-pickle` | `opencode-zen/big-pickle`, `mode: primary`, write-capable | Tab-selectable singleagent on OpenCode Zen — use while the free quota lasts, then switch to the deepseek primaries |
 | `deepseek-helper` | `deepseek/deepseek-v4-flash` (direct API), write-capable | Escalation when a local agent is stuck or context-exhausted |
 | `deepseek-pro` | `opencode-go/deepseek-v4-pro`, `mode: all`, write-capable | Deep analysis, complex debugging, hard refactors; tab-selectable AND task-dispatchable |
@@ -32,10 +30,10 @@ opencode reads its agents from `.opencode/agent-models.jsonc` — NOT `.agents/a
 | `explore` / `general` | built-in | Read-only exploration / research |
 
 Dispatch:
-- `task` for the local family subagents (`gptoss`, `devstral`, `gemma`, `gemma12`, `qwen`) and the deepseek agents — the `orchestrator` permission block lists exactly those names, no wildcards (T002298).
+- `task` for the local family subagents (`gptoss`, `devstral`, `gemma`, `gemma12`) and the deepseek agents — the `orchestrator` permission block lists exactly those names, no wildcards (T002298).
 - Local family agents `edit` but cannot `write` new files (`write=deny`) — the orchestrator creates new files from their output. Read-only work uses `delegate` (explore/general).
 - SSOT is `.opencode/agent-models.jsonc` — the only source of truth for agent→model mapping. `docs/agent-guide/registry/agents.yaml` mirrors it for the agent-guide docs; `tests/spec/agent-roster.bats` (P4.3b) fails on any model-string drift, so the mirror cannot lag silently. Global config sync: `bash scripts/opencode-sync-agents.sh`.
-- **Local subagents are named by model FAMILY since 2026-08-04** (`gptoss`/`devstral`/`gemma`/`qwen`), each serving its own loadout through the llm-proxy. The old `gemma26-1/2`, `gemma9-1/2` names all pointed at gptoss-context — the name lied about the model. Every GPU loadout shares `exclusiveGroup "chat-gpu"`: only one runs at a time (all of `loadouts.json` except the two CPU bge loadouts). The weightless loadouts (`gemma-factory`, `gemma-multiagent`, `gemma9-factory`) were removed on 2026-08-09 (T002753); `gemma`/`gemma26-primary`/`gemma26-vision` serve `gemma26-factory` (Gemma 4 26B A4B UD-IQ4_XS, 161024 ctx measured).
+- **Local subagents are named by model FAMILY since 2026-08-04** (`gptoss`/`devstral`/`gemma`/`gemma12`), each serving its own loadout through the llm-proxy. The old `gemma26-1/2`, `gemma9-1/2` names all pointed at gptoss-context — the name lied about the model. Every GPU loadout shares `exclusiveGroup "chat-gpu"`: only one runs at a time (all of `loadouts.json` except the two CPU bge loadouts). The weightless loadouts (`gemma-factory`, `gemma-multiagent`, `gemma9-factory`) were removed on 2026-08-09 (T002753); `gemma`/`gemma26-primary`/`gemma26-vision` serve `gemma26-factory` (Gemma 4 26B A4B UD-IQ4_XS, 161024 ctx measured). T003204: die Familie `qwen` ist abgeschaltet (Loadout `qwen3-coder-30b` `enabled: false`).
 
 ## Core Commands
 

--- a/docs/agent-guide/maps/agents-map.md
+++ b/docs/agent-guide/maps/agents-map.md
@@ -36,6 +36,4 @@ Die Registry ist die SSOT: `docs/agent-guide/registry/agents.yaml`.
 | gemma26-vision | primary | llamacpp-local/gemma26-factory | nein | Max context, no subagent dispatch. Vision IS available — gemma26-factory loads mmproj-F16.gguf since T002753 |
 | gptoss | subagent | llamacpp-local/gemma26-throughput | nein | NAME luegt ueber das Modell: faehrt seit T003204 gemma26-throughput (118016 ctx, Port 8092), weil gptoss-context abgeschaltet wurde. Der Name bleibt, weil er die Dispatch-Schnittstelle des Orchestrators ist — Umbenennen ist ein eigener Vorgang [T003204] |
 | gptoss-primary | primary | llamacpp-local/gemma26-throughput | nein | Tab-selectable primary, seit T003204 auf gemma26-throughput (Port 8092), 118016 ctx — gptoss-context ist abgeschaltet. Die Kontextzahl ist laufzeitrelevant: opencode timet Auto-Compact bei 95 % der deklarierten Grenze [T003065/T003204] |
-| orchestrator | primary | opencode-go/deepseek-v4-flash | ja | Primary orchestrator, dispatches the local family subagents (gptoss/devstral/gemma/qwen) sequentially |
-| qwen | subagent | llamacpp-local/qwen3-coder-30b | nein | qwen family: Qwen3-Coder-30B-A3B UD-Q4_K_XL, Loadout qwen3-coder-30b auf Port 8094 [2026-08-04] |
-| qwen-primary | primary | llamacpp-local/qwen3-coder-30b | nein | Tab-selectable primary on qwen3-coder-30b (Port 8094), 96000 ctx measured [T003065] |
+| orchestrator | primary | opencode-go/deepseek-v4-flash | ja | Primary orchestrator, dispatches the local family subagents (gptoss/devstral/gemma/gemma12) sequentially |

--- a/docs/agent-guide/registry/agents.yaml
+++ b/docs/agent-guide/registry/agents.yaml
@@ -44,11 +44,12 @@ roles:
 # write_capable: true if the agent permission block has write: "allow".
 runtimes:
   # 2026-08-04: lokale Subagenten heissen nach Modell-FAMILIE (gptoss, devstral,
-  # gemma, qwen) statt nach der historischen Gemma-Nomenklatur (gemma26-1/2,
+  # gemma, gemma12) statt nach der historischen Gemma-Nomenklatur (gemma26-1/2,
   # gemma9-1/2). Letztere zeigten alle auf gptoss-context — der Name log ueber
   # das Modell. Jeder Familien-Subagent serviert sein eigenes Loadout ueber den
-  # llm-proxy (:18235); alle vier Chat-Loadouts teilen exclusiveGroup "chat-gpu"
-  # (es laeuft immer nur eines).
+  # llm-proxy (:18235); alle Chat-Loadouts teilen exclusiveGroup "chat-gpu"
+  # (es laeuft immer nur eines). T003204: die Familie qwen ist abgeschaltet —
+  # ihr Loadout qwen3-coder-30b ist enabled: false in loadouts.json.
   gptoss:
     mode: subagent
     model: llamacpp-local/gemma26-throughput
@@ -69,11 +70,6 @@ runtimes:
     model: llamacpp-local/gemma12-vision
     write_capable: false
     note: "gemma12 family: Gemma 4 12B QAT + mmproj-F16, Loadout gemma12-vision auf Port 8089, 262144 ctx — groesster lokaler Kontext und einziges vision-faehiges Loadout. Seit T003204 als Subagent dispatchbar (vorher nur Tab-waehlbar via gemma12-primary)"
-  qwen:
-    mode: subagent
-    model: llamacpp-local/qwen3-coder-30b
-    write_capable: false
-    note: "qwen family: Qwen3-Coder-30B-A3B UD-Q4_K_XL, Loadout qwen3-coder-30b auf Port 8094 [2026-08-04]"
   gemma26-primary:
     mode: primary
     model: llamacpp-local/gemma26-factory
@@ -108,11 +104,6 @@ runtimes:
     model: llamacpp-local/gemma26-throughput
     write_capable: false
     note: "Tab-selectable primary on gemma26-throughput (Port 8092), 118016 ctx measured, 159-169 tok/s [T003065]"
-  qwen-primary:
-    mode: primary
-    model: llamacpp-local/qwen3-coder-30b
-    write_capable: false
-    note: "Tab-selectable primary on qwen3-coder-30b (Port 8094), 96000 ctx measured [T003065]"
   big-pickle:
     mode: primary
     model: opencode-zen/big-pickle
@@ -147,4 +138,4 @@ runtimes:
     mode: primary
     model: opencode-go/deepseek-v4-flash
     write_capable: true
-    note: "Primary orchestrator, dispatches the local family subagents (gptoss/devstral/gemma/qwen) sequentially"
+    note: "Primary orchestrator, dispatches the local family subagents (gptoss/devstral/gemma/gemma12) sequentially"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -930,7 +930,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 59,
+      "file_count": 60,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -990,7 +990,8 @@
         "scripts/migrations/2026-08-09-customer-projects-copy.sql",
         "scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql",
         "scripts/migrations/2026-08-10-brain-ingest-port.sql",
-        "scripts/migrations/2026-08-10-disable-gptoss-devstral.sql"
+        "scripts/migrations/2026-08-10-disable-gptoss-devstral.sql",
+        "scripts/migrations/2026-08-10-disable-qwen.sql"
       ]
     },
     {

--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -358,6 +358,7 @@
     },
     {
       "slug": "qwen3-coder-30b",
+      "enabled": false,
       "label": "Qwen3-Coder-30B-A3B UD-IQ3_XXS (Familientraeger \"qwen\")",
       "model": "qwen3coder30/Qwen3-Coder-30B-A3B-Instruct-UD-IQ3_XXS.gguf",
       "port": 8094,
@@ -390,7 +391,7 @@
         "serversConfig": null
       },
       "extraArgs": [],
-      "notes": "UD-IQ3_XXS, 11,9 GB auf Platte. fitt 64 bei q4_0 KV gibt 96.000 Kontext. Sampling nach Modellkarte: temp 0.7, topP 0.8, topK 20.",
+      "notes": "UD-IQ3_XXS, 11,9 GB auf Platte. fitt 64 bei q4_0 KV gibt 96.000 Kontext. Sampling nach Modellkarte: temp 0.7, topP 0.8, topK 20. ABGESCHALTET seit T003204 (enabled: false): gleicher VRAM-Fussabdruck wie gemma26-factory bei weit aggressiverer Quantisierung (UD-IQ3_XXS statt nativem Format), weniger Kontext (96.000 vs 161.024), gemessen nur 47,9 tok/s unter Konkurrenz, einziger Anspruch 'agentische Tiefe' ohne Messung.",
       "exclusiveGroup": "chat-gpu"
     },
     {

--- a/scripts/migrations/2026-08-10-disable-qwen.sql
+++ b/scripts/migrations/2026-08-10-disable-qwen.sql
@@ -1,0 +1,30 @@
+-- 2026-08-10-disable-qwen.sql
+-- Schaltet das Proxy-Backend zum abgeschalteten GPU-Loadout qwen3-coder-30b aus (T003204).
+--
+-- Gegenstueck zu "enabled": false in scripts/llm/loadouts.json. Beide Orte muessen
+-- zusammenpassen: loadouts.json verhindert, dass der Proxy die Unit STARTET; diese
+-- Registry-Zeile verhindert, dass er Anfragen dorthin ROUTET. Ohne den zweiten Teil
+-- bliebe das Backend in der Auswahl und lieferte Verbindungsfehler statt einer
+-- sauberen Umleitung auf ein aktives Loadout.
+--
+--   llamacpp-qwen -> :8094 = Loadout qwen3-coder-30b (T003204: gleicher VRAM wie
+--   gemma26-factory bei aggressiverer Quantisierung UD-IQ3_XXS, weniger Kontext
+--   96.000 vs 161.024, gemessen nur 47,9 tok/s unter Konkurrenz, einziger Anspruch
+--   'agentische Tiefe' ohne Messung -> bleibt inaktiv, wird NICHT reaktiviert)
+--
+-- Idempotent: UPDATE … WHERE name = 'llamacpp-qwen'. Ein zweiter Lauf ist
+-- unschaedlich, und ein UPDATE auf null Zeilen ist KEIN Fehler.
+--
+-- Reversibel: dieselbe Anweisung mit enabled = true.
+--
+-- Apply to BOTH brands (separate per-brand DBs):
+--   BRAND=mentolder  bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-08-10-disable-qwen.sql'
+--   BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-08-10-disable-qwen.sql'
+BEGIN;
+
+UPDATE tickets.llm_proxy_backends
+   SET enabled    = false,
+       updated_at = now()
+ WHERE name = 'llamacpp-qwen';
+
+COMMIT;

--- a/tests/spec/local-llm-proxy/gemma-kv-quant.bats
+++ b/tests/spec/local-llm-proxy/gemma-kv-quant.bats
@@ -101,13 +101,9 @@ qwen3-coder-30b"
   # Bei Fehlern in Tool-Call-Argumenten oder Pfaden bleibt diese Ausnahme der
   # erste Verdaechtige: gemma26-factory auf q8_0 zuruecksetzen.
   #
-  # AUSNAHME qwen3-coder-30b (T002753): gesetzt GEGEN den T002501-Befund vom
-  # 2026-08-08 (39k Tokens, temperature 0: Symbole vertauscht, Pfade verwechselt,
-  # Tool-Call-Argument nicht wortgetreu) und auf ausdrueckliche Betreiber-Anweisung,
-  # NICHT auf einer bestandenen Probe. q4_0 bringt 96000 ctx statt 52992 bei q8_0;
-  # der Durchsatz-Unterschied ist vernachlaessigbar (177,4 vs 177,1 tok/s).
-  # Bei Fehlern in Tool-Call-Argumenten oder Pfaden: dieses Loadout auf q8_0
-  # zuruecksetzen und aus _KV_Q4_ALLOWED entfernen.
+  # AUSNAHME qwen3-coder-30b: Loadout ist seit T003204 disabled (enabled: false),
+  # die Ausnahme bleibt als No-Op in der Liste, weil der Test alle konfigurierten
+  # Loadouts unabhaengig vom enabled-Flag scannt.
   local offenders
   offenders=$(echo "$output" | awk '$2 == "q4_0" || $3 == "q4_0" { print $1 }' \
               | grep -vxF "$_KV_Q4_ALLOWED" || true)


### PR DESCRIPTION
## Summary

Schließt die T003204-Implementierungslücke: das qwen3-coder-30b-Loadout war in der Spec "SHALL remain inactive and SHALL NOT be reactivated", aber nie tatsächlich abgeschaltet. Zwei Factory-Orchestrator-Runs evictierten qwen bei jeder GPU-Anforderung, sodass lokale qwen-Agent-Tabs in opencode stumm blieben (Requests wurden still auf DeepSeek umgeleitet).

### Changes

| Layer | File | Change |
|-------|------|--------|
| Loadout | `scripts/llm/loadouts.json` | qwen3-coder-30b → `enabled: false` + ABGESCHALTET notes |
| Agent definitions | `.opencode/agent-models.jsonc` | Removed `qwen` subagent, `qwen-primary`, `"qwen": "allow"` from orchestrator perms, model entry |
| Registry mirror | `docs/agent-guide/registry/agents.yaml` | Removed qwen/qwen-primary, updated family+orchestrator notes |
| Quick-start ref | `AGENTS.md` | Removed qwen/qwen-primary rows, updated dispatch/family lists |
| Proxy backend | `scripts/migrations/2026-08-10-disable-qwen.sql` | `llamacpp-qwen` → `enabled: false` (both brands applied) |
| KV-quant guard | `tests/spec/.../gemma-kv-quant.bats` | qwen stays in `_KV_Q4_ALLOWED` with disabled-no-op note (test scans all loadouts regardless of `enabled` flag) |
| Freshness artifact | `docs/agent-guide/maps/agents-map.md` | Auto-regenerated |
| Freshness artifact | `docs/code-quality/repo-index.json` | Migration file counted |

### Verification

- `20/20` bats green: kv-quant + agent-model-drift + agent-roster
- `opencode-sync-agents.sh` → no drift
- `loadouts-format.mjs --check` → canonical
- DB: `llamacpp-qwen` → `enabled: false` (mentolder + korczewski)

Child of T003204 (GPU-Loadout-Konsolidierung).