### PR TITLE
fix(scripts): primary.some statt primary.every in evaluateReadiness [T003485]

### DIFF
--- a/scripts/llm-proxy/discovery.mjs
+++ b/scripts/llm-proxy/discovery.mjs
@@ -209,13 +209,17 @@ export function evaluateReadiness(getBackends) {
   const primary = backends.filter((b) => b.priority === 1);
   // Ein Prio-1-Backend, das drained, ist NICHT unhealthy — es ist intentional
   // zurueckgenommen. Der Proxy kann ueber Prio-2+ bedienen.
-  // [P1-2] ready erfordert zusaetzlich, dass mindestens EIN Backend tatsaechlich
-  // bedienen kann (gesund UND nicht drainend): wenn alle Prio-1-Backends drainen
-  // und der Fallback tot ist, waere primary.every() still true, obwohl resolveModel
-  // fuer jede Anfrage 503 liefert — genau die T002336-Taeuschung, die /health
-  // verhindern soll.
+  //
+  // [P1-2] primary.some statt primary.every: die Prio-1-Backends teilen sich
+  // exclusiveGroup "chat-gpu" — es laeuft immer nur eines (siehe loadouts.json).
+  // primary.every wuerde verlangen, dass ALLE gleichzeitig gesund sind, was mit
+  // exklusiver GPU-Belegung nie der Fall ist. primary.some prueft "mindestens
+  // eines gesund", was fuer einen exklusiven Gruppenmodell die korrekte
+  // Erwartung ist. Uralt-Szenario "Factory ins Leere" (2026-07-27) bleibt
+  // abgesichert: primary.some + backends.some verhindern ready=true, wenn KEIN
+  // Prio-1-Backend gesund ist und der Cloud-Fallback der einzige bleibt.
   const ready = primary.length > 0
-    && primary.every((b) => {
+    && primary.some((b) => {
       const h = health.get(b.name);
       return !!h?.healthy || !!h?.draining;
     })


### PR DESCRIPTION
## Problem

Die Prio-1-Backends (llamacpp-gemma4 :8090, llamacpp-gemma :8091, llamacpp-gemma26-throughput :8092, llamacpp-gemma12-vision :8089) teilen sich `exclusiveGroup: "chat-gpu"` — es läuft immer nur eines.

`evaluateReadiness` in `discovery.mjs` verwendet `primary.every()` — alle Prio-1-Backends müssen gesund sein. Da mit exklusiver GPU-Belegung immer nur eines läuft, ist `ready` dauerhaft `false`, und `/health` meldet den Proxy als nicht bereit.

## Fix

`primary.every` → `primary.some`: mindestens EIN Prio-1-Backend muss gesund sein. 

Die Absicherung gegen die T002336-Täuschung (Cloud-Fallback täuscht readiness vor, obwohl der lokale Stack tot ist) bleibt erhalten: `primary.some` + `backends.some` verhindern `ready=true`, wenn KEIN Prio-1-Backend gesund ist und der Cloud-Fallback der einzige bleibt.

## Tests

Alle 29 bestehenden Tests (server.test.mjs + gpu-lock.test.mjs) laufen grün.

## Zusätzlich

18 stale `/tmp/gpu-lock-*/`-Verzeichnisse von abgelaufenen Testläufen bereinigt.