### PR TITLE
fix(website): Metrik-Endpunkt unter seinem echten Pfad ansprechen [T003459]

### DIFF
--- a/website/src/components/DeliveryHistory.svelte
+++ b/website/src/components/DeliveryHistory.svelte
@@ -32,7 +32,7 @@
     loading = true;
     error = false;
     try {
-      const res = await fetch(`/api/admin/delivery-metrics?window=${window}`, { credentials: 'same-origin' });
+      const res = await fetch(`/sdlc/api/delivery-metrics?window=${window}`, { credentials: 'same-origin' });
       if (!res.ok) { error = true; return; }
       const json = (await res.json()) as ApiResponse;
       data = json;

--- a/website/src/components/DevStatusTabs.svelte
+++ b/website/src/components/DevStatusTabs.svelte
@@ -7,6 +7,8 @@
   import KiRoutingPanel from './sdlc/factory/KiRoutingPanel.svelte';
   import LlmProxyPanel from './sdlc/factory/LlmProxyPanel.svelte';
   import DependencyGraph from './DependencyGraph.svelte';
+  import InsightsTab from './sdlc/factory/InsightsTab.svelte';
+  import DeliveryHistory from './DeliveryHistory.svelte';
   import AdminTabs from './admin/ui/AdminTabs.svelte';
   import KostenTab from './sdlc/factory/KostenTab.svelte';
   import type { FloorPayload } from '../lib/factory-floor-types';
@@ -70,7 +72,7 @@
   async function loadParallel() {
     try {
       parallelLoading = true;
-      const res = await fetch('/api/factory/parallel-status');
+      const res = await fetch('/sdlc/api/factory/parallel-status');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       parallel = (await res.json()) as ParallelStatus;
       parallelError = null;
@@ -85,7 +87,7 @@
   async function forceTick() {
     try {
       forcing = true;
-      const res = await fetch('/api/factory/force-tick', { method: 'POST' });
+      const res = await fetch('/sdlc/api/factory/force-tick', { method: 'POST' });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       await loadParallel();
     } catch (err) {
@@ -189,11 +191,16 @@
   <ControlPanel />
   <div class="control-extras"><FactoryModelSlots /><KiRoutingPanel /><LlmProxyPanel /></div>
 {:else if activeTab === 'analytics'}
+  <!--
+    [T003459] Zeigt wieder Inhalt statt eines Verweises. T003417 ersetzte die
+    vier Analytics-Komponenten hier durch einen Platzhaltertext ("nutze das
+    Cockpit"), obwohl das Delta-Spec jenes Change nur die Cockpit-Seite
+    abdeckte — auf dieser Seite war es ein unspezifizierter Funktionsverlust.
+    InsightsTab liefert dieselben Kennzahlen aus derselben Quelle.
+  -->
   <div class="analytics-tab-wrap">
-    <p style="color: var(--admin-text-mute); padding: 2rem; text-align: center;">
-      Analytics-Ansicht wurde in den neuen Insights-Tab verschoben.
-      <br><small>Bitte das SDLC Cockpit (&uuml;ber Command Bar → Insights) nutzen.</small>
-    </p>
+    <InsightsTab />
+    <DeliveryHistory window="7d" />
   </div>
 {:else if activeTab === 'kosten'}
   <KostenTab />

--- a/website/src/components/cockpit/CockpitRail.svelte
+++ b/website/src/components/cockpit/CockpitRail.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import PilotLight from '../sdlc/factory/PilotLight.svelte';
   import type { CockpitMode } from './CommandBar.svelte';
+  import { getSharedMetrics } from '../../lib/stores/factory-floor-store';
+  import { deriveMetrics, formatCycleTime } from '../../lib/sdlc/factory-metrics-derive';
+  import type { DerivedMetrics } from '../../lib/sdlc/factory-metrics-derive';
 
   export type Phase = 'triage' | 'planung' | 'bauen' | 'review' | 'deploy' | 'ship';
 
@@ -29,6 +32,23 @@
   } = $props();
 
   let sections = $state<RailSection[]>([]);
+
+  // [T003459] Die Metrik-Sektion zeigte durchgehend '—'. Die Daten liegen in
+  // `tickets.v_factory_metrics` und kommen ueber denselben Store wie im
+  // Insights-Tab; ein zweiter Abruf entsteht nicht, `getSharedMetrics` teilt
+  // Cache und laufende Anfrage. Faellt der Abruf aus, bleibt '—' stehen: die
+  // Rail ist Beiwerk und soll keinen Fehlerdialog aufmachen.
+  let metrics = $state<DerivedMetrics | null>(null);
+  const METRICS_WINDOW_DAYS = 7;
+
+  async function loadMetrics() {
+    try {
+      const payload = await getSharedMetrics();
+      metrics = deriveMetrics(payload.metrics ?? [], METRICS_WINDOW_DAYS);
+    } catch {
+      metrics = null;
+    }
+  }
 
   function buildSections(): RailSection[] {
     switch (mode) {
@@ -143,8 +163,21 @@
             id: 'metrics',
             label: 'Metriken',
             items: [
-              { key: 'throughput', label: 'Durchsatz (7d)', value: '—' },
-              { key: 'avg_time', label: 'Ø Zeit plan→done', value: '—' },
+              {
+                key: 'throughput',
+                label: `Ausgeliefert (${METRICS_WINDOW_DAYS}d)`,
+                value: metrics ? String(metrics.shipped) : '—',
+              },
+              {
+                key: 'avg_time',
+                label: 'Ø Zeit plan→done',
+                value: formatCycleTime(metrics?.avgCycleTimeH ?? null),
+              },
+              {
+                key: 'escalations',
+                label: `Eskalationen (${METRICS_WINDOW_DAYS}d)`,
+                value: metrics ? String(metrics.escalations) : '—',
+              },
             ],
           },
           {
@@ -162,8 +195,14 @@
   // Der `$effect` laeuft auch beim ersten Rendern — ein zusaetzliches `onMount`
   // mit demselben Rumpf war redundant und baute die Sektionen doppelt auf.
   $effect(() => {
-    void mode; void phase; // consume reactive deps
+    void mode; void phase; void metrics; // consume reactive deps
     sections = buildSections();
+  });
+
+  // Nur im Insights-Modus laden — in den anderen Modi zeigt die Rail keine
+  // Kennzahlen aus dieser Quelle, ein Abruf waere dort reiner Netzverkehr.
+  $effect(() => {
+    if (mode === 'insights' && metrics === null) void loadMetrics();
   });
 </script>
 

--- a/website/src/components/cockpit/CommandBar.svelte
+++ b/website/src/components/cockpit/CommandBar.svelte
@@ -69,7 +69,7 @@
     // Fetch parallel status for tick countdown
     async function loadParallel() {
       try {
-        const res = await fetch('/api/factory/parallel-status');
+        const res = await fetch('/sdlc/api/factory/parallel-status');
         if (res.ok) {
           const data = await res.json();
           if (data.nextTickAt) nextTickAt = data.nextTickAt;

--- a/website/src/components/cockpit/OverviewDashboard.svelte
+++ b/website/src/components/cockpit/OverviewDashboard.svelte
@@ -34,7 +34,7 @@
     error = null;
     try {
       // Aggregate from existing endpoints
-      const res = await fetch('/api/cockpit/portfolio');
+      const res = await fetch('/sdlc/api/cockpit/portfolio');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
 

--- a/website/src/components/sdlc/factory/FactoryObservability.svelte
+++ b/website/src/components/sdlc/factory/FactoryObservability.svelte
@@ -65,7 +65,7 @@
 
   onMount(async () => {
     try {
-      const res = await fetch('/api/factory-observability', { credentials: 'same-origin' });
+      const res = await fetch('/sdlc/api/factory-observability', { credentials: 'same-origin' });
       if (!res.ok) throw new Error(`API ${res.status}`);
       data = await res.json();
     } catch (e) {

--- a/website/src/components/sdlc/factory/InsightsTab.svelte
+++ b/website/src/components/sdlc/factory/InsightsTab.svelte
@@ -1,27 +1,33 @@
 <script lang="ts">
-  let traceCount = $state(0);
-  let recording = $state(false);
-  let throughput = $state('—');
-  let avgTime = $state('—');
+  import { onMount } from 'svelte';
+  import { getSharedMetrics } from '../../../lib/stores/factory-floor-store';
+  import { deriveMetrics, formatCycleTime } from '../../../lib/sdlc/factory-metrics-derive';
+  import type { DerivedMetrics } from '../../../lib/sdlc/factory-metrics-derive';
 
+  const WINDOW_DAYS = 7;
+
+  let derived = $state<DerivedMetrics | null>(null);
+  let loadError = $state<string | null>(null);
+  let loading = $state(true);
+
+  // Kein stiller catch: schlaegt der Abruf fehl, wird das ANGEZEIGT statt als
+  // '—' getarnt. Genau diese Tarnung liess den 404 auf /api/factory-metrics
+  // wie "keine Daten vorhanden" aussehen [T003459].
   async function loadMetrics() {
+    loading = true;
+    loadError = null;
     try {
-      // In a real implementation, these would come from dedicated API endpoints
-      // For now, show placeholder values that indicate the architecture is in place
-    } catch {
-      // silent
+      const payload = await getSharedMetrics(true);
+      derived = deriveMetrics(payload.metrics ?? [], WINDOW_DAYS);
+    } catch (e) {
+      loadError = e instanceof Error ? e.message : String(e);
+      derived = null;
+    } finally {
+      loading = false;
     }
   }
 
-  function toggleRecording() {
-    recording = !recording;
-    if (recording) {
-      // Start recording traces
-      traceCount = 0;
-    }
-  }
-
-  $effect(() => { loadMetrics(); });
+  onMount(loadMetrics);
 </script>
 
 <div class="insights">
@@ -30,48 +36,59 @@
 
   <section class="insights__section">
     <h3>Metriken</h3>
-    <div class="insights__grid">
-      <div class="metric-card">
-        <span class="metric-card__label">Durchsatz (7 Tage)</span>
-        <span class="metric-card__value">{throughput}</span>
+    {#if loadError}
+      <p class="insights__error" role="alert" data-testid="metrics-error">
+        Metriken nicht abrufbar: {loadError}
+        <button class="insights__retry" onclick={loadMetrics}>Erneut versuchen</button>
+      </p>
+    {:else}
+      <div class="insights__grid" data-testid="metrics-grid" aria-busy={loading}>
+        <div class="metric-card">
+          <span class="metric-card__label">Ausgeliefert ({WINDOW_DAYS} Tage)</span>
+          <span class="metric-card__value">{derived ? derived.shipped : '—'}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-card__label">Ø Zeit Planung → Done</span>
+          <span class="metric-card__value">{formatCycleTime(derived?.avgCycleTimeH ?? null)}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-card__label">Eskalationen ({WINDOW_DAYS} Tage)</span>
+          <span class="metric-card__value">{derived ? derived.escalations : '—'}</span>
+        </div>
+        <div class="metric-card">
+          <span class="metric-card__label">Tage mit Daten</span>
+          <span class="metric-card__value">{derived ? `${derived.daysCovered}/${WINDOW_DAYS}` : '—'}</span>
+        </div>
       </div>
-      <div class="metric-card">
-        <span class="metric-card__label">Ø Zeit Planung → Done</span>
-        <span class="metric-card__value">{avgTime}</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-card__label">Offene PRs</span>
-        <span class="metric-card__value">—</span>
-      </div>
-      <div class="metric-card">
-        <span class="metric-card__label">Blockierte Tickets</span>
-        <span class="metric-card__value">—</span>
-      </div>
-    </div>
+    {/if}
   </section>
 
   <section class="insights__section">
     <h3>Trace-Recording</h3>
     <p class="insights__subtitle">
-      Zeichnet Agent-Entscheidungen und Factory-Durchl&auml;ufe für Finetuning auf.
-      Die Traces werden in der Ticket-Datenbank persistiert.
+      Soll Agent-Entscheidungen und Factory-Durchl&auml;ufe für Finetuning
+      aufzeichnen und in der Ticket-Datenbank persistieren.
     </p>
 
+    <!--
+      [T003459] Der Schalter ist deaktiviert, nicht entfernt. Er schaltete
+      bisher nur eine lokale Variable um und zeigte dann "Recording laeuft" an,
+      ohne dass irgendetwas aufgezeichnet oder persistiert wurde — eine
+      Zusicherung, die die Oberflaeche nicht einloesen konnte. Ein sichtbar
+      deaktivierter Schalter mit Begruendung ist ehrlicher als ein Knopf, der
+      Aufzeichnung vortaeuscht. Die geplante Datenform bleibt als Zielbild.
+    -->
     <div class="trace-controls">
-      <button
-        class="trace-toggle"
-        class:active={recording}
-        onclick={toggleRecording}
-      >
-        {recording ? '⏹ Recording l\u00e4uft' : '▶ Aufzeichnung starten'}
+      <button class="trace-toggle" disabled data-testid="trace-toggle">
+        ▶ Aufzeichnung starten
       </button>
-      {#if recording}
-        <span class="trace-count">{traceCount} Traces aufgezeichnet</span>
-      {/if}
+      <span class="trace-count" data-testid="trace-status">
+        Noch nicht implementiert — es gibt keinen Endpunkt, der Traces entgegennimmt.
+      </span>
     </div>
 
     <div class="trace-info">
-      <p><strong>Aufgezeichnete Daten:</strong></p>
+      <p><strong>Geplante Datenform:</strong></p>
       <ul>
         <li>Ticket-ID &amp; Agent-Modell</li>
         <li>Phase (scout, design, plan, implement, verify, deploy)</li>
@@ -172,13 +189,40 @@
     transition: background 0.15s;
   }
 
-  .trace-toggle:hover {
+  .trace-toggle:hover:not(:disabled) {
     background: var(--admin-surface-hover);
   }
 
-  .trace-toggle.active {
-    background: oklch(0.62 0.20 25 / 0.15);
-    border-color: oklch(0.62 0.20 25);
+  /* Bewusst deaktiviert [T003459] — sichtbar ausgegraut, damit niemand eine
+     Funktion erwartet, die es noch nicht gibt. */
+  .trace-toggle:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .insights__error {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--admin-error, #d77a6e);
+    border-radius: var(--admin-radius-sm, 4px);
+    background: oklch(0.62 0.20 25 / 0.08);
+    color: var(--admin-error, #d77a6e);
+    font-family: var(--admin-font-mono, monospace);
+    font-size: var(--admin-text-sm);
+  }
+
+  .insights__retry {
+    padding: 0.25rem 0.75rem;
+    background: transparent;
+    border: 1px solid currentColor;
+    border-radius: var(--admin-radius-sm, 4px);
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: inherit;
   }
 
   .trace-count {

--- a/website/src/lib/sdlc/factory-metrics-derive.test.ts
+++ b/website/src/lib/sdlc/factory-metrics-derive.test.ts
@@ -1,0 +1,89 @@
+// [T003459] Rechenregeln der Insights-Kennzahlen.
+// Prüfmodus: Rückgabewerte der Funktionen, keine Quelltext-Muster.
+import { describe, it, expect } from 'vitest';
+import { deriveMetrics, windowRows, formatCycleTime } from './factory-metrics-derive';
+import type { FactoryMetricRow } from '../stores/factory-floor-store';
+
+function row(day: string, shipped: number, cycle: number | null, esc = 0): FactoryMetricRow {
+  return { day, features_shipped: shipped, avg_cycle_time_h: cycle, escalations: esc, total_features: shipped };
+}
+
+describe('windowRows', () => {
+  it('nimmt die neuesten Tage, unabhängig von der Eingabereihenfolge', () => {
+    const rows = [row('2026-08-01', 1, 2), row('2026-08-05', 1, 2), row('2026-08-03', 1, 2)];
+    expect(windowRows(rows, 2).map((r) => r.day)).toEqual(['2026-08-05', '2026-08-03']);
+  });
+
+  it('liefert bei weniger Zeilen als Fenstergröße alles zurück', () => {
+    expect(windowRows([row('2026-08-01', 1, 2)], 7)).toHaveLength(1);
+  });
+
+  it('liefert für ein Fenster von 0 Tagen nichts', () => {
+    expect(windowRows([row('2026-08-01', 1, 2)], 0)).toEqual([]);
+  });
+});
+
+describe('deriveMetrics', () => {
+  it('summiert Auslieferungen und Eskalationen im Fenster', () => {
+    const rows = [row('2026-08-05', 3, 10, 1), row('2026-08-04', 2, 10, 2)];
+    const d = deriveMetrics(rows, 7);
+    expect(d.shipped).toBe(5);
+    expect(d.escalations).toBe(3);
+    expect(d.daysCovered).toBe(2);
+  });
+
+  it('zählt nur Tage innerhalb des Fensters', () => {
+    const rows = Array.from({ length: 30 }, (_, i) =>
+      row(`2026-08-${String(30 - i).padStart(2, '0')}`, 1, 5),
+    );
+    expect(deriveMetrics(rows, 7).shipped).toBe(7);
+  });
+
+  // Der eigentliche Kern: gewichtet, nicht als Mittel der Tagesmittel.
+  it('gewichtet die Zykluszeit nach der Tagesmenge', () => {
+    // Tag A: 1 Ticket à 100 h, Tag B: 9 Tickets à 10 h.
+    // Ungewichtet wären das (100+10)/2 = 55 h — das Mittel der Tagesmittel.
+    // Gewichtet: (100*1 + 10*9) / 10 = 19 h. Der Ausreißertag darf die Woche
+    // nicht dominieren.
+    const rows = [row('2026-08-05', 1, 100), row('2026-08-04', 9, 10)];
+    expect(deriveMetrics(rows, 7).avgCycleTimeH).toBe(19);
+  });
+
+  it('lässt Tage ohne Auslieferung den Schnitt nicht gegen null ziehen', () => {
+    // Der ruhige Tag trägt keine Zykluszeit bei und darf auch nicht im Nenner
+    // stehen — sonst meldete ein Wochenende eine Verbesserung.
+    const rows = [row('2026-08-05', 4, 12), row('2026-08-04', 0, null)];
+    expect(deriveMetrics(rows, 7).avgCycleTimeH).toBe(12);
+  });
+
+  it('liefert null statt 0, wenn im Fenster nichts ausgeliefert wurde', () => {
+    // Positiv-Anker: mit Daten kommt eine Zahl heraus …
+    expect(deriveMetrics([row('2026-08-05', 2, 8)], 7).avgCycleTimeH).toBe(8);
+    // … ohne Daten aber null — 0 h wäre eine Aussage, die niemand gemessen hat.
+    expect(deriveMetrics([row('2026-08-05', 0, null)], 7).avgCycleTimeH).toBeNull();
+    expect(deriveMetrics([], 7).avgCycleTimeH).toBeNull();
+  });
+
+  it('übersteht fehlende Felder ohne NaN', () => {
+    const broken = [{ day: '2026-08-05' } as unknown as FactoryMetricRow];
+    const d = deriveMetrics(broken, 7);
+    expect(d.shipped).toBe(0);
+    expect(d.escalations).toBe(0);
+    expect(d.avgCycleTimeH).toBeNull();
+  });
+});
+
+describe('formatCycleTime', () => {
+  it('zeigt Stunden unter einem Tag', () => {
+    expect(formatCycleTime(3.25)).toBe('3.3 h');
+  });
+
+  it('rechnet ab 24 h in Tage um', () => {
+    expect(formatCycleTime(36)).toBe('1.5 d');
+  });
+
+  it('zeigt für fehlende Werte den Platzhalter', () => {
+    expect(formatCycleTime(null)).toBe('—');
+    expect(formatCycleTime(NaN)).toBe('—');
+  });
+});

--- a/website/src/lib/sdlc/factory-metrics-derive.ts
+++ b/website/src/lib/sdlc/factory-metrics-derive.ts
@@ -1,0 +1,63 @@
+// [T003459] Ableitung der Insights-Kennzahlen aus den Tageszeilen der View
+// `tickets.v_factory_metrics`. Bewusst frei von DOM und fetch, damit die
+// Rechenregeln einzeln pruefbar sind — die Komponenten reichen nur durch.
+import type { FactoryMetricRow } from '../stores/factory-floor-store';
+
+export interface DerivedMetrics {
+  /** Summe der ausgelieferten Features im Fenster. */
+  shipped: number;
+  /** Nach Tagesmenge gewichtete Zykluszeit in Stunden, null wenn nichts lief. */
+  avgCycleTimeH: number | null;
+  /** Eskalationen im Fenster. */
+  escalations: number;
+  /** Zahl der Tage, die tatsaechlich Daten beigesteuert haben. */
+  daysCovered: number;
+}
+
+/**
+ * Die Zeilen kommen laut `listFactoryMetrics()` neuester Tag zuerst. Darauf
+ * verlassen wir uns NICHT: bei einer Sortieraenderung in der View waere sonst
+ * still das falsche Fenster ausgewertet, ohne dass ein Test anschlaegt. Deshalb
+ * wird hier explizit nach `day` absteigend sortiert.
+ */
+export function windowRows(rows: FactoryMetricRow[], days: number): FactoryMetricRow[] {
+  return [...rows]
+    .sort((a, b) => (a.day < b.day ? 1 : a.day > b.day ? -1 : 0))
+    .slice(0, Math.max(0, days));
+}
+
+export function deriveMetrics(rows: FactoryMetricRow[], days = 7): DerivedMetrics {
+  const win = windowRows(rows, days);
+
+  const shipped = win.reduce((s, r) => s + (r.features_shipped ?? 0), 0);
+  const escalations = win.reduce((s, r) => s + (r.escalations ?? 0), 0);
+
+  // Gewichtet nach features_shipped, nicht als Mittel der Tagesmittel: ein Tag
+  // mit einem einzigen Ticket wuerde sonst genauso schwer wiegen wie ein Tag
+  // mit zwanzig, und ein einzelner Ausreisser koennte die Woche dominieren.
+  // Tage ohne Auslieferung tragen keine Zykluszeit bei und fallen deshalb aus
+  // Zaehler UND Nenner — sie duerfen den Schnitt nicht gegen null ziehen.
+  let weighted = 0;
+  let weight = 0;
+  for (const r of win) {
+    if (r.avg_cycle_time_h == null) continue;
+    const n = r.features_shipped ?? 0;
+    if (n <= 0) continue;
+    weighted += r.avg_cycle_time_h * n;
+    weight += n;
+  }
+
+  return {
+    shipped,
+    avgCycleTimeH: weight > 0 ? weighted / weight : null,
+    escalations,
+    daysCovered: win.length,
+  };
+}
+
+/** Stunden menschenlesbar: unter 24 h in Stunden, darueber in Tagen. */
+export function formatCycleTime(hours: number | null): string {
+  if (hours == null || !Number.isFinite(hours)) return '—';
+  if (hours < 24) return `${hours.toFixed(1)} h`;
+  return `${(hours / 24).toFixed(1)} d`;
+}

--- a/website/src/lib/stores/factory-floor-store.test.ts
+++ b/website/src/lib/stores/factory-floor-store.test.ts
@@ -28,3 +28,72 @@ describe('factory-floor-store', () => {
     expect(m.floorSubscriberCount()).toBe(0);
   });
 });
+
+// [T003459] getSharedMetrics fetchte '/api/factory-metrics'. Diese Route gibt es
+// nicht — der Endpunkt liegt unter '/sdlc/api/factory-metrics'. Jeder Aufruf lief
+// in einen 404, r.json() warf auf der HTML-Fehlerseite, die Promise rejectete.
+// Weil der Fehler still verschluckt wurde, sahen die Konsumenten nur '—'.
+describe('getSharedMetrics', () => {
+  const OK = { brand: 'mentolder', metrics: [], activeFeatures: [], flags: [] };
+
+  function mockFetch() {
+    const spy = vi.fn(async (url: string) => {
+      if (url === '/sdlc/api/factory-metrics') {
+        return { ok: true, status: 200, json: async () => OK } as unknown as Response;
+      }
+      // Astro liefert für unbekannte Routen eine HTML-Fehlerseite, kein JSON.
+      return {
+        ok: false,
+        status: 404,
+        json: async () => { throw new SyntaxError('Unexpected token < in JSON'); },
+      } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  }
+
+  it('ruft den Endpunkt unter seinem tatsächlichen Pfad auf', async () => {
+    const spy = mockFetch();
+    const m = await import('./factory-floor-store');
+
+    await expect(m.getSharedMetrics(true)).resolves.toMatchObject({ brand: 'mentolder' });
+    expect(spy).toHaveBeenCalledWith('/sdlc/api/factory-metrics', expect.anything());
+  });
+
+  it('meldet einen HTTP-Fehler, statt ihn als leere Payload durchzureichen', async () => {
+    // Positiv-Anker: der Erfolgsfall oben liefert Daten — die Ablehnung hier
+    // ist also eine Aussage über das Fehlerverhalten, nicht über einen
+    // generell kaputten Aufruf.
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'fetch_failed' }),
+    } as unknown as Response)));
+    const m = await import('./factory-floor-store');
+
+    await expect(m.getSharedMetrics(true)).rejects.toThrow(/500/);
+  });
+
+  it('cached den Erfolgsfall und fetcht nicht erneut', async () => {
+    const spy = mockFetch();
+    const m = await import('./factory-floor-store');
+
+    await m.getSharedMetrics(true);
+    await m.getSharedMetrics();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('cached einen Fehler NICHT — der nächste Aufruf versucht es erneut', async () => {
+    let attempt = 0;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) return { ok: false, status: 503, json: async () => ({}) } as unknown as Response;
+      return { ok: true, status: 200, json: async () => OK } as unknown as Response;
+    }));
+    const m = await import('./factory-floor-store');
+
+    await expect(m.getSharedMetrics(true)).rejects.toThrow();
+    // Ein gecachter Fehlschlag hätte die Kachel dauerhaft auf '—' festgenagelt.
+    await expect(m.getSharedMetrics()).resolves.toMatchObject({ brand: 'mentolder' });
+  });
+});

--- a/website/src/lib/stores/factory-floor-store.ts
+++ b/website/src/lib/stores/factory-floor-store.ts
@@ -52,14 +52,45 @@ export function acquireFloor(): () => void {
   };
 }
 
-export interface FactoryMetricsPayload { brand: string; metrics: unknown[]; activeFeatures: unknown[]; flags: unknown[]; }
+/** Eine Tageszeile aus `tickets.v_factory_metrics`, neuester Tag zuerst. */
+export interface FactoryMetricRow {
+  day: string;
+  features_shipped: number;
+  avg_cycle_time_h: number | null;
+  escalations: number;
+  total_features: number;
+}
+
+export interface FactoryMetricsPayload {
+  brand: string;
+  metrics: FactoryMetricRow[];
+  activeFeatures: unknown[];
+  flags: unknown[];
+}
+
+// [T003459] Der Endpunkt liegt unter /sdlc/api/, NICHT unter /api/. Ein
+// website/src/pages/api/factory-metrics.ts hat es nie gegeben; der Aufruf lief
+// seit dem SDLC-Umzug (T002624) in einen 404. Weil die Konsumenten den Fehler
+// still schluckten, sah es nach "keine Daten vorhanden" statt nach "Route
+// falsch" aus — und war die Begruendung, mit der die Analytics-Komponenten in
+// T003417 als "never worked" geloescht wurden.
+const METRICS_ENDPOINT = '/sdlc/api/factory-metrics';
+
 let metricsCache: FactoryMetricsPayload | null = null;
 let metricsInflight: Promise<FactoryMetricsPayload> | null = null;
+
 export async function getSharedMetrics(force = false): Promise<FactoryMetricsPayload> {
   if (!force && metricsCache) return metricsCache;
   if (!metricsInflight) {
-    metricsInflight = fetch('/api/factory-metrics', { credentials: 'same-origin' })
-      .then((r) => r.json() as Promise<FactoryMetricsPayload>)
+    metricsInflight = fetch(METRICS_ENDPOINT, { credentials: 'same-origin' })
+      .then(async (r) => {
+        // Den Status pruefen, BEVOR der Body gelesen wird: eine Fehlerantwort
+        // traegt `{ error: … }` und wuerde als gueltige Payload durchgehen —
+        // die Kachel zeigte dann dauerhaft leere Werte, ohne dass irgendwo ein
+        // Fehler auftaucht. Genau diese Tarnung hat den 404 so lange verdeckt.
+        if (!r.ok) throw new Error(`${METRICS_ENDPOINT} antwortete mit ${r.status}`);
+        return (await r.json()) as FactoryMetricsPayload;
+      })
       .then((p) => { metricsCache = p; return p; })
       .finally(() => { metricsInflight = null; });
   }

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -1,0 +1,206 @@
+// [T003459] Guard gegen tote fetch-Pfade auf SDLC-API-Routen.
+//
+// Prüfmodus: Ergebnis einer Auflösung — jeder aus dem Quellbaum gefetchte
+// /api/…-Pfad wird gegen die tatsächlich vorhandenen Astro-Routendateien
+// aufgelöst. Der Test prüft also, ob der Aufruf ein Ziel HAT, nicht wie er
+// geschrieben ist.
+//
+// Hintergrund: ADR-006 Etappe 1 (T002624) verschob die SDLC-Seiten von
+// /admin/ nach /sdlc/. Die API-Routen zogen mit, `src/middleware/redirect-map.ts`
+// deckt aber ausschließlich Seitenpfade ab — für /api/ gibt es dort weder
+// Einträge noch eine Präfix-Regel. Verschärfend filtert der sdlc-Build die
+// Routen (src/integrations/build-target.mjs behält nur /sdlc/** plus eine
+// Infra-Allowlist), sodass die /api/-Ziele im SDLC-Console-Image gar nicht
+// existieren. Jeder nicht nachgezogene Aufruf lief seither still in einen 404.
+// Bei getSharedMetrics blieb das unbemerkt und wurde am Ende als "never worked"
+// zur Begründung, funktionierende Komponenten zu löschen (T003417).
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = join(ROOT, 'src');
+const PAGES = join(SRC, 'pages');
+
+function walk(dir: string, out: string[] = []): string[] {
+  if (!existsSync(dir)) return out;
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else out.push(p);
+  }
+  return out;
+}
+
+/** Alle Routen, die Astro aus src/pages/ ableitet, als URL-Pfade. */
+function routePaths(): Set<string> {
+  const routes = new Set<string>();
+  for (const file of walk(PAGES)) {
+    if (!/\.(ts|js|astro)$/.test(file)) continue;
+    let rel = relative(PAGES, file).replace(/\\/g, '/');
+    rel = rel.replace(/\.(ts|js|astro)$/, '');
+    rel = rel.replace(/\/index$/, '');
+    routes.add('/' + rel);
+  }
+  return routes;
+}
+
+/**
+ * Statisch analysierbare fetch('/api/…')-Ziele aus dem Quellbaum.
+ *
+ * `partial: true` heisst, dass der Pfad zur Laufzeit weitergebaut wird — per
+ * Template-Platzhalter (`${id}`) oder String-Konkatenation (`'/api/poll/' + id`).
+ * Solche Pfade dürfen NUR als Präfix geprüft werden. Wer sie wie vollständige
+ * Pfade behandelt, meldet `/api/poll` als tot, obwohl `/api/poll/[id]/answer`
+ * existiert — und ein Guard, der Fehlalarme produziert, wird abgeschaltet.
+ */
+function fetchedApiPaths(): Array<{ file: string; path: string; partial: boolean }> {
+  const found: Array<{ file: string; path: string; partial: boolean }> = [];
+  const re = /fetch\(\s*([`'"])(\/api\/[^`'"?\s$]*)([^)]{0,12})/g;
+  for (const file of walk(SRC)) {
+    if (!/\.(ts|svelte|astro)$/.test(file)) continue;
+    if (/\.(test|spec)\.ts$/.test(file)) continue;
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(re)) {
+      const [, quote, literal, tail] = m;
+      const path = literal.replace(/\/$/, '');
+      const partial =
+        tail.startsWith('${') ||
+        literal.endsWith('/') ||
+        new RegExp(`^${quote === '`' ? '`' : quote}\\s*\\+`).test(tail);
+      found.push({ file: relative(ROOT, file), path, partial });
+    }
+  }
+  return found;
+}
+
+/**
+ * Trifft der Pfad eine Route — auch über eine dynamische Route wie [id]?
+ * Bei `partial` genügt es, dass IRGENDEINE Route mit diesem Präfix beginnt:
+ * der Rest des Pfades entsteht erst zur Laufzeit.
+ */
+function resolves(path: string, routes: Set<string>, partial = false): boolean {
+  if (routes.has(path)) return true;
+  const parts = path.split('/').filter(Boolean);
+  for (const route of routes) {
+    const rp = route.split('/').filter(Boolean);
+    const rest = rp.findIndex((s) => s.startsWith('[...'));
+    if (partial) {
+      if (rp.length < parts.length) continue;
+    } else if (rest >= 0 ? parts.length < rest : rp.length !== parts.length) {
+      continue;
+    }
+    const ok = parts.every((seg, i) => {
+      const r = rp[i];
+      if (r === undefined) return false;
+      if (r.startsWith('[...')) return true;
+      if (r.startsWith('[') && r.endsWith(']')) return true;
+      return r === seg;
+    }) && (partial || rp.every((seg, i) => {
+      if (seg.startsWith('[...')) return true;
+      if (seg.startsWith('[') && seg.endsWith(']')) return parts[i] !== undefined;
+      return seg === parts[i];
+    }));
+    if (ok) return true;
+  }
+  return false;
+}
+
+function sdlcCounterpart(path: string): string {
+  return path.replace(/^\/api\/(admin\/)?/, '/sdlc/api/');
+}
+
+// Die Sanierung läuft in Etappen zu je sechs Dateien (ein Ticket pro Etappe).
+// Bis alle durch sind, hält diese Liste die noch nicht sanierten Dateien fest.
+// Sie darf ausschliesslich SCHRUMPFEN — jede Etappe streicht ihre sechs
+// Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
+// eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
+const PENDING_FILES: string[] = [
+  // Etappe 2 — Ticket-Interaktion [T003478]
+  'src/components/TicketQuickCreate.svelte',
+  'src/components/TicketQuickEdit.svelte',
+  'src/components/admin/TicketActionBar.svelte',
+  'src/components/admin/TicketAttachmentsPanel.svelte',
+  'src/components/admin/TicketDetailSections.astro',
+  'src/components/admin/GrillingStepper.svelte',
+  // Etappe 3 — Planung und QA [T003479]
+  'src/components/PlanningOffice.svelte',
+  'src/components/PlanningOfficeTriage.svelte',
+  'src/components/QaModal.svelte',
+  'src/components/admin/DorPanel.svelte',
+  'src/components/DependencyGraph.svelte',
+  'src/pages/admin/fragebogen/[assignmentId].astro',
+  // Etappe 4 — KI-Konfiguration und Prompts [T003480]
+  'src/components/admin/KiKonfiguration.svelte',
+  'src/components/admin/KiCoachingDrawer.svelte',
+  'src/components/sdlc/factory/KiRoutingPanel.svelte',
+  'src/components/admin/PromptLibraryManager.svelte',
+  'src/lib/prompt-insert.ts',
+  'src/components/sdlc/factory/LlmProxyPanel.svelte',
+  // Etappe 5 — Ops-Tabs und Logging [T003481]
+  'src/components/admin/ops/DatenbankTab.svelte',
+  'src/components/admin/ops/DienstTab.svelte',
+  'src/components/admin/ops/DnsZertTab.svelte',
+  'src/components/admin/ops/LogsTab.svelte',
+  'src/components/assistant/LogsSidekickView.svelte',
+  'src/lib/logging/error-report.ts',
+  // Etappe 6 — Platform-Tabs und Architektur [T003482]
+  'src/components/admin/platform/AssetTicketDrawer.svelte',
+  'src/components/admin/platform/BackupStatusCard.svelte',
+  'src/components/admin/platform/HardwareTab.svelte',
+  'src/components/admin/platform/HealthTab.svelte',
+  'src/components/admin/platform/SoftwareTab.svelte',
+  'src/components/admin/ArchitekturGraph.svelte',
+  // Etappe 7 — Factory-Budget und Systemtest [T003483]
+  'src/components/sdlc/factory/FactoryBudgetPage.svelte',
+  'src/components/sdlc/factory/FactoryModelSlots.svelte',
+  'src/components/SystemtestReplayDrawer.svelte',
+  'src/lib/systemtest/recorder.ts',
+  'src/pages/sdlc/systemtest/board.astro',
+  'src/layouts/AdminLayout.astro',
+  // Etappe 8 — Assistant-Views [T003484]
+  'src/components/assistant/LlmProxyView.svelte',
+  'src/components/assistant/SupportView.svelte',
+];
+
+describe('API-Routen sind erreichbar', () => {
+  const routes = routePaths();
+  const fetched = fetchedApiPaths();
+
+  it('findet überhaupt Routen und fetch-Aufrufe', () => {
+    // Positiv-Anker: ohne ihn bestünde der Guard unten vakuos, sobald die
+    // Erkennung kaputtgeht — eine leere Liste verletzt jede Allaussage nicht.
+    expect(routes.size).toBeGreaterThan(50);
+    expect(fetched.length).toBeGreaterThan(20);
+  });
+
+  it('löst bekannte Routen korrekt auf — statisch, dynamisch und als Präfix', () => {
+    // Positiv-Anker für den Auflöser selbst. Ohne diese Fälle könnte ein
+    // kaputter Auflöser, der immer `true` liefert, die Allaussage unten
+    // klaglos bestehen lassen.
+    expect(resolves('/api/health', routes)).toBe(true);
+    expect(resolves('/api/poll/abc/answer', routes)).toBe(true);
+    expect(resolves('/api/poll', routes, true)).toBe(true);
+    expect(resolves('/api/gibt-es-nicht-xyz', routes)).toBe(false);
+  });
+
+  it('jeder gefetchte /api/-Pfad trifft eine existierende Route', () => {
+    const dead = fetched.filter((f) => !resolves(f.path, routes, f.partial));
+    const report = dead
+      .filter((d) => !PENDING_FILES.includes(d.file))
+      .map((d) => {
+        const sdlc = sdlcCounterpart(d.path);
+        return `${d.file}: ${d.path}${resolves(sdlc, routes, d.partial) ? `  → existiert als ${sdlc}` : ''}`;
+      });
+    expect(report).toEqual([]);
+  });
+
+  it('die Übergangsliste enthält nur Dateien, die wirklich noch defekt sind', () => {
+    // Verhindert, dass PENDING_FILES zur toten Ausnahmeliste verkommt.
+    const stillDead = new Set(
+      fetched.filter((f) => !resolves(f.path, routes, f.partial)).map((f) => f.file),
+    );
+    expect(PENDING_FILES.filter((f) => !stillDead.has(f))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Befund

`getSharedMetrics()` fetchte `/api/factory-metrics`. **Diese Route existiert nicht** — der Endpunkt liegt ausschließlich unter `/sdlc/api/factory-metrics`.

Ursache ist der SDLC-Umzug **ADR-006 Etappe 1 (T002624)**: die Seiten zogen von `/admin/` nach `/sdlc/`, die API-Routen zogen mit — aber `src/middleware/redirect-map.ts` deckt ausschließlich **Seitenpfade** ab; für `/api/` gibt es dort weder Einträge noch eine Präfix-Regel. Verschärfend filtert der sdlc-Build die Routen (`src/integrations/build-target.mjs` behält nur `/sdlc/**` plus eine Infra-Allowlist), sodass die `/api/`-Ziele im SDLC-Console-Image gar nicht existieren.

Der Aufruf lief also seit dem Umzug in einen 404. Weil der Fehler still verschluckt wurde, sah es nach „keine Daten vorhanden" aus statt nach „Route falsch" — und wurde in T003417 zur Begründung **„never worked"**, mit der die vier Analytics-Komponenten gelöscht wurden. Nicht das Konzept war defekt, sondern ein Pfad.

## Umfang

Repo-weit sind **88 fetch-Aufrufe in 44 Dateien** betroffen. Jeder hat ein existierendes `/sdlc/api/`-Gegenstück — keine Unbekannten. Die Sanierung läuft in 8 Etappen zu je sechs Dateien:

| Etappe | Ticket | Bereich |
|---|---|---|
| 1/8 | **T003459** (dieser PR) | Metriken + Guard |
| 2/8 | T003478 | Ticket-Interaktion |
| 3/8 | T003479 | Planung und QA |
| 4/8 | T003480 | KI-Konfiguration und Prompts |
| 5/8 | T003481 | Ops-Tabs und Logging |
| 6/8 | T003482 | Platform-Tabs und Architektur |
| 7/8 | T003483 | Factory-Budget und Systemtest |
| 8/8 | T003484 | Assistant-Views |

## Der Guard

`website/tests/api-route-reachability.test.ts` löst jeden gefetchten `/api/`-Pfad gegen die vorhandenen Astro-Routen auf (inklusive dynamischer `[id]`- und Rest-Routen) und nennt das `/sdlc/api/`-Gegenstück gleich mit.

`PENDING_FILES` hält die noch offenen 38 Dateien mit ihrer Ticket-Nummer. Ein vierter Test erzwingt, dass die Liste **nur schrumpfen** kann: wer eine Datei saniert und den Eintrag stehen lässt, macht den Guard rot. Eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.

## Diese Etappe

Sanierte Pfade: `factory-floor-store.ts`, `CommandBar.svelte`, `OverviewDashboard.svelte`, `DeliveryHistory.svelte`, `DevStatusTabs.svelte`, `FactoryObservability.svelte`.

Dazu inhaltlich:

- **`factory-metrics-derive.ts`** leitet die Kennzahlen aus `tickets.v_factory_metrics` ab. Die Zykluszeit wird **nach Tagesmenge gewichtet** — das Mittel der Tagesmittel ließe einen Tag mit einem Ticket so schwer wiegen wie einen mit zwanzig. Tage ohne Auslieferung fallen aus Zähler *und* Nenner, sonst meldete ein ruhiges Wochenende eine Verbesserung.
- **`getSharedMetrics` prüft `r.ok` vor dem Body.** Eine Fehlerantwort trägt `{ error: … }` und wäre sonst als gültige Payload durchgegangen — genau diese Tarnung hat den 404 so lange verdeckt.
- **InsightsTab und Insights-Rail zeigen echte Werte**; ein Abruffehler wird angezeigt statt als `—` getarnt.
- **Der Trace-Recording-Schalter ist sichtbar deaktiviert.** Er schaltete nur eine lokale Variable um und meldete „Recording läuft", ohne irgendetwas aufzuzeichnen — es gibt keinen Endpunkt, der Traces entgegennimmt.
- **Der Analytics-Tab in `dev-status` zeigt wieder Inhalt.** T003417 ersetzte ihn durch einen Verweis aufs Cockpit, obwohl das Delta-Spec jenes Change diese Seite nicht abdeckte.

## Verifikation

| Gate | Ergebnis |
|---|---|
| Guard + derive + store (23 Tests) | grün |
| Cockpit-Komponententests (20) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` (1263 Dateien) | 0 errors |
| `pnpm build` | grün |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh