### PR TITLE
fix(website): SDLC-API-Pfade Etappe 2/8 — Ticket-Interaktion [T003478]

### DIFF
--- a/website/src/components/TicketQuickCreate.svelte
+++ b/website/src/components/TicketQuickCreate.svelte
@@ -81,7 +81,7 @@
     if (!adminCanSubmit) return;
     submitting = true; result = null;
     try {
-      const res = await fetch('/api/admin/tickets', {
+      const res = await fetch('/sdlc/api/tickets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -97,7 +97,7 @@
         // Fetch external_id (T######) — POST returns UUID only
         let externalId = '';
         if (data.id) {
-          const detail = await fetch(`/api/admin/tickets/${data.id}`).then(r => r.json()).catch(() => null);
+          const detail = await fetch(`/sdlc/api/tickets/${data.id}`).then(r => r.json()).catch(() => null);
           externalId = detail?.ticket?.externalId ?? '';
         }
         result = { success: true, message: `Ticket angelegt${externalId ? ` (${externalId})` : ''}.` };
@@ -124,7 +124,7 @@
     try {
       const title = `[${CATEGORY_LABELS[portalCategory]}] ${portalDescription.trim().slice(0, 80)}${portalDescription.length > 80 ? '…' : ''}`;
       const desc = `Kategorie: ${CATEGORY_LABELS[portalCategory]}\nE-Mail: ${portalEmail.trim()}\nURL: ${window.location.href}\n\n${portalDescription.trim()}${portalFiles.length > 0 ? `\n\n(${portalFiles.length} Screenshot(s) beigefügt — konnten nicht hochgeladen werden.)` : ''}`;
-      const res = await fetch('/api/admin/tickets', {
+      const res = await fetch('/sdlc/api/tickets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -138,7 +138,7 @@
       if (res.ok) {
         let externalId = '';
         if (data.id) {
-          const detail = await fetch(`/api/admin/tickets/${data.id}`).then(r => r.json()).catch(() => null);
+          const detail = await fetch(`/sdlc/api/tickets/${data.id}`).then(r => r.json()).catch(() => null);
           externalId = detail?.ticket?.externalId ?? '';
         }
         result = { success: true, message: externalId ? `Meldung als ${externalId} aufgenommen.` : 'Vielen Dank! Meldung übermittelt.' };

--- a/website/src/components/TicketQuickEdit.svelte
+++ b/website/src/components/TicketQuickEdit.svelte
@@ -77,7 +77,7 @@
   async function loadRecent() {
     loadingList = true;
     try {
-      const res = await fetch('/api/admin/tickets?status=open&limit=5');
+      const res = await fetch('/sdlc/api/tickets?status=open&limit=5');
       if (res.ok) {
         const data = await res.json();
         recentTickets = data.items ?? [];
@@ -90,7 +90,7 @@
     clearTimeout(searchTimer);
     if (query.length < 2) { searchResults = []; return; }
     searchTimer = setTimeout(async () => {
-      const res = await fetch(`/api/admin/tickets?q=${encodeURIComponent(query)}&limit=5`);
+      const res = await fetch(`/sdlc/api/tickets?q=${encodeURIComponent(query)}&limit=5`);
       if (res.ok) {
         const data = await res.json();
         searchResults = data.items ?? [];
@@ -99,7 +99,7 @@
   }
 
   async function selectTicket(t: TicketSummary) {
-    const res = await fetch(`/api/admin/tickets/${t.id}`);
+    const res = await fetch(`/sdlc/api/tickets/${t.id}`);
     if (!res.ok) return;
     const data = await res.json();
     const ticket = data.ticket;
@@ -126,7 +126,7 @@
     savingField = 'status'; fieldError = null;
     const prev = selectedTicket.status;
     try {
-      const res = await fetch(`/api/admin/tickets/${selectedTicket.id}/transition`, {
+      const res = await fetch(`/sdlc/api/tickets/${selectedTicket.id}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: editStatus }),
@@ -150,7 +150,7 @@
     if (!selectedTicket) return;
     savingField = field; fieldError = null;
     try {
-      const res = await fetch(`/api/admin/tickets/${selectedTicket.id}`, {
+      const res = await fetch(`/sdlc/api/tickets/${selectedTicket.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ [field]: value || null }),
@@ -172,7 +172,7 @@
     if (!portalComment.trim()) return;
     portalSubmitting = true; portalResult = null;
     try {
-      const res = await fetch('/api/tickets/comment', {
+      const res = await fetch('/sdlc/api/tickets/comment', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/website/src/components/admin/GrillingStepper.svelte
+++ b/website/src/components/admin/GrillingStepper.svelte
@@ -49,7 +49,7 @@
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
   async function patch(body: Record<string, unknown>) {
-    await fetch(`/api/admin/tickets/${ticketId}`, {
+    await fetch(`/sdlc/api/tickets/${ticketId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/website/src/components/admin/GrillingStepper.test.ts
+++ b/website/src/components/admin/GrillingStepper.test.ts
@@ -41,7 +41,7 @@ describe('GrillingStepper', () => {
     await new Promise((r) => setTimeout(r, 1000));
     await waitFor(() => expect(global.fetch).toHaveBeenCalled());
     const [url, opts] = vi.mocked(global.fetch).mock.calls.at(-1)!;
-    expect(url).toBe('/api/admin/tickets/t1');
+    expect(url).toBe('/sdlc/api/tickets/t1');
     expect(opts?.method).toBe('PATCH');
     const body = JSON.parse(opts?.body as string);
     expect(body.grillingAnswers[QN].q1).toBe('Meine Antwort');

--- a/website/src/components/admin/TicketActionBar.svelte
+++ b/website/src/components/admin/TicketActionBar.svelte
@@ -40,7 +40,7 @@
 
   async function searchLink() {
     if (linkQuery.trim().length < 2) { linkResults = []; return; }
-    const r = await fetch(`/api/admin/tickets?q=${encodeURIComponent(linkQuery)}&limit=10`);
+    const r = await fetch(`/sdlc/api/tickets?q=${encodeURIComponent(linkQuery)}&limit=10`);
     if (r.ok) {
       const j = await r.json() as { items: ListedTicket[] };
       linkResults = j.items.filter(it => it.id !== ticketId);
@@ -51,7 +51,7 @@
     busy = true; error = '';
     const needsResolution = nextStatus === 'done' || nextStatus === 'archived';
     if (needsResolution && !resolution) { error = 'Resolution erforderlich für done/archived.'; busy = false; return; }
-    const r = await fetch(`/api/admin/tickets/${ticketId}/transition`, {
+    const r = await fetch(`/sdlc/api/tickets/${ticketId}/transition`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         status: nextStatus,
@@ -66,7 +66,7 @@
 
   async function submitComment() {
     busy = true; error = '';
-    const r = await fetch(`/api/admin/tickets/${ticketId}/comments`, {
+    const r = await fetch(`/sdlc/api/tickets/${ticketId}/comments`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ body: commentBody, visibility: commentVisibility }),
     });
@@ -77,7 +77,7 @@
   async function submitLink() {
     busy = true; error = '';
     if (!linkSelectedId) { error = 'Ziel-Ticket wählen.'; busy = false; return; }
-    const r = await fetch(`/api/admin/tickets/${ticketId}/links`, {
+    const r = await fetch(`/sdlc/api/tickets/${ticketId}/links`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         toId: linkSelectedId, kind: linkKind,

--- a/website/src/components/admin/TicketAttachmentsPanel.svelte
+++ b/website/src/components/admin/TicketAttachmentsPanel.svelte
@@ -28,7 +28,7 @@
     uploadError = '';
     const form = e.target as HTMLFormElement;
     const fd = new FormData(form);
-    const r = await fetch(`/api/admin/tickets/${ticketId}/attachments`, {
+    const r = await fetch(`/sdlc/api/tickets/${ticketId}/attachments`, {
       method: 'POST',
       body: fd,
     });
@@ -63,7 +63,7 @@
         <li class="flex items-center gap-3">
           {#if a.hasDataUrl}
             <a
-              href={`/api/admin/tickets/${ticketId}/attachments/${a.id}`}
+              href={`/sdlc/api/tickets/${ticketId}/attachments/${a.id}`}
               download={a.filename}
               class="text-gold hover:underline flex-1 truncate"
             >{a.filename}</a>

--- a/website/src/components/admin/TicketAttachmentsPanel.test.ts
+++ b/website/src/components/admin/TicketAttachmentsPanel.test.ts
@@ -26,7 +26,7 @@ describe('TicketAttachmentsPanel', () => {
       props: { ticketId: 't1', attachments: [baseAttachment] },
     });
     const link = screen.getByRole('link', { name: 'test.pdf' }) as HTMLAnchorElement;
-    expect(link.href).toContain('/api/admin/tickets/t1/attachments/att-1');
+    expect(link.href).toContain('/sdlc/api/tickets/t1/attachments/att-1');
     expect(link.getAttribute('download')).toBe('test.pdf');
   });
 

--- a/website/src/components/admin/TicketDetailSections.astro
+++ b/website/src/components/admin/TicketDetailSections.astro
@@ -63,7 +63,7 @@ const { ticket, timeline } = Astro.props;
     btn.addEventListener('click', async () => {
       if (!confirm('Verknüpfung entfernen?')) return;
       const linkId = btn.getAttribute('data-link-id');
-      const r = await fetch(`/api/admin/tickets/${ticketId}/links?linkId=${linkId}`, { method: 'DELETE' });
+      const r = await fetch(`/sdlc/api/tickets/${ticketId}/links?linkId=${linkId}`, { method: 'DELETE' });
       if (r.ok) location.reload();
       else alert('Fehler beim Entfernen.');
     });

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -117,13 +117,6 @@ function sdlcCounterpart(path: string): string {
 // Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
 // eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
 const PENDING_FILES: string[] = [
-  // Etappe 2 — Ticket-Interaktion [T003478]
-  'src/components/TicketQuickCreate.svelte',
-  'src/components/TicketQuickEdit.svelte',
-  'src/components/admin/TicketActionBar.svelte',
-  'src/components/admin/TicketAttachmentsPanel.svelte',
-  'src/components/admin/TicketDetailSections.astro',
-  'src/components/admin/GrillingStepper.svelte',
   // Etappe 3 — Planung und QA [T003479]
   'src/components/PlanningOffice.svelte',
   'src/components/PlanningOfficeTriage.svelte',


### PR DESCRIPTION
Etappe 2 von 8 der SDLC-API-Pfad-Sanierung. Ursache, Umfang und Etappenplan: **T003459** / PR #4151.

## Was hier passiert

Sechs Dateien der Ticket-Oberfläche fetchten `/api/admin/tickets` bzw. `/api/tickets/comment`. Diese Routen existieren nicht — sie liegen unter `/sdlc/api/tickets`. Seit dem SDLC-Umzug (T002624) lief jeder dieser Aufrufe in einen 404.

| Datei | Pfade |
|---|---|
| `TicketQuickCreate.svelte` | 1 |
| `TicketQuickEdit.svelte` | 2 |
| `TicketActionBar.svelte` | 1 |
| `TicketAttachmentsPanel.svelte` | 1 |
| `TicketDetailSections.astro` | 1 |
| `GrillingStepper.svelte` | 1 |

Die Assertions in `GrillingStepper.test.ts` und `TicketAttachmentsPanel.test.ts` sind mitgezogen — sie prüfen den aufgerufenen Pfad.

Die sechs Einträge fallen aus `PENDING_FILES`. Der Guard erzwingt, dass dort nur noch wirklich defekte Dateien stehen: ein stehengelassener Eintrag macht ihn rot.

## Verifikation

| Gate | Ergebnis |
|---|---|
| `api-route-reachability` Guard | grün |
| Betroffene Komponententests (19) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh