### PR TITLE
fix(website): SDLC-API-Pfade Etappe 3/8 — Planung und QA [T003479]

### DIFF
--- a/website/src/components/DependencyGraph.svelte
+++ b/website/src/components/DependencyGraph.svelte
@@ -43,7 +43,7 @@
 
   async function fetchGraph() {
     try {
-      const r = await fetch('/api/tickets/graph');
+      const r = await fetch('/sdlc/api/tickets/graph');
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       graphData = await r.json();
       error = null;

--- a/website/src/components/PlanningOffice.svelte
+++ b/website/src/components/PlanningOffice.svelte
@@ -61,7 +61,7 @@
   async function load() {
     loading = true;
     try {
-      const r = await fetch('/api/admin/planungsbuero');
+      const r = await fetch('/sdlc/api/planungsbuero');
       if (r.ok) {
         const data = await r.json();
         items = data.items;
@@ -77,7 +77,7 @@
   }
 
   async function patch(extId: string, body: Record<string, unknown>) {
-    await fetch(`/api/admin/planungsbuero/${extId}`, {
+    await fetch(`/sdlc/api/planungsbuero/${extId}`, {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
@@ -97,7 +97,7 @@
   // Toggle the Lastenheft lock. Locking needs >=1 requirement (server-enforced) and
   // forwards the ticket into the autopilot lane → it leaves the Planungsbüro.
   async function toggleLock(it: PlanItem) {
-    const r = await fetch(`/api/admin/planungsbuero/${it.extId}`, {
+    const r = await fetch(`/sdlc/api/planungsbuero/${it.extId}`, {
       method: 'PATCH',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ lastenheftLocked: !it.lastenheftLocked }),
@@ -115,7 +115,7 @@
   }
 
   async function promote(it: PlanItem) {
-    const r = await fetch(`/api/planning-office/${it.extId}/promote`, {
+    const r = await fetch(`/sdlc/api/planning-office/${it.extId}/promote`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ override }),
@@ -138,7 +138,7 @@
 
   async function addIdea() {
     if (!newTitle.trim()) return;
-    const r = await fetch('/api/planning-office', {
+    const r = await fetch('/sdlc/api/planning-office', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ title: newTitle.trim(), brand: _brand, effort: newEffort }),

--- a/website/src/components/PlanningOfficeTriage.svelte
+++ b/website/src/components/PlanningOfficeTriage.svelte
@@ -12,7 +12,7 @@
   async function triageAction(action: 'apply' | 'discard') {
     busy = true;
     try {
-      await fetch(`/api/admin/planungsbuero/${extId}`, {
+      await fetch(`/sdlc/api/planungsbuero/${extId}`, {
         method: 'PATCH',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ triageAction: action }),

--- a/website/src/components/QaModal.svelte
+++ b/website/src/components/QaModal.svelte
@@ -40,7 +40,7 @@
     submitting = true;
     error = '';
     try {
-      const res = await fetch('/api/admin/qa-reviews', {
+      const res = await fetch('/sdlc/api/qa-reviews', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/website/src/components/admin/DorPanel.svelte
+++ b/website/src/components/admin/DorPanel.svelte
@@ -18,7 +18,7 @@
     saving = true;
     toast = null;
     try {
-      const response = await fetch('/api/admin/openspec/save-proposal', {
+      const response = await fetch('/sdlc/api/openspec/save-proposal', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/website/src/components/admin/DorPanel.test.ts
+++ b/website/src/components/admin/DorPanel.test.ts
@@ -51,7 +51,7 @@ describe('DorPanel', () => {
     const saveBtn = screen.getByRole('button', { name: 'Speichern' });
     await fireEvent.click(saveBtn);
 
-    expect(fetchSpy).toHaveBeenCalledWith('/api/admin/openspec/save-proposal', {
+    expect(fetchSpy).toHaveBeenCalledWith('/sdlc/api/openspec/save-proposal', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/website/src/pages/admin/fragebogen/[assignmentId].astro
+++ b/website/src/pages/admin/fragebogen/[assignmentId].astro
@@ -556,7 +556,7 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
     submitBtn.disabled = true;
     bugModalError.classList.add('hidden');
     try {
-      const r = await fetch('/api/admin/tickets', {
+      const r = await fetch('/sdlc/api/tickets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ type: 'bug', title: desc.trim().slice(0, 80), description: desc }),
@@ -566,7 +566,7 @@ const maxScore = Math.max(...scores.map(s => s.threshold_high ?? s.final_score ?
         // Fetch external_id (T-number) from the detail endpoint
         let ticketId = '';
         try {
-          const detail = await fetch(`/api/admin/tickets/${data.id}`).then(r => r.json()).catch(() => null);
+          const detail = await fetch(`/sdlc/api/tickets/${data.id}`).then(r => r.json()).catch(() => null);
           ticketId = detail?.ticket?.externalId ?? '';
         } catch { /* best-effort */ }
         const resultEl = document.getElementById(`bug-result-${activeBugStepId}`);

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -117,13 +117,6 @@ function sdlcCounterpart(path: string): string {
 // Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
 // eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
 const PENDING_FILES: string[] = [
-  // Etappe 3 — Planung und QA [T003479]
-  'src/components/PlanningOffice.svelte',
-  'src/components/PlanningOfficeTriage.svelte',
-  'src/components/QaModal.svelte',
-  'src/components/admin/DorPanel.svelte',
-  'src/components/DependencyGraph.svelte',
-  'src/pages/admin/fragebogen/[assignmentId].astro',
   // Etappe 4 — KI-Konfiguration und Prompts [T003480]
   'src/components/admin/KiKonfiguration.svelte',
   'src/components/admin/KiCoachingDrawer.svelte',


### PR DESCRIPTION
Etappe 3 von 8. Ursache, Umfang und Etappenplan: **T003459** / PR #4151.

Sechs Dateien aus Planungsbüro, QA und Abhängigkeitsgraph riefen Routen auf, die es unter `/api/` nicht gibt:

| Datei | Pfade |
|---|---|
| `PlanningOffice.svelte` | 2 |
| `PlanningOfficeTriage.svelte` | 1 |
| `QaModal.svelte` | 1 |
| `admin/DorPanel.svelte` | 1 |
| `DependencyGraph.svelte` | 1 |
| `pages/admin/fragebogen/[assignmentId].astro` | 1 |

Die Assertion in `DorPanel.test.ts` ist mitgezogen. Die sechs Einträge fallen aus `PENDING_FILES`.

## Verifikation

| Gate | Ergebnis |
|---|---|
| Guard + DorPanel-Tests (8) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh