### PR TITLE
fix(website): SDLC-API-Pfade Etappe 4/8 — KI-Konfiguration und Prompts [T003480]

### DIFF
--- a/website/src/components/admin/KiCoachingDrawer.svelte
+++ b/website/src/components/admin/KiCoachingDrawer.svelte
@@ -32,7 +32,7 @@
   let newCatalogId = $state('');
   let newDisplayName = $state('');
 
-  async function load() { loadError = ''; try { const [cRes, pRes] = await Promise.all([fetch('/api/admin/ki/catalog'), fetch('/api/admin/coaching/ki-config')]); if (!cRes.ok || !pRes.ok) throw new Error('Laden fehlgeschlagen'); catalog = (await cRes.json()).catalog; providers = (await pRes.json()).providers; loaded = true; } catch (err) { loadError = err instanceof Error ? err.message : 'Unbekannter Fehler'; } }
+  async function load() { loadError = ''; try { const [cRes, pRes] = await Promise.all([fetch('/sdlc/api/ki/catalog'), fetch('/api/admin/coaching/ki-config')]); if (!cRes.ok || !pRes.ok) throw new Error('Laden fehlgeschlagen'); catalog = (await cRes.json()).catalog; providers = (await pRes.json()).providers; loaded = true; } catch (err) { loadError = err instanceof Error ? err.message : 'Unbekannter Fehler'; } }
 
   $effect(() => { load(); });
 

--- a/website/src/components/admin/KiKonfiguration.svelte
+++ b/website/src/components/admin/KiKonfiguration.svelte
@@ -103,10 +103,10 @@
     loadError = '';
     try {
       const [pRes, eRes, mRes, cRes] = await Promise.all([
-        fetch('/api/admin/ki/providers'),
-        fetch('/api/admin/ki/env-status'),
-        fetch('/api/admin/ki/embeddings'),
-        fetch('/api/admin/ki/catalog'),
+        fetch('/sdlc/api/ki/providers'),
+        fetch('/sdlc/api/ki/env-status'),
+        fetch('/sdlc/api/ki/embeddings'),
+        fetch('/sdlc/api/ki/catalog'),
       ]);
       if (!pRes.ok || !eRes.ok || !mRes.ok || !cRes.ok) throw new Error('Laden fehlgeschlagen');
       const p = await pRes.json();
@@ -144,7 +144,7 @@
     if (editId !== -1 && !form.api_key.trim()) { delete payload.api_key; }
     else { payload.api_key = form.api_key.trim() || null; }
     const isNew = editId === -1;
-    const res = await fetch(isNew ? '/api/admin/ki/providers' : `/api/admin/ki/providers/${editId}`, {
+    const res = await fetch(isNew ? '/sdlc/api/ki/providers' : `/sdlc/api/ki/providers/${editId}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -161,7 +161,7 @@
   async function changePriority(e: ProviderEntry, delta: number) {
     const next = e.priority + delta;
     if (next < 0) return;
-    const res = await fetch(`/api/admin/ki/providers/${e.id}`, {
+    const res = await fetch(`/sdlc/api/ki/providers/${e.id}`, {
       method: 'PUT', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ priority: next }),
     });
@@ -174,7 +174,7 @@
   }
 
   async function doDelete(id: number) {
-    const res = await fetch(`/api/admin/ki/providers/${id}`, { method: 'DELETE' });
+    const res = await fetch(`/sdlc/api/ki/providers/${id}`, { method: 'DELETE' });
     confirmingDelete = null;
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
@@ -185,7 +185,7 @@
   }
 
   async function saveEmbed(primary: string, fallback: string | null) {
-    const res = await fetch('/api/admin/ki/embeddings', {
+    const res = await fetch('/sdlc/api/ki/embeddings', {
       method: 'PUT', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ primary, fallback }),
     });

--- a/website/src/components/admin/PromptLibraryManager.svelte
+++ b/website/src/components/admin/PromptLibraryManager.svelte
@@ -50,8 +50,8 @@
       isActive: fActive,
     };
     const url = editingId === null
-      ? '/api/admin/prompt-library'
-      : `/api/admin/prompt-library/${editingId}`;
+      ? '/sdlc/api/prompt-library'
+      : `/sdlc/api/prompt-library/${editingId}`;
     const method = editingId === null ? 'POST' : 'PUT';
     try {
       const res = await fetch(url, {
@@ -79,7 +79,7 @@
 
   async function toggleActive(p: Prompt) {
     try {
-      const res = await fetch(`/api/admin/prompt-library/${p.id}`, {
+      const res = await fetch(`/sdlc/api/prompt-library/${p.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -100,7 +100,7 @@
   async function remove(p: Prompt) {
     if (!confirm(`Vorlage „${p.title}“ löschen?`)) return;
     try {
-      const res = await fetch(`/api/admin/prompt-library/${p.id}`, { method: 'DELETE' });
+      const res = await fetch(`/sdlc/api/prompt-library/${p.id}`, { method: 'DELETE' });
       if (res.ok) {
         prompts = prompts.filter(x => x.id !== p.id);
         if (editingId === p.id) resetForm();

--- a/website/src/components/sdlc/factory/KiRoutingPanel.svelte
+++ b/website/src/components/sdlc/factory/KiRoutingPanel.svelte
@@ -37,8 +37,8 @@
   async function loadProvidersAndCatalog() {
     try {
       const [provRes, catRes] = await Promise.all([
-        fetch('/api/admin/ki/providers', { credentials: 'same-origin' }),
-        fetch('/api/admin/ki/catalog', { credentials: 'same-origin' }),
+        fetch('/sdlc/api/ki/providers', { credentials: 'same-origin' }),
+        fetch('/sdlc/api/ki/catalog', { credentials: 'same-origin' }),
       ]);
       if (provRes.ok) {
         const { entries: e, health: h } = await provRes.json();
@@ -122,7 +122,7 @@
     if (editId !== -1 && !form.api_key.trim()) { delete payload.api_key; }
     else { payload.api_key = form.api_key.trim() || null; }
     const isNew = editId === -1;
-    const res = await fetch(isNew ? '/api/admin/ki/providers' : `/api/admin/ki/providers/${editId}`, {
+    const res = await fetch(isNew ? '/sdlc/api/ki/providers' : `/sdlc/api/ki/providers/${editId}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -139,7 +139,7 @@
   async function changePriority(e: ProviderEntry, delta: number) {
     const next = e.priority + delta;
     if (next < 0) return;
-    const res = await fetch(`/api/admin/ki/providers/${e.id}`, {
+    const res = await fetch(`/sdlc/api/ki/providers/${e.id}`, {
       method: 'PUT', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ priority: next }),
     });
@@ -152,7 +152,7 @@
   }
 
   async function doDelete(id: number) {
-    const res = await fetch(`/api/admin/ki/providers/${id}`, { method: 'DELETE' });
+    const res = await fetch(`/sdlc/api/ki/providers/${id}`, { method: 'DELETE' });
     confirmingDelete = null;
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));

--- a/website/src/components/sdlc/factory/LlmProxyPanel.svelte
+++ b/website/src/components/sdlc/factory/LlmProxyPanel.svelte
@@ -37,8 +37,8 @@
     try {
       loading = true;
       const [stRes, slotRes] = await Promise.all([
-        fetch('/api/admin/llm-proxy/status', { credentials: 'same-origin' }),
-        fetch('/api/factory-model-slots', { credentials: 'same-origin' }),
+        fetch('/sdlc/api/llm-proxy/status', { credentials: 'same-origin' }),
+        fetch('/sdlc/api/factory-model-slots', { credentials: 'same-origin' }),
       ]);
       if (!stRes.ok) throw new Error(`HTTP ${stRes.status}`);
       state = (await stRes.json()) as ProxyState;
@@ -54,7 +54,7 @@
   async function probe() {
     try {
       probing = true;
-      await fetch('/api/admin/llm-proxy/reload', { method: 'POST', credentials: 'same-origin' });
+      await fetch('/sdlc/api/llm-proxy/reload', { method: 'POST', credentials: 'same-origin' });
       await load();
     } finally {
       probing = false;
@@ -62,7 +62,7 @@
   }
 
   async function patchBackend(id: number, patch: Record<string, unknown>) {
-    const res = await fetch(`/api/admin/llm-proxy/backends/${id}`, {
+    const res = await fetch(`/sdlc/api/llm-proxy/backends/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(patch),
@@ -75,7 +75,7 @@
   function bump(b: BackendState, delta: number) { patchBackend(b.id, { priority: Math.max(0, b.priority + delta) }); }
 
   async function saveForm() {
-    const url = editId ? `/api/admin/llm-proxy/backends/${editId}` : '/api/admin/llm-proxy/backends';
+    const url = editId ? `/sdlc/api/llm-proxy/backends/${editId}` : '/sdlc/api/llm-proxy/backends';
     const res = await fetch(url, {
       method: editId ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/website/src/lib/prompt-insert.test.ts
+++ b/website/src/lib/prompt-insert.test.ts
@@ -44,7 +44,7 @@ describe('loadActivePrompts', () => {
       json: async () => ({ prompts }),
     });
     const result = await loadActivePrompts();
-    expect(fetchMock).toHaveBeenCalledWith('/api/admin/prompt-library');
+    expect(fetchMock).toHaveBeenCalledWith('/sdlc/api/prompt-library');
     expect(result).toEqual(prompts);
   });
 
@@ -72,7 +72,7 @@ describe('recordPromptUse', () => {
   it('POSTs to the per-id use endpoint', async () => {
     fetchMock.mockResolvedValue({ ok: true });
     await recordPromptUse(7);
-    expect(fetchMock).toHaveBeenCalledWith('/api/admin/prompt-library/7/use', { method: 'POST' });
+    expect(fetchMock).toHaveBeenCalledWith('/sdlc/api/prompt-library/7/use', { method: 'POST' });
   });
 
   it('swallows network errors (usage tracking is best-effort)', async () => {

--- a/website/src/lib/prompt-insert.ts
+++ b/website/src/lib/prompt-insert.ts
@@ -29,7 +29,7 @@ export function insertPromptBody(draft: string, body: string): string {
  */
 export async function loadActivePrompts(): Promise<PromptOption[]> {
   try {
-    const res = await fetch('/api/admin/prompt-library');
+    const res = await fetch('/sdlc/api/prompt-library');
     if (!res.ok) return [];
     const data = (await res.json()) as { prompts?: PromptOption[] };
     return data.prompts ?? [];
@@ -44,7 +44,7 @@ export async function loadActivePrompts(): Promise<PromptOption[]> {
  */
 export async function recordPromptUse(id: number): Promise<void> {
   try {
-    await fetch(`/api/admin/prompt-library/${id}/use`, { method: 'POST' });
+    await fetch(`/sdlc/api/prompt-library/${id}/use`, { method: 'POST' });
   } catch {
     /* best-effort: ignore */
   }

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -117,13 +117,6 @@ function sdlcCounterpart(path: string): string {
 // Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
 // eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
 const PENDING_FILES: string[] = [
-  // Etappe 4 — KI-Konfiguration und Prompts [T003480]
-  'src/components/admin/KiKonfiguration.svelte',
-  'src/components/admin/KiCoachingDrawer.svelte',
-  'src/components/sdlc/factory/KiRoutingPanel.svelte',
-  'src/components/admin/PromptLibraryManager.svelte',
-  'src/lib/prompt-insert.ts',
-  'src/components/sdlc/factory/LlmProxyPanel.svelte',
   // Etappe 5 — Ops-Tabs und Logging [T003481]
   'src/components/admin/ops/DatenbankTab.svelte',
   'src/components/admin/ops/DienstTab.svelte',


### PR DESCRIPTION
Etappe 4 von 8. Ursache, Umfang und Etappenplan: **T003459** / PR #4151.

Die bislang dichteste Etappe — dreizehn Aufrufe in sechs Dateien:

| Datei | Pfade |
|---|---|
| `admin/KiKonfiguration.svelte` | 4 |
| `sdlc/factory/LlmProxyPanel.svelte` | 4 |
| `sdlc/factory/KiRoutingPanel.svelte` | 2 |
| `admin/KiCoachingDrawer.svelte` | 1 |
| `admin/PromptLibraryManager.svelte` | 1 |
| `lib/prompt-insert.ts` | 1 |

Betroffen waren `/api/admin/ki/*` (providers, catalog, env-status, embeddings), `/api/admin/llm-proxy/*` (status, reload, backends) sowie `/api/admin/prompt-library` und `/api/factory-model-slots`. Alle liegen unter `/sdlc/api/`.

Die Assertions in `prompt-insert.test.ts` sind mitgezogen. Die sechs Einträge fallen aus `PENDING_FILES`.

## Verifikation

| Gate | Ergebnis |
|---|---|
| Guard + prompt-insert-Tests (13) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh