### PR TITLE
fix(website): SDLC-API-Pfade Etappe 5/8 — Ops-Tabs und Logging [T003481]

### DIFF
--- a/website/src/components/admin/ops/DatenbankTab.svelte
+++ b/website/src/components/admin/ops/DatenbankTab.svelte
@@ -22,7 +22,7 @@
   async function loadJobs() {
     jobsLoading = true;
     try {
-      const res = await fetch(`/api/admin/ops/backup/list?cluster=${cluster}`);
+      const res = await fetch(`/sdlc/api/ops/backup/list?cluster=${cluster}`);
       const j = await res.json();
       if (res.ok) jobs = j.jobs;
       else triggerError = j.error ?? `Fehler ${res.status}`;
@@ -33,7 +33,7 @@
   async function triggerBackup() {
     triggerLoading = true; triggerMsg = null; triggerError = null;
     try {
-      const res = await fetch('/api/admin/ops/backup/trigger', {
+      const res = await fetch('/sdlc/api/ops/backup/trigger', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ cluster }),
       });
@@ -49,7 +49,7 @@
     if (!restoreJob) return;
     restoreLoading = true; restoreError = null;
     try {
-      const res = await fetch('/api/admin/ops/restore', {
+      const res = await fetch('/sdlc/api/ops/restore', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ cluster, db: restoreDb, backupJobName: restoreJob.name }),
       });

--- a/website/src/components/admin/ops/DienstTab.svelte
+++ b/website/src/components/admin/ops/DienstTab.svelte
@@ -19,7 +19,7 @@
   async function load() {
     try {
       loading = deployments.length === 0;
-      const res = await fetch('/api/admin/ops/deployments/list');
+      const res = await fetch('/sdlc/api/ops/deployments/list');
       if (res.ok) { const j = await res.json(); deployments = j.deployments; error = null; }
       else { const j = await res.json().catch(() => ({})); error = j.error ?? `Fehler ${res.status}`; }
     } catch (e) { error = (e as Error).message; }
@@ -32,7 +32,7 @@
     const { type, deployment: d } = pending;
     try {
       const body = type === 'scale' ? JSON.stringify({ replicas: scaleTarget }) : '{}';
-      const res = await fetch(`/api/admin/ops/deployments/${d.ns}/${d.name}/${type}`, {
+      const res = await fetch(`/sdlc/api/ops/deployments/${d.ns}/${d.name}/${type}`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' }, body,
       });
       const j = await res.json();

--- a/website/src/components/admin/ops/DnsZertTab.svelte
+++ b/website/src/components/admin/ops/DnsZertTab.svelte
@@ -13,7 +13,7 @@
   async function loadCerts() {
     certsLoading = true; certsError = null;
     try {
-      const res = await fetch('/api/admin/ops/certs');
+      const res = await fetch('/sdlc/api/ops/certs');
       if (res.ok) { certsData = await res.json(); }
       else { const j = await res.json().catch(() => ({})); certsError = j.error ?? `Fehler ${res.status}`; }
     } catch (e) { certsError = (e as Error).message; }

--- a/website/src/components/admin/ops/LogsTab.svelte
+++ b/website/src/components/admin/ops/LogsTab.svelte
@@ -31,7 +31,7 @@
   async function loadPods() {
     podsError = null;
     try {
-      const res = await fetch(`/api/admin/cluster/pods-list?ns=${encodeURIComponent(ns)}`);
+      const res = await fetch(`/sdlc/api/cluster/pods-list?ns=${encodeURIComponent(ns)}`);
       const j = await res.json();
       if (!res.ok) { podsError = j.error ?? `Fehler ${res.status}`; return; }
       pods = j.pods;

--- a/website/src/components/assistant/LogsSidekickView.svelte
+++ b/website/src/components/assistant/LogsSidekickView.svelte
@@ -61,7 +61,7 @@
   async function loadPods() {
     podError = null;
     try {
-      const res = await fetch(`/api/admin/cluster/pods-list?ns=${encodeURIComponent(ns)}`, { credentials: 'same-origin' });
+      const res = await fetch(`/sdlc/api/cluster/pods-list?ns=${encodeURIComponent(ns)}`, { credentials: 'same-origin' });
       const j = await res.json();
       if (!res.ok) { podError = j.error ?? `Fehler ${res.status}`; return; }
       pods = j.pods ?? [];

--- a/website/src/lib/logging/error-report.test.ts
+++ b/website/src/lib/logging/error-report.test.ts
@@ -17,7 +17,7 @@ describe('error-report', () => {
     
     await postError(report);
 
-    expect(mockFetch).toHaveBeenCalledWith('/api/admin/ops/error-log', expect.objectContaining({
+    expect(mockFetch).toHaveBeenCalledWith('/sdlc/api/ops/error-log', expect.objectContaining({
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'same-origin',

--- a/website/src/lib/logging/error-report.ts
+++ b/website/src/lib/logging/error-report.ts
@@ -14,7 +14,7 @@ export interface ErrorReport {
  */
 export async function postError(report: ErrorReport): Promise<void> {
   try {
-    const response = await fetch('/api/admin/ops/error-log', {
+    const response = await fetch('/sdlc/api/ops/error-log', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'same-origin',
@@ -33,7 +33,7 @@ export async function postError(report: ErrorReport): Promise<void> {
  */
 export async function fetchErrorHistory(sinceHours = 24): Promise<LogEntry[]> {
   try {
-    const response = await fetch(`/api/admin/ops/error-log?since=${sinceHours}h`, {
+    const response = await fetch(`/sdlc/api/ops/error-log?since=${sinceHours}h`, {
       credentials: 'same-origin',
     });
     if (!response.ok) {

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -117,13 +117,6 @@ function sdlcCounterpart(path: string): string {
 // Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
 // eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
 const PENDING_FILES: string[] = [
-  // Etappe 5 — Ops-Tabs und Logging [T003481]
-  'src/components/admin/ops/DatenbankTab.svelte',
-  'src/components/admin/ops/DienstTab.svelte',
-  'src/components/admin/ops/DnsZertTab.svelte',
-  'src/components/admin/ops/LogsTab.svelte',
-  'src/components/assistant/LogsSidekickView.svelte',
-  'src/lib/logging/error-report.ts',
   // Etappe 6 — Platform-Tabs und Architektur [T003482]
   'src/components/admin/platform/AssetTicketDrawer.svelte',
   'src/components/admin/platform/BackupStatusCard.svelte',


### PR DESCRIPTION
Etappe 5 von 8. Ursache, Umfang und Etappenplan: **T003459** / PR #4151.

| Datei | Pfade |
|---|---|
| `admin/ops/DatenbankTab.svelte` | 3 |
| `admin/ops/DienstTab.svelte` | 2 |
| `admin/ops/DnsZertTab.svelte` | 1 |
| `admin/ops/LogsTab.svelte` | 1 |
| `assistant/LogsSidekickView.svelte` | 1 |
| `lib/logging/error-report.ts` | 1 |

Betroffen waren `/api/admin/ops/*` (deployments, error-log, logs), `/api/admin/cluster/*` und `/api/admin/backup-status`.

**Bemerkenswert:** `error-report.ts` meldet Client-Fehler an `/sdlc/api/ops/error-log` — der **Meldeweg für Fehler war selbst tot**. Ein Ausfall im Browser erreichte das Log nie, was gut erklärt, warum die übrigen 404 so lange unbemerkt blieben.

Die Assertions in `error-report.test.ts` sind mitgezogen. Die sechs Einträge fallen aus `PENDING_FILES`.

## Verifikation

| Gate | Ergebnis |
|---|---|
| Guard + error-report-Tests (7) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh