### PR TITLE
fix(website): SDLC-API-Pfade Etappe 7/8 — Factory-Budget und Systemtest [T003483]

### DIFF
--- a/website/src/components/SystemtestReplayDrawer.svelte
+++ b/website/src/components/SystemtestReplayDrawer.svelte
@@ -37,7 +37,7 @@
 
     try {
       // 1. fetch NDJSON
-      const r = await fetch(`/api/admin/evidence/${evidenceId}/replay`, {
+      const r = await fetch(`/sdlc/api/evidence/${evidenceId}/replay`, {
         credentials: 'same-origin',
       });
       if (!r.ok) {

--- a/website/src/components/sdlc/factory/FactoryBudgetPage.svelte
+++ b/website/src/components/sdlc/factory/FactoryBudgetPage.svelte
@@ -55,7 +55,7 @@
   async function loadData() {
     try {
       loading = true; error = '';
-      const [sRes, rRes] = await Promise.all([fetch('/api/factory-budget'), fetch('/api/factory-budget?recent=true')]);
+      const [sRes, rRes] = await Promise.all([fetch('/sdlc/api/factory-budget'), fetch('/sdlc/api/factory-budget?recent=true')]);
       if (!sRes.ok || !rRes.ok) throw new Error('Fehler beim Laden');
       summary = await sRes.json();
       recentRuns = await rRes.json();
@@ -73,7 +73,7 @@
       saving = true; saveSuccess = false; saveError = '';
       const parsed = parseFloat(limitInput);
       if (isNaN(parsed) || parsed < 0) throw new Error('Ungültiges Limit');
-      const res = await fetch('/api/factory-budget', {
+      const res = await fetch('/sdlc/api/factory-budget', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ limit: parsed })
@@ -93,7 +93,7 @@
     if (!ticketSearchId.trim()) return;
     try {
       searchingTicket = true; ticketSearchError = ''; ticketRows = [];
-      const res = await fetch(`/api/factory-budget?ticketId=${encodeURIComponent(ticketSearchId.trim())}`);
+      const res = await fetch(`/sdlc/api/factory-budget?ticketId=${encodeURIComponent(ticketSearchId.trim())}`);
       if (!res.ok) throw new Error('Ticket nicht gefunden');
       ticketRows = await res.json();
       if (ticketRows.length === 0) ticketSearchError = 'Keine Budgetdaten gefunden.';

--- a/website/src/components/sdlc/factory/FactoryModelSlots.svelte
+++ b/website/src/components/sdlc/factory/FactoryModelSlots.svelte
@@ -24,7 +24,7 @@
   async function loadData() {
     try {
       loading = true;
-      const res = await fetch('/api/factory-model-slots');
+      const res = await fetch('/sdlc/api/factory-model-slots');
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       slots = data.slots;
@@ -49,7 +49,7 @@
     }
 
     try {
-      const res = await fetch('/api/factory-model-slots', {
+      const res = await fetch('/sdlc/api/factory-model-slots', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ phase, provider, modelId, baseUrl }),

--- a/website/src/layouts/AdminLayout.astro
+++ b/website/src/layouts/AdminLayout.astro
@@ -219,7 +219,7 @@ const brandWord = config.meta.siteTitle.replace(/\.de$/i, '').toLowerCase();
           const refresh = function() {
       const ctrl = new AbortController();
       const t = setTimeout(function() { ctrl.abort(); }, 3000);
-      fetch('/api/cluster/status', { signal: ctrl.signal })
+      fetch('/sdlc/api/cluster/status', { signal: ctrl.signal })
         .then(function(r) { return r.ok ? r.json() : null; })
         .then(function(s) {
           clearTimeout(t);

--- a/website/src/lib/sdlc/systemtest/failure-bridge.test.ts
+++ b/website/src/lib/sdlc/systemtest/failure-bridge.test.ts
@@ -187,7 +187,7 @@ describe.skipIf(!dbAvailable)('openFailureTicket', () => {
     expect(t.rows[0].parent_id).toBeTruthy();
     expect(t.rows[0].description).toContain('Login lands on /portal');
     expect(t.rows[0].description).toContain('Login button stays disabled.');
-    expect(t.rows[0].description).toContain(`/api/admin/evidence/${evidenceId}/replay`);
+    expect(t.rows[0].description).toContain(`/sdlc/api/evidence/${evidenceId}/replay`);
     expect(t.rows[0].description).toContain(`/admin/fragebogen/${f.assignmentId}`);
 
     // The auto-created parent epic is type='project', component='systemtest'

--- a/website/src/lib/systemtest/recorder.test.ts
+++ b/website/src/lib/systemtest/recorder.test.ts
@@ -68,7 +68,7 @@ describe('startRecorder', () => {
     expect(result).toEqual({ evidenceId: 'ev-1', partial: false });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe('/api/admin/evidence/upload');
+    expect(url).toBe('/sdlc/api/evidence/upload');
     expect(init?.method).toBe('POST');
     const body = lastBody(fetchMock);
     expect(body).toMatchObject({
@@ -260,7 +260,7 @@ describe('startRecorder', () => {
     const pageFetch = vi.fn(async (input: RequestInfo | URL) => {
       n++;
       // Every call after boot is a "page" fetch except the final upload call.
-      if (String(input) === '/api/admin/evidence/upload') return uploadFetch();
+      if (String(input) === '/sdlc/api/evidence/upload') return uploadFetch();
       return new Response('ok', { status: 200 });
     });
     vi.stubGlobal('fetch', pageFetch);
@@ -288,7 +288,7 @@ describe('startRecorder', () => {
     let calls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       calls++;
-      if (String(input) === '/api/admin/evidence/upload') {
+      if (String(input) === '/sdlc/api/evidence/upload') {
         return new Response(JSON.stringify({}), { status: 200 });
       }
       throw new Error('offline');
@@ -339,7 +339,7 @@ describe('startRecorder', () => {
 
     expect(sendBeaconMock).toHaveBeenCalledTimes(1);
     const [url, blob] = sendBeaconMock.mock.calls[0];
-    expect(url).toBe('/api/admin/evidence/upload');
+    expect(url).toBe('/sdlc/api/evidence/upload');
     expect(blob).toBeInstanceOf(Blob);
 
     // A second pagehide with an empty buffer is a no-op.

--- a/website/src/lib/systemtest/recorder.ts
+++ b/website/src/lib/systemtest/recorder.ts
@@ -119,7 +119,7 @@ export function startRecorder(opts: RecorderOpts): RecorderHandle {
     const delays = [5_000, 15_000, 45_000];
     for (let attemptN = 0; ; attemptN++) {
       try {
-        const res = await fetch('/api/admin/evidence/upload', {
+        const res = await fetch('/sdlc/api/evidence/upload', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body,
@@ -162,7 +162,7 @@ export function startRecorder(opts: RecorderOpts): RecorderHandle {
       ],
       { type: 'application/json' },
     );
-    navigator.sendBeacon('/api/admin/evidence/upload', blob);
+    navigator.sendBeacon('/sdlc/api/evidence/upload', blob);
   };
   window.addEventListener('pagehide', handlePageHide);
   window.addEventListener('beforeunload', handlePageHide);

--- a/website/src/pages/sdlc/systemtest/board.astro
+++ b/website/src/pages/sdlc/systemtest/board.astro
@@ -291,7 +291,7 @@ const COLUMNS: Array<{ key: string; title: string; hint: string }> = [
 
   async function poll(): Promise<void> {
     try {
-      const r = await fetch('/api/admin/systemtest/board', { credentials: 'same-origin' });
+      const r = await fetch('/sdlc/api/systemtest/board', { credentials: 'same-origin' });
       if (!r.ok) {
         const msg = `Board konnte nicht geladen werden (HTTP ${r.status}).`;
         banner.textContent = msg;

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -117,13 +117,6 @@ function sdlcCounterpart(path: string): string {
 // Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
 // eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
 const PENDING_FILES: string[] = [
-  // Etappe 7 — Factory-Budget und Systemtest [T003483]
-  'src/components/sdlc/factory/FactoryBudgetPage.svelte',
-  'src/components/sdlc/factory/FactoryModelSlots.svelte',
-  'src/components/SystemtestReplayDrawer.svelte',
-  'src/lib/systemtest/recorder.ts',
-  'src/pages/sdlc/systemtest/board.astro',
-  'src/layouts/AdminLayout.astro',
   // Etappe 8 — Assistant-Views [T003484]
   'src/components/assistant/LlmProxyView.svelte',
   'src/components/assistant/SupportView.svelte',


### PR DESCRIPTION
Etappe 7 von 8. Ursache, Umfang und Etappenplan: **T003459** / PR #4151.

| Datei | Pfad |
|---|---|
| `layouts/AdminLayout.astro` | `/api/cluster/status` |
| `sdlc/factory/FactoryBudgetPage.svelte` | `/api/factory-budget` |
| `sdlc/factory/FactoryModelSlots.svelte` | `/api/factory-model-slots` |
| `SystemtestReplayDrawer.svelte` | `/api/admin/evidence` |
| `lib/systemtest/recorder.ts` | `/api/admin/evidence/upload` |
| `pages/sdlc/systemtest/board.astro` | `/api/admin/systemtest/board` |

**`AdminLayout.astro` hat die größte Reichweite der ganzen Sanierung:** der Cluster-Status-Indikator sitzt im Layout und war damit auf *jeder* Admin- und SDLC-Seite tot.

Die Assertions in `recorder.test.ts` und `failure-bridge.test.ts` sind mitgezogen. Nach dieser Etappe verbleiben 2 Dateien in `PENDING_FILES` (Etappe 8, T003484).

## Verifikation

| Gate | Ergebnis |
|---|---|
| Guard + Systemtest-Tests (23 grün, 6 übersprungen) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` | 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh