### PR TITLE
fix(website): SDLC-API-Pfade Etappe 8/8 — Assistant-Views [T003484]

### DIFF
--- a/website/src/components/assistant/LlmProxyView.svelte
+++ b/website/src/components/assistant/LlmProxyView.svelte
@@ -11,7 +11,7 @@
   async function load() {
     try {
       loading = true;
-      const res = await fetch('/api/admin/llm-proxy/status', { credentials: 'same-origin' });
+      const res = await fetch('/sdlc/api/llm-proxy/status', { credentials: 'same-origin' });
       state = res.ok ? ((await res.json()) as ProxyState) : null;
     } finally {
       loading = false;
@@ -19,13 +19,13 @@
   }
 
   async function reload() {
-    try { busy = true; await fetch('/api/admin/llm-proxy/reload', { method: 'POST', credentials: 'same-origin' }); await load(); }
+    try { busy = true; await fetch('/sdlc/api/llm-proxy/reload', { method: 'POST', credentials: 'same-origin' }); await load(); }
     finally { busy = false; }
   }
 
   async function toggle(b: BackendState) {
     busy = true;
-    await fetch(`/api/admin/llm-proxy/backends/${b.id}`, {
+    await fetch(`/sdlc/api/llm-proxy/backends/${b.id}`, {
       method: 'PUT', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ enabled: !b.enabled }),
     });

--- a/website/src/components/assistant/SupportView.svelte
+++ b/website/src/components/assistant/SupportView.svelte
@@ -83,7 +83,7 @@
     try {
       const title = `[${CATEGORY_LABELS[category]}] ${description.trim().slice(0, 80)}${description.length > 80 ? '…' : ''}`;
       const desc = `Kategorie: ${CATEGORY_LABELS[category]}\nE-Mail: ${email.trim()}\nURL: ${window.location.href}\n\n${description.trim()}${files.length > 0 ? `\n\n(${files.length} Screenshot(s) beigefügt — konnten nicht hochgeladen werden.)` : ''}`;
-      const res = await fetch('/api/admin/tickets', {
+      const res = await fetch('/sdlc/api/tickets', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -97,7 +97,7 @@
       if (res.ok) {
         let externalId = '';
         if (data.id) {
-          const detail = await fetch(`/api/admin/tickets/${data.id}`).then(r => r.json()).catch(() => null);
+          const detail = await fetch(`/sdlc/api/tickets/${data.id}`).then(r => r.json()).catch(() => null);
           externalId = detail?.ticket?.externalId ?? '';
         }
         const successMsg = externalId

--- a/website/tests/api-route-reachability.test.ts
+++ b/website/tests/api-route-reachability.test.ts
@@ -111,17 +111,12 @@ function sdlcCounterpart(path: string): string {
   return path.replace(/^\/api\/(admin\/)?/, '/sdlc/api/');
 }
 
-// Die Sanierung läuft in Etappen zu je sechs Dateien (ein Ticket pro Etappe).
-// Bis alle durch sind, hält diese Liste die noch nicht sanierten Dateien fest.
-// Sie darf ausschliesslich SCHRUMPFEN — jede Etappe streicht ihre sechs
-// Einträge. Steht hier eine Datei, die längst sauber ist, schlägt der Test an:
-// eine Ausnahmeliste, die niemand aufräumt, verdeckt sonst neue Fehler.
-const PENDING_FILES: string[] = [
-  // Etappe 8 — Assistant-Views [T003484]
-  'src/components/assistant/LlmProxyView.svelte',
-  'src/components/assistant/SupportView.svelte',
-];
-
+// [T003484] Die etappenweise Sanierung ist abgeschlossen; die Uebergangsliste
+// PENDING_FILES ist entfallen. Sie hielt waehrend der acht Etappen die noch
+// nicht sanierten Dateien und wurde von einem eigenen Test bewacht, der
+// erzwang, dass sie nur schrumpft. Mit leerer Liste waere dieser Test vakuos
+// gewesen — er haette nichts mehr behauptet. Wird wieder etappenweise
+// migriert, gehoert beides zurueck: Liste UND Schrumpf-Guard.
 describe('API-Routen sind erreichbar', () => {
   const routes = routePaths();
   const fetched = fetchedApiPaths();
@@ -145,20 +140,11 @@ describe('API-Routen sind erreichbar', () => {
 
   it('jeder gefetchte /api/-Pfad trifft eine existierende Route', () => {
     const dead = fetched.filter((f) => !resolves(f.path, routes, f.partial));
-    const report = dead
-      .filter((d) => !PENDING_FILES.includes(d.file))
-      .map((d) => {
-        const sdlc = sdlcCounterpart(d.path);
-        return `${d.file}: ${d.path}${resolves(sdlc, routes, d.partial) ? `  → existiert als ${sdlc}` : ''}`;
-      });
+    const report = dead.map((d) => {
+      const sdlc = sdlcCounterpart(d.path);
+      return `${d.file}: ${d.path}${resolves(sdlc, routes, d.partial) ? `  → existiert als ${sdlc}` : ''}`;
+    });
     expect(report).toEqual([]);
   });
 
-  it('die Übergangsliste enthält nur Dateien, die wirklich noch defekt sind', () => {
-    // Verhindert, dass PENDING_FILES zur toten Ausnahmeliste verkommt.
-    const stillDead = new Set(
-      fetched.filter((f) => !resolves(f.path, routes, f.partial)).map((f) => f.file),
-    );
-    expect(PENDING_FILES.filter((f) => !stillDead.has(f))).toEqual([]);
-  });
 });


### PR DESCRIPTION
**Schlussetappe.** Ursache, Umfang und Etappenplan: **T003459** / PR #4151.

| Datei | Pfade |
|---|---|
| `assistant/LlmProxyView.svelte` | 3 |
| `assistant/SupportView.svelte` | 1 |

Damit sind **alle 88 toten fetch-Aufrufe in 44 Dateien** saniert.

## Rückbau der Übergangsmechanik

`PENDING_FILES` entfällt mitsamt seinem Schrumpf-Guard. Die Liste hielt während der acht Etappen die noch offenen Dateien und wurde von einem eigenen Test bewacht, der erzwang, dass sie nur kleiner wird.

Mit leerer Liste hätte dieser Test nichts mehr behauptet und wäre vakuos bestanden — genau der Fall, den die Positiv-Anker-Konvention (T002356-M1) ausschließt. Ein Kommentar an seiner Stelle beschreibt den Mechanismus für den Fall, dass wieder etappenweise migriert wird.

## Was bleibt

Der Guard `website/tests/api-route-reachability.test.ts` steht ab jetzt **fail-closed**: jeder neue `fetch` auf einen `/api/`-Pfad ohne Route fällt in CI auf — mitsamt Hinweis auf das `/sdlc/api/`-Gegenstück. Er löst statische, dynamische (`[id]`) und Rest-Routen (`[...slug]`) auf und behandelt zur Laufzeit zusammengebaute Pfade als Präfix, damit er keine Fehlalarme produziert.

## Verifikation

| Gate | Ergebnis |
|---|---|
| `api-route-reachability` Guard (3) | grün |
| ESLint `--max-warnings 0` | grün |
| `astro check` | 0 errors |
| `pnpm build` | grün |

## Gesamtbilanz der Sanierung

| Etappe | Ticket | PR |
|---|---|---|
| 1/8 Metriken + Guard | T003459 | #4151 |
| 2/8 Ticket-Interaktion | T003478 | #4154 |
| 3/8 Planung und QA | T003479 | #4156 |
| 4/8 KI-Konfiguration und Prompts | T003480 | #4158 |
| 5/8 Ops-Tabs und Logging | T003481 | #4160 |
| 6/8 Platform-Tabs und Architektur | T003482 | #4161 |
| 7/8 Factory-Budget und Systemtest | T003483 | #4163 |
| 8/8 Assistant-Views | T003484 | dieser PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh