### PR TITLE
fix(factory): rollup-publish Divergenz-Rebuild nutzt mixed reset statt --soft [T003240]

### DIFF
--- a/scripts/factory/rollup-publish.sh
+++ b/scripts/factory/rollup-publish.sh
@@ -98,11 +98,13 @@ if ! $GIT push -q -u origin "$BRANCH" ${amend_expected:+--force-with-lease="$BRA
   # dauerhaft blockieren. Ein `git rebase origin/${BRANCH}` scheitert hier aber mit
   # add/add-Konflikt: der eigene amendierte Commit hat die Basis als Parent, und der
   # Remote-Stand enthaelt tasks.md bereits. Stattdessen legen wir den Branch-Pointer
-  # auf den aktuellen Remote-Tip (reset --soft) und committen unseren Plan neu darauf.
-  # Index+Worktree behalten den generierten Stand; fremde Commits bleiben in der
-  # Historie erhalten.
+  # auf den aktuellen Remote-Tip (MIXED reset — der Index folgt dem origin-Baum,
+  # der Worktree behaelt den generierten Stand) und committen unseren Plan neu darauf.
+  # Wichtig: reset OHNE --soft — ein --soft liesse den alten Index stehen und der
+  # neue Commit wuerde fremde Remote-Dateien (z.B. parallel.txt) als Deletion
+  # mitnehmen. Fremde Commits bleiben in der Historie erhalten.
   $GIT fetch -q origin "$BRANCH"
-  if ! $GIT reset -q --soft "origin/${BRANCH}"; then
+  if ! $GIT reset -q "origin/${BRANCH}"; then
     echo "rollup-publish: FEHLER — reset auf origin/${BRANCH} fehlgeschlagen." >&2
     echo "  Der Plan ist lokal committet, aber nicht auf origin: ${CHANGE_DIR}" >&2
     exit 1

--- a/tests/spec/mishap-rollup/rollup-branch-progress.bats
+++ b/tests/spec/mishap-rollup/rollup-branch-progress.bats
@@ -172,4 +172,11 @@ remote_count() {
   [ "$status" -eq 0 ] || { echo "Publish bleibt bei divergiertem Remote haengen"; false; }
   [ "$(remote_tip)" != "$diverged" ] || {
     echo "Remote-Tip unveraendert — der divergierte Stand hat den Push dauerhaft blockiert"; false; }
+  # Der parallele Commit (fremde Datei parallel.txt) muss den Rebuild ueberleben.
+  # Ohne die Trennung von Index (mixed reset) und Worktree wuerde der neue Commit
+  # die fremde Datei als Deletion mitnehmen — der Generator haette Fremdarbeit
+  # stillschweigend zerstoert.
+  git -C "$TR" fetch -q origin "$BR"
+  run git -C "$TR" show "FETCH_HEAD:parallel.txt"
+  [ "$status" -eq 0 ] || { echo "Fremde Datei parallel.txt wurde vom Divergenz-Rebuild verworfen"; false; }
 }


### PR DESCRIPTION
Aus dem repo-hygiene-Lauf: fertige, getestete Implementierung, nie eingereicht.

**Befund:** Beim Divergenz-Rebuild in `scripts/factory/rollup-publish.sh` behielt `git reset --soft` den Index des divergierten Remote-Stands. Fremde Dateien auf dem Branch (beobachtet an `parallel.txt`) landeten dadurch als **Deletion** im neu gebauten Commit — der Rebuild löschte Arbeit, die er nie angefasst hatte.

`--mixed` setzt den Index mit zurück, sodass nur die tatsächlich neu geschriebenen Dateien in den Commit gehen.

**Tests:** 8/8 grün in `tests/spec/mishap-rollup/`, darunter der bestehende Schutz "ein fremder Commit auf dem Branch wird nicht überschrieben" (T002931) — genau die Zusicherung, die der `--soft`-Reset unterlief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QeKoff5VbEUHH9NW6GJzKh