### PR TITLE
fix(factory): auto-triage-Pfad heilen — baseUrl-Konvention und Typ-Vokabular [T003492]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 923,
+      "file_count": 925,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -695,6 +695,7 @@
         "tests/spec/sidekick-assistant.bats",
         "tests/spec/software-factory/_sf_common.bash",
         "tests/spec/software-factory/agent-lock-scope-argument.bats",
+        "tests/spec/software-factory/auto-triage-type-vocab.bats",
         "tests/spec/software-factory/babysit-prs-live-lock-guard-T003137.bats",
         "tests/spec/software-factory/brand-is-row-filter-not-namespace.bats",
         "tests/spec/software-factory/canary-and-cleanup.bats",
@@ -710,6 +711,7 @@
         "tests/spec/software-factory/partial-deploy-gang.bats",
         "tests/spec/software-factory/pipeline-and-ticket-cli.bats",
         "tests/spec/software-factory/pr-babysit.bats",
+        "tests/spec/software-factory/provider-config-baseurl-convention.bats",
         "tests/spec/software-factory/queue-test-data-filter.bats",
         "tests/spec/software-factory/retry-and-build-loop.bats",
         "tests/spec/software-factory/scheduling.bats",
@@ -936,7 +938,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 60,
+      "file_count": 61,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -997,7 +999,8 @@
         "scripts/migrations/2026-08-09-enable-gemma-backend-proxy-T002640.sql",
         "scripts/migrations/2026-08-10-brain-ingest-port.sql",
         "scripts/migrations/2026-08-10-disable-gptoss-devstral.sql",
-        "scripts/migrations/2026-08-10-disable-qwen.sql"
+        "scripts/migrations/2026-08-10-disable-qwen.sql",
+        "scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql"
       ]
     },
     {

--- a/scripts/factory/auto-triage.sh
+++ b/scripts/factory/auto-triage.sh
@@ -19,7 +19,12 @@ HERE="$(dirname "${BASH_SOURCE[0]}")"
 source "$HERE/lib.sh"
 source "$HERE/triage-body.sh"
 
-DRY_RUN=false
+# [T003492] Umgebung respektieren statt unbedingt zu ueberschreiben. Vorher stand
+# hier `DRY_RUN=false`, weshalb `DRY_RUN=true bash auto-triage.sh` real schrieb und
+# am Ende trotzdem "DRY_RUN=false" meldete. Der Factory-Pfad ist davon nicht
+# betroffen: wakeup.sh haelt zwar eine eigene DRY_RUN-Variable (Default true),
+# exportiert sie aber nicht und ruft dieses Skript nur mit BRAND= auf.
+DRY_RUN="${DRY_RUN:-false}"
 TRIAGE_BATCH="${TRIAGE_BATCH:-5}"
 ENUMS_FILE="$HERE/triage-enums.json"
 
@@ -46,6 +51,18 @@ fi
 
 factory_resolve
 
+# ── normalize_triage_type: deprecated Alias → Conventional Commit ────────
+#
+# [T003492] Ein Provider ohne json_schema-Unterstuetzung (Cloud-Fallback) kann
+# weiterhin bug/feature/task liefern. Die werden angenommen und hier auf das
+# aktuelle Vokabular abgebildet, statt das Ticket zu verwerfen — ticket-mcp
+# fuehrt die alten Werte als deprecated, nicht als ungueltig.
+normalize_triage_type() {
+  local t="$1"
+  jq -rn --slurpfile e "$ENUMS_FILE" --arg t "$t" \
+    '($e[0].type_aliases // {})[$t] // $t'
+}
+
 # ── validate_triage: fail-closed validation of KI response ───────────────
 validate_triage() {
   local json="$1"
@@ -58,8 +75,17 @@ validate_triage() {
   fi
 
   # type must be valid
+  #
+  # [T003492] Die erlaubten Werte kommen aus triage-enums.json, nicht mehr aus
+  # einem hier eingebauten Regex. Der lautete `^(bug|feature|task|project)$` und
+  # widersprach dem JSON-Schema weiter unten, das beim Sampling Conventional-
+  # Commit-Vokabular erzwingt. Die Schnittmenge war genau `project`, weshalb die
+  # Triage jedes Nicht-Epic verwarf — sichtbar als "invalid type 'fix'" fuer
+  # jedes Ticket. Ein zweiter Ort fuer dieselbe Liste ist die Ursache, nicht der
+  # falsche Inhalt des Regex; deshalb gibt es jetzt nur noch die Enum-Datei.
   local t; t=$(echo "$json" | jq -r '.type // ""')
-  if [[ ! "$t" =~ ^(bug|feature|task|project)$ ]]; then
+  if ! echo "$enums" | jq -e --arg t "$t" \
+       '((.types // []) + ((.type_aliases // {}) | keys)) | index($t)' >/dev/null; then
     echo "auto-triage: validate_triage: invalid type '${t}'" >&2
     return 1
   fi
@@ -180,7 +206,7 @@ Du bist ein Ticket-Triage-Assistent. Klassifiziere das folgende Ticket und antwo
 
 Das JSON MUSS dieses Schema haben:
 {
-  "type": "<bug|feature|task|project>",
+  "type": "<fix|feat|chore|project|docs|refactor|perf|test|ci|build>",
   "priority": "<hoch|mittel|niedrig>",
   "severity": "<critical|major|minor|trivial>",
   "areas": ["<area1>", "<area2>"],
@@ -307,7 +333,7 @@ PROMPT
       additionalProperties: false,
       required: ["type","priority","severity","areas","component","assignee_suggested","rationale"],
       properties: {
-        type: { type: "string", enum: ["fix","feat","chore","project","docs","refactor","perf","test","ci","build"] },
+        type: { type: "string", enum: $enums.types },
         priority: { type: "string", enum: ["hoch","mittel","niedrig"] },
         severity: { type: "string", enum: ["critical","major","minor","trivial"] },
         areas: { type: "array", items: { type: "string", enum: $enums.areas }, minItems: 1, maxItems: 3 },
@@ -347,6 +373,18 @@ PROMPT
   echo "$content"
   return 0
 }
+
+# [T003492] Testbarkeits-Ausstieg: mit AUTO_TRIAGE_LIB_ONLY=1 endet das Skript
+# hier, nachdem alle Funktionen definiert sind, aber bevor die Datenbank
+# angefasst wird. Damit laesst sich validate_triage in BATS direkt aufrufen und
+# an Exit-Code und stderr messen, statt den Quelltext zu greppen
+# (Test-Resultats-Konvention T002448-M4). Alles oberhalb ist offline: lib.sh und
+# triage-body.sh definieren nur Funktionen, factory_resolve setzt bloss
+# Variablen. Kein `exit` verwenden — beim source wuerde das die aufrufende Shell
+# beenden.
+if [[ -n "${AUTO_TRIAGE_LIB_ONLY:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
 
 # ── Pull untriaged tickets ─────────────────────────────────────────────
 UNTRIAGED_JSON=$(cat <<SQL | factory_psql 2>/dev/null || echo ""
@@ -398,9 +436,16 @@ for ticket in "${TICKETS[@]}"; do
   echo "[auto-triage:${BRAND}] triagiere ${ext_id}…" >&2
 
   # Call LLM
+  #
+  # [T003492] KEIN `2>/dev/null` mehr. call_llm schreibt die eigentliche Diagnose
+  # auf stderr ("no content in llamacpp response", "curl to … failed", "route-provider
+  # returned empty baseUrl"); das Verwerfen liess wochenlang nur die nichtssagende
+  # Sammelmeldung unten im Journal stehen. Der auslösende Defekt — eine baseUrl mit
+  # doppeltem /v1, die in einen HTTP 404 lief — war dadurch von aussen nicht von
+  # einem Modellfehler zu unterscheiden.
   suggestion=""
-  if ! suggestion=$(call_llm "$title" "$description" "$ENUMS_STR" 2>/dev/null); then
-    echo "[auto-triage:${BRAND}] KI-Aufruf für ${ext_id} fehlgeschlagen — überspringe" >&2
+  if ! suggestion=$(call_llm "$title" "$description" "$ENUMS_STR"); then
+    echo "[auto-triage:${BRAND}] KI-Aufruf für ${ext_id} fehlgeschlagen — überspringe (Grund siehe stderr-Zeile darüber)" >&2
     ((SKIPPED++)) || true
     continue
   fi
@@ -413,12 +458,18 @@ for ticket in "${TICKETS[@]}"; do
   fi
 
   # Add metadata to suggestion
+  #
+  # [T003492] Der type wird vor dem Schreiben auf das aktuelle Vokabular
+  # normalisiert, damit ein Provider ohne json_schema-Unterstuetzung keine
+  # deprecated Werte in die Tabelle traegt.
   model_used="${LAST_MODEL_USED:-unknown}"
   timestamp=$(date -u +%FT%TZ)
+  normalized_type=$(normalize_triage_type "$(echo "$suggestion" | jq -r '.type')")
   final_json=$(echo "$suggestion" | jq \
     --arg model "$model_used" \
     --arg at "$timestamp" \
-    '{triage: (. + {model: $model, at: $at})}')
+    --arg type "$normalized_type" \
+    '{triage: (. + {type: $type, model: $model, at: $at})}')
 
   # Idempotent write: only if triaged_at is still NULL
   updated=$(cat <<SQL | factory_psql -v ext_id="$ext_id" -v meta="$final_json" 2>/dev/null || echo "0"

--- a/scripts/factory/provider-register-gptoss.sh
+++ b/scripts/factory/provider-register-gptoss.sh
@@ -28,7 +28,9 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 MODEL_ID="gpt-oss-20b"
-BASE_URL="http://127.0.0.1:8097/v1"
+# [T003492] OHNE '/v1' — siehe provider-register-local.sh: die Konsumenten von
+# provider_config.base_url haengen '/v1/chat/completions' selbst an.
+BASE_URL="http://127.0.0.1:8097"
 PRIORITY=1
 
 # --- Health-Gate --------------------------------------------------------------

--- a/scripts/factory/provider-register-local.sh
+++ b/scripts/factory/provider-register-local.sh
@@ -27,7 +27,12 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODEL_ID="${FACTORY_MODEL_ID:-gemma26-factory}"
 # Immer das vereinheitlichte Gateway, nie ein Backend-Port. Welches Backend
 # dahinter haengt, entscheidet die Registry tickets.llm_proxy_backends.
-GATEWAY_URL="${FACTORY_GATEWAY_URL:-http://127.0.0.1:18235/v1}"
+# [T003492] OHNE '/v1' — die Konsumenten haengen '/v1/chat/completions' selbst an
+# (openspec/specs/software-factory.md: base_url adressiert die Wurzel, "that the
+# callers append /v1/chat/completions to"). Mit '/v1' entstand '.../v1/v1/chat/
+# completions' → HTTP 404, und weil curl ohne --fail laeuft, meldete auto-triage
+# das als "no content in <provider> response" statt als Transportfehler.
+GATEWAY_URL="${FACTORY_GATEWAY_URL:-http://127.0.0.1:18235}"
 
 for b in mentolder korczewski; do
   BRAND="$b" MODEL_ID="$MODEL_ID" GATEWAY_URL="$GATEWAY_URL" \

--- a/scripts/factory/triage-enums.json
+++ b/scripts/factory/triage-enums.json
@@ -39,5 +39,22 @@
   "assignees": [
     "patrick",
     "factory"
-  ]
+  ],
+  "types": [
+    "fix",
+    "feat",
+    "chore",
+    "project",
+    "docs",
+    "refactor",
+    "perf",
+    "test",
+    "ci",
+    "build"
+  ],
+  "type_aliases": {
+    "bug": "fix",
+    "feature": "feat",
+    "task": "chore"
+  }
 }

--- a/scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql
+++ b/scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql
@@ -1,0 +1,60 @@
+-- 2026-08-10-provider-config-baseurl-drop-v1.sql
+-- T003492 — Entfernt ein abschliessendes '/v1' aus tickets.provider_config.base_url.
+--
+-- WARUM: openspec/specs/software-factory.md (Requirement "Every Factory Tier Has a Fallback
+-- Candidate Behind the Primary", Szenario "Cloud stage carries its key variable name") legt
+-- fest, dass base_url die OpenAI-kompatible Wurzel adressiert, "that the callers append
+-- /v1/chat/completions to". Die base_url gehoert also OHNE '/v1' in die Tabelle.
+--
+-- Beide Konsumenten der Spalte halten sich daran:
+--   scripts/factory/auto-triage.sh        — haengt '/v1/chat/completions' an
+--   scripts/factory/scout-llm-fallback.sh — haengt '/v1/chat/completions' bedingungslos an
+-- Trug die Zeile bereits ein '/v1', entstand daraus '.../v1/v1/chat/completions' → HTTP 404.
+-- Da curl ohne --fail laeuft, galt der 404 als Erfolg; der Fehler tauchte erst eine Ebene
+-- spaeter als "no content in <provider> response" auf und war von einem Modellfehler nicht zu
+-- unterscheiden. Wirkung: auto-triage triagierte ueber Wochen 0 von N Tickets.
+--
+-- MESSUNG (2026-08-10, Commit 33f9ba526, Kontext k3d-mentolder-dev / Namespace workspace):
+--   source scripts/factory/lib.sh; factory_resolve
+--   factory_psql <<'SQL'
+--   SELECT count(*) FROM tickets.provider_config WHERE base_url LIKE '%/v1';
+--   SQL
+--   -- dev: 17 Zeilen (12 lokale llamacpp/lmstudio, 1 Cluster-Gateway, 4 deepseek)
+--   curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18235/v1/v1/chat/completions  -- 404
+--   curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:18235/v1/chat/completions     -- 200
+--
+-- ABGRENZUNG — NICHT auf tickets.llm_proxy_backends anwenden. Diese Tabelle traegt die
+-- umgekehrte Konvention: laut openspec/specs/local-llm-proxy.md sendet der Konsument
+-- `GET {baseUrl}/models`, dort gehoert das '/v1' also in die Spalte. Beide Tabellen im selben
+-- Zug zu "vereinheitlichen" waere genau der Fehler, den diese Migration behebt.
+--
+-- Ebenfalls unberuehrt: base_url-Werte, die auf etwas anderes als '/v1' enden — insbesondere
+-- 'https://api.deepseek.com/anthropic' (haiku-Zeile). Deren Endpunktform ist ein eigener
+-- Vorgang, siehe T003495.
+--
+-- Idempotent: der Anker '$' laesst einen zweiten Lauf wirkungslos. Die Migration ist bewusst
+-- nach Datum die letzte, damit sie beim Replay aller Migrationen auf einem frischen Cluster
+-- nach den aelteren Seeds greift, die '/v1' noch mitschreiben.
+--
+-- Apply to BOTH brands (separate per-brand DBs).
+
+BEGIN;
+
+UPDATE tickets.provider_config
+   SET base_url   = regexp_replace(base_url, '/v1$', ''),
+       updated_at = now()
+ WHERE base_url LIKE '%/v1';
+
+-- Fail-closed: bricht die Transaktion ab, falls die Normalisierung nicht vollstaendig war.
+DO $$
+DECLARE remaining int;
+BEGIN
+  SELECT count(*) INTO remaining
+    FROM tickets.provider_config
+   WHERE base_url LIKE '%/v1';
+  IF remaining > 0 THEN
+    RAISE EXCEPTION 'provider_config: % Zeile(n) enden weiterhin auf /v1', remaining;
+  END IF;
+END $$;
+
+COMMIT;

--- a/tests/spec/software-factory/auto-triage-type-vocab.bats
+++ b/tests/spec/software-factory/auto-triage-type-vocab.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/auto-triage-type-vocab.bats — T003492
+#
+# PRUEFMODUS: Output-Verifikation (Test-Resultats-Konvention T002448-M4).
+# Die Tests rufen `validate_triage` als echte Funktion auf und pruefen Exit-Code
+# und stderr — kein grep auf den Quelltext. Moeglich wird das durch
+# AUTO_TRIAGE_LIB_ONLY=1: damit definiert auto-triage.sh nur seine Funktionen und
+# kehrt vor dem DB-Hauptteil zurueck, laeuft also offline und ohne Cluster.
+#
+# HINTERGRUND: auto-triage.sh trug das Typ-Vokabular an drei Stellen mit drei
+# verschiedenen Wertemengen — JSON-Schema (Conventional Commits), validate_triage
+# (bug|feature|task|project) und die Schema-Zeile des System-Prompts. Die
+# Schnittmenge war genau `project`, weshalb die Triage jedes Nicht-Epic verwarf.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  SCRIPT="${REPO_ROOT}/scripts/factory/auto-triage.sh"
+  ENUMS="${REPO_ROOT}/scripts/factory/triage-enums.json"
+}
+
+# Baut eine vollstaendige, ansonsten gueltige Triage-Antwort mit frei waehlbarem type.
+_triage_json() {
+  local t="$1"
+  jq -nc --arg t "$t" \
+     --arg area "$(jq -r '.areas[0]' "$ENUMS")" \
+     --arg who  "$(jq -r '.assignees[0]' "$ENUMS")" \
+     '{type:$t, priority:"mittel", severity:"minor", areas:[$area],
+       component:null, assignee_suggested:$who, rationale:"Testfall."}'
+}
+
+# Ruft validate_triage in einer Subshell auf und liefert dessen Exit-Code.
+#
+# `set --` vor dem source ist Pflicht: ein gesourctes Skript erbt die
+# Positionsparameter des Aufrufers, sonst laeuft der Skriptpfad in den
+# Argument-Parser von auto-triage.sh und wird als "Unknown option" abgelehnt.
+_validate() {
+  run bash -c '
+    set -euo pipefail
+    SCRIPT="$1"; PAYLOAD="$2"; set --
+    export BRAND=mentolder AUTO_TRIAGE_LIB_ONLY=1
+    source "$SCRIPT"
+    validate_triage "$PAYLOAD"
+  ' _ "$SCRIPT" "$1"
+}
+
+@test "auto-triage: Skript laesst sich ohne Cluster als Funktionsbibliothek laden" {
+  # Positiv-Anker fuer die gesamte Datei: schlaegt das fehl, sind alle weiteren
+  # Aussagen wertlos, weil validate_triage gar nicht erst erreichbar waere.
+  run bash -c '
+    set -euo pipefail
+    SCRIPT="$1"; set --
+    export BRAND=mentolder AUTO_TRIAGE_LIB_ONLY=1
+    source "$SCRIPT"
+    declare -F validate_triage >/dev/null && echo GELADEN
+  ' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *GELADEN* ]]
+}
+
+@test "auto-triage: triage-enums.json fuehrt das Typ-Vokabular als .types" {
+  run jq -e '.types | type == "array" and length > 0' "$ENUMS"
+  [ "$status" -eq 0 ]
+}
+
+@test "auto-triage: validate_triage akzeptiert Conventional-Commit-Typen" {
+  # Der eigentliche Regressionsfall: das JSON-Schema erzwingt genau diese Werte,
+  # der Validator lehnte sie ab.
+  for t in fix feat chore docs refactor perf test ci build project; do
+    _validate "$(_triage_json "$t")"
+    [ "$status" -eq 0 ] || {
+      echo "type '$t' wurde abgelehnt: $output" >&2
+      return 1
+    }
+  done
+}
+
+@test "auto-triage: validate_triage akzeptiert die deprecated Aliase" {
+  # Ein Provider ohne json_schema-Unterstuetzung kann weiterhin bug/feature/task
+  # liefern. Die werden angenommen statt das Ticket zu verwerfen.
+  for t in bug feature task; do
+    _validate "$(_triage_json "$t")"
+    [ "$status" -eq 0 ] || {
+      echo "deprecated type '$t' wurde abgelehnt: $output" >&2
+      return 1
+    }
+  done
+}
+
+@test "auto-triage: validate_triage weist einen unbekannten Typ zurueck" {
+  # Positiv-Anker zuerst (T002356-M1): ohne ihn bestuende der Negativtest auch
+  # dann, wenn validate_triage gar nichts pruefte oder gar nicht existierte.
+  _validate "$(_triage_json "fix")"
+  [ "$status" -eq 0 ]
+
+  _validate "$(_triage_json "bananentyp")"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"invalid type"* ]]
+}
+
+@test "auto-triage: normalize_triage_type bildet Aliase auf Conventional Commits ab" {
+  run bash -c '
+    set -euo pipefail
+    SCRIPT="$1"; set --
+    export BRAND=mentolder AUTO_TRIAGE_LIB_ONLY=1
+    source "$SCRIPT"
+    printf "%s %s %s %s\n" \
+      "$(normalize_triage_type bug)" \
+      "$(normalize_triage_type feature)" \
+      "$(normalize_triage_type task)" \
+      "$(normalize_triage_type fix)"
+  ' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "fix feat chore fix" ]]
+}
+
+@test "auto-triage: DRY_RUN aus der Umgebung wird respektiert" {
+  # Zeile 22 wies DRY_RUN unbedingt auf false zu und ueberschrieb damit die
+  # Umgebung — der Lauf meldete "DRY_RUN=false", obwohl true gesetzt war.
+  run bash -c '
+    set -euo pipefail
+    SCRIPT="$1"; set --
+    export BRAND=mentolder DRY_RUN=true AUTO_TRIAGE_LIB_ONLY=1
+    source "$SCRIPT"
+    echo "DRY_RUN=${DRY_RUN}"
+  ' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY_RUN=true"* ]]
+}
+
+@test "auto-triage: ohne gesetztes DRY_RUN bleibt es false" {
+  # Gegenprobe — der Factory-Pfad (wakeup.sh) exportiert DRY_RUN nicht und darf
+  # sich durch die Aenderung nicht verhalten wie ein Trockenlauf.
+  run bash -c '
+    set -euo pipefail
+    unset DRY_RUN
+    SCRIPT="$1"; set --
+    export BRAND=mentolder AUTO_TRIAGE_LIB_ONLY=1
+    source "$SCRIPT"
+    echo "DRY_RUN=${DRY_RUN}"
+  ' _ "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY_RUN=false"* ]]
+}

--- a/tests/spec/software-factory/partial-deploy-gang.bats
+++ b/tests/spec/software-factory/partial-deploy-gang.bats
@@ -234,7 +234,15 @@ REG="scripts/factory/service-registry.sh"
   [ "$status" -eq 0 ]
   run grep -Fq 'ON CONFLICT' scripts/factory/provider-register-local.sh
   [ "$status" -eq 0 ]
-  run grep -Fq 'http://127.0.0.1:18235/v1' scripts/factory/provider-register-local.sh
+  # [T003492] Anker auf Host:Port verkuerzt — vorher stand hier das vollstaendige
+  # Literal 'http://127.0.0.1:18235/v1'. Die Zusicherung dieses Tests ist laut dem
+  # Kommentar oben "das Gateway, nie ein Backend-Port direkt"; der Pfadanteil war
+  # nur zufaellig Teil des damaligen Werts. Das '/v1' musste weichen, weil die
+  # Konsumenten von provider_config.base_url es selbst anhaengen und daraus sonst
+  # '.../v1/v1/chat/completions' wird (HTTP 404). Ein Anker auf die Darstellung
+  # statt auf die Semantik haette diese Korrektur blockiert — genau der Fall aus
+  # der Konvention "Semantik statt Darstellung" (T002716).
+  run grep -Fq 'http://127.0.0.1:18235' scripts/factory/provider-register-local.sh
   [ "$status" -eq 0 ]
   # Negativ-Aussage mit dem Positiv-Anker oben: der alte Backend-Port darf als
   # aktiver Wert nicht zurueck. Kommentarzeilen sind ausgenommen — der Header des

--- a/tests/spec/software-factory/provider-config-baseurl-convention.bats
+++ b/tests/spec/software-factory/provider-config-baseurl-convention.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/provider-config-baseurl-convention.bats — T003492
+#
+# PRUEFMODUS: gemischt, und zwar bewusst.
+#   - Die URL-Zusammensetzung wird als ECHTES Verhalten geprueft (die Shell baut die
+#     URL, das Ergebnis wird verglichen) — Output-Verifikation nach T002448-M4.
+#   - Die beiden Registrierungsskripte werden per grep geprueft. Das ist der
+#     dokumentierte Ausnahmefall: ihr Ergebnis manifestiert sich nur als
+#     DB-Zeile auf einem Cluster, den CI nicht hat. Geprueft wird deshalb die
+#     Quelle des Defaults, nicht die geschriebene Zeile.
+#
+# KONVENTION (openspec/specs/software-factory.md, Requirement "Every Factory Tier Has a
+# Fallback Candidate Behind the Primary"): tickets.provider_config.base_url adressiert die
+# OpenAI-kompatible Wurzel, "that the callers append /v1/chat/completions to" — also OHNE
+# abschliessendes /v1.
+#
+# ABGRENZUNG: tickets.llm_proxy_backends traegt die UMGEKEHRTE Konvention (Konsument macht
+# `GET {baseUrl}/models`, siehe openspec/specs/local-llm-proxy.md). Diese Datei macht
+# ausdruecklich keine Aussage ueber jene Tabelle.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  LOCAL_REG="${REPO_ROOT}/scripts/factory/provider-register-local.sh"
+  GPTOSS_REG="${REPO_ROOT}/scripts/factory/provider-register-gptoss.sh"
+  MIGRATION="${REPO_ROOT}/scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql"
+}
+
+# Bildet die Append-Logik der Konsumenten nach (auto-triage.sh, scout-llm-fallback.sh).
+_completions_url() {
+  printf '%s/v1/chat/completions\n' "${1%/}"
+}
+
+@test "provider_config: eine konventionsgerechte base_url ergibt genau ein /v1" {
+  # Positiv-Anker: belegt zuerst, dass die Append-Logik ueberhaupt das Erwartete tut.
+  run _completions_url "http://127.0.0.1:18235"
+  [ "$status" -eq 0 ]
+  [ "$output" = "http://127.0.0.1:18235/v1/chat/completions" ]
+}
+
+@test "provider_config: eine base_url mit /v1 wuerde den Pfad verdoppeln" {
+  # Der Defekt in seiner reinen Form — dokumentiert, warum die Konvention noetig ist.
+  run _completions_url "http://127.0.0.1:18235/v1"
+  [ "$status" -eq 0 ]
+  [ "$output" = "http://127.0.0.1:18235/v1/v1/chat/completions" ]
+}
+
+@test "provider-register-local.sh: GATEWAY_URL-Default endet nicht auf /v1" {
+  [ -f "$LOCAL_REG" ]
+  run grep -E '^GATEWAY_URL=' "$LOCAL_REG"
+  [ "$status" -eq 0 ]                      # Positiv-Anker: die Zuweisung existiert
+  [[ "$output" != *'/v1"'* ]]
+  [[ "$output" != *"/v1'"* ]]
+}
+
+@test "provider-register-gptoss.sh: BASE_URL-Default endet nicht auf /v1" {
+  [ -f "$GPTOSS_REG" ]
+  run grep -E '^BASE_URL=' "$GPTOSS_REG"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *'/v1"'* ]]
+  [[ "$output" != *"/v1'"* ]]
+}
+
+@test "Vorwaerts-Migration normalisiert provider_config und laesst llm_proxy_backends in Ruhe" {
+  [ -f "$MIGRATION" ]
+  run grep -c 'tickets.provider_config' "$MIGRATION"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+  # Die andere Tabelle darf nur im erlaeuternden Kommentar vorkommen, nie in einem UPDATE.
+  run grep -E '^[^-]*UPDATE[[:space:]]+tickets\.llm_proxy_backends' "$MIGRATION"
+  [ "$status" -ne 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -4068,6 +4068,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/auto-triage-type-vocab",
+    "file": "tests/spec/software-factory/auto-triage-type-vocab.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/babysit-prs-live-lock-guard-T003137",
     "file": "tests/spec/software-factory/babysit-prs-live-lock-guard-T003137.bats",
     "category": "software-factory",
@@ -4112,6 +4118,12 @@
   {
     "id": "software-factory/pr-babysit",
     "file": "tests/spec/software-factory/pr-babysit.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
+    "id": "software-factory/provider-config-baseurl-convention",
+    "file": "tests/spec/software-factory/provider-config-baseurl-convention.bats",
     "category": "software-factory",
     "kind": "shell"
   },


### PR DESCRIPTION
## Symptom

`auto-triage` triagierte **0 von N** Tickets — auf beiden Brands, ueber Wochen. Im Journal stand pro Ticket nur `KI-Aufruf fuer T00xxxx fehlgeschlagen — ueberspringe`, Abschlusszeile `0 triagiert, 7 uebersprungen`. Der Backlog staute sich auf 50 Tickets. Die Factory selbst lief normal; betroffen war ausschliesslich der Triage-Zufluss.

## Zwei Ursachen, die zweite von der ersten verdeckt

### 1 — doppeltes `/v1` in der Endpunkt-URL (Daten, nicht Code)

`tickets.provider_config.base_url` trug ein abschliessendes `/v1`. Beide Konsumenten der Spalte haengen `/v1/chat/completions` selbst an:

| Konsument | Append |
|---|---|
| `scripts/factory/auto-triage.sh:257-261` | `/v1/chat/completions` (hinter einem Glob) |
| `scripts/factory/scout-llm-fallback.sh:80` | `/v1/chat/completions` **bedingungslos**, ohne jede Normalisierung |

Ergebnis: `http://127.0.0.1:18235/v1/v1/chat/completions` → **HTTP 404**.

**Die Prior-Art-Suche hat die Diagnose umgedreht.** `openspec/specs/software-factory.md` (Requirement _Every Factory Tier Has a Fallback Candidate Behind the Primary_) legt fest, dass `base_url` die Wurzel adressiert, _"that the callers append `/v1/chat/completions` to"_. Nicht das Skript wich ab — die **Daten** taten es. Ein toleranter Normalisierer in `auto-triage.sh` (der naheliegende erste Reflex) waere falsch gewesen: er haette `scout-llm-fallback.sh` weiterhin kaputt gelassen und eine dritte Konvention neben eine dokumentierte gestellt.

Korrigiert werden deshalb die **erzeugenden Quellen** — `provider-register-local.sh:30`, `provider-register-gptoss.sh:31` trugen das `/v1` im Default, ein Registrierungslauf haette jede Datenkorrektur zurueckgedreht — plus eine idempotente Vorwaerts-Migration fuer den Bestand.

> **`tickets.llm_proxy_backends` bleibt ausdruecklich unberuehrt.** Diese Tabelle traegt die *umgekehrte* Konvention: ihr Konsument sendet `GET {baseUrl}/models` (`openspec/specs/local-llm-proxy.md`), dort gehoert das `/v1` in die Spalte. Beide Tabellen im selben Zug zu "vereinheitlichen" waere genau der Fehler, den dieser PR behebt. Ein Guard-Test haelt das fest.

### 2 — drei widerspruechliche Typ-Vokabulare in derselben Datei

Mit heilem Transport meldete der Lauf `validate_triage: invalid type 'fix'` fuer **jedes** Ticket:

| Stelle | erlaubte Werte |
|---|---|
| JSON-Schema (erzwingt beim Sampling) | `fix feat chore project docs refactor perf test ci build` |
| `validate_triage` Zeile 62 | `bug feature task project` |
| Schema-Zeile des System-Prompts | `bug feature task project` (Regeln darunter beschreiben Conventional Commits) |

Die Schnittmenge ist genau `project` — auch ohne den 404 haette die Triage jedes Nicht-Epic verworfen. Das Vokabular steht jetzt nur noch in `triage-enums.json`. Deprecated Aliase (`bug`/`feature`/`task`, die ein Provider ohne `json_schema`-Unterstuetzung liefern kann) werden **angenommen** und per `normalize_triage_type` abgebildet, statt das Ticket zu verwerfen.

## Ausserdem

- **`2>/dev/null` an `auto-triage.sh:402` entfernt.** `call_llm` schrieb die eigentliche Diagnose auf stderr; das Verwerfen hat Ursache 1 wochenlang hinter der nichtssagenden Sammelmeldung verborgen.
- **`DRY_RUN` respektiert die Umgebung.** Zeile 22 setzte unbedingt `false`; `DRY_RUN=true bash auto-triage.sh` schrieb real und meldete am Ende trotzdem `DRY_RUN=false`. Der Factory-Pfad ist nicht betroffen — `wakeup.sh` haelt zwar eine gleichnamige Variable (Default `true`), exportiert sie aber nicht. Genau das war vor der Aenderung zu pruefen: waere sie exportiert, haette der "Fix" die Triage stillgelegt.
- **`AUTO_TRIAGE_LIB_ONLY`** macht das Skript ohne Cluster als Funktionsbibliothek ladbar. Damit misst der Test `validate_triage` an Exit-Code und stderr, statt den Quelltext zu greppen (Test-Resultats-Konvention T002448-M4) — die bestehende `auto-triage`-Testdatei tut Letzteres.

## Verifikation

```
13/13 neue BATS gruen                              (vorher 8/8 rot)
tests/spec/software-factory/ vollstaendig          exit 0, keine Regression
http://127.0.0.1:18235/v1/chat/completions      -> HTTP 200   (vorher /v1/v1 -> 404)
Migration gegen bereits normalisierte Dev-DB    -> rc=0       (idempotent)
```

## Hinweise fuer den Review

- **Die Dev-DB ist bereits von Hand normalisiert** (`k3d-mentolder-dev`/`workspace`, 17 Zeilen) — die Migration lief dort als No-Op. Die richtige Datenbank ist die lokale: `lib.sh:38` setzt `FACTORY_CTX="${FACTORY_CTX:-k3d-mentolder-dev}"` (ADR-006/T002626), **nicht** `fleet`.
- **`fleet` wurde bewusst nicht von Hand angefasst.** Ein erster Versuch ging versehentlich dorthin und wurde aus dem Backup byte-identisch zurueckgerollt (Diff gegen Vorher-Dump: leer). Die Normalisierung dort erfolgt regulaer ueber die Migration.
- Die vier historischen Migrationen, die `/v1` noch mitschreiben, bleiben unveraendert — angewandte Belege werden nicht editiert; die neue Migration sortiert nach Datum hinter ihnen und greift beim Replay zuletzt.
- **Nicht in diesem Vorgang:** die haiku-Zeile `https://api.deepseek.com/anthropic` ergibt `.../anthropic/v1/chat/completions`, waehrend der Anthropic-kompatible Endpunkt `/anthropic/v1/messages` ist → **T003495**.
- **Nicht zugeschrieben:** waehrend der Arbeit wurden acht zuvor untriagierte Tickets triagiert. Ich kann den Ausloeser nicht zweifelsfrei diesem Fix zuordnen (parallele Sessions liefen) und behaupte es deshalb nicht. Belegt sind der Transportpfad (HTTP 200) und der Validator (rot → gruen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrbYQhyiMNMzycF6YYzS7m