### PR TITLE
chore(plans): update mishap-incident-rollup from container batches [T003201]

### DIFF
--- a/openspec/changes/mishap-incident-rollup/proposal.md
+++ b/openspec/changes/mishap-incident-rollup/proposal.md
@@ -1,0 +1,12 @@
+# Proposal: mishap-incident-rollup
+
+## Why
+
+Fortlaufende Sammlung nicht-kritischer Mishaps aus dem Buffer.
+Dieser Plan wird automatisch von `scripts/factory/mishap-rollup.sh` [T002407]
+generiert und geupdated, sobald der Rollup-Container neue Batch-Kommentare hat.
+
+## What
+
+Die Batch-Kommentare auf dem Container-Ticket werden in Tasks uebersetzt,
+die der Factory-Dispatcher abarbeitet.

--- a/openspec/changes/mishap-incident-rollup/specs/mishap-rollup.md
+++ b/openspec/changes/mishap-incident-rollup/specs/mishap-rollup.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Mishap rollup generates compliant change per run
+
+The mishap rollup generator (`scripts/factory/mishap-rollup.sh`) SHALL produce a plan-only change in
+`openspec/changes/mishap-incident-rollup/` that archives completed changes into the archive tree and
+consolidates SSOT specs.
+
+#### Scenario: Rollup change satisfies OpenSpec validation
+
+- **GIVEN** the rollup has run on the container ticket
+- **WHEN** OpenSpec validation scans `openspec/changes/`
+- **THEN** the change passes validation (has specs/, proposal.md, tasks.md)

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:12 UTC. Die Eintraege stammen aus den
+2026-08-10 00:18 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:02 UTC. Die Eintraege stammen aus den
+2026-08-10 01:05 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:38 UTC. Die Eintraege stammen aus den
+2026-08-10 00:43 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:47 UTC. Die Eintraege stammen aus den
+2026-08-10 01:53 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:51 UTC. Die Eintraege stammen aus den
+2026-08-10 00:55 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:31 UTC. Die Eintraege stammen aus den
+2026-08-10 01:36 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:08 UTC. Die Eintraege stammen aus den
+2026-08-10 00:12 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:39 UTC. Die Eintraege stammen aus den
+2026-08-09 10:41 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:07 UTC. Die Eintraege stammen aus den
+2026-08-09 05:13 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 02:18 UTC. Die Eintraege stammen aus den
+2026-08-10 02:24 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:55 UTC. Die Eintraege stammen aus den
+2026-08-10 01:02 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:13 UTC. Die Eintraege stammen aus den
+2026-08-09 05:56 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:04 UTC. Die Eintraege stammen aus den
+2026-08-09 05:05 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:14 UTC. Die Eintraege stammen aus den
+2026-08-10 01:19 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:00 UTC. Die Eintraege stammen aus den
+2026-08-10 00:04 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:39 UTC. Die Eintraege stammen aus den
+2026-08-10 01:44 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:33 UTC. Die Eintraege stammen aus den
+2026-08-09 23:37 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:55 UTC. Die Eintraege stammen aus den
+2026-08-10 00:00 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:43 UTC. Die Eintraege stammen aus den
+2026-08-10 00:47 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:10 UTC. Die Eintraege stammen aus den
+2026-08-10 01:14 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 02:03 UTC. Die Eintraege stammen aus den
+2026-08-10 02:14 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:04 UTC. Die Eintraege stammen aus den
+2026-08-10 00:08 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 02:24 UTC. Die Eintraege stammen aus den
+2026-08-10 02:28 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:52 UTC. Die Eintraege stammen aus den
+2026-08-09 23:55 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:47 UTC. Die Eintraege stammen aus den
+2026-08-10 00:51 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:44 UTC. Die Eintraege stammen aus den
+2026-08-09 23:46 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:35 UTC. Die Eintraege stammen aus den
+2026-08-10 00:38 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:57 UTC. Die Eintraege stammen aus den
+2026-08-10 02:03 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:31 UTC. Die Eintraege stammen aus den
+2026-08-09 23:33 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:41 UTC. Die Eintraege stammen aus den
+2026-08-09 10:49 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:46 UTC. Die Eintraege stammen aus den
+2026-08-09 23:52 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure
@@ -560,6 +560,177 @@ VORHANDENE BAUSTEINE FUER EINEN BESSEREN GUARD:
 FOLGEKOSTEN, falls unveraendert: Beinahe-Duplikate werden getrennt geplant und getrennt
 dispatcht. In diesem Lauf haette das drei Agenten gleichzeitig an denselben roten
 Shard-4-Guard gesetzt (T002941 / T003001 / T003006).
+### Mishap-Rollup — 10 Eintraege (2026-08-09 23:49 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | degraded | scripts/hooks/worktree-write-guard.sh | worktree-write-guard: SID-basiertes Besitzmodell unterscheidet nebenlaeufige Subagenten einer Session nicht — Meldung fuehrt in die Irre |
+| 2 | suspicious | skills/ticket-ops Step 3.6 (Dispatch-Prompt) | ticket-ops-Dispatchvorlage sagt nicht, welchen Lock-Scope der Subagent selbst setzen soll |
+| 3 | process | skills/repo-hygiene (repo-hygiene-ops.md §1) | repo-hygiene §1: Freshness-Generat macht jeden fertigen Worktree dauerhaft dirty — `worktree remove` ohne `--force` schlägt regelhaft fehl |
+| 4 | process | scripts/ticket.sh + ticket-mcp (mishap-buffer) | Mishap-Buffer kennt keinen Rücknahmepfad — ein behobener Befund erscheint beim Flush trotzdem als offener Punkt im Rollup |
+| 5 | drift | scripts/openspec.sh | Half-archived change mcp-config-mutation-race detected during repo-hygiene |
+| 6 | suspicious | ci/freshness-gate | Archive PR #4083 failed freshness gate — openspec-status.json not committed after archive |
+| 7 | suspicious | scripts/factory/babysit-prs.sh | babysit-prs.sh entfernt Worktrees ohne den live-Lock-Guard aus T002896 |
+| 8 | degraded | Taskfile.yml:test:changed | test:changed startet Live-E2E gegen korczewski bei reiner openspec/-Aenderung |
+| 9 | drift | scripts/validate-commit-msg.sh | Commit-Scope 'openspec' abgelehnt, obwohl das ganze Repo von OpenSpec spricht |
+| 10 | degraded | scripts/openspec.sh | openspec.sh archive skaliert nicht im Batch (~3s pro Change, Node-Start je Delta) |
+
+**1. worktree-write-guard: SID-basiertes Besitzmodell unterscheidet nebenlaeufige Subagenten einer Session nicht — Meldung fuehrt in die Irre** (degraded, scripts/hooks/worktree-write-guard.sh)
+
+Beobachtet 2026-08-09 bei einem ticket-ops-Dispatch mit 6 parallelen Subagenten. WICHTIG: Der urspruengliche Agentenbericht war ungenau; die hier beschriebene Fassung ist gegen den Quellcode korrigiert.
+
+BERICHTET WURDE: "Die Meldung listet unter 'Dieser Session gehoeren:' die Worktrees FREMDER Sessions auf."
+
+TATSAECHLICH (scripts/hooks/worktree-write-guard.sh:132-157): `MY_WTS` sammelt alle
+Worktrees, deren Lock-Owner dieselbe SID traegt. Alle sechs Subagenten liefen unter
+DERSELBEN Session-SID (im Lock-Bestand nachgeprueft: sechs branch-Claims, identisches
+owner_sid). Aus Sicht des Guards gehoerten die Worktrees also korrekt "dieser Session".
+Die Meldung ist im Modell des Guards richtig — sie wurde nur als "fremd" gelesen.
+
+DER EIGENTLICHE DEFEKT liegt eine Ebene tiefer: das SID-basierte Besitzmodell kann
+NEBENLAEUFIGE SUBAGENTEN einer Session nicht voneinander unterscheiden. Fuer Regel 2
+(Zeile 147-152) heisst das: Agent A darf in Agent B's Worktree schreiben, weil beide
+dieselbe SID tragen. Der Guard schuetzt gegen fremde SESSIONS, nicht gegen paralleles
+Arbeiten INNERHALB einer Session — genau das Szenario, das ticket-ops erzeugt.
+
+DAS IST DIESELBE GEBROCHENE ANNAHME WIE IN T003102: "eine Session = eine SID" haelt
+nicht, sobald MCP-Server, Subagenten und CI-Workflows im selben Vorgang schreiben.
+Dort verhindert sie den Abschluss, hier den Schutz. Beide Tickets sollten gemeinsam
+betrachtet werden — eine Vererbungskennung (Parent-SID plus Actor-Kennung) wuerde
+beide Faelle adressieren.
+
+ZUSATZBEFUND: In der Auflistung erschienen Worktrees doppelt. Ursache ist plausibel,
+dass mehrere Locks unterschiedlichen Scopes (branch- und worktree-Scope) auf denselben
+Pfad zeigen und die Schleife jeden Treffer anhaengt, ohne zu deduplizieren
+(Zeile 138: `MY_WTS+=("$wt")` ohne Existenzpruefung).
+
+KLEINE VERBESSERUNG UNABHAENGIG DAVON: Die Meldezeile "Dieser Session gehoeren:" sollte
+sagen, WOHER der Besitz stammt (z. B. "Claims dieser SID (auch anderer Subagenten):"),
+damit sie nicht als Eigenbesitz des aufrufenden Akteurs gelesen wird. Genau diese
+Fehllesung kostete beim Debuggen Zeit.
+**2. ticket-ops-Dispatchvorlage sagt nicht, welchen Lock-Scope der Subagent selbst setzen soll** (suspicious, skills/ticket-ops Step 3.6 (Dispatch-Prompt))
+
+Beobachtet 2026-08-09, von einem der sechs Welle-1-Agenten ausdruecklich als Verbesserungswunsch zurueckgemeldet ("Dispatch-Prompt sollte kuenftig klarstellen, welcher Claim (branch vs. ticket) vom Sub-Agenten selbst zu setzen ist").
+
+BEFUND: ticket-ops Step 3.6 beschreibt die Lock-Vergabe ausschliesslich aus Sicht des
+ORCHESTRATORS ("agent-lock.sh claim ticket <ext-id> ... --label ticket-ops"). Was der
+dispatchte Subagent in seinem Worktree selbst claimen muss, steht nirgends — obwohl
+scripts/hooks/worktree-write-guard.sh Regel 2 ohne eigenen Claim jeden Write ablehnt.
+
+FOLGE IN DIESEM LAUF: Vier von sechs Agenten liefen in die Guard-Blockade und mussten
+den richtigen Claim selbst herleiten. Zwei setzten den falschen (ticket-scoped), der
+nach T003102 den spaeteren Abschluss blockiert und vom Orchestrator manuell wieder
+freigegeben werden musste. Sechs Agenten, vier unabhaengige Herleitungen desselben
+Schrittes, zwei Fehlgriffe — das ist ein Vorlagen-Problem, kein Agenten-Problem.
+
+ZU ERGAENZEN in der Dispatch-Vorlage von Step 3.6, woertlich als Prompt-Baustein:
+    "Setze zu Beginn im Worktree:
+       bash scripts/agent-lock.sh claim branch <branch> --worktree <pfad> --branch <branch>
+     Setze KEINEN ticket-scoped Lock (T003102 — blockiert den spaeteren Abschluss durch
+     Subagent, ticket-mcp und post-merge.yml).
+     Gib den Branch-Lock am Ende deiner Arbeit wieder frei."
+
+Haengt inhaltlich am Mishap "Drei Regelwerke widersprechen sich beim agent-lock-Scope"
+aus demselben Lauf — dort liegt die Ursache, hier die konkrete Textstelle, die sie
+weitertraegt.
+**3. repo-hygiene §1: Freshness-Generat macht jeden fertigen Worktree dauerhaft dirty — `worktree remove` ohne `--force` schlägt regelhaft fehl** (process, skills/repo-hygiene (repo-hygiene-ops.md §1))
+
+BEOBACHTET (repo-hygiene-Lauf 2026-08-09/10, Worktree .worktrees/factory-worktree-reaper-T002896)
+
+repo-hygiene-ops.md §1 schreibt vor, `git worktree remove <pfad>` OHNE `--force` aufzurufen, und begründet das ausdrücklich als "Schutz bei ungetrackten Dateien". Dieser Schutz greift in der Praxis nicht, weil er regelhaft am falschen Signal scheitert.
+
+BEFUND
+Der Worktree war inhaltlich vollständig abgeschlossen: PR #4068 gemergt (mergedAt 2026-08-09T21:55:02Z), Squash-Commit e78a30777 in origin/main, Upstream [gone]. Der Blob-Vergleich pro Datei gegen origin/main (§2-Form) zeigte genau EINE Abweichung: website/src/data/openspec-status.json — ein reines Freshness-Generat. Der Inhalt der Abweichung war ausschliesslich regenerierter Archivstatus FREMDER Tickets (T002814 plan_staged -> archived, T002849 zusaetzlicher archived-Eintrag), also kein Byte eigener Arbeit.
+
+`git status --porcelain` meldet dafuer ` M website/src/data/openspec-status.json`. Nach der woertlichen Regel aus §1 ("MUSS leer sein — sonst kein Remove") ist der Worktree damit nicht entfernbar, und `git worktree remove` ohne `--force` verweigert.
+
+WARUM DAS STOERT
+Das ist keine Ausnahme, sondern der Normalfall: jeder Worktree, in dem ein Plan gestaged oder archiviert wurde, traegt danach ein regeneriertes openspec-status.json. Der Aufraeumpfad landet damit routinemaessig im `--force`-Zweig — also in genau der Eskalation, die §1 als bewusste Ausnahme kennzeichnet. Ein Schutzmechanismus, der bei fast jedem legitimen Aufruf uebersprungen werden muss, schuetzt nicht mehr: er trainiert `--force` als Standardgriff an, und dann faellt echte ungesicherte Arbeit im selben Zweig nicht mehr auf.
+
+ABGRENZUNG
+Der Vorcheck selbst ist nicht falsch — er misst nur zu grob. Die verlaessliche Messung stand im selben Runbook bereits daneben (§2, Blob-Vergleich pro Datei gegen origin/main); sie unterscheidet Generat von Arbeit, `git status --porcelain` nicht.
+
+MOEGLICHE AUFLOESUNG (nicht entschieden)
+a) §1-Vorcheck um eine Generat-Allowlist ergaenzen (dieselbe, die scripts/branch-reaper.sh bereits fuehrt): Abweichungen ausschliesslich in Plan-/Generat-Pfaden gelten als sauber, `--force` ist dann keine Eskalation mehr, sondern der belegte Normalfall.
+b) Vor dem Remove `git checkout -- <generat-pfade>` im Worktree, damit der Vorcheck wieder eine echte Aussage trifft.
+**4. Mishap-Buffer kennt keinen Rücknahmepfad — ein behobener Befund erscheint beim Flush trotzdem als offener Punkt im Rollup** (process, scripts/ticket.sh + ticket-mcp (mishap-buffer))
+
+BEOBACHTET (2026-08-09/10, repo-hygiene-Lauf + anschliessende Chore T003121)
+
+ABLAUF
+1. 22:02Z: Befund als Mishap gemeldet — "repo-hygiene §1: Freshness-Generat macht jeden fertigen Worktree dauerhaft dirty" (Buffer-Eintrag 3/10).
+2. Direkt danach in derselben Sitzung behoben: Ticket T003121, PR #4075, gemergt 22:35Z. Der Befund existiert seit 33 Minuten nicht mehr.
+3. Der Buffer-Eintrag steht unveraendert weiter drin. `get_mishap_buffer` zeigt ihn, `report_mishap` kann nur anfuegen, `flush_mishap_buffer` schreibt ALLE Eintraege in den Rollup-Container.
+
+WIRKUNG
+Beim naechsten Flush (spaetestens bei 10 Eintraegen oder nach 7 Tagen) landet ein bereits geschlossener Befund als offener Punkt im Rollup-Ticket. Wer den Rollup abarbeitet, untersucht etwas, das auf main schon behoben ist — im Zweifel inklusive erneutem Fix. Das Fenster ist genau die Spanne zwischen Erfassung und Flush, also bis zu 7 Tage; in dieser Spanne liegt jeder Befund, den eine Sitzung selbst behebt, und "selbst beheben" ist der Normalfall, nicht die Ausnahme.
+
+ABGRENZUNG — das ist NICHT der Dedupe-Fall aus T002844
+T002844 beschreibt die umgekehrte Richtung: der Buffer ist fuer die Ticket-Suche unsichtbar, deshalb entsteht ein DUPLIKAT. Hier ist der Eintrag sichtbar und korrekt erfasst — er ist nur inzwischen GEGENSTANDSLOS, und dafuer gibt es keinen Weg. Beide Faelle teilen die Ursache (Buffer und Tickets sind zwei Zustandsraeume ohne Verbindung), aber nicht die Auswirkung.
+
+UMGEHUNG im aktuellen Lauf
+Hinweis als Kommentar an T003121 gehaengt, damit die Spur beim Rollup auffindbar ist. Das ist Handarbeit und traegt nur, solange jemand daran denkt.
+
+MOEGLICHE AUFLOESUNGEN (nicht entschieden)
+a) `resolve_mishap`/`withdraw_mishap` mit Index oder Titel-Match, das den Eintrag mit Verweis auf das loesende Ticket aus dem Buffer nimmt.
+b) Beim Flush jeden Eintrag gegen die Tickets pruefen und geschlossene als "bereits behoben durch T00XXXX" markieren statt sie als offenen Punkt zu fuehren — loest zugleich die Richtung aus T002844, weil beide Quellen dann in EINEM Aufruf zusammenkommen.
+c) Nichts tun und die Handarbeit als Konvention im mishap-tracker-Skill festhalten (schwaechste Variante, aber billig).
+**5. Half-archived change mcp-config-mutation-race detected during repo-hygiene** (drift, scripts/openspec.sh)
+
+During repo-hygiene run, mcp-config-mutation-race was found in a half-archived state: the archive target 2026-08-10-mcp-config-mutation-race already existed in openspec/changes/archive/ while the source directory was still present in openspec/changes/. openspec.sh archive refuses to re-archive an existing target. The half-archive-check.sh script detected it correctly. Manual cleanup: verify delta was in SSOT, then rm -rf the source. Root cause unknown — possibly a prior archive that crashed after moving files but before removing source.
+**6. Archive PR #4083 failed freshness gate — openspec-status.json not committed after archive** (suspicious, ci/freshness-gate)
+
+PR #4083 (archive-only, no code changes) failed CI because website/src/data/openspec-status.json was regenerated by task freshness:check but not committed to the PR branch. The pre-commit hook did not catch this because the archive work was done in a worktree where the artifact was staged but the commit didn't include it. The openspec archive operation (moving/deleting change dirs) changes the openspec status map, which in turn triggers a freshness regeneration — but the regenerated artifact wasn't added to the commit.
+**7. babysit-prs.sh entfernt Worktrees ohne den live-Lock-Guard aus T002896** (suspicious, scripts/factory/babysit-prs.sh)
+
+Beobachtung (T003129): Ein aktiver Worktree unter .worktrees/openspec-archive-backlog-T003129 verschwand mitten in einem laufenden Batch ("getcwd: cannot access parent directories"), obwohl der Branch einen frisch geclaimten, lebenden agent-lock trug. 41 bereits verarbeitete Archivierungen gingen verloren, der Lauf musste komplett neu aufgesetzt werden.
+
+Verifikation korrigiert die naheliegende Hypothese: .git/agent-locks/.reap.log zeigt fuer 01:27:45 den Eintrag "branch/chore/openspec-archive-backlog-T003129 worktree-missing". Der Lock wurde also stale, WEIL der Worktree fehlte — nicht umgekehrt. agent-lock hat korrekt gearbeitet; "agent-lock.sh reap" ruft ohnehin nur "git worktree prune" auf und entfernt keine existierenden Verzeichnisse.
+
+Wer den Worktree entfernt hat, bleibt ungeklaert. Bei der Suche nach Kandidaten faellt aber eine reale Inkonsistenz auf, unabhaengig davon ob sie hier zugeschlagen hat:
+
+- scripts/factory/cleanup.sh prueft VOR dem Removal "agent-lock.sh check-branch-live" und ueberspringt dann (Guard aus T002896, an zwei Stellen: EXIT-Trap Zeile 29 und Hauptpfad Zeile 43). Begruendung im Kommentar: "Der Factory-Autopilot darf aktiv geclaimte Fremd-Worktrees nicht entfernen."
+- scripts/factory/watchdog.sh Zeile 76 prueft wenigstens auf uncommitted changes und ueberspringt dann mit Kommentar am Ticket.
+- scripts/factory/babysit-prs.sh Zeile 222 hat WEDER das eine noch das andere: "git worktree remove "$WT" --force >/dev/null 2>&1 || rm -rf "$WT"". Kein check-branch-live, keine Dirty-Pruefung, und der rm -rf-Fallback setzt sich sogar ueber ein fehlgeschlagenes git worktree remove hinweg.
+
+Der Guard aus T002896 wurde offenbar nur in cleanup.sh eingezogen, obwohl babysit-prs.sh dieselbe Operation ausfuehrt. Vorschlag: check-branch-live auch dort vorschalten, und den rm -rf-Fallback entfernen oder ebenfalls hinter den Guard legen.
+
+Praktischer Workaround bis dahin: Worktrees fuer laengere Batch-Laeufe ausserhalb von .worktrees/ anlegen (z.B. im Session-Scratchpad). Der zweite Anlauf lief dort unbehelligt durch.
+**8. test:changed startet Live-E2E gegen korczewski bei reiner openspec/-Aenderung** (degraded, Taskfile.yml:test:changed)
+
+Beobachtung (T003129): Ein Diff, der ausschliesslich openspec/ und das generierte website/src/data/openspec-status.json beruehrt (kein einziger ausfuehrbarer Code), loeste in "task test:changed" den Teiltask test:e2e:korczewski aus. Der scheiterte am Auth-Setup gegen die Live-Site (korczewski-auth-setup.spec.ts:44, "authenticate korczewski website admin"), 48 Tests liefen gar nicht erst. Exit 201.
+
+Der Taskfile-Kommentar beschreibt genau diesen Fall als bereits geloest (T002255): "Generierte Artefakte (linguist-generated in .gitattributes) vor der Selektion entfernen: sie liegen im Diff JEDES Changes mit OpenSpec-Artefakt und wuerden sonst Playwright fuer Changes ohne Website-Bezug starten." Der Filter greift hier nicht — vermutlich weil openspec/specs/website-core.md im Diff liegt und als website-Bezug gewertet wird, obwohl es eine Spezifikationsdatei ist.
+
+Warum das mehr als kosmetisch ist: derselbe Taskfile-Kommentar haelt fest, dass CI fuer PRs nur test:spec:changed plus manifests.bats faehrt, NICHT das volle test:changed — "der lokale Lauf war also strenger als das Gate, das er simuliert". Ein Agent, der den Verifikationsblock woertlich befolgt, steht damit vor einem roten Ergebnis, das keine Regression ist, und muss zwischen "falsche Regression melden", "blind weitermachen" und "Zeit an einem Umgebungsproblem verbrennen" waehlen. Genau diese Wahl beschreibt der Kommentar zu T002375-p4 bereits fuer den k3d-Fall, wo daraufhin ein sichtbarer Skip eingebaut wurde.
+
+Bestaetigung, dass es ein Fehlalarm war: test:spec:changed lief mit 220 ok / 0 Fehlschlaegen, task openspec:validate 11/11 gruen, freshness:check exit 0, und PR #4086 ging mit 18/18 gruenen Checks durch.
+
+Vorschlag: dieselbe Erreichbarkeits-/Relevanzpruefung wie fuer die k3d-Gruppe auch fuer die E2E-Gruppe, oder openspec/specs/*.md aus der Website-Domain-Zuordnung nehmen — eine Spec-Datei ist kein Website-Code.
+**9. Commit-Scope 'openspec' abgelehnt, obwohl das ganze Repo von OpenSpec spricht** (drift, scripts/validate-commit-msg.sh)
+
+Beobachtung (T003129): "chore(openspec): 54 gemergte Changes archivieren [T003129]" wurde vom commit-msg-Hook abgelehnt: "unknown scope 'openspec' — 'openspec' wurde zu 'plans' konsolidiert (T002328)". Korrekt ist chore(plans).
+
+Warum das wiederholt Zeit kostet: der abgelehnte Scope ist ueberall sonst der etablierte Begriff. Das Verzeichnis heisst openspec/, die Tasks heissen openspec:validate / openspec:propose / openspec:apply / openspec:archive, die Slash-Commands heissen /opsx:*, die Skills heissen openspec-propose / openspec-apply-change / openspec-archive-change, und CLAUDE.md hat einen eigenen Abschnitt "OpenSpec native change workflow". Ein Agent, der einen Commit fuer eine openspec/-Aenderung schreibt, waehlt den naheliegenden Scope — und der ist der falsche.
+
+Der Hook selbst weist darauf hin, dass CI hier nicht schuetzt: "Der CI-PR-Titel-Check (amannn/action-semantic-pull-request) prueft keinen Scope — ein gruener PR-Titel ist keine Garantie fuer diesen Scope." Der Fehler faellt also erst lokal beim Commit auf, nach dem Verfassen der vollstaendigen Message.
+
+Kosten pro Vorfall gering (ein Fehlversuch), Haeufigkeit aber strukturell: jede openspec-Aenderung eines Agenten, der die Konsolidierung nicht auswendig kennt.
+
+Vorschlag (eines von beiden, nicht beide):
+(a) 'openspec' als Alias auf 'plans' in validate-commit-msg.sh zulassen — die Konsolidierung bliebe inhaltlich bestehen, nur der naheliegende Name wuerde nicht mehr bestrafen; oder
+(b) einen Satz in CLAUDE.md beim OpenSpec-Abschnitt: "Commits zu openspec/ tragen den Scope 'plans', nicht 'openspec' (T002328)."
+**10. openspec.sh archive skaliert nicht im Batch (~3s pro Change, Node-Start je Delta)** (degraded, scripts/openspec.sh)
+
+Beobachtung (T003129): Beim Abbau des Archivierungsrueckstands (98 offene Changes) brauchte "scripts/openspec.sh archive <slug>" rund 3 Sekunden pro Change. Ursache: _merge_delta startet fuer jede einzelne Delta-Datei einen eigenen Node-Prozess ("node scripts/openspec-merge.mjs apply ..."), der Prozessstart dominiert die eigentliche Arbeit.
+
+Praktische Folge: eine Schleife ueber 59 Changes laeuft rund drei Minuten und schlaegt damit in jedes Default-Kommandotimeout (2 Minuten). Der erste Lauf brach nach 41 verarbeiteten Changes ab und musste gestueckelt bzw. mit erhoehtem Timeout wiederholt werden. Fuer den Normalfall — ein Change am Ende eines dev-flow-execute — ist das irrelevant; relevant wird es genau dann, wenn ein Rueckstand aufgeholt werden soll, also im Wartungsfall.
+
+Das ist kein Fehlverhalten, nur schlechte Batch-Ergonomie. Zwei denkbare Wege:
+(a) ein Batch-Modus, der mehrere Slugs in EINEM Node-Prozess abarbeitet (openspec-merge.mjs bekaeme eine Liste statt eines Paares); oder
+(b) schlicht dokumentieren, dass Block-Archivierungen im Hintergrund oder in Portionen zu fahren sind.
+
+Randnotiz aus demselben Lauf, gleiche Ursachenklasse: openspec.sh archive prueft den Ticket-Status fail-closed (done/archived) und verweigert sonst — das hat sauber funktioniert und mehrere nicht abgeschlossene Changes korrekt abgewiesen. Der Guard ist nicht das Problem, nur die Wiederholrate.
 
 ## Verify (RED → GREEN)
 

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:53 UTC. Die Eintraege stammen aus den
+2026-08-10 01:57 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure
@@ -731,6 +731,158 @@ Das ist kein Fehlverhalten, nur schlechte Batch-Ergonomie. Zwei denkbare Wege:
 (b) schlicht dokumentieren, dass Block-Archivierungen im Hintergrund oder in Portionen zu fahren sind.
 
 Randnotiz aus demselben Lauf, gleiche Ursachenklasse: openspec.sh archive prueft den Ticket-Status fail-closed (done/archived) und verweigert sonst — das hat sauber funktioniert und mehrere nicht abgeschlossene Changes korrekt abgewiesen. Der Guard ist nicht das Problem, nur die Wiederholrate.
+### Mishap-Rollup — 10 Eintraege (2026-08-10 01:56 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | degraded | skills/references/ticket-ops-procedures.md | ticket-ops Step 1.1: Triage-Query überschreitet bei ~96 offenen Tickets das mcp-postgres-Token-Limit |
+| 2 | degraded | skills/references/ticket-ops-procedures.md | ticket-ops Step 1.1 dokumentiert einen jq-Ausdruck, der am MCP-Ergebnis scheitert |
+| 3 | degraded | skills/references/ticket-ops-procedures.md (Step 3.1/3.2) | ticket-ops Wellenbildung: areas-Konfliktheuristik erkennt Kollisionen über generierte Artefakte nicht |
+| 4 | suspicious | .githooks/post-commit (openspec-embed) | openspec-embed post-commit meldet "Backend nicht erreichbar" auf :8081, das Backend antwortet aber mit 200 |
+| 5 | suspicious | repo/git | 4 Stashes verschwanden während repo-hygiene §0-Inventur — refs/stash komplett weg, Mechanismus ungeklärt |
+| 6 | drift | tickets | 285 von 881 done-Tickets ohne resolution (32%) — darunter T003121/T003129 von heute |
+| 7 | process | scripts/branch-reaper.sh + skills/references/repo-hygiene-ops.md §2 | branch-reaper.sh --dry-run ohne --ticket nicht aufrufbar, Runbook dokumentiert ihn als manuellen Inspektionsblick |
+| 8 | process | .claude/skills/references/repo-hygiene-ops.md §3 (Konfliktprobe) | repo-hygiene-ops §3: dokumentierte Konfliktprobe ist im Normalfall nicht gangbar (invasiver Arbeitsbaum-Merge in dirty Worktree) |
+| 9 | process | scripts/branch-reaper.sh | branch-reaper.sh meldet "DELETED", löscht aber nur den Remote-Ref — lokaler Branch überlebt |
+| 10 | process | .claude/skills/references/repo-hygiene-ops.md §2 | repo-hygiene §2: [gone]-Prune läuft VOR branch-reaper, der selbst neue [gone]-Refs erzeugt |
+
+**1. ticket-ops Step 1.1: Triage-Query überschreitet bei ~96 offenen Tickets das mcp-postgres-Token-Limit** (degraded, skills/references/ticket-ops-procedures.md)
+
+Beobachtet 2026-08-10 im ticket-ops-Lauf (96 offene Tickets, is_test_data=false).
+
+BEFUND: Die in ticket-ops-procedures.md §Step 1.1 vorgeschriebene json_agg-Query liefert 52.548 Zeichen und wird von mcp__mcp-postgres__query mit "exceeds maximum allowed tokens" abgewiesen. Das Ergebnis landet stattdessen in einer Datei im Tool-Results-Verzeichnis; die Query ist über MCP nicht mehr direkt konsumierbar.
+
+VERIFIZIERT: Die Abweisung trat beim ersten Aufruf auf, Zeichenzahl aus der Fehlermeldung.
+
+WARUM RELEVANT: Der Skalierungsbruch ist nicht dokumentiert. Die Prozedur wurde erkennbar für kleinere Ticketmengen geschrieben (das Beispiel im Entscheidungsbaum nennt "Open Tickets (N=17)"). Ein Agent, der sie wörtlich befolgt, läuft bei wachsendem Backlog in einen Fehlschlag und muss den Umweg selbst herleiten — hier über die Ergebnisdatei plus jq/python.
+
+VORSCHLAG: Entweder die Query von vornherein in eine Datei schreiben lassen und dort weiterverarbeiten, oder sie chunken (LIMIT/OFFSET nach Priorität), oder die Feldliste kürzen — 'readiness' und 'depends_on' machen einen erheblichen Teil der Nutzlast aus und werden in Phase 1 nur aggregiert gebraucht.
+
+ABGRENZUNG: Kein Defekt von mcp-postgres — das Limit ist gewollt. Der Defekt liegt in der Prozedur, die ihn nicht berücksichtigt.
+**2. ticket-ops Step 1.1 dokumentiert einen jq-Ausdruck, der am MCP-Ergebnis scheitert** (degraded, skills/references/ticket-ops-procedures.md)
+
+Beobachtet 2026-08-10 im ticket-ops-Lauf.
+
+BEFUND: ticket-ops-procedures.md Zeile 79 schreibt zur Weiterverarbeitung der Triage-Query vor: "das Ergebnis wird mit `jq -r '.result[]'` verarbeitet, nicht mit Split-by-Pipe".
+
+Das mcp-postgres-Ergebnis hat aber die Form `[{"result": "<json-string>"}]` — ein Array mit einem Objekt, dessen Feld 'result' einen JSON-STRING enthält (nicht ein Array). Der dokumentierte Ausdruck scheitert; korrekt ist `jq -r '.[0].result'`, dessen Ausgabe dann erneut als JSON geparst wird.
+
+VERIFIZIERT: `grep -n "result\[\]" .claude/skills/references/ticket-ops-procedures.md` → Treffer in Zeile 79. Der erste Parse-Versuch dieses Laufs scheiterte entsprechend mit einem JSONDecodeError; `jq -r '.[0].result'` lief durch.
+
+WARUM RELEVANT: Die Zeile stammt aus T002422, wo sie die Umstellung von Pipe-Spalten auf JSON begründet — die Begründung ist richtig, nur der konkrete Ausdruck stimmt nicht mit dem Ausgabeformat überein. Kostet jeden Nutzer der Prozedur einen Fehlschlag.
+
+VORSCHLAG: Zeile 79 auf `jq -r '.[0].result'` korrigieren und den doppelten Parse-Schritt benennen. Hängt inhaltlich am separat gemeldeten Skalierungsbruch derselben Query — beide Korrekturen betreffen denselben Absatz.
+**3. ticket-ops Wellenbildung: areas-Konfliktheuristik erkennt Kollisionen über generierte Artefakte nicht** (degraded, skills/references/ticket-ops-procedures.md (Step 3.1/3.2))
+
+Beobachtet 2026-08-10 im ticket-ops-Welle-1-Dispatch mit 4 parallelen dev-flow-plan-Einheiten.
+
+BEFUND: Die Soft-Conflict-Kante aus Step 3.1 serialisiert zwei Tickets, wenn sie einen `areas`-Eintrag teilen. Sie fängt nicht, dass ALLE VIER Welle-1-Branches dieselbe generierte Datei ändern: website/src/data/openspec-status.json. Jede dev-flow-plan-Einheit legt ein openspec/changes/<slug>/ an, woraus die Statuskarte regeneriert und mitcommittet wird.
+
+VERIFIZIERT (alle vier Branches, nicht nur eine Stichprobe):
+  git diff --name-only origin/main..fix/agent-lock-scope-regelwerk-T003116   -> Treffer
+  git diff --name-only origin/main..fix/agent-lock-sid-detection-T003110     -> Treffer
+  git diff --name-only origin/main..fix/no-unasked-stash-T003078             -> Treffer
+  git diff --name-only origin/main..fix/babysit-prs-live-lock-guard-T003137  -> Treffer
+
+WARUM DIE HEURISTIK VERSAGT: Keine der vier Einheiten trägt `website` in ihren areas — die areas lauten scripts/agent-lock.sh, skills/dev-flow-chore, scripts/factory/babysit-prs.sh usw. Die Kollision entsteht nicht über die inhaltlich berührten Bereiche, sondern über ein GENERIERTES Artefakt, das jeder Planlauf als Nebenwirkung anfasst. Eine areas-basierte Heuristik kann das strukturell nicht sehen.
+
+FOLGE: Die vier PRs sind nicht gleichzeitig merge-fähig. Sie müssen seriell durch, jede nach dem Merge der vorigen mit `task freshness:regenerate`. Das war beim Aufstellen des Masterplans nicht sichtbar und fiel erst beim Nachprüfen der fertigen Branches auf.
+
+VORSCHLAG: Freshness-Generate (openspec-status.json, test-inventory.json) als implizite geteilte area der Wellenbildung behandeln — oder schlichter: Wellen aus dev-flow-plan grundsätzlich als seriell-mergend kennzeichnen und das im Masterplan-Format ausweisen, statt Merge-Parallelität zu suggerieren, die es nicht gibt.
+
+ABGRENZUNG: T003133 (Freshness-Generat macht Worktrees dirty), T003136 (Archive-PR am Freshness-Gate gescheitert) und T003105 (Rebase verliert Freshness-Artefakte) beschreiben Folgen desselben Generats. Dieser Befund ist ein anderer: die fehlende ERKENNUNG in der Wellenbildung von ticket-ops.
+**4. openspec-embed post-commit meldet "Backend nicht erreichbar" auf :8081, das Backend antwortet aber mit 200** (suspicious, .githooks/post-commit (openspec-embed))
+
+Beobachtet 2026-08-10, bei DREI von vier parallel laufenden dev-flow-plan-Agenten.
+
+BERICHTET WURDE: Der post-commit-Hook openspec-embed schlug fehl, weil kein Embedding-Backend erreichbar sei — genannt wurden 127.0.0.1:8081 (bge-mcp) und, von einem weiteren Agenten, der bekannte Port-15432-Konflikt. Non-fatal, kein Commit wurde blockiert.
+
+NACHERHEBUNG WIDERSPRICHT DER MELDUNG (das ist der eigentliche Befund):
+  curl http://127.0.0.1:8081/health   -> HTTP 200
+  ss -ltnp | grep -E ':(8081|15432)'  -> beide Ports haben einen Lauscher
+      127.0.0.1:8081  kubectl pid=753980
+      127.0.0.1:15432 kubectl pid=50718
+
+Die Port-Forwards standen also zum Zeitpunkt der Nacherhebung. Ob sie während der Agentenläufe kurzzeitig weg waren, lässt sich nachträglich nicht klären — deshalb ist die naheliegende Lesart ("Backend war tot") NICHT belegt, und die Meldung des Hooks bleibt fragwürdig: sie behauptet Nichterreichbarkeit als Ursache, obwohl das Backend erreichbar ist.
+
+WARUM RELEVANT: Eine Fehlermeldung, die eine falsche Ursache nennt, kostet beim Debuggen mehr als gar keine. Dasselbe Muster ist im Bestand bereits zweimal erfasst — T002909 (plan-qa-check.sh meldet "Gateway not reachable", obwohl der Gateway erreichbar ist) und T002912 (Postgres-Socket-Meldung trotz erreichbarer DB). Drei Werkzeuge mit demselben Fehlbild deuten auf eine gemeinsame Ursache im Erreichbarkeits-Check, nicht auf drei unabhängige Defekte.
+
+VORSCHLAG: Prüfen, ob die drei Stellen denselben Probe-Code teilen. Falls ja, dort ansetzen statt dreimal einzeln. Mindestens sollte der Hook den tatsächlichen Fehler (Timeout? HTTP-Status? DNS?) ausgeben statt ihn zu "nicht erreichbar" zu verallgemeinern.
+
+[Teilweise UNVERIFIED — der Zustand während der Agentenläufe ist nachträglich nicht rekonstruierbar; verifiziert ist nur der Widerspruch zur Nacherhebung.]
+**5. 4 Stashes verschwanden während repo-hygiene §0-Inventur — refs/stash komplett weg, Mechanismus ungeklärt** (suspicious, repo/git)
+
+Während repo-hygiene §0 (2026-08-10 ~02:30Z) wurden 4 Stashes inventarisiert (stash@{0} worktree-create-auto-stash 02:06, stash@{1} wip-before-chore T002649 01:48, stash@{2} WIP auf 7815d6592 (#4082) 01:19, stash@{3} WIP auf 0cee50e43 [T002896] 00:04). Minuten später war refs/stash vollständig weg — weder git stash list noch reflog show refs/stash liefern etwas. Kein Hook, kein Script im Repo droppt Stashes (grep über scripts/ + .git/hooks/ leer). Inhalte sind verifiziert NICHT verloren: stash@{2}/stash@{3}-Inhalt steht in origin/main (Archiv-Commits #4083 + factory-reclaim-lock-respect-Delta), stash@{0} enthielt keine unikaten Bytes (nur Deletionen eines aktiven Changes, T002658 planning), stash@{1} war ein regenerierbarer openspec-status.json-Generat. Commit-Objekte hängen noch (dangling, via git fsck auffindbar) und wären bis GC wiederherstellbar. Befund: unerklärte Fremd-Drop-Aktion (vermutlich parallele Session/Workflow mit git stash clear) — Problemraum T003078 (ungefragtes Stashen). Kein Datenverlust, aber Mechanismus ungeklärt und Folge-Läufe können echte Arbeit treffen.
+**6. 285 von 881 done-Tickets ohne resolution (32%) — darunter T003121/T003129 von heute** (drift, tickets)
+
+SELECT count FILTER (status='done' AND resolution IS NULL) über tickets.tickets ergibt 285/881 (32%). Die Konvention (repo-hygiene-ops §3, mishap-tracker) verlangt bei status=done eine resolution (fixed für fix/*, shipped für feature/*). Heute gemergte PRs #4075 (T003121) und #4086 (T003129) wurden als done ohne resolution abgeschlossen — auch frische Tickets betroffen, nicht nur Altbestand. Kein offenes Ticket dazu vorhanden. Empfehlung: Backfill-Regel (z.B. per Post-Merge-Hook oder cockpit_audit) für done ohne resolution, oder resolution bei done-Writes verpflichtend erzwingen.
+**7. branch-reaper.sh --dry-run ohne --ticket nicht aufrufbar, Runbook dokumentiert ihn als manuellen Inspektionsblick** (process, scripts/branch-reaper.sh + skills/references/repo-hygiene-ops.md §2)
+
+`.claude/skills/references/repo-hygiene-ops.md` §2 ("Verwaiste Remote-Branches") dokumentiert:
+
+    bash scripts/branch-reaper.sh --ticket T00XXXX --dry-run   # zeigt REAP-/KEEP-Zeilen mit Begründung
+
+und rahmt das als "im Post-Merge-Workflow läuft er automatisch, manuell zum Nachsehen". Der Nachsehen-Fall braucht aber gerade kein Ticket — man will die Kandidatenliste sehen, nicht eine Löschung einem Vorgang zuordnen.
+
+BELEG: `bash scripts/branch-reaper.sh --dry-run` bricht mit Exit 2 ab: "FEHLER: --ticket ist erforderlich (Format T######)". Usage: `branch-reaper.sh --ticket T###### [--dry-run] [--remote <name>] [--repo <pfad>]`.
+
+FOLGE: Wer §2 zum reinen Nachsehen befolgt, muss eine Ticketnummer erfinden oder eine fremde einsetzen. Beides ist unerwünscht — eine erfundene Nummer erzeugt im Zweifel einen Archiv-Tag unter falscher Zuordnung, eine fremde hängt die Aktion an einen unbeteiligten Vorgang.
+
+Beobachtet im repo-hygiene-Lauf 2026-08-10: 17 Remote-Branches außer main, davon 5 mit lokalem Worktree — die Kandidatenliste blieb ungeprüft, weil der Dry-Run nicht ohne Ticket lief.
+
+ZUSCHNITT: Entweder `--dry-run` das `--ticket` erlassen (der Dry-Run schreibt per Definition nichts, ein Archiv-Tag entsteht dabei nicht), oder die Runbook-Zeile so korrigieren, dass sie den Zwang nennt statt einen ticketlosen Blick zu suggerieren.
+**8. repo-hygiene-ops §3: dokumentierte Konfliktprobe ist im Normalfall nicht gangbar (invasiver Arbeitsbaum-Merge in dirty Worktree)** (process, .claude/skills/references/repo-hygiene-ops.md §3 (Konfliktprobe))
+
+Beobachtet 2026-08-10 während eines repo-hygiene-Laufs an PR #4091. VERIFIZIERT durch Messung, nicht nur berichtet.
+
+DER WIDERSPRUCH (zwei Stellen desselben Runbooks):
+
+(a) §3 „Leere Checkliste kann auch Konflikt heißen" [T002822] schreibt als Gegenprobe einen
+    invasiven Arbeitsbaum-Merge vor:
+        git merge origin/main --no-commit --no-ff   # danach: git merge --abort
+        git diff --name-only --diff-filter=U
+
+(b) §1 „Generat-Abweichungen sind kein Befund" hält an anderer Stelle desselben Dokuments fest,
+    dass jeder Worktree, in dem ein Plan gestaged oder archiviert wurde, dauerhaft ein
+    abweichendes website/src/data/openspec-status.json trägt — das ist ausdrücklich der
+    NORMALFALL, nicht die Ausnahme.
+
+Ein PR-Worktree erfüllt (b) praktisch immer. Damit läuft (a) auf einen Merge in einen dirty
+Arbeitsbaum hinaus, und zwar genau in der Datei, die main ebenfalls fortschreibt.
+
+GEMESSEN:
+- git -C .worktrees/agent-lock-scope-regelwerk-T003116 status --porcelain
+  → " M website/src/data/openspec-status.json"
+- PR #4091: mergeStateStatus=DIRTY, statusCheckRollup=[] (0 Einträge),
+  gh run list --branch … → [] (null Runs) — exakt das T002822-Symptom.
+
+DIE NICHT-INVASIVE ALTERNATIVE, die dieselbe Frage beantwortet:
+    git merge-tree --write-tree --name-only origin/main <branch>
+Exit 0 + Tree-SHA  = konfliktfrei → Phantomkonflikt aus merge=ours (T002823)
+Exit != 0 + Dateiliste = echter Konflikt
+Der Aufruf fasst weder Working Tree noch Index an, braucht also keinen sauberen Worktree und
+kein anschließendes --abort (dessen Vergessen im dokumentierten Weg einen halbfertigen Merge
+hinterlässt — verwandt mit T002766).
+
+Hier lieferte er sofort: exit=0, Tree a9984a261215047e18e3322a3f4d75db609fb891 → Phantomkonflikt.
+Auf dieser Grundlage wurde der lokale Merge-Weg aus §3 gefahren (merge + freshness:regenerate +
+push); PR #4091 wechselte danach von DIRTY auf BLOCKED mit 15 Checks, CI lief an, Auto-Merge ist
+aktiv.
+
+ZU ÄNDERN (Vorschlag, nicht präjudiziert):
+In §3 die merge-tree-Form als primäre Gegenprobe nennen und den Arbeitsbaum-Merge auf den Fall
+zurücknehmen, in dem man die Konfliktmarker tatsächlich sehen will. Die Reihenfolge
+„mergeStateStatus lesen → bei UNKNOWN/DIRTY probe-mergen" bleibt unverändert richtig; nur das
+Werkzeug des zweiten Schritts passt nicht zum dokumentierten Normalzustand der Worktrees.
+
+Kein Defekt an einem Skript — eine Runbook-Lücke: der empfohlene Weg kollidiert mit einer
+Bedingung, die dasselbe Runbook 200 Zeilen weiter oben als Regelfall beschreibt.
+**9. branch-reaper.sh meldet "DELETED", löscht aber nur den Remote-Ref — lokaler Branch überlebt** (process, scripts/branch-reaper.sh)
+
+`bash scripts/branch-reaper.sh --ticket T002623` gab "DELETED chore/adr006-sdlc-topologie-T002623 (archiviert als refs/tags/reaped/...)" aus. Danach war der Remote-Branch weg und der Archiv-Tag lokal wie remote gesetzt — der LOKALE Branch-Ref existierte aber unverändert weiter (`git rev-parse --verify` lieferte 3c600d7bf). Belegt in scripts/branch-reaper.sh Zeilen 189-205: die Schleife führt ausschliesslich `git push $REMOTE $sha:refs/tags/...` und `git push $REMOTE --delete $branch` aus; ein `git branch -d/-D` kommt im gesamten Skript nicht vor (`grep -nE 'branch -D|git branch'` findet nur die echo-Zeile). Die Meldung "DELETED $branch" ist unqualifiziert und liest sich als vollstaendige Loeschung — sie beschreibt aber nur die Remote-Haelfte. Folge: nach jedem Reap bleiben lokale Leichen liegen, deren Upstream ab da [gone] ist. Zuschnitt eines Fixes: entweder Meldung auf "DELETED remote/$branch" praezisieren, oder den lokalen Ref mitloeschen, wenn er auf denselben SHA zeigt wie der Archiv-Tag.
+**10. repo-hygiene §2: [gone]-Prune läuft VOR branch-reaper, der selbst neue [gone]-Refs erzeugt** (process, .claude/skills/references/repo-hygiene-ops.md §2)
+
+In repo-hygiene-ops.md §2 steht der [gone]-Aufraeumpfad (git fetch --prune + force-delete gemergter Branches) VOR dem Unterabschnitt "Verwaiste Remote-Branches (ohne PR)", der branch-reaper.sh aufruft. Der Reaper loescht aber Remote-Branches und erzeugt damit GENAU die [gone]-Refs, die der vorangegangene Schritt haette aufraeumen sollen. Real beobachtet am 2026-08-10: der Prune zu Beginn fand null [gone]-Branches, nach dem Reap von chore/adr006-sdlc-topologie-T002623 war dieser eine [gone] — im selben Lauf raeumte ihn nichts mehr weg. Erschwerend: der §2-[gone]-Pfad verlangt einen nachweislich gemergten PR, und Reaper-Kandidaten haben per Definition KEINEN PR (deshalb greift der Reaper ueberhaupt). Der [gone]-Pfad haette ihn also auch beim naechsten Lauf uebersprungen ("SKIP — upstream gone but no merged PR found"). Manuell aufgeraeumt ueber den Archiv-Tag als Sicherheitsanker (`git rev-parse --verify refs/tags/reaped/$b` vorhanden -> `git branch -D` belegt sicher). Zuschnitt: entweder Reihenfolge umdrehen, oder den Archiv-Tag als zweites zulaessiges Positiv-Signal im [gone]-Pfad dokumentieren.
 
 ## Verify (RED → GREEN)
 

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 02:28 UTC. Die Eintraege stammen aus den
+2026-08-10 02:34 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:05 UTC. Die Eintraege stammen aus den
+2026-08-09 05:06 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:22 UTC. Die Eintraege stammen aus den
+2026-08-10 01:27 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -1,0 +1,1092 @@
+---
+title: "mishap-incident-rollup — Implementation Plan"
+ticket_id: T002784
+domains: [factory]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# mishap-incident-rollup — Implementation Plan
+
+_Container-Ticket: T002784_
+
+Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
+2026-08-09 04:59 UTC. Die Eintraege stammen aus den
+Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
+
+## File Structure
+
+```
+<Der Implementer traegt hier die tatsaechlich geaenderten Dateien nach>
+```
+
+## Mishap-Batches
+
+_Uebernommen von T002601 (status=done, fuer den Rollup-Treiber unsichtbar) — Defekt T002783._
+
+### Mishap-Rollup — 9 Eintraege (2026-08-09 01:55 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | degraded |  | ticket.sh --attempts-Validierung scheitert bei regulaerer Nutzung |
+| 2 | degraded |  | Agent-Lock schuetzt nicht: zweiter Akteur arbeitete ohne Lock im selben Worktree |
+| 3 | degraded |  | Abgebrochener CI-Lauf ist in der Aggregation nicht von echtem Fehlschlag unterscheidbar |
+| 4 | drift | mcp/mcp-postgres · docs | mcp-postgres liest eingefrorene fleet-Kopie statt lokaler SSOT — Triage las 3 bereits-done Tickets als offen |
+| 5 | drift | factory · tickets/lifecycle | 7 Tickets plan_staged ohne Plan-Artefakte (T002768–T002774) — dev-flow-execute kann sie nicht verarbeiten |
+| 6 | drift | repo | Main-Checkout dirty — Post-T002753-Docs, stale Fixture, untracked Hook |
+| 7 | drift | factory | T002762 (SF-TEST-*, is_test_data=true) im Factory-Backlog |
+| 8 | suspicious | skills/repo-hygiene | Hauptcheckout wurde mitten im repo-hygiene-Lauf von fremder Hand gestasht — §0-Befund veraltete unbemerkt |
+| 9 | drift | scripts/agent-lock.sh | Branch-Lock überlebt Reap trotz totem PID und fehlendem Worktree — plus Korrektur zum vorigen Mishap |
+
+**1. ticket.sh --attempts-Validierung scheitert bei regulaerer Nutzung** (degraded, )
+
+Gefunden am 2026-08-09 bei der Umsetzung von T002620 (Reparatur der FA-SF-26-Watchdog-Tests).
+
+Beim Versuch, den vollstaendigen watchdog.sh-Pfad live zu verifizieren, lief der Agent in einen vorbestehenden Fehler in der --attempts-Validierung von scripts/ticket.sh. Der Fehler ist unabhaengig von T002620 und war der Grund, warum stattdessen auf einen read-only RED->GREEN-Nachweis ausgewichen wurde.
+
+WARUM DAS ZAEHLT: Der Watchdog-Eskalationspfad fuehrt einen Attempt-Counter (Status-Reset, Slot-Freigabe, Comment, Worktree-Cleanup, Attempt-Counter — siehe T002620-Beschreibung). Wenn dessen CLI-Einstiegspunkt bei regulaerer Nutzung scheitert, ist der Zaehler-Teil des Eskalationspfads praktisch nicht bedienbar und auch nicht live pruefbar. Das ist dieselbe Struktur wie der Befund von T002620 selbst: ein Pfad, der als getestet gilt, ist es nicht.
+
+ZUSATZBEFUND aus demselben Lauf, bereits mitbehoben: seed_test_feature war in der setup() von tests/spec/software-factory/scheduling.bats nicht gesourced — ein latenter Defekt unabhaengig vom updated_at-Backdating.
+
+NAECHSTER SCHRITT: Die genaue Fehlermeldung reproduzieren (bash scripts/ticket.sh … --attempts <n>) und die Validierung gegen die tatsaechlich vorgesehenen Aufrufformen pruefen. Test nach Repo-Konvention mit Output-Verifikation, eigene Datei unter tests/spec/software-factory/.</description>
+<parameter name="component">scripts/ticket.sh
+**2. Agent-Lock schuetzt nicht: zweiter Akteur arbeitete ohne Lock im selben Worktree** (degraded, )
+
+Beobachtet am 2026-08-09 bei der Ausfuehrung von T002679.
+
+HERGANG: ticket-ops hielt einen gueltigen Lock (scope=ticket, id=T002679, state=live, label=ticket-ops-execute) und dispatchte einen Agenten in .worktrees/brain-ingest-chunking-T002679. Parallel arbeitete ein opencode-Lauf (drei Prozesse plus scripts/factory/wakeup.sh) IM SELBEN WORKTREE: er editierte Dateien, committete den Stand des ersten Agenten, pushte und oeffnete PR #3892. Zwischenzeitlich setzte er brain-ingest-transform.sh auf die head -c-Fassung zurueck und den lokalen Branch auf einen frischen Scaffold-Commit — aus Sicht des ersten Agenten war die Implementierung damit lokal verschwunden.
+
+Der zweite Akteur hielt KEINEN Lock. Der Lock-Mechanismus ist kooperativ: er meldet Besitz, verhindert aber keinen Zugriff. Wer ihn nicht abfragt, ist von ihm nicht betroffen.
+
+AUSGANG (verifiziert, kein Schaden): Der erste Agent brach ab statt einen Push-Wettlauf zu fuehren und sicherte seinen Stand als origin/backup/T002679-infra-agent-a2ee6146f. Der Diff Sicherung -> origin/feature/brain-ingest-chunking-T002679 enthaelt ausschliesslich HINZUGEKOMMENE Dateien (die gemergten T002659/T002709-Aenderungen plus Release-Artefakte); alle vier neuen Skripte sind vorhanden und der fail-closed MAX_SOURCE_CHARS-Guard steht. Der aktuelle Stand ist eine Obermenge.
+
+WARUM DAS TROTZDEM ZAEHLT: Der Ausgang war Glueck plus die Umsicht des ersten Agenten, nicht Wirkung eines Schutzmechanismus. Zwei nicht koordinierte Schreiber in einem Worktree koennen einander Arbeit vernichten; ein Backup-Branch entsteht nur, wenn ein Agent auf die Idee kommt.
+
+VORSCHLAG: Beim Betreten eines Worktrees pruefen, ob ein fremder Lock auf dem zugehoerigen Ticket oder Branch liegt, und bei Treffer abbrechen — auf BEIDEN Wegen (Claude-Code-Agenten und opencode/factory-Laeufe). Alternativ eine Lockdatei IM Worktree, die jeder Schreiber sieht, statt nur einer zentralen Liste, die abgefragt werden muss.
+
+VERWANDT: T002498-M6 (Lock-Scope-Vollstaendigkeit), T002422 (Pre-Check vor claim).</description>
+<parameter name="component">scripts/agent-lock.sh · Worktree-Koordination
+**3. Abgebrochener CI-Lauf ist in der Aggregation nicht von echtem Fehlschlag unterscheidbar** (degraded, )
+
+Beobachtet am 2026-08-09 an PR #3892 (T002679).
+
+BEFUND: Der CI-Lauf 31286855491 auf Head a2ad33bc2 wurde als Ganzes abgebrochen (cancelled). In der PR-Aggregation erschien das als "10 failed" — zehn FAILURE/CANCELLED-Eintraege. Der eine echte failure-Eintrag, "Factory + OpenSpec + Guards", war ein 5-Sekunden-Job, dessen Log woertlich SHARDS_RESULT: cancelled als Ursache nennt. Ein abgebrochener Lauf sieht in der Aggregation also aus wie ein Fehlschlag.
+
+KOSTEN: Die Verwechslung hat zwei Agenten Zeit gekostet. Der erste erklaerte die roten Eintraege als Supersede-Artefakt und schloss daraus faelschlich auf "im Grunde gruen" — der Lauf war aber kein Nachweis, sondern gar KEIN Ergebnis. Nach einem Neustart lagen darunter zwei echte Fehlschlaege (Freshness-Drift in openspec-status.json/repo-index.json sowie die Race aus T002779). Beide Fehlurteile — "rot, also kaputt" und "abgebrochen, also harmlos" — folgen aus derselben nicht unterscheidbaren Anzeige.
+
+UNGEKLAERT UND EIGENSTAENDIG VERDAECHTIG: Was den Lauf abgebrochen hat, liess sich nicht feststellen. Es gab KEINEN neueren Lauf fuer dieselbe SHA (die Concurrency-Gruppe ci-CI-refs/pull/3892/merge hatte nichts zu verdraengen), arbitration.yml cancelt nichts, und ein aelterer Lauf auf 173ec2869 lief zu dem Zeitpunkt noch weiter. Das deutet auf ein externes gh run cancel. Wenn das haeufiger vorkommt, bricht jemand oder etwas fremde CI-Laeufe ab.
+
+VORSCHLAG: (1) In der CI-Fix-Schleife (.claude/skills/references/) festhalten, dass ein cancelled-Lauf KEIN Ergebnis ist und neu gestartet werden muss, statt interpretiert zu werden — weder als gruen noch als rot. (2) Den Aggregat-Job so gestalten, dass er cancelled sichtbar von failure trennt, statt SHARDS_RESULT: cancelled als failure zu melden. (3) Bei Wiederholung die Herkunft der Cancel-Ereignisse untersuchen.
+
+VERWANDT: T002779 (Race auf docs/agent-guide/registry/mcp.yaml unter bats -j).</description>
+<parameter name="component">.github/workflows/ci.yml · CI-Fix-Schleife
+**4. mcp-postgres liest eingefrorene fleet-Kopie statt lokaler SSOT — Triage las 3 bereits-done Tickets als offen** (drift, mcp/mcp-postgres · docs)
+
+mcp__mcp-postgres__query (127.0.0.1:13001) wird per kubectl --context fleet port-forward auf svc/claude-code-mcp-monolith (default ns) bedient — also die per ADR-006 E3 EINGEFRORENE fleet-Kopie des tickets-Schemas (SELECT ja, INSERT/UPDATE/DELETE nein). Die lokale SSOT liegt auf k3d-mentolder-dev/workspace/shared-db (Default von scripts/ticket.sh). Verifiziert: ss zeigt Port 13001 an kubectl --context fleet; ticket.sh-Header dokumentiert die Freeze-Situation nur dort, nicht im MCP-Tool-Guide §mcp-postgres. Folge: der erste Triage-Lauf las T002714 als plan_staged (lokal: in_progress), T002722/T002679/T002709 als offen (lokal: bereits done) und loeste redundante Closure-Writes aus. Empfehlung: MCP-Tool-Guide §mcp-postgres um den Freeze-Hinweis ergaenzen oder 13001 auf die lokale shared-db umziehen.
+**5. 7 Tickets plan_staged ohne Plan-Artefakte (T002768–T002774) — dev-flow-execute kann sie nicht verarbeiten** (drift, factory · tickets/lifecycle)
+
+T002768, T002769, T002770, T002771, T002772, T002773, T002774 haben lokal status=plan_staged, aber KEINEN gestagten Plan: keine FACTORY-PLAN-REF-Kommentarzeile, keine ticket_plans-Zeile, kein Branch (lokal/remote), kein openspec/changes/-Dir, kein Commit. Verifiziert: ticket_plans-Join leer, git log --all leer, Change-Dir-Suche leer. Die plan_staged-Statuszahl (9) speist die Factory-Kommissionierung — dispatcher-bridge wuerde dev-flow-execute auf Plan-lose Tickets loslassen und scheitern. Ursache vermutlich die parallele ticket-ops-Welle (Sid fa33ecd9), die Mishap-Fix-Tickets anlegte und Status setzte ohne Staging-Ceremonie. Empfehlung: entweder stage-plan fuer die 7 nachziehen oder Status auf triage zuruecksetzen; solange ungeklaert, sind sie KEIN Execution-Wave-Kandidat.
+**6. Main-Checkout dirty — Post-T002753-Docs, stale Fixture, untracked Hook** (drift, repo)
+
+git status --porcelain zeigt: M .opencode/agent-models.jsonc (Quants-Doku-Update), M AGENTS.md (gemma26-factory statt alter Loadouts), D openspec/changes/tcc-fixture-3511572/* (stale Test-Fixture, 1092 Zeilen), ?? .githooks/post-rewrite (neuer Hook, ungetrackt). Alle Änderungen sind Maintenance-Reste ohne funktionalen Patch — kein laufendes Ticket, in dessen Worktree sie gezogen werden könnten. Aufgefallen während repo-hygiene §0.
+**7. T002762 (SF-TEST-*, is_test_data=true) im Factory-Backlog** (drift, factory)
+
+factory_queue zeigt T002762 im Backlog. Das ist ein E2E-Testdaten-Ticket mit is_test_data=true. T002781 (ticket.sh list filtert is_test_data nicht) adressiert den Root-Cause, ist aber noch in triage. Der Backlog-Slot ist faktisch blockiert, bis T002781 implementiert ist. Aufgefallen während repo-hygiene §5.
+**8. Hauptcheckout wurde mitten im repo-hygiene-Lauf von fremder Hand gestasht — §0-Befund veraltete unbemerkt** (suspicious, skills/repo-hygiene)
+
+BEOBACHTUNG (verifiziert, repo-hygiene-Lauf 2026-08-09)
+
+Zu Beginn des Laufs (§0 Arbeitsbaum und Stashes), eigene Messung:
+    git status --porcelain  ->  M .opencode/agent-models.jsonc
+                                M AGENTS.md
+                                ?? .githooks/post-rewrite
+    git stash list          ->  LEER
+    git worktree list       ->  main + 3 Worktrees
+
+Am Ende desselben Laufs, dieselben Befehle:
+    git status --porcelain  ->  nur noch ?? .githooks/post-rewrite
+    git stash list          ->  stash@{0}: On main: repo-hygiene: pre-T002769-plan
+                                dirty main checkout
+    git worktree list       ->  zusaetzlich .worktrees/plan-staged-guard-T002769
+
+Zeitstempel (git log -g refs/stash bzw. stat): Stash 2026-08-09T03:36:03+02:00, Worktree
+03:37:21 — beide innerhalb dieses Laufs.
+
+URHEBER IST NICHT BELEGT [UNVERIFIED]
+
+Die naheliegende Erklaerung waere der Factory-Tick — mcp__factory-mcp__factory_status
+meldete tick_running=true, und T002769 stand als plan_staged in der Queue. Diese
+Zuschreibung haelt der Pruefung aber NICHT stand: eine repo-weite Suche nach der
+Stash-Nachricht ("dirty main checkout") findet keinen Treffer, und der einzige
+git-stash-push im Repo steht in scripts/worktree-create.sh:154 mit der abweichenden
+Nachricht "worktree-create-auto-stash". Die Nachricht "repo-hygiene: pre-T002769-plan
+dirty main checkout" ist von Hand formuliert — also von einer nebenlaeufigen
+Agenten-Session, nicht von versioniertem Code. ListAgents meldete 53 Peer-Sessions.
+Welche es war, ist offen.
+
+Kein Verzeichnis .agent-locks/ vorhanden — zum Zeitpunkt der Kollision hielt niemand
+einen Lock auf den Hauptcheckout, auch ich nicht.
+
+FOLGE
+
+Kein Datenverlust: der Stash-Inhalt wurde per git diff "stash@{0}^" "stash@{0}"
+verifiziert und ist mit dem urspruenglich gefundenen Diff identisch; er ist in Ticket
+T002782 samt Wiederauffind-Anleitung ueber die Stash-Nachricht dokumentiert
+(stash@{0} ist relativ und verschiebt sich bei weiteren Stashes).
+
+Der Schaden ist ein anderer: der §0-Befund, auf dem eine Nutzerentscheidung beruhte
+(Routing der drei ungeticketen Aenderungen in ein chore-Ticket), war zum Zeitpunkt des
+Berichts nicht mehr der Ist-Zustand. Aufgefallen ist es nur, weil am Ende zufaellig noch
+einmal git status lief. Ohne diese Wiederholung haette der Bericht einen Arbeitsbaum
+beschrieben, den es nicht mehr gab — und der Nutzer haette die Aenderungen an der
+genannten Stelle nicht gefunden.
+
+STRUKTURELLER KERN
+
+repo-hygiene §0 liest den Hauptcheckout und leitet daraus Entscheidungen ab, haelt aber
+keinen Lock dagegen und prueft nicht, ob nebenlaeufige Schreiber aktiv sind. Der
+Factory-Status wird erst in §5 abgefragt, also NACH der Auswertung — obwohl ein laufender
+Tick eine Vorbedingung fuer §0 ist, nicht eine Randnotiz am Schluss.
+
+DENKBARE ABHILFE (nicht entschieden)
+- §0 fragt Factory-Status und aktive Sessions VOR der Arbeitsbaum-Inspektion ab und
+  meldet einen laufenden Schreiber als ausdruecklichen Vorbehalt am Befund.
+- Oder: §0 wiederholt die Inspektion am Ende und vergleicht; eine Abweichung wird
+  gemeldet statt stillschweigend ueberschrieben.
+- Oder: repo-hygiene nimmt fuer die Dauer des Laufs einen agent-lock auf den
+  Hauptcheckout (scripts/agent-lock.sh).
+Welche davon traegt, ist eine eigene Untersuchung — insbesondere weil der Urheber hier
+gerade NICHT der Factory-Tick war und ein Lock gegen fremde Agenten-Sessions nur wirkt,
+wenn diese ihn auch lesen.
+**9. Branch-Lock überlebt Reap trotz totem PID und fehlendem Worktree — plus Korrektur zum vorigen Mishap** (drift, scripts/agent-lock.sh)
+
+KORREKTUR ZUM VORHERGEHENDEN EINTRAG (gleiche Session, 2026-08-09)
+
+Der Mishap "Hauptcheckout wurde mitten im repo-hygiene-Lauf von fremder Hand gestasht"
+enthaelt eine falsche Behauptung: "Kein Verzeichnis .agent-locks/ vorhanden — zum
+Zeitpunkt der Kollision hielt niemand einen Lock". Das ist falsch. Ich hatte im
+Repo-Wurzelverzeichnis nachgesehen; der Lock-Store liegt aber laut _lock_dir() in
+scripts/agent-lock.sh unter "$(git rev-parse --git-common-dir)/agent-locks", also
+.git/agent-locks/. Dort lagen sechs lebende Claims.
+
+Damit klaert sich auch der offene Punkt "Urheber ist nicht belegt": ticket/T002769 war
+mit Label "opencode-flow-plan" (sid 289461) geclaimt. Die Stash-Nachricht
+"repo-hygiene: pre-T002769-plan dirty main checkout" passt dazu. Der Urheber war eine
+opencode-Planungssession — nicht der Factory-Tick, wie zuerst vermutet, und nicht
+"niemand mit Lock", wie danach behauptet. Wer den vorigen Eintrag liest, muss diesen
+mitlesen.
+
+EIGENSTAENDIGER BEFUND: Branch-Lock ueberlebt zwei Reap-Laeufe
+
+    $ cat .git/agent-locks/branch__fix-ticket-read-path-T002781.json
+    { "scope": "branch", "id": "fix/ticket-read-path-T002781",
+      "owner_sid": "fa33ecd9-...", "owner_pid": "127574",
+      "worktree": "/home/patrick/Bachelorprojekt/.worktrees/ticket-read-path-T002781",
+      "created_at": "1786238180", "heartbeat_at": "1786238180" }
+
+Zustand zum Pruefzeitpunkt:
+  - PID 127574: ps -p 127574 -> nicht vorhanden (tot)
+  - worktree-Pfad: von mir entfernt, existiert nicht mehr
+  - owner_sid: fremde Session, nicht meine (ffe41dfa-...)
+  - heartbeat_at == created_at, rund 28 Minuten alt
+
+Trotzdem meldet agent-lock.sh list den Eintrag nach ZWEI aufeinanderfolgenden reap-Laeufen
+weiterhin als STATE=live. Im selben Lauf wurden andere Locks sehr wohl geerntet
+(.reap.log: ticket/T002767 heartbeat-ttl, ticket/T002781 heartbeat-ttl), und der Reaper
+kennt worktree-missing nachweislich als Grund — er hat ticket/T002645 genau damit geerntet
+(1786239054 ticket/T002645 worktree-missing).
+
+VERMUTUNG (nicht verifiziert): worktree-missing und/oder pid-dead werden fuer scope=ticket
+ausgewertet, fuer scope=branch aber nicht — oder der Branch-Scope hat eine deutlich
+laengere Heartbeat-TTL. Welche der beiden zutrifft, ist ohne Lesen der Reap-Bedingungen in
+scripts/agent-lock.sh nicht entschieden.
+
+FOLGE: Ein Claim auf branch "fix/ticket-read-path-T002781" wird blockiert, obwohl der
+Halter tot und sein Worktree weg ist. T002781 ist ein offenes Ticket in triage — die
+naechste Session, die daran arbeiten will, laeuft in den toten Lock.
+
+TEST (Output-Verifikation, T002448-M4): Einen Branch-Lock mit totem PID und fehlendem
+Worktree anlegen, reap AUSFUEHREN und pruefen, dass der Lock danach WEG ist (bzw. list ihn
+nicht mehr als live fuehrt) — nicht die Reap-Bedingungen im Quelltext greppen. Positiv-Anker
+(T002356-M1): im selben Test zeigen, dass ein Branch-Lock mit LEBENDEM Halter den Reap
+ueberlebt, sonst besteht der Test auch bei einem Reaper, der wahllos alles loescht.
+### Mishap-Rollup — kuratierte Uebernahme aus 14 gestrandeten Batches (2026-08-09)
+
+Nachgezogen aus den Containern T002557/T002575/T002597/T002601 (alle `done`, fuer den Rollup-Treiber unsichtbar — Defekt T002783). Quelle: 14 unverarbeitete Batch-Kommentare vom 2026-08-02 bis 2026-08-09 mit 128 Eintragszeilen, davon 109 eindeutig.
+
+**Auswahl:** 44 Eintraege hatten bereits ein eigenes Ticket (Titelabgleich gegen 2079 Tickets), 24 waren einmalige Zustandsbeobachtungen, 9 sind anderweitig dokumentiert oder abgedeckt. Es bleiben die folgenden strukturellen Befunde ohne eigenes Ticket. Die Klassifikation erfolgte auf Titelebene mit Stichproben-Verifikation, nicht als Einzelaudit jedes Eintrags.
+
+| # | Typ | Befund |
+|---|---|---|
+| 1 | degraded | KORREKTUR zum vorigen Eintrag: task pr:refresh verweigert Branches, die in einem Worktree ausgecheckt sind |
+| 2 | degraded | Offener PR wird durch parallelen OpenSpec-Archive-Merge rot, ohne automatisches Nachziehen |
+| 3 | degraded | Ticket-Auto-Close bei Mehr-PR-Vorgaengen: done bei 1/7 Fortschritt |
+| 4 | degraded | Vitest-Dateien liegen zwischen node:test-Suiten und machen Sammellaeufe strukturell rot |
+| 5 | degraded | branch-reaper.sh: fehlende Merge-Base wird als "keine Abweichung" gewertet |
+| 6 | degraded | dev-flow-execute-Subagenten beenden sich beim Warten auf Hintergrundlaeufe — Arbeit bleibt halbfertig liegen |
+| 7 | degraded | devflow-ci-watch.sh meldet nach Force-Push (Rebase) stale Check-Ergebnisse der alten SHA statt der neuen |
+| 8 | degraded | freshness:check misst lokal gegen den Branch, CI gegen den Merge-Commit |
+| 9 | degraded | llm-proxy haelt loadouts.mjs im Speicher — kennt nach einem Merge neue Felder nicht |
+| 10 | degraded | openspec-status.json ist per Konstruktion blind fuer plan_staged-Tickets |
+| 11 | degraded | plan-context.sh --with-openspec liefert 170+ Proposals, Direktive nicht befolgbar |
+| 12 | degraded | post-commit openspec-embed-Hook meldet "fetch failed" — Changes bleiben unindiziert |
+| 13 | degraded | repo-hygiene-ops §2 setzt volle Historie voraus — Hauptcheckout war shallow |
+| 14 | degraded | repo-hygiene-ops.md §3 umgeht vier vorhandene PR-Werkzeuge zugunsten handgeschriebener gh/git-Kommandos |
+| 15 | degraded | worktree-create.sh prueft die erste Ticket-ID im Branchnamen, nicht die eigene |
+| 16 | degraded | worktree-create.sh: lokale Aenderungen an Dateien im FF-Bereich gehen beim main-Sync still verloren |
+| 17 | degraded | worktree-write-guard erfasst keine Bash-Schreibzugriffe |
+| 18 | drift | Doku-Drift: ticket_links traegt 340+ PR-Selbstkanten, Skill-Referenz schliesst das aus |
+| 19 | drift | G-AGENTIC07 auf main rot: ein verwaister aktiver Skill ohne Referenzquelle |
+| 20 | drift | dev-flow-plan Fix-Pfad: stage-plan (Schritt 4.5) steht vor Commit (Schritt 5), ist so aber nicht ausfuehrbar |
+| 21 | process | "behind N" gegen den eigenen Feature-Remote ist kein Beleg fuer fehlende Arbeit |
+| 22 | process | Subagent-Abbruch: letzte Ausgabezeile suggerierte Fortschritt, Dateien waren leer |
+| 23 | process | dev-flow-e2e empfiehlt test/*-Branch, pre-commit verlangt feature/fix/chore/docs + T###### |
+| 24 | process | mishap-tracker erzeugt Duplikat-Incident zu einem bereits gestagten Plan |
+| 25 | suspicious | agent-lock list zeigt Lock mit "--label" als Scope-Wert (Argument-Parsing) |
+| 26 | suspicious | branch-reaper.sh erzwingt --ticket auch im reinen --dry-run-Inventarlauf |
+| 27 | suspicious | browser.newContext() im storageState-Projekt lieferte authentifizierten Kontext |
+| 28 | suspicious | devflow-ci-watch meldet "Keine CI-Checks gefunden", nachdem es zehn gruene Checks gelistet hat |
+| 29 | suspicious | mcp-sync-Guard meldet auf veralteter Branch-Basis roten Drift, der lokal nicht existiert |
+| 30 | suspicious | test:spec:changed uebersieht staged-aber-uncommittete Tests und meldet "No matching spec tests" |
+| 31 | suspicious | ticket.sh list --status <unbekannt> liefert still [] statt eines Fehlers |
+
+Volltext der Einzeleintraege: Batch-Kommentare 9913, 10114, 10273, 10413, 10672, 10718, 10839, 10840, 11241, 11242, 13115, 13249, 13429, 13727 in `tickets.ticket_comments`.
+### Volltexte der 31 uebernommenen Befunde (Archiv vor Loeschung der Altcontainer)
+
+Gesichert am 2026-08-09, bevor T002541/T002557/T002575/T002597/T002601 entfernt wurden. Die Zeiger auf die urspruenglichen Kommentar-IDs im vorigen Kommentar verfallen mit der Loeschung — dies hier ist der Ersatz.
+
+---
+
+#### 1. KORREKTUR zum vorigen Eintrag: task pr:refresh verweigert Branches, die in einem Worktree ausgecheckt sind
+
+_(degraded, skills/references/repo-hygiene-ops)_
+
+Korrigiert den unmittelbar vorhergehenden Buffer-Eintrag "repo-hygiene-ops.md §3 umgeht vier vorhandene PR-Werkzeuge". Dessen Fix-Richtung ("Heilpfad auf `task pr:refresh -- <pr>` als Primaerweg umstellen, manuelle Prozedur zum Fallback degradieren") ist in dieser Form FALSCH und darf nicht so umgesetzt werden.
+
+BEOBACHTUNG:
+    $ task pr:refresh -- --dry-run 3856
+    pr-refresh: PR 3856: Branch feature/e3-sdlc-tickets-lokal-T002626 ist ausgecheckt in
+                /home/patrick/Bachelorprojekt/.worktrees/e3-sdlc-tickets-lokal — abgebrochen.
+    pr-refresh: Bilanz — 0 geheilt, 0 uebersprungen, 1 abgelehnt.
+    exit status 1
+
+scripts/pr-refresh.sh lehnt einen PR ab, sobald dessen Branch in einem Worktree ausgecheckt ist. Das ist plausibel als Schutz (das Skript will den Branch selbst auschecken/rebasen und wuerde sonst mit dem Worktree kollidieren), aber es trifft den Regelfall von repo-hygiene: die offenen PRs dieses Repos haben typischerweise genau einen zugehoerigen Worktree unter .worktrees/. In diesem Lauf galt das fuer beide offenen PRs.
+
+FOLGE FUER DIE FIX-RICHTUNG:
+Die manuelle Prozedur in §3 (git merge origin/main → task freshness:regenerate → task test:inventory → commit → push) ist NICHT obsolet — sie ist der korrekte Weg fuer worktree-ausgecheckte Branches, und PR #3856 wurde in diesem Lauf zweimal so geheilt. Der eigentliche Mangel ist enger als zuerst formuliert: §3 nennt weder das Werkzeug noch seine Vorbedingung. Richtige Ergaenzung waere eine Fallunterscheidung:
+  - Branch NICHT in einem Worktree ausgecheckt → `task pr:refresh -- <pr>`
+  - Branch in einem Worktree ausgecheckt (Regelfall) → manuelle Prozedur, im Worktree ausgefuehrt
+Zusaetzlich waere zu pruefen, ob pr-refresh.sh den Worktree-Fall selbst bedienen koennte (im vorhandenen Worktree mergen statt den Branch andernorts auszuchecken) — dann entfiele die Fallunterscheidung.
+
+Der Teilbefund zu scripts/ci-pr-health.sh aus dem vorigen Eintrag bleibt unveraendert gueltig: es erkennt "CI nie gestartet" via Exit 2 und hat keine Worktree-Vorbedingung, ist also uneingeschraenkt als Triage-Schritt in §3 aufnehmbar.
+
+ZUSATZBEOBACHTUNG (belegt die Wiederkehr): Nach dem Merge von PR #3867 nach main fiel PR #3856 sofort wieder auf mergeStateStatus=DIRTY zurueck, weil beide PRs dieselben generierten Artefakte (test-inventory.json, repo-index.json) beruehren. Die Heilung musste im selben Lauf zweimal ausgefuehrt werden. Das ist die in T002347 beschriebene Ursache, hier mit Messpunkt.
+
+---
+
+#### 2. Offener PR wird durch parallelen OpenSpec-Archive-Merge rot, ohne automatisches Nachziehen
+
+_(degraded, ci/openspec-validate)_
+
+PR #3669 war 5 Commits hinter main und CI rot (Factory OpenSpec + Guards, Factory spec shard 3), weil der Branch noch das inzwischen von PR #3671 archivierte OpenSpec-Change-Verzeichnis openspec/changes/fix-plan-intel-merge unarchiviert trug. Kollateralschaden: jeder offene PR mit eigenem OpenSpec-Change kann durch einen fremden Archive-Merge auf main rot werden, ohne dass etwas am PR selbst falsch ist. Kein automatischer Rebase-Trigger dafür vorhanden. Manuell per REST-Update behoben.
+
+---
+
+#### 3. Ticket-Auto-Close bei Mehr-PR-Vorgaengen: done bei 1/7 Fortschritt
+
+_(degraded, scripts/factory/pipeline.js)_
+
+T002569 (OpenSpec-Rueckstau, 7 geplante Chargen) wurde nach dem Merge von PR #3694 ("archive OpenSpec-Charge 1 [T002569]") automatisch auf done gesetzt. Zu dem Zeitpunkt standen 166 von urspruenglich 181 Changes noch unarchiviert — der Vorgang war zu etwa 1/7 erledigt.
+
+Ursache: der Merge-Automatismus schliesst jede im PR-Titel referenzierte Ticket-ID, unabhaengig vom tatsaechlichen Fortschritt. Bei einem Vorgang, der per Plan bewusst ueber mehrere PRs laeuft, ist das strukturell falsch.
+
+VERSCHAERFEND: Der Rueckweg ist per Wrapper versperrt. `mcp__ticket-mcp__transition_status` lehnt ab mit "Cannot transition from 'done' to 'in_progress' — terminal tickets can only transition to 'archived'". Die Korrektur ging nur per direktem psql-UPDATE am Guard vorbei. Wer den Fehlzustand bemerkt, muss also eine Schutzregel umgehen, um ihn zu beheben.
+
+VERIFIZIERT 2026-08-02: PR #3693 und #3694 gemergt, `git ls-tree -d origin/main openspec/changes/` zaehlt 166 unarchivierte Verzeichnisse, Ticket stand auf done/resolution=NULL. Zurueckgesetzt auf in_progress per psql.
+
+VORSCHLAG: Entweder der Auto-Close prueft eine Fortschritts-Bedingung (z.B. Plan-Tasks alle abgehakt), oder mehrteilige Vorgaenge markieren sich als solche und sind vom Auto-Close ausgenommen. Alternativ ein dokumentierter, nicht-SQL Rueckweg fuer genau diesen Fall.
+
+---
+
+#### 4. Vitest-Dateien liegen zwischen node:test-Suiten und machen Sammellaeufe strukturell rot
+
+_(degraded, scripts/llm-proxy)_
+
+scripts/llm-proxy/mcp-bridge.test.mjs und scripts/llm/ui-config-seed.test.mjs importieren aus 'vitest', liegen aber im selben Verzeichnis wie echte node:test-Suiten (loadouts/runner/server/models.test.mjs).
+
+Unter `node --test` geben sie irrefuehrende Fehler, die nach Produktionsfehlern aussehen statt nach falschem Runner:
+  mcp-bridge:      "Vitest mocker was not initialized in this environment. vi.queueMock() is forbidden."
+  ui-config-seed:  "TypeError: Cannot read properties of undefined (reading 'config')"
+
+Folge: `node --test scripts/llm-proxy/` ist per Konstruktion rot, obwohl alle vier echten Suiten gruen sind. Beide Dateien verhalten sich auf main genauso — vorbestehend, nicht durch einen aktuellen PR verursacht. Unter `npx vitest run` laufen sie sauber (3/3 geprueft).
+
+Kostete zweimal Diagnosezeit: einmal beim Sammellauf, einmal bei der Frage, ob eine eigene Aenderung sie gebrochen hatte.
+
+Vorschlag: Namenskonvention (*.vitest.mjs) oder ein Kommentarheader in Zeile 1, der den zustaendigen Runner nennt — die Dateien sagen es derzeit erst im Import.
+
+---
+
+#### 5. branch-reaper.sh: fehlende Merge-Base wird als "keine Abweichung" gewertet
+
+_(degraded, scripts/branch-reaper.sh)_
+
+VERIFIZIERT (2026-08-02, repo-hygiene-Lauf).
+
+BEFUND: scripts/branch-reaper.sh:109 in _diverging_files():
+  mb="$(git merge-base "$REMOTE/main" "$ref" 2>/dev/null)" || return 0
+Schlaegt git merge-base fehl (keine gemeinsame Historie), kehrt die Funktion mit Exit 0 und OHNE jede Ausgabe zurueck. Der Aufrufer kann eine leere Abweichungsliste nicht von einer nie durchgefuehrten Messung unterscheiden — beides sieht aus wie "Branch weicht nicht von main ab" und damit wie eine Reap-Freigabe.
+
+Damit faellt genau das zweite der beiden Sicherheitssignale aus, die der Reaper laut Dokumentation verlangt ("Blob-Diff leer" UND "Ticket done"). Uebrig bleibt "Ticket done" allein — und die SSOT-Referenz repo-hygiene-ops.md haelt ausdruecklich fest, dass dieses Signal allein bei T002431 die einzige Kopie eines nie gemergten Deliverables geloescht haette.
+
+REAL AUFGETRETEN: origin/chore/mishap-t002408 hatte heute keine gemeinsame Merge-Base mit origin/main (git merge-base exit 1). Der Branch war nach manueller Pruefung tatsaechlich harmlos (beide Plan-Dateien blob-identisch in main, Ticket T002408 done, kein PR) und wurde geloescht — die Freigabe kam aber aus einer Pruefung, die in diesem Pfad nichts geprueft haette.
+
+GLEICHES MUSTER, ZWEITE STELLE: Der in repo-hygiene-ops.md §2 dokumentierte Handbetrieb-Schnipsel hat denselben Defekt ohne den kaschierenden Exit-Code:
+  mb=$(git merge-base origin/main "$b")
+  for f in $(git diff --name-only "$mb" "$b"); do ...
+Bei leerem $mb meldet git "fatal: ambiguous argument ''" auf stderr und die Schleife laeuft null Runden — auf stdout nicht von einem sauberen Ergebnis unterscheidbar.
+
+VORSCHLAG: In beiden Faellen die leere Antwort explizit vom negativen Befund trennen, statt aus Abwesenheit auf Unbedenklichkeit zu schliessen:
+  mb="$(git merge-base "$REMOTE/main" "$ref" 2>/dev/null)" || { printf 'KEINE-MERGE-BASE\n'; return 0; }
+Der Marker faellt dann in die Abweichungsliste, faellt durch die Allowlist und fuehrt zu KEEP statt REAP. Das ist dieselbe Korrektur, die repo-hygiene-ops.md §3 fuer gh-Antworten bereits vorschreibt ("Leere Antwort ist KEIN Urteil", T002498-M5) — hier fehlt sie auf der git-Seite.
+
+---
+
+#### 6. dev-flow-execute-Subagenten beenden sich beim Warten auf Hintergrundlaeufe — Arbeit bleibt halbfertig liegen
+
+_(degraded, .claude/skills/dev-flow-execute)_
+
+BEFUND (2026-08-02, Fan-out von 6 dev-flow-execute-Subagenten aus ticket-ops Phase 3): DREI VON DREI Agenten, die sich bis dahin beendet hatten, stoppten im selben Zustand — sie hatten einen Lauf im Hintergrund gestartet und beendeten sich in Erwartung einer Benachrichtigung, die einen Subagenten nicht mehr erreicht.
+
+Belegte Faelle, je woertlich aus der Abschlussmeldung:
+- T002504: "Waiting for the background `task test:changed` run (and the completion watcher) to finish — I'll resume once notified."
+- T002435: "Waiting for the background CI-watch loop to complete before continuing."
+- T002467: "I'll pause here and wait for the background verification task to complete."
+
+AUSWIRKUNG: Der Agent meldet sich als `completed`, ohne fertig zu sein. T002504 hatte zu diesem Zeitpunkt weder Commit noch PR. Ohne einen Orchestrator, der die Abschlussmeldungen gegenliest und per SendMessage nachfasst, waeren die Branches halbfertig liegen geblieben und haetten von aussen wie erledigte Arbeit ausgesehen — der gefaehrlichere Fall, weil nichts rot wird. Bei allen drei genuegte eine Aufforderung, den Stand selbst nachzusehen; danach liefen sie sauber bis Auto-Merge durch (T002435 → PR #3677).
+
+URSACHE (Hypothese, nicht verifiziert): Das Warte-Idiom von dev-flow-execute (Hintergrundlauf starten, auf Notification warten) setzt einen Lebenszyklus voraus, den ein Subagent nicht hat. Im Hauptloop funktioniert es, im Fan-out nicht.
+
+MOEGLICHE ABHILFEN, zu bewerten: (a) dev-flow-execute weist an, Verifikationslaeufe im Fan-out-Kontext im VORDERGRUND mit Timeout zu fahren statt im Hintergrund; (b) die Subagent-Provisionierung ergaenzt eine Direktive "warte nie auf eine Notification, pruefe den Stand selbst"; (c) der Dispatcher prueft jede `completed`-Meldung gegen den tatsaechlichen Branch-Zustand (Commit vorhanden? PR vorhanden? Auto-Merge gesetzt?), bevor er sie als fertig wertet. Variante (c) ist unabhaengig von der Ursache wirksam und deshalb der robusteste Kandidat.
+
+---
+
+#### 7. devflow-ci-watch.sh meldet nach Force-Push (Rebase) stale Check-Ergebnisse der alten SHA statt der neuen
+
+_(degraded, scripts)_
+
+T002561: Nach `git push --force-with-lease` (Rebase gegen origin/main wegen eines konkurrierenden Merges) lief `devflow-ci-watch.sh` erneut und meldete "18 CI-Checks, alle grün" — aber mit denselben Run-/Job-IDs wie vor dem Force-Push. Ein direkter Abgleich über `gh api repos/.../commits/<neue-SHA>/check-runs` zeigte die Checks noch als `in_progress` für die neue SHA. Das Skript scheint gecachte Rollup-Daten zu nutzen, die kurz nach einem Force-Push die alte SHA widerspiegeln, statt gegen die aktuelle `headRefOid` zu verifizieren. Ohne manuellen Gegencheck wäre ein Merge auf Basis stale gemeldeter grüner Checks versucht worden. Vorschlag: Skript soll die aktuelle `headRefOid` explizit gegen die Check-Run-SHA abgleichen und bei Mismatch neu pollen.
+
+---
+
+#### 8. freshness:check misst lokal gegen den Branch, CI gegen den Merge-Commit
+
+_(degraded, Taskfile.yml)_
+
+PR #3658 scheiterte dreimal an "docs/code-quality/repo-index.json regenerated but not staged", waehrend lokal `task freshness:check` durchgehend "All generated artifacts are fresh" meldete. Auch ein direkter Aufruf von scripts/code-quality/emit-index.mjs erzeugte lokal keinen Diff.
+
+URSACHE (nach dem Rebase belegt): CI prueft den MERGE-Commit aus PR-Head und aktuellem main, nicht den Branch allein. Zwischen Abzweig und Pruefung waren mehrere PRs auf main gelandet; der gemergte Zustand enthielt also mehr Dateien. Der Index-Generator scannt `git ls-files` PLUS untracked-but-not-ignored (scripts/code-quality/scan.mjs), das Ergebnis haengt damit direkt an der Dateimenge.
+
+Nach `git rebase origin/main` aenderten sich prompt beide Artefakte: repo-index.json +2/-1, test-inventory.json +6 Zeilen. Genau die Differenz, die CI sah und die lokale Messung nicht sehen konnte.
+
+WARUM ES ZEIT KOSTETE: Beide Messungen waren korrekt, sie massen nur Verschiedenes. Ein Re-Run des Jobs half deshalb nicht — es war kein Flake, sondern eine veraltete Basis. Diagnostiziert wurde erst, nachdem der PR zusaetzlich auf DIRTY ging und ein Rebase ohnehin faellig war.
+
+VORSCHLAG: Die Fehlermeldung von freshness:check koennte nennen, gegen welche Basis gemessen wurde, oder der Task koennte warnen, wenn der Branch hinter origin/main liegt ("HEAD ist N Commits hinter origin/main — CI misst gegen den Merge-Commit, das Ergebnis kann abweichen"). Der Hinweis kostet eine Zeile und haette hier drei Anlaeufe gespart.
+
+VERWANDT, gleiche Fehlerklasse in derselben Session: `git show origin/main:<pfad>` im Worktree lieferte einen veralteten Stand, woraufhin gueltige Tests als verwaist geloescht wurden (Mishap bereits erfasst). Beide Male war die Referenz falsch, nicht die Messung.
+
+---
+
+#### 9. llm-proxy haelt loadouts.mjs im Speicher — kennt nach einem Merge neue Felder nicht
+
+_(degraded, scripts/llm-proxy/server.mjs)_
+
+Beim Stop/Start von llama-gemma26-factory ueber den llm-proxy (POST /admin/loadouts/<slug>/start) antwortete dieser:
+
+  {"error":{"code":"start_error","message":"loadouts.json: loadouts[4]: unbekanntes Feld 'tools'"}}
+
+Das Feld 'tools' ist seit PR #3640 im Validator (scripts/llm-proxy/loadouts.mjs). Der llm-proxy-Prozess lief seit 08:26:39 aus /home/patrick/Bachelorprojekt; #3640 wurde gegen 08:50 gemergt. Die Datei auf der Platte war also neu, der Prozess hielt die alte Fassung im Speicher.
+
+FOLGE, nicht bloss kosmetisch: Das Loadout war zu dem Zeitpunkt bereits GESTOPPT (der Stop lief ueber denselben Proxy und gelang). Der fehlgeschlagene Start liess gemma26-factory unten — die Factory hatte kein Modell, bis der Proxy neu gestartet und das Loadout erneut hochgefahren war. Insgesamt rund 10 Minuten.
+
+Die Reihenfolge macht es gefaehrlich: Stop gelingt (alter Code reicht dafuer), Start scheitert (neuer Code noetig). Wer beides als Paar denkt, steht danach ohne laufendes Modell da.
+
+VORSCHLAG: Nach einem Merge, der scripts/llm-proxy/* beruehrt, gehoert systemctl --user restart llm-proxy.service in den post-merge-Pfad — analog zu dem, was devflow-post-merge-deploy.sh fuer Cluster-Pfade tut. Alternativ koennte der Proxy seine Modul-Memoisierung beim Erkennen einer geaenderten loadouts.mjs verwerfen; das ist aber der groessere Eingriff.
+
+Verwandt: der Proxy memoisiert auch die Backend-Tabelle (loadBackendsOnce in backends.mjs) — dieselbe Klasse Problem fuer Aenderungen an tickets.llm_proxy_backends.
+
+---
+
+#### 10. openspec-status.json ist per Konstruktion blind fuer plan_staged-Tickets
+
+_(degraded, scripts/openspec-status-map.sh)_
+
+ticket-ops-procedures Step 1.3 schreibt den Lookup `get_openspec_status` gegen website/src/data/openspec-status.json vor. Am 2026-08-02 lieferte er fuer ALLE 14 offenen Tickets einen leeren Status. VERIFIZIERT: Die Datei ist nicht defekt — 41663 Bytes, 379 Top-Level-Keys. Sie enthaelt aber keinen der aktuellen Changes, weil diese in Feature-Branches liegen und der Index aus main gebaut wird (`grep -rl` auf openspec/changes/*/.ticket findet auf main keinen der Slugs zu T002433-T002438, waehrend die Changes in den jeweiligen Branches committet vorliegen). Damit ist der Lookup strukturell wirkungslos fuer genau die Ticketklasse, fuer die Step 1.3 ihn abfragt: plan_staged-Tickets haben ihren Change definitionsgemaess noch nicht auf main. Entweder muss scripts/openspec-status-map.sh Branch-Changes mitindizieren, oder Step 1.3 muss den Branch-Stand direkt lesen. Nebenbefund: die Datei war im Hauptcheckout uncommitted modifiziert.
+
+---
+
+#### 11. plan-context.sh --with-openspec liefert 170+ Proposals, Direktive nicht befolgbar
+
+_(degraded, scripts/plan-context.sh)_
+
+CLAUDE.md schreibt vor, den Output von `bash scripts/plan-context.sh <role> --with-openspec` vor JEDEM Agent-Dispatch in den Prompt zu injizieren. Der Output umfasst derzeit ueber 170 Proposals, weil plan-context.sh `openspec/changes/` als Menge der AKTIVEN Vorhaben liest und dort der Archivierungs-Rueckstau liegt.
+
+WIRKUNG: Die Direktive ist fuer Multi-Agent-Dispatches praktisch nicht befolgbar — der Block wuerde den Prompt dominieren. In diesem ticket-ops-Lauf wurde sie fuer beide Welle-1-Dispatches bewusst uebergangen und die Abweichung im jeweiligen Agent-Prompt begruendet.
+
+STATUS DER BEHEBUNG: T002569 baut den Rueckstau ab. Stand 2026-08-02 sind PR #3693 (Guard-Fix) und #3694 (Charge 1) gemergt, 166 von urspruenglich 181 Changes stehen noch. Nach Abschluss aller 7 Chargen schrumpft der Feed auf die real offenen Vorhaben und die Direktive wird wieder sinnvoll.
+
+Kein eigener Fix noetig — hier festgehalten, damit die bewusste Abweichung nachvollziehbar ist und damit sichtbar bleibt, dass eine dokumentierte Pflicht derzeit nicht erfuellbar ist.
+
+---
+
+#### 12. post-commit openspec-embed-Hook meldet "fetch failed" — Changes bleiben unindiziert
+
+_(degraded, hooks/openspec-embed)_
+
+Beim Commit des T002569-Plans meldete der post-commit-Hook `openspec-embed` "fetch failed" (Embedding-Backend nicht erreichbar). Der Hook ist nicht-fatal, der Commit ging durch.
+
+WIRKUNG: Der neue Change ist nicht in pgvector indiziert. Die semantische Suche ueber OpenSpec-Changes (u.a. `openspec_find_similar` in factory-mcp, das vor dem Anlegen eines Proposals auf Duplikate prueft) sieht ihn nicht. Da der Hook still fail-open ist, faellt das nur auf, wenn man die Hook-Ausgabe liest — die Luecke waechst unbemerkt mit jedem Commit, der bei nicht erreichbarem Backend entsteht.
+
+Zusammenhang mit T002570: dort wurde gerade das Embedding-Routing korrigiert (bge-m3 primaer statt Voyage-Default, tote :8095-Fallbacks entfernt). Ob der Hook denselben Endpunkt nutzt und der Fehler nach dem Merge von PR #3692 verschwindet, ist NICHT geprueft — waere aber der erste Verdacht.
+
+VORSCHLAG: Pruefen, ob openspec-embed nach T002570 wieder durchlaeuft; falls ja, einen Nachindizierungs-Lauf fuer die zwischenzeitlich unindizierten Changes anstossen. Falls nein, eigene Ursachensuche.
+
+---
+
+#### 13. repo-hygiene-ops §2 setzt volle Historie voraus — Hauptcheckout war shallow
+
+_(degraded, skills/references/repo-hygiene-ops)_
+
+Beobachtet 2026-08-03 beim /repo-hygiene-Lauf. Der Hauptcheckout /home/patrick/Bachelorprojekt war ein Shallow Clone (.git/shallow vorhanden, `git log --oneline origin/main | wc -l` = 12).
+
+Folge: `git merge-base origin/main <branch>` scheiterte mit rc=1 fuer JEDEN der 7 Feature-Branches ("keine gemeinsame Historie"). Die in repo-hygiene-ops.md §2 dokumentierte Blob-Vergleichsschleife baut auf `mb=$(git merge-base ...)` auf und lief damit mit leerem $mb ins `fatal: ambiguous argument ''`. Der naheliegende Ausweichweg `git diff --name-only origin/main <branch>` (Zwei-Punkt) meldete stattdessen hunderte Phantom-Loeschungen unter .claude/skills/unsloth-buddy/** — die Branches lagen dort lediglich hinter main. Eine Reap-Entscheidung auf dieser Basis haette die Diff-Signatur falsch gelesen.
+
+Nach `git fetch --unshallow` lieferte dieselbe Schleife das korrekte Bild: alle 7 Branches tragen echte ungemergte Dateien, kein einziger war Reap-Kandidat.
+
+Vorschlag: in repo-hygiene-ops.md §2 einen Vorcheck aufnehmen, z.B.
+  [ -f "$(git rev-parse --git-dir)/shallow" ] && git fetch --unshallow
+Auch `git branch --merged main` ist im Shallow-Zustand strukturell unbrauchbar, ohne dass es das anzeigt.
+
+---
+
+#### 14. repo-hygiene-ops.md §3 umgeht vier vorhandene PR-Werkzeuge zugunsten handgeschriebener gh/git-Kommandos
+
+_(degraded, skills/references/repo-hygiene-ops)_
+
+BEOBACHTUNG (/repo-hygiene-Lauf 2026-08-08)
+
+Die SSOT-Referenz .claude/skills/references/repo-hygiene-ops.md §3 ("PR-Triage") schreibt eine manuelle Prozedur vor: rohes `gh pr list --json statusCheckRollup`, und zum Heilen eines CONFLICTING-PR `git merge origin/main` + `task freshness:regenerate` + commit + push, mit REST-`update-branch` als Eskalation. Sie nennt keines der vier Werkzeuge, die das Repo für genau diesen Zweck bereits hat.
+
+VERIFIKATION (grep -c gegen repo-hygiene-ops.md):
+  task pr:refresh              → 0 Treffer
+  scripts/ci-pr-health.sh      → 0 Treffer
+  scripts/factory/babysit-prs.sh → 0 Treffer
+  scripts/devflow-ci-watch.sh  → 0 Treffer
+
+Belege, dass die Werkzeuge existieren und passen:
+- `task --list` zeigt: "pr:refresh: Rebase konfliktbehaftete PRs auf origin/main und heilt Konflikte in generierten Artefakten. Usage: task pr:refresh -- [--dry-run] <pr-nummer>..." (entstanden aus T002413, Status done).
+- scripts/ci-pr-health.sh dokumentiert im Kopf und implementiert in Zeile 216 den Exit-Code 2 = "no checks found at all (CI never started)".
+
+KONKRETER SCHADEN IN DIESEM LAUF:
+1. PR #3856 (T002626) stand auf mergeStateStatus=CONFLICTING. GitHub startet auf solchen PRs keine Workflows: statusCheckRollup hatte 0 Einträge. In `gh pr list` sah der PR dadurch nicht rot aus, sondern unauffällig — er war schlicht ungetestet. Nach dem Heilen sprang die Zahl von 0 auf 15 Checks. Ein Aufruf von scripts/ci-pr-health.sh hätte das mit Exit 2 sofort gemeldet; §3 sieht ihn nicht vor.
+2. Ich habe #3856 anschließend von Hand geheilt (git merge origin/main, task freshness:regenerate, task test:inventory, commit, push), obwohl `task pr:refresh -- 3856` denselben Vorgang automatisiert.
+
+MITURSACHE (Verhalten des Agenten): CLAUDE.md verlangt "Never look up or hardcode task commands. Use the task oracle instead: bash scripts/vda.sh oracle '<goal>'". Ich habe den Oracle nicht befragt, sondern die in der Skill-Referenz hartkodierten Kommandos ausgeführt — genau deshalb blieben die vier Werkzeuge unentdeckt. Die Referenz macht diesen Fehler leicht, weil sie fertige Kommandozeilen anbietet, gegen die der Oracle-Vorrang nicht sichtbar konkurriert.
+
+FIX-RICHTUNG:
+- §3 um `scripts/ci-pr-health.sh --pr <n>` als ersten Triage-Schritt ergänzen und Exit 2 ausdrücklich als "CI nie gestartet, meist CONFLICTING" ausdeuten.
+- Heilpfad auf `task pr:refresh -- <pr>` als Primärweg umstellen; die manuelle merge+regenerate-Prozedur zum dokumentierten Fallback degradieren (sie bleibt wertvoll, wenn pr:refresh scheitert).
+- Prüfen, ob dieselbe Lücke in anderen Skill-Referenzen besteht, die rohe gh-Kommandos einbetten.
+
+ABGRENZUNG (bewusst NICHT als eigener Mishap gemeldet, Dedupe):
+- Uncommittete Einzelkopie-Arbeit im Worktree fix/flux-artifact-versioning-T002706 und Drift im main-Checkout → gedeckt von T002709 (plan_staged).
+- Wiederkehrende Reibung durch committete generierte Artefakte → gedeckt von T002347.
+
+---
+
+#### 15. worktree-create.sh prueft die erste Ticket-ID im Branchnamen, nicht die eigene
+
+_(degraded, scripts/worktree-create.sh)_
+
+`bash scripts/worktree-create.sh fix/restore-t002549-rollback-T002552 …` wurde abgelehnt mit:
+  "ERROR: Ticket-ID im Branch-Namen ist kleingeschrieben. Verwende T002549 statt t002549."
+
+Die Branch-eigene ID T002552 stand korrekt grossgeschrieben am Ende; t002549 war nur ein Kontextverweis auf das zurueckgerollte Ticket.
+
+Ursache verifiziert (scripts/worktree-create.sh:226):
+  _ticket_id=$(echo "$BRANCH" | grep -oE '[tT][0-9]{6,}' | head -1 || true)
+
+`head -1` nimmt die ERSTE ID im Namen, unabhaengig davon, ob sie die des Branches ist. Der Fehlertext benennt dadurch die falsche ID als Problem und fuehrt in die Irre — er verlangt T002549 dort, wo T002552 gemeint ist.
+
+Kein Schaden, umgangen durch Umbenennen auf fix/restore-rollback-T002552. Sinnvoll waere, die letzte statt der ersten ID zu nehmen (Konvention: die eigene ID steht am Ende) oder mehrere IDs zu tolerieren, solange mindestens eine korrekt geschrieben ist.
+
+---
+
+#### 16. worktree-create.sh: lokale Aenderungen an Dateien im FF-Bereich gehen beim main-Sync still verloren
+
+_(degraded, scripts/worktree-create.sh)_
+
+BEOBACHTUNG (2026-08-08, dev-flow-plan fuer T002729)
+Vor dem Aufruf standen im Haupt-Checkout drei uncommittete Aenderungen:
+  M scripts/llm/loadouts.json
+  D tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts
+  M website/src/data/test-inventory.json
+
+scripts/worktree-create.sh meldete "local main synced to origin/main" und fuehrte dabei einen
+Fast-Forward von ba0040c8c auf 11969ff50 aus (4 Commits). Danach:
+  M scripts/llm/loadouts.json          -> ueberlebt
+  tests/e2e/specs/fa-59-...spec.ts     -> Loeschung rueckgaengig, Datei wieder auf Platte (23:04)
+  website/src/data/test-inventory.json -> Aenderung verworfen
+`git stash list` ist leer, es liegt also kein Stash zur Wiederherstellung bereit.
+
+MUSTER
+Genau die beiden Dateien verschwanden, die im FF-Bereich ebenfalls geaendert wurden:
+`git diff --stat ba0040c8c 11969ff50 -- website/src/data/test-inventory.json` meldet
++30 Zeilen aus 8a0e518f2 (#3856) und 2dbaef3b5 (#3867). loadouts.json war im FF-Bereich
+nicht betroffen und blieb erhalten. Die Vermutung ist daher, dass der Stash-Pop bei
+Kollision zugunsten des Remote-Stands aufloest, statt abzubrechen.
+
+WARUM DAS ZAEHLT
+Das Skript besitzt einen Stash-Mechanismus (_needs_pop / _wc_stash_pop_or_warn, Zeile 177),
+der genau diesen Fall abdecken soll. Wer ihn kennt, verlaesst sich darauf und committet
+vorher nicht. Der Verlust ist still: die Zusammenfassungszeile meldet Erfolg
+("local main synced to origin/main"), und ohne Stash-Eintrag gibt es keinen offensichtlichen
+Wiederherstellungspfad.
+
+Erschwerend: der Sync laeuft, obwohl der Aufrufer nur einen Worktree anlegen wollte. In
+dieser Session war ausdruecklich angekuendigt, main NICHT zu bewegen, weil fremde
+uncommittete Arbeit im Baum lag — das Skript tat es intern trotzdem.
+
+EINSCHRAENKUNG DER BEOBACHTUNG
+Die Skriptausgabe wurde mit `tail -15` abgeschnitten. Eine Warnung aus
+_wc_stash_pop_or_warn koennte weiter oben gestanden haben und uebersehen worden sein. Der
+Datenverlust selbst ist unabhaengig davon belegt (git status vorher/nachher, leere
+stash list).
+
+SCHADEN IM KONKRETEN FALL: gering. test-inventory.json ist ein generiertes Artefakt
+(`task test:inventory`), und die rueckgaengig gemachte Spec-Loeschung stellt den
+origin/main-Stand wieder her. Der Pfad selbst ist aber allgemein und trifft beim
+naechsten Mal handgeschriebenen Code.
+
+VORSCHLAG ZUR PRUEFUNG
+Entweder fail-closed abbrechen, wenn der Arbeitsbaum schmutzig ist und der FF-Bereich
+dieselben Dateien beruehrt, oder den Konflikt beim Pop stehen lassen statt aufzuloesen —
+in beiden Faellen mit einer Meldung, die den Sync als das benennt, was er ist.
+
+---
+
+#### 17. worktree-write-guard erfasst keine Bash-Schreibzugriffe
+
+_(degraded, scripts/hooks/worktree-write-guard.sh)_
+
+scripts/hooks/worktree-write-guard.sh blockierte einen Edit auf einen fremd geclaimten Worktree korrekt. Ein `cat >> datei` im selben Worktree lief unmittelbar davor ungehindert durch — in einem zweiten, ebenfalls geclaimten Worktree wurde dadurch committet UND gepusht, bevor der Lock ueberhaupt sichtbar wurde.
+
+Ursache belegt: der Hook zieht den Zielpfad aus `file_path`/`notebook_path` der Tool-Eingabe (Zeile 48-49). Bash-Aufrufe haben kein solches Feld, fallen also durch. Der Guard schuetzt damit genau den Pfad, den ein disziplinierter Agent ohnehin nimmt, und nicht den, ueber den die Umgehung faktisch passiert.
+
+Verifiziert: `grep -c worktree-write-guard .githooks/pre-commit` = 0 — der Guard ist dort NICHT verankert, der Vorschlag ist also noch offen.
+
+Vorschlag: Aufruf im pre-commit-Hook ergaenzen (dort ist er werkzeugunabhaengig und faengt auch Bash-Schreibzugriffe ab), oder mindestens im Hook-Kopf dokumentieren, dass Bash ungeprueft bleibt — derzeit liest sich der Guard wie ein vollstaendiger Schutz.
+
+---
+
+#### 18. Doku-Drift: ticket_links traegt 340+ PR-Selbstkanten, Skill-Referenz schliesst das aus
+
+_(drift, skills/references/ticket-ops-procedures)_
+
+KORREKTUR EINER EIGENEN FEHLBEOBACHTUNG — beim Verifizieren widerlegt, deshalb umklassifiziert statt gemeldet wie urspruenglich notiert.
+
+Beobachtet: tickets.ticket_links enthaelt Kanten mit from_id = to_id und kind='pr'. Zuerst als Datenmuell fuer zwei Tickets notiert. Die Gegenpruefung (`WHERE f.id = l.to_id`) zeigt: es sind ueber 340 solcher Zeilen, durchgehend seit T000099. Das ist also das REGULAERE Muster, wie eine PR-Verknuepfung am Ticket vermerkt wird — kein Fehler.
+
+DER EIGENTLICHE BEFUND ist eine Doku-Diskrepanz: `.claude/skills/references/ticket-ops-procedures.md` sagt woertlich "Never use ticket_links for PR references — it is ticket→ticket only", und der ticket-ops-Skill-Body wiederholt "ticket_links ist ticket→ticket, **nie** fuer PR-Referenzen". Die gelebte Praxis widerspricht dem seit hunderten Zeilen.
+
+WIRKUNG: gering, aber irrefuehrend. Wer die Doku liest und die Tabelle sieht, haelt den Bestand fuer korrupt und koennte "aufraeumen". Fuer den Phase-3-Graphenaufbau ist es folgenlos, weil dort auf kind IN ('blocks','blocked_by') gefiltert wird.
+
+VORSCHLAG: Doku an die Praxis angleichen — kind='pr' als legitime Selbstkante beschreiben und klarstellen, dass fuer Abhaengigkeitsgraphen nur blocks/blocked_by zaehlen. Alternativ die Praxis aendern, was aber 340+ Zeilen migrieren hiesse und keinen erkennbaren Nutzen haette.
+
+---
+
+#### 19. G-AGENTIC07 auf main rot: ein verwaister aktiver Skill ohne Referenzquelle
+
+_(drift, skills/OVERVIEW.md)_
+
+`bash scripts/health-goals-check.sh` meldet auf `main` `🔴 G-AGENTIC07 1 (Ziel =0)` — „Verwaiste aktive Skills (keine Referenzquelle, nur getrackte)".
+
+Verifiziert: sowohl im Hauptcheckout auf altem main-Stand als auch im Chore-Worktree derselbe Wert 1, unverändert vor und nach dem Vendoring von `unsloth-buddy` (das Gate blieb bei 1, der neue Skill ist über den Vendor-Block in `.claude/skills/OVERVIEW.md` referenziert). Bestandsbefund, nicht durch T002590 verursacht.
+
+Zum Vergleich: das benachbarte G-AGENTIC06 (Skill-Zähler 28 behauptet vs. 29 real getrackte SKILL.md) war ebenfalls seit längerem rot und wurde in PR #3716 nebenbei mitkorrigiert (Zähler jetzt 30, Gate grün). G-AGENTIC07 blieb bewusst unangetastet, weil die Ursachenanalyse — welcher Skill ist verwaist und soll er entfernt oder referenziert werden — außerhalb der Chore lag.
+
+---
+
+#### 20. dev-flow-plan Fix-Pfad: stage-plan (Schritt 4.5) steht vor Commit (Schritt 5), ist so aber nicht ausfuehrbar
+
+_(drift, skills/dev-flow-plan)_
+
+Beobachtet bei T002595.
+
+Die Schrittfolge des Fix-Pfads in .claude/skills/references/dev-flow-plan-phases.md lautet:
+  Schritt 4.5: Plan stagen (ticket.sh stage-plan ...)
+  Schritt 5:   Commit & Push
+
+In dieser Reihenfolge ausgefuehrt bricht Schritt 4.5 ab:
+  ERROR: Plan file 'openspec/changes/<slug>/tasks.md' does not exist on branch
+  '<branch>' or in HEAD.
+  Die Datei muss committed sein, bevor stage-plan sie referenzieren kann.
+
+stage-plan liest die Plandatei aus dem Commit, nicht aus dem Arbeitsbaum. Die dokumentierte Reihenfolge ist daher nicht durchfuehrbar; korrekt ist commit -> push -> stage-plan.
+
+Bemerkenswert: der Fehler ist gutartig (klare Meldung, exit 0, kein Datenverlust) und kostet nur einen Durchlauf. Er trifft aber jeden, der den Fix-Pfad wortgetreu abarbeitet, und ist in der SKILL.md-Fassung des Feature-Pfads ebenfalls in dieser Reihenfolge notiert (dort Schritt 4.5 vor Schritt 5).
+
+Moegliche Richtung (nicht umgesetzt): die beiden Schritte in dev-flow-plan-phases.md und dev-flow-plan/SKILL.md tauschen, oder in Schritt 4.5 den Hinweis ergaenzen, dass der Plan-Commit vorausgehen muss.
+
+---
+
+#### 21. "behind N" gegen den eigenen Feature-Remote ist kein Beleg fuer fehlende Arbeit
+
+_(process, skills/ticket-ops)_
+
+EIGENER MESSFEHLER, dokumentiert damit er nicht wiederkehrt.
+
+`git status -sb` meldete fuer fix/bge-embed-routing-T002570: "ahead 22, behind 3". Ich las das als fehlende Arbeit und gab es als Auftragspraemisse an einen Subagenten weiter ("die 3 fehlenden Commits einholen"). Der Subagent pruefte nach und widerlegte es: die 3 Commits auf dem Remote waren stale Vor-Rebase-Duplikate mit IDENTISCHEN patch-ids zu bereits lokal vorhandenen Commits, und `merge-base HEAD origin/main == origin/main`. Ein Merge haette doppelte Commits erzeugt. Richtige Aufloesung war ein --force-with-lease-Push.
+
+WIRKUNG: Eine falsche Praemisse im Agent-Prompt haette ohne die Gegenpruefung des Subagenten zu einer verdoppelten Historie gefuehrt. Der Subagent hat die Anweisung korrekt in Frage gestellt, statt sie auszufuehren.
+
+LEHRE: "behind N" gegenueber dem Remote des EIGENEN Feature-Branch (nicht gegenueber main) entsteht regelmaessig nach einem lokalen Rebase und bedeutet dann gerade NICHT fehlende Arbeit. Vor dem Einholen pruefen: `git patch-id` auf beide Seiten bzw. `git merge-base HEAD origin/main`. Nur wenn merge-base VOR origin/main liegt, fehlt wirklich etwas.
+
+VORSCHLAG: In die Verifikations-Referenz aufnehmen — die Formulierung "X behind" ist im Repo-Alltag haeufig und wird verlaesslich falsch gelesen.
+
+---
+
+#### 22. Subagent-Abbruch: letzte Ausgabezeile suggerierte Fortschritt, Dateien waren leer
+
+_(process, skills/ticket-ops)_
+
+Ein Planungs-Subagent brach an einem API-Stream-Stall ab ("Response stalled mid-stream"). Seine letzte Ausgabezeile lautete "Now generating the frozen batch manifest" und las sich, als sei die Analyse abgeschlossen und nur die Ausgabe offen.
+
+TATSAECHLICHER ZUSTAND nach dem Abbruch (gemessen, nicht angenommen): proposal.md 73 Bytes mit leeren "## Why"/"## What"-Abschnitten, tasks.md nur mit dem Template-Platzhalter "<author fills this in — list of new/changed files>", specs/-Delta 135 Bytes Skelett, nichts committed, alles untracked. Die gesamte Analyse war verloren.
+
+WIRKUNG: Haette ich den Bericht des Agenten fuer bare Muenze genommen, waere ein leeres Skelett als fertiger Plan durchgegangen. Beim Fortsetzen musste dem Agenten der gemessene Dateizustand ausdruecklich mitgegeben werden ("verlass dich nicht auf deine Erinnerung") — ein wieder aufgenommener Agent haelt seinen abgebrochenen Kontext sonst fuer gueltigen Fortschritt.
+
+LEHRE fuer alle Runbook-Skills, die Subagenten dispatchen: Nach JEDEM failed-Notification den Arbeitsstand auf der Platte MESSEN (git log, git status, Dateigroessen), bevor der Agent fortgesetzt oder sein Ergebnis bewertet wird. Die letzte Ausgabezeile eines abgebrochenen Agenten ist kein Fortschrittsbeleg.
+
+ZUSATZ: Ein per SendMessage fortgesetzter Agent behaelt seinen Kontext — das ist bei Transport-Fehlern (Stream-Stall) die richtige Wahl gegenueber einem Neustart. Bei einem vom Nutzer GESTOPPTEN Agenten ist die Fortsetzung dagegen gesperrt ("was stopped by the user and won't be resumed"); dort muss ein neuer Agent mit dem gemessenen Stand gebrieft werden.
+
+---
+
+#### 23. dev-flow-e2e empfiehlt test/*-Branch, pre-commit verlangt feature/fix/chore/docs + T######
+
+_(process, skills/dev-flow-e2e)_
+
+dev-flow-e2e SKILL.md Schritt "AUSSTIEG" empfiehlt "test/*-Branch". Der pre-commit-Hook des Repos lehnt test/* ab: "kein gueltiges Typ-Praefix. Erlaubt: feature/ fix/ chore/ docs/", zusätzlich zwingend Ticket-ID im Branch (T002600 statt t002600). Erster Commit wurde blockiert; Workaround: Ticket angelegt (T002600) + Branch auf chore/fa-58-admin-cockpit-e2e-T002600 umbenannt. Friction: Skill-Doku divergiert von Repo-Hook — SSOT (dev-flow-e2e SKILL.md AUSSTIEG) sollte auf die Branch-Konvention des git-workflow-Skills zeigen.
+
+---
+
+#### 24. mishap-tracker erzeugt Duplikat-Incident zu einem bereits gestagten Plan
+
+_(process, skills/mishap-tracker)_
+
+Ich meldete die kaputten Ziele G-LLM01/G-LLM02 mit `type=broken` an `report_mishap`. Der Tracker legte daraufhin sofort das Incident-Ticket T002583 an (`needs_human`, `hoch`, `major`).
+
+Der Fix war zu diesem Zeitpunkt BEREITS GEPLANT: der T002442-Plan (gestaged auf `chore/zielfamilie-llm-stack-T002442`, Commit 492e0cf41, Task 4) ersetzt den Messblock beider Ziele durch `scripts/lib/llm-stack-measure.sh` und deckt alle vier gemeldeten Defekte ab. T002583 war also ein Duplikat zu einem Vorgang, der wenige Minuten zuvor in derselben Sitzung gestagt wurde.
+
+URSACHE: Der `incident`/`broken`/`security`-Pfad umgeht den Buffer und legt sofort ein Ticket an — ohne Abgleich gegen bestehende Tickets oder gestagte Pläne. Der Dedupe-Guard des ticket-ops-Skills greift nur beim Intake neuer Ticketzeilen, nicht bei diesem Pfad.
+
+AUFLOESUNG im konkreten Fall: `T002442 --[fixes]--> T002583` verknuepft, T002583 auf `blocked` gesetzt und sein Scope per Kommentar auf den verbleibenden eigenstaendigen Rest reduziert (systematischer Audit aller 21 Zielfamilien auf dieselbe Fehlerklasse). Das Ticket bleibt also sinnvoll, aber nur weil es einen Rest gab — ohne den waere es reiner Muell gewesen.
+
+VORSCHLAG: Vor dem Anlegen eines Incident-Tickets die offenen Tickets und die gestagten Plaene (`openspec/changes/*/tasks.md`, `ticket_plans`) auf die betroffene Komponente pruefen. Mindestens: die eigene Meldung mit einem Hinweis versehen, wenn ein Ticket mit ueberlappender Komponente in `plan_staged` steht.
+
+EIGENANTEIL: Ich haette vor dem `report_mishap`-Aufruf pruefen koennen, dass ich denselben Defekt gerade selbst habe einplanen lassen — der Agent hatte ihn in seinem Bericht genannt. Der Tracker macht es einem aber auch nicht leicht: `type=broken` fuehlt sich fuer einen echten Defekt richtig an, und dass diese Wahl den Dedupe umgeht, steht nicht im Aufrufpfad.
+
+---
+
+#### 25. agent-lock list zeigt Lock mit "--label" als Scope-Wert (Argument-Parsing)
+
+_(suspicious, scripts/agent-lock.sh)_
+
+`bash scripts/agent-lock.sh list` gibt aus:
+
+  SCOPE          ID                       TOOL     SID        STATE  LABEL
+  --label        devflow-T002569          claude   263874bd-193f-419e-88f7-f10deb99ca08 live
+
+Das Flag `--label` wurde als Scope-POSITIONSARGUMENT gelesen, der eigentliche Label-Wert ("devflow-T002569") landete im ID-Feld. Der Aufrufer hat vermutlich `claim --label devflow-T002569 ...` ohne vorangehende scope/id-Positionsargumente aufgerufen, und cmd_claim nimmt $1/$2 ungeprueft als scope/id.
+
+WIRKUNG: Der Lock ist ueber `check ticket T002569` NICHT auffindbar — er haengt an einem Phantom-Scope. Eine Session, die den regulaeren Pre-Check faehrt, sieht das Ticket als frei und koennte parallel darauf zugreifen. Das ist genau die Luecke, die T002498-M6 fuer den branch-Scope beschreibt, hier aber durch einen Parsing-Fehler statt durch Scope-Wahl entsteht.
+
+VERIFIZIERT 2026-08-02: Ausgabe oben reproduziert; der Lock gehoert einer fremden Session (nicht meiner SID) und wurde deshalb nicht angefasst.
+
+VORSCHLAG: cmd_claim sollte ablehnen, wenn das Scope-Argument mit "-" beginnt — ein Scope ist immer eines aus {ticket, branch, worktree, ...}. Eine Allowlist-Pruefung auf $1 faengt den ganzen Fehlerfall ab.
+
+---
+
+#### 26. branch-reaper.sh erzwingt --ticket auch im reinen --dry-run-Inventarlauf
+
+_(suspicious, scripts/branch-reaper.sh)_
+
+VERIFIZIERT (2026-08-02, repo-hygiene-Lauf): `bash scripts/branch-reaper.sh --dry-run` endet mit "FEHLER: --ticket ist erforderlich (Format T######)".
+
+WARUM DAS STOERT: Die SSOT-Referenz repo-hygiene-ops.md §2 fuehrt den Reaper unter "Verwaiste Remote-Branches (ohne PR)" als das Werkzeug ein, das genau jene Faelle abdeckt, die --merged und [gone] nicht erfassen — und nennt den Dry-Run ausdruecklich "manuell zum Nachsehen". Beim Housekeeping ist der Ticketbezug aber gerade das Unbekannte: man hat eine Liste verwaister Branches und sucht zu jedem das Ticket. Die Kandidatenauswahl im Skript laeuft ueber `grep -i -- "$TICKET_ID"` gegen die Remote-Branch-Namen (Zeile 119-125), setzt die gesuchte Antwort also als Eingabe voraus.
+
+FOLGE IM HEUTIGEN LAUF: Der Inventarschritt musste von Hand nachgebaut werden (git for-each-ref + gh pr list + Blob-Vergleich pro Branch) — also genau die Logik, die im Skript bereits steht und dort besser geprueft ist. Der handgebaute Nachbau traf dabei prompt den Merge-Base-Defekt aus dem Schwester-Mishap.
+
+VORSCHLAG: Einen ticketlosen Inventarmodus ergaenzen (z.B. `--all --dry-run`), der ueber alle Remote-Branches iteriert und pro Branch REAP/KEEP mit Begruendung ausgibt, ohne zu loeschen. Die Ticket-Aufloesung kann dabei aus dem Branch-Namen abgeleitet werden (dieselbe T[0-9]{6}-Extraktion, die repo-hygiene-ops.md §3 fuer PRs beschreibt); Branches ohne ableitbare ID werden als KEEP mit Begruendung "keine Ticket-ID im Namen" gemeldet. Loeschen bleibt an --ticket gebunden.
+
+---
+
+#### 27. browser.newContext() im storageState-Projekt lieferte authentifizierten Kontext
+
+_(suspicious, tests/e2e)_
+
+In fa-58-admin-cockpit.spec.ts T20 (mentolder-Projekt mit use.storageState) sollte browser.newContext({ ignoreHTTPSErrors: true }) einen unauthentifizierten Kontext ergeben. Der Test schlug fehl: page.url() blieb auf /admin/cockpit (authentifizierte Seite). curl bestätigt unauthentifiziert → 302 nach /login. Workaround: playwright.request.newContext({ storageState: { cookies: [], origins: [] } }) + maxRedirects:0 → erwartetes 302. Ursache unklar — vermutlich StorageState-Vererbung über die Browser-Instanz bei manuell erzeugten Kontexten in Playwright Test 1.61.
+
+---
+
+#### 28. devflow-ci-watch meldet "Keine CI-Checks gefunden", nachdem es zehn gruene Checks gelistet hat
+
+_(suspicious, scripts/devflow-ci-watch.sh)_
+
+Bei PR #3843 (T002704) endete scripts/devflow-ci-watch.sh mit Exit 5 und der Meldung "⚠ Keine CI-Checks gefunden (total_count=0) — CI wurde nie gestartet oder laeuft noch." — unmittelbar NACHDEM dieselbe Ausgabe zehn Checks mit Status "pass" aufgelistet hatte.
+
+Ursache ist eine voruebergehend leere API-Antwort: ein direkt danach abgesetztes 'gh pr view --json statusCheckRollup' lieferte 'null' statt der Liste. GitHub berechnet das Rollup zeitweise neu; die Checks waren nicht verschwunden.
+
+Das ist genau die Verwechslung, gegen die die Konvention aus T002498-M5 geschrieben wurde: die auswertende Logik muss eine LEERE Antwort von einer NEGATIVEN unterscheiden. Hier fuehrt total_count=0 zu der Aussage "CI wurde nie gestartet", was in diesem Fall nachweislich falsch war — und die Meldung ist zusaetzlich irrefuehrend, weil sie zwei sich ausschliessende Deutungen ("nie gestartet ODER laeuft noch") in einem Satz anbietet und daraus einen Fehler-Exit macht.
+
+Der eigentliche Merge-Blocker war ein anderer und wurde von der Meldung verdeckt: mergeStateStatus=DIRTY / mergeable=CONFLICTING. Lokal rebaste der Branch konfliktfrei — das bekannte merge=ours-Phantommuster. Wer der Skriptmeldung glaubt, sucht den Fehler in der CI statt im Merge-Status.
+
+Vorschlag: bei total_count=0 nicht urteilen, sondern erneut abfragen und erst nach mehreren leeren Antworten in Folge eskalieren — und die Meldung um den aktuellen mergeStateStatus ergaenzen.
+
+---
+
+#### 29. mcp-sync-Guard meldet auf veralteter Branch-Basis roten Drift, der lokal nicht existiert
+
+_(suspicious, scripts/mcp-sync.sh)_
+
+Beobachtet 2026-08-03 an PR #3723 (chore/toolset-divergenzen-T002596).
+
+CI rot: "Factory spec shard 4" → `not ok 36 mcp-sync.sh check stays green — headers are generated, not hand-edited`, Diff-Ausgabe "1,49d0" gegen .mcp.json. Im zugehoerigen Worktree meldete `bash scripts/mcp-sync.sh check` jedoch 4x OK (.mcp.json, .opencode/opencode.jsonc, mcp_config.json, scripts/llm/mcp-servers.json).
+
+Der PR aenderte .mcp.json ueberhaupt nicht (Diff: .claude/settings.json, AGENTS.md, CLAUDE.md, toolset-map.md, capabilities.yaml). Tatsaechliche Ursache war reine Branch-Staleness — die Basis lag 9 Commits hinter main. Nach `gh api --method PUT repos/.../pulls/3723/update-branch` lief CI durch und Auto-Merge feuerte (mergedAt 2026-08-03T04:01:16Z).
+
+Reibung: weder das Job-Log noch mergeStateStatus=BLOCKED unterschieden "echter Registry-Drift" von "Basis veraltet". Die Fehlausgabe zeigt einen kompletten .mcp.json-Inhalt als geloescht und liest sich wie ein realer Drift; die Diagnose kostete drei Log-Abrufe plus einen lokalen Gegencheck. Ein Hinweis im Guard-Fehlertext ("Basis vs. origin/main pruefen") oder ein vorgelagerter Staleness-Check im CI wuerde diesen Umweg sparen.
+
+---
+
+#### 30. test:spec:changed uebersieht staged-aber-uncommittete Tests und meldet "No matching spec tests"
+
+_(suspicious, scripts/find-changed-tests.sh)_
+
+Beobachtet bei T002593. Nach `git add` einer NEUEN Datei tests/spec/dev-flow-plan/plan-lint-task-count.bats (10 Tests) meldete `task test:spec:changed`: "No matching spec tests for this diff" — und lief exit 0 durch.
+
+Ursache (verifiziert): scripts/find-changed-tests.sh:17 baut die Dateiliste aus
+  git diff --name-only HEAD origin/main
+Das vergleicht COMMITS, nicht den Index. Staged-aber-uncommittete Dateien sind darin nicht enthalten.
+
+Warum das mehr ist als eine Reihenfolge-Frage: der Verify-Block (references/verification-block.md) sieht `task test:spec:changed` VOR dem Commit vor, und die Meldung ist positiv formuliert ("No matching spec tests for this diff") statt als Warnung. Sie liest sich damit wie eine Aussage ueber die CI-Abdeckung ("meine neuen Tests laufen auf keinem PR" — vgl. den bekannten Fall aus pr-testabdeckung-unterverzeichnisse) statt wie "du hast noch nicht committed". Nach dem Commit lief dieselbe Suite mit 110/110 gruen, die neuen Tests darunter.
+
+Moegliche Richtungen (nicht umgesetzt):
+- Die Diff-Basis um den Index erweitern (`git diff --name-only HEAD` erfasst unstaged, `--cached` den Index) oder
+- die Meldung um einen Hinweis ergaenzen, wenn `git diff --cached --name-only` Testdateien enthaelt, die in der Auswahl fehlen.
+
+Kein Datenverlust, kein CI-Risiko — CI selbst arbeitet immer gegen Commits und ist korrekt.
+
+---
+
+#### 31. ticket.sh list --status <unbekannt> liefert still [] statt eines Fehlers
+
+_(suspicious, scripts/ticket.sh)_
+
+Beobachtet bei T002595, mit Folgeschaden.
+
+`./scripts/ticket.sh list --status open` liefert `[]`. "open" ist kein gueltiger Status-Wert (gueltig sind triage, backlog, plan_staged, done, ...). Statt den unbekannten Filterwert abzulehnen, gibt der Befehl eine leere Liste zurueck.
+
+Folgeschaden (real eingetreten): Die Duplikatssuche vor dem Anlegen eines Bug-Tickets lief mit genau diesem Aufruf. Die leere Antwort las sich als "es gibt kein passendes Ticket", woraufhin T002594 (bge-embed OOMKilled) angelegt wurde - ein Duplikat des seit 2026-08-02 bestehenden T002580, das auf status=backlog steht und deshalb aus dem Filter fiel. T002594 musste als resolution=duplicate wieder geschlossen werden. Eine fremde Session arbeitete zu dem Zeitpunkt bereits auf fix/bge-embed-oom-T002580.
+
+Warum das mehr ist als ein Tippfehler: eine leere Liste ist ein legitimes Ergebnis. Der Aufrufer kann "kein Treffer" nicht von "Filter ungueltig" unterscheiden. Bei einer Duplikatssuche ist das die gefaehrlichste Verwechslung, weil beide Faelle zur selben falschen Handlung fuehren (neues Ticket anlegen).
+
+Moegliche Richtung (nicht umgesetzt): unbekannte --status-Werte gegen die Enum pruefen und mit exit != 0 plus Auflistung der gueltigen Werte ablehnen. Analog fuer andere Filter-Flags mit Enum-Domaene.
+Watchdog: pipeline stale > 30min (no phase progress write, class=INFRA). Returned to queue (triage); slot released. [INFRA 1/3 | tier=haiku]
+### Mishap-Rollup — 10 Eintraege (2026-08-09 03:52 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | drift | scripts/plan-lint.sh | plan-lint W3 zaehlt einen in der Prosa erwaehnten Pfad als gelistete Datei |
+| 2 | drift | skills/openspec-flow-plan, skills/openspec-propose | Delta-Spec-Header-Format in openspec-flow-plan/openspec-propose nicht explizit dokumentiert |
+| 3 | suspicious | scripts/agent-lock.sh | Agent-Lock auto-reset blockiert Branch-Wechsel im main-Checkout |
+| 4 | drift | tests/lib/factory-test-fixtures.sh | seed_test_feature dokumentiert TICKET_TEST_DB_OK nicht — Fehlschlag liest sich als fehlender DB-Pod |
+| 5 | process | scripts/worktree-create.sh | worktree-create.sh: refactor-Präfix nicht in Branch-Allowlist (nur feature/fix/chore/docs) |
+| 6 | suspicious | tests/spec/ticket-system | Pre-existing T002732 backfill-id-sequence test failures (3 tests) sichtbar in test:changed |
+| 7 | degraded | skills/openspec-archive-change | Plan archiviert, Deliverable nie gemergt — archivierter Change ohne seine Implementierung auf main |
+| 8 | drift | repo/githooks | Zwei Commit-Message-Validatoren mit unterschiedlichem Scope-Vokabular |
+| 9 | suspicious | skills/git-workflow | Abgelehnter Commit gefolgt von erfolgreichem Push sieht aus wie ein erfolgreicher Push |
+| 10 | degraded | skills/dev-flow-plan | Gestagter, nie implementierter Plan stand als roter PR in der Queue |
+
+**1. plan-lint W3 zaehlt einen in der Prosa erwaehnten Pfad als gelistete Datei** (drift, scripts/plan-lint.sh)
+
+BEOBACHTUNG (Planungslauf T002783, 2026-08-09)
+
+Der Plan enthielt unterhalb der File-Structure-Tabelle einen Fliesstext-Satz:
+
+    Positiv-Kontrolle: `scripts/agent-lock.sh` gibt unter demselben Aufruf 265 zurueck,
+    der Messpfad funktioniert also.
+
+Der Linter meldete daraufhin:
+
+    ⚠ W3: `scripts/agent-lock.sh` is listed in File Structure but no task references it
+    PLAN-LINT: PASS (0 hard, 1 warn)
+
+Die Datei stand NICHT in der Tabelle. Sie war Beleg dafuer, dass der residual_budget-Pfad
+ueberhaupt misst — genau die Gegenprobe, die die Konvention "leere Antwort ist kein Urteil"
+verlangt, wenn zwei Zieldateien ein leeres Budget liefern. W3 scheint jeden
+Backtick-Pfad im Abschnitt als Tabelleneintrag zu lesen, statt nur die Tabellenzeilen.
+
+FOLGE: gering, aber in eine unerwuenschte Richtung. Die Warnung verschwand erst, als ich
+den Pfad aus dem Satz entfernte ("ein gemessenes Shell-Skript (agent-lock)"). Der Linter
+draengt damit dazu, Belege UNSPEZIFISCHER zu formulieren — waehrend derselbe Regelsatz an
+anderer Stelle konkrete, nachpruefbare Angaben verlangt. Wer die Warnung schnell loswerden
+will, loescht eher den Beleg als ihn zu praezisieren.
+
+NICHT GEPRUEFT: ob W3 nur Backtick-Pfade im Umfeld der Tabelle erfasst oder im ganzen
+Dokument, und ob dieselbe Verwechslung auch B1a/B1b betrifft. Das waere der erste Schritt
+einer Umsetzung.
+
+TEST (Output-Verifikation, T002448-M4): plan-lint.sh gegen einen Plan AUSFUEHREN, dessen
+File-Structure-Tabelle Datei A listet und dessen Prosa Datei B in Backticks erwaehnt,
+wobei B von keiner Task referenziert wird. Erwartung: keine W3-Warnung zu B. Positiv-Anker
+(T002356-M1): im selben Test ein tatsaechlich in der TABELLE gelistetes, unreferenziertes
+A verwenden und zeigen, dass W3 dafuer sehr wohl anschlaegt — sonst besteht der Test auch
+bei einem Linter, der W3 gar nicht mehr auswertet.
+**2. Delta-Spec-Header-Format in openspec-flow-plan/openspec-propose nicht explizit dokumentiert** (drift, skills/openspec-flow-plan, skills/openspec-propose)
+
+Fünf Mishap-Fix-PRs (#3905-#3909) waren alle durch CI blockiert, weil ihre Delta-Spec-Dateien nicht dem validierten Format entsprachen:
+
+1. `## ADDED:` / `## MODIFIED:` statt `## ADDED Requirements` / `## MODIFIED Requirements` (ohne "Requirements" im Header)
+2. Keine `#### Scenario:`-Blöcke unter den `### Requirement:`-Blöcken
+
+Der CI-Check `scripts/openspec-validate.test.ts` → `validateTree` verlangt exakt das Pattern `## (ADDED|MODIFIED|REMOVED|RENAMED) Requirements` und mindestens einen `#### Scenario:`-Block pro Requirement.
+
+Root Cause: Die `openspec-flow-plan` und `openspec-propose` Skills dokumentierten das Pflicht-Format nicht explizit genug — `openspec-propose` nannte zwar `## ADDED Requirements` aber nicht den Scenario-Zwang; `openspec-flow-plan` verwies nur auf die T001304-Delta-Konvention ohne Format-Details.
+
+Fix: PR #3910 ergänzt beide Skills um explizite Format-Vorgaben inkl. der vier gültigen Header-Varianten, dem Requirement→Scenario-Pattern und dem Hinweis auf die CI-Blockade.
+**3. Agent-Lock auto-reset blockiert Branch-Wechsel im main-Checkout** (suspicious, scripts/agent-lock.sh)
+
+Beim ticket-ops-Durchlauf am 2026-08-09: Beim Versuch, von `fix/openspec-flow-plan-delta-header-format` auf `main` zu wechseln, setzte AGENT-LOCK den Checkout wiederholt auf den alten Branch zurück.
+
+Beobachtete Meldung (mehrfach): `AGENT-LOCK: main-Checkout auf 'fix/openspec-flow-plan-delta-header-format' zurückgesetzt (Lock-Halter aktiv)`.
+
+Dies passierte trotz `git checkout -B fix/delta-spec-header-doc-T002772 origin/main` — der Lock-Mechanismus überschrieb den Branch-Wechsel.
+
+Workaround: `git worktree add` umging das Problem; der Commit für PR #3910 wurde im isolierten Worktree durchgeführt.
+**4. seed_test_feature dokumentiert TICKET_TEST_DB_OK nicht — Fehlschlag liest sich als fehlender DB-Pod** (drift, tests/lib/factory-test-fixtures.sh)
+
+BEOBACHTUNG (Planungslauf T002781, 2026-08-09)
+
+Ein neuer BATS-Test rief seed_test_feature "mentolder" auf. Ergebnis:
+
+    ERROR: no shared-db pod found in namespace workspace
+           (context bats-no-cluster-t002224)
+
+Die Meldung liest sich wie ein Infrastrukturproblem — kein Pod, Cluster weg. Tatsaechlich
+lief der Cluster, und derselbe kubectl-Aufruf mit --context k3d-mentolder-dev fand den Pod
+sofort. Der Kontext bats-no-cluster-t002224 ist ein ABSICHTLICHER Sentinel aus
+scripts/vda/ticket/_ticket-core.sh:31: unter BATS zeigt ticket.sh bewusst ins Leere, damit
+Tests keine echten Ticketzeilen schreiben. Der Kommentar dort ist ausfuehrlich und nennt den
+Anlass — rund 130 Geisterzeilen zwischen dem 2026-07-03 und dem 2026-07-26. Das Opt-in
+heisst TICKET_TEST_DB_OK=1.
+
+DER DEFEKT IST NICHT DER SCHUTZ, SONDERN WO ER DOKUMENTIERT IST
+
+seed_test_feature in tests/lib/factory-test-fixtures.sh ist die Funktion, die ein
+Testautor aufruft. Ihr Kopfkommentar lautet vollstaendig:
+
+    # seed_test_feature <brand> [touched_file ...] → echoes the new external_id
+
+Kein Wort zu TICKET_TEST_DB_OK. Die Begruendung steht in _ticket-core.sh — einer Datei,
+die der Testautor nicht liest, weil sie zwei Ebenen unter dem aufgerufenen Werkzeug liegt.
+Wer den Hinweis nicht kennt, diagnostiziert einen Cluster- oder Namespace-Fehler; genau
+das ist hier passiert und hat einen Debug-Zyklus gekostet.
+
+Verschaerfend: die Meldung nennt zwar den Kontextnamen, aber "bats-no-cluster-t002224"
+liest sich wie ein verunglueckter Default, nicht wie eine absichtliche Sperre. Ein Hinweis
+im Fehlertext ("unter BATS gesperrt — TICKET_TEST_DB_OK=1 zum Opt-in") haette gereicht.
+
+VORSCHLAG (nicht entschieden)
+- Den Kopfkommentar von seed_test_feature um die Vorbedingung ergaenzen.
+- Oder die Sperre selbst sprechen lassen: wenn CTX der Sentinel ist und _pgpod scheitert,
+  eine eigene Meldung ausgeben statt der generischen "no shared-db pod"-Zeile.
+Die zweite Variante wirkt an jeder Aufrufstelle, nicht nur an der, die man gerade liest.
+
+TEST (Output-Verifikation, T002448-M4): seed_test_feature unter BATS OHNE
+TICKET_TEST_DB_OK AUSFUEHREN und pruefen, dass die Fehlermeldung das Opt-in benennt.
+Positiv-Anker (T002356-M1): im selben Test mit gesetztem TICKET_TEST_DB_OK=1 zeigen, dass
+der Seed durchlaeuft und eine external_id liefert — sonst besteht der Test auch bei einer
+Fixture, die immer fehlschlaegt.
+**5. worktree-create.sh: refactor-Präfix nicht in Branch-Allowlist (nur feature/fix/chore/docs)** (process, scripts/worktree-create.sh)
+
+Beim Dispatch von T002627 (type=refactor) wurde der Branch refactor/sdlc-routes-remove-T002627 von worktree-create.sh abgelehnt. Erlaubt sind nur feature/fix/chore/docs. Workaround: feature/ statt refactor/ verwendet. Ticket-Typ "refactor" sollte entweder ein erlaubtes Branch-Präfix bekommen oder beim Anlegen automatisch auf feature/chore normalisiert werden.
+**6. Pre-existing T002732 backfill-id-sequence test failures (3 tests) sichtbar in test:changed** (suspicious, tests/spec/ticket-system)
+
+Während test:changed für T002783 liefen 3 Tests in tests/spec/ticket-system/backfill-id-sequence.bats (T002732) rot. Nicht durch T002783 verursacht, aber sie erscheinen in jedem test:changed-Lauf, der ticket.sh-Änderungen enthält, und kosten jedes Mal Diagnosezeit. Sollten entweder gefixt oder als known-flaky markiert werden.
+**7. Plan archiviert, Deliverable nie gemergt — archivierter Change ohne seine Implementierung auf main** (degraded, skills/openspec-archive-change)
+
+Beobachtet 2026-08-09 während repo-hygiene. PR #3919 archivierte den Change nach openspec/changes/archive/2026-08-09-fa-59-e2e-spec-positive-assertion und merged das Delta in openspec/specs/e2e-testing.md. Die eigentliche Implementierung von T002730 — die positive Assertion toBe(403) in tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts sowie die beiden BATS-Guards in tests/spec/e2e-testing.bats — lag jedoch ausschliesslich auf dem noch OFFENEN Branch von PR #3914. main trug damit einen als erledigt geltenden, archivierten Change ohne sein Deliverable; die Spec enthielt weiterhin das negative not.toBe(404), das der Change gerade beseitigen sollte.
+
+Verschaerfend: PR #3914 haette in seiner damaligen Fassung den bereits archivierten Change unter openspec/changes/ wieder auferstehen lassen (alle 8 Plan-Dateien als Additions), zusaetzlich mit einer Delta-Spec nach Change-Slug statt Parent-SSOT-Slug benannt.
+
+Der Check aus CLAUDE.md M10 (T002506) beschreibt genau diesen Fall — vor dem Abschluss per git show origin/main:<pfad> belegen, dass die Deliverable-Dateien wirklich auf main liegen. Er lief nicht. Bemerkenswert ist, dass hier keine manuelle Closure vorlag, sondern ein Archive-PR: die M10-Regel ist heute auf manuelle done/shipped-Faelle formuliert und deckt den Archive-Pfad nicht ab.
+
+Behoben im Lauf: #3914 traegt jetzt nur noch das Deliverable, die auferstandene Kopie ist entfernt, PR umbenannt zu fix(e2e-testing). Verifiziert nach Merge: origin/main enthaelt 2x toBe(403) und 3x T002730-Referenzen.
+**8. Zwei Commit-Message-Validatoren mit unterschiedlichem Scope-Vokabular** (drift, repo/githooks)
+
+Beobachtet 2026-08-09. `fix(mcp-gateway): …` besteht den PR-Titel-Check "Conventional Commits" (grün auf PR #3918, dessen Titel genau so lautet), wird aber vom lokalen .githooks/commit-msg abgelehnt: "✗ unknown scope 'mcp-gateway' — did you mean 'mcp'?". Dasselbe bei `chore(tickets):`.
+
+Verifiziert: `bash .githooks/commit-msg` gegen eine Testnachricht liefert reproduzierbar die Ablehnung; `bash scripts/validate-commit-msg.sh scopes` fuehrt mcp, plans, ci und test, aber kein mcp-gateway und kein tickets.
+
+Die Folge ist nicht nur Reibung: der PR-Titel ist die naheliegendste Vorlage fuer die Commit-Message auf demselben Branch, und er ist nachweislich gruen. Wer ihn uebernimmt, laeuft in die Ablehnung. Kostete in diesem Lauf zwei verworfene Commits.
+
+Denkbar: dieselbe Scope-Allowlist auch auf den PR-Titel anwenden, oder die Ablehnungsmeldung um den Hinweis ergaenzen, dass der PR-Titel-Check ein anderes Vokabular nutzt.
+**9. Abgelehnter Commit gefolgt von erfolgreichem Push sieht aus wie ein erfolgreicher Push** (suspicious, skills/git-workflow)
+
+Beobachtet 2026-08-09, zweimal (PR #3918 und PR #3915). Ablauf: `git commit …` wird vom commit-msg-Hook abgelehnt ("No commit was created — commit-msg hook rejected the message (conventional-commit format check)"), der im selben Kommando nachfolgende `git push` laeuft daraufhin durch und meldet ganz normal "   <alt>..<neu>  HEAD -> <branch>".
+
+Uebertragen wurde in beiden Faellen nur der zuvor erzeugte Merge-Commit — der eigentliche Fix blieb liegen. Die Push-Ausgabe ist von einem erfolgreichen Push nicht zu unterscheiden: sie nennt einen echten SHA-Bereich und einen echten Branch.
+
+Zwei Faktoren verstaerken das: (a) die Ablehnungsmeldung erscheint weit oben in der Ausgabe und wird von der nachfolgenden Hook- und Push-Ausgabe verdraengt; (b) `git push` hat keinen Grund zu scheitern, weil der Branch ja tatsaechlich Commits hat.
+
+Verallgemeinerbar und deshalb notiert: der Erfolg des LETZTEN Kommandos in einer Kette sagt nichts ueber den Erfolg des vorherigen. Konsequenz fuer Runbooks: nach einem Commit den erzeugten SHA per `git log -1 --oneline` pruefen, statt die Push-Ausgabe als Bestaetigung zu lesen — oder commit und push mit && verketten (so macht es scripts/factory/mishap-rollup.sh laut eigenem Skriptkopf bereits bewusst).
+**10. Gestagter, nie implementierter Plan stand als roter PR in der Queue** (degraded, skills/dev-flow-plan)
+
+Beobachtet 2026-08-09 an PR #3918 (T002719). Der Branch trug ausschliesslich die Commits "chore: anchor branch" und "chore(plans): add failing test + stage plan" — also den dev-flow-plan-Ausgang, ohne dev-flow-execute. Trotzdem existierte ein offener PR mit dem Titel eines fertigen Fixes ("fix(mcp-gateway): agy headless mcp tool permissions via --dangerously-skip-permissions").
+
+Der PR hatte vier rote Checks. Zwei davon stammten allein daraus, dass die Implementierung nicht committet war: die Delta-Spec openspec/changes/agy-headless-mcp-permissions/specs/mcp-gateway.md existierte im Worktree als UNTRACKED (daher "missing specs/ delta dir" in der OpenSpec-validateTree-Pruefung), und die zugehoerige SSOT-Ergaenzung in openspec/specs/mcp-gateway.md lag dort uncommittet (daher der rote BATS-Guard, der genau dieses Requirement greppt).
+
+Die Arbeit war also getan, nur nie festgeschrieben — im Worktree einer Session, deren PID nicht mehr lief.
+
+Das Problem ist die Lesart von aussen: ein roter PR mit Fix-Titel liest sich als "kaputter Fix, Diagnose noetig", nicht als "Plan gestagt, Implementierung ausstehend". In einer Queue mit mehreren PRs kostet das gezielt Zeit an der falschen Stelle. Denkbar: Plan-only-Branches gar nicht als PR oeffnen, oder als Draft mit erkennbarem Titel-Praefix.
+### Mishap-Rollup — 10 Eintraege (2026-08-09 04:24 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | drift | skills/dev-flow-plan | Von dev-flow-plan erzeugter Failing-Test war strukturell CI-untauglich (Drittanbieter-Binary) |
+| 2 | suspicious | skills/repo-hygiene | gh pr checks meldet "no checks reported", obwohl Runs für denselben HEAD-SHA existieren |
+| 3 | drift | skills/repo-hygiene | CONFLICTING PR unterdrückt CI — Symptom ist von "noch nicht gestartet" nicht unterscheidbar |
+| 4 | drift | skills/repo-hygiene | merge=ours-Phantomkonflikt: update-branch antwortet 422, lokaler Merge läuft konfliktfrei |
+| 5 | suspicious | scripts/openspec-half-archive-check.sh | Halb archivierter Zustand im Hauptcheckout — uncommittet, vom half-archive-Guard nicht erfasst |
+| 6 | drift | openspec/changes | Delta-Spec nach Change-Slug statt Parent-SSOT-Slug benannt — Archivierung wird scheitern (T002666) |
+| 7 | suspicious | scripts/agent-lock.sh | agent-lock claim ticket returns exit 0 but lock not held |
+| 8 | suspicious | scripts/pre-push hook | Pre-push hook rejects valid push due to stale scope commits from rebased main |
+| 9 | degraded | devflow/merge pipeline | PR #3926 went DIRTY/CONFLICTING immediately after creation — rebase needed 3 attempts |
+| 10 | process | dev-flow-plan | Planung widersprach einer bestehenden Design-Entscheidung, die erst nach der Nutzerfrage gefunden wurde |
+
+**1. Von dev-flow-plan erzeugter Failing-Test war strukturell CI-untauglich (Drittanbieter-Binary)** (drift, skills/dev-flow-plan)
+
+Beobachtet 2026-08-09 an PR #3918. Der von dev-flow-plan als TDD-Rotphase erzeugte Test tests/spec/mcp-gateway/agy-mcp-permissions.bats enthielt:
+
+    @test "agy binary supports --dangerously-skip-permissions flag" {
+      run agy --help
+      [ "$status" -eq 0 ]
+      ...
+    }
+
+`agy` ist ein lokal installiertes Drittanbieter-CLI. Verifiziert: `grep -rn 'agy' .github/workflows/*.yml` liefert 0 Treffer — kein Workflow installiert es. Der Test waere in CI also DAUERHAFT rot gewesen, ohne je eine Aussage ueber das Repository zu treffen; er misst die Ausstattung des Runners, nicht den Zustand des Codes.
+
+Das ist keine Kleinigkeit im Rotphasen-Kontext: ein Test, der aus Umgebungsgruenden nie gruen werden kann, ist von einem Test, der wegen fehlender Implementierung rot ist, in der CI-Ausgabe nicht zu unterscheiden. Die Rotphase verliert damit ihre Aussagekraft.
+
+Behoben im Lauf mit dem im Repo etablierten Muster (tests/spec/sealed-secret-cluster-drift.bats: kein erreichbarer Cluster -> skip):
+    command -v agy >/dev/null 2>&1 || skip "agy binary not installed"
+Verifiziert in beiden Richtungen: mit agy im PATH laeuft der Test durch, mit PATH=/usr/bin:/bin skippt er sauber.
+
+Denkbar als Konvention: wenn ein geplanter Test ein externes Binary oder einen Dienst voraussetzt, gehoert der Verfuegbarkeits-Guard schon in die Rotphase.
+**2. gh pr checks meldet "no checks reported", obwohl Runs für denselben HEAD-SHA existieren** (suspicious, skills/repo-hygiene)
+
+Beobachtet 2026-08-09 an PR #3916. `gh pr checks 3916` antwortete "no checks reported on the 'fix/main-checkout-freshness-cleanup-T002664' branch", und `gh pr view 3916 --json statusCheckRollup` lieferte ein LEERES Array.
+
+Gleichzeitig zeigte `gh run list --branch fix/main-checkout-freshness-cleanup-T002664` fuenf abgeschlossene Runs, darunter einen CI-Run mit conclusion=failure (databaseId 31291991475). Der PR-HEAD (9b4fb48cbdb3ee604c65fc5f8c720dbbe9436a24) war identisch mit dem Remote-Branch-Tip — es lag also kein nachtraeglicher Push vor, der den Rollup entwertet haette.
+
+Die Fehldiagnose, in die das fuehrt: "keine Checks" liest sich als "Workflows noch nicht gestartet / Queue klemmt" und lenkt die Untersuchung auf die Actions-Infrastruktur, waehrend der PR in Wahrheit an zwei konkreten BATS-Tests scheiterte. Gefunden nur, weil zusaetzlich `gh run list` abgefragt wurde.
+
+Konsequenz fuer repo-hygiene §3: eine leere Checkliste ist KEIN Urteil ueber den CI-Zustand — dasselbe Muster, das der Abschnitt bereits fuer mergedAt festhaelt. Bei leerem Rollup immer gegen `gh run list --branch <b>` gegenpruefen, bevor "noch keine Checks" berichtet wird.
+**3. CONFLICTING PR unterdrückt CI — Symptom ist von "noch nicht gestartet" nicht unterscheidbar** (drift, skills/repo-hygiene)
+
+Beobachtet 2026-08-09 an PR #3915. Der PR hatte NULL Workflow-Runs (`gh run list --branch fix/ticket-mcp-update-fields-T002714` war komplett leer), weil er mit main konfligierte.
+
+Dass ein CONFLICTING PR die CI unterdrueckt, ist in docs/superpowers/references/gotchas-footguns.md dokumentiert. Sein SYMPTOM ist es nicht: `gh pr checks` liefert exakt dieselbe Meldung "no checks reported on the branch" wie bei einem noch nicht gestarteten Lauf. Ohne einen lokalen Merge-Versuch ist der Konflikt als Ursache nicht erkennbar — und `mergeStateStatus` stand zu dem Zeitpunkt auf UNKNOWN, half also auch nicht.
+
+Der Konflikt selbst war trivial: ein Append-Konflikt in der Commands-Zeile von scripts/ticket.sh (`update-fields` auf dem Branch, `rollup-container` aus main). Aufloesung durch Behalten BEIDER Kommandos, verifiziert nach Merge auf origin/main (5x update-fields, 4x rollup-container).
+
+Vorschlag fuer repo-hygiene §3: bei leerer Checkliste zuerst `mergeStateStatus` pruefen und, falls UNKNOWN oder DIRTY, lokal `git merge origin/main --no-commit` gegen den Branch versuchen — das trennt "Konflikt" von "noch nicht gestartet" eindeutig.
+**4. merge=ours-Phantomkonflikt: update-branch antwortet 422, lokaler Merge läuft konfliktfrei** (drift, skills/repo-hygiene)
+
+Beobachtet 2026-08-09 an PR #3915, zweiter Durchgang (nach vier zwischenzeitlichen Merges nach main). GitHub meldete mergeStateStatus=DIRTY, und
+
+    gh api --method PUT repos/Paddione/Bachelorprojekt/pulls/3915/update-branch \
+      -f expected_head_sha=<head>
+
+antwortete mit HTTP 422 "merge conflict between base and head".
+
+Lokal war davon nichts zu sehen: `git merge origin/main` in einem frischen Worktree auf denselben Branch lief glatt durch, `git diff --name-only --diff-filter=U` blieb LEER. Ursache ist der dokumentierte merge=ours-Effekt — die Freshness-Generate (website/src/data/openspec-status.json, test-inventory.json) tragen in .gitattributes einen Custom-Merge-Driver, den GitHub nicht ausfuehrt.
+
+Bestaetigung eines bekannten Gotchas, hier mit einem Zusatz, der die Diagnose beschleunigt haette: der REST-Fallback aus repo-hygiene-ops ("PR-Branch auf main nachziehen") HILFT IN DIESEM FALL NICHT — er scheitert an genau demselben Phantomkonflikt mit 422. Der Abschnitt liest sich heute so, als sei update-branch der Weg und der lokale Merge nur die Nachbereitung. Tatsaechlich ist bei merge=ours-Konflikten der lokale Merge der EINZIGE Weg: mergen, Artefakte regenerieren, Merge-Commit pushen.
+**5. Halb archivierter Zustand im Hauptcheckout — uncommittet, vom half-archive-Guard nicht erfasst** (suspicious, scripts/openspec-half-archive-check.sh)
+
+Beobachtet 2026-08-09 im Hauptcheckout /home/patrick/Bachelorprojekt. `git status` zeigte 19 Zeilen: drei Change-Verzeichnisse (agy-headless-mcp-permissions, qwen3-coder-loadout, routes-manifest-stacktrace-fallback-T002666) als geloescht unter openspec/changes/, dieselben Inhalte als UNTRACKED unter openspec/changes/archive/2026-08-09-*, plus regeneriertes openspec-status.json.
+
+Die Verschiebung war inhaltlich getreu (alle 15 Dateien byteidentisch, gleiche Dateizahlen je Change — geprueft gegen HEAD). Sie war aber UNVOLLSTAENDIG: die Delta-Specs waren nicht in die SSOT-Specs gemerged. Fuer qwen3-coder-loadout haette ein Commit das Requirement "Qwen3-Coder is available as an additive chat loadout" aus dem aktiven Baum entfernt, ohne dass es je in openspec/specs/local-llm-proxy.md ankommt — stiller Verlust eines Requirements.
+
+Herkunft: KEIN post-merge-Hook erzeugt das (.githooks/post-merge enthaelt nichts zu archive/openspec). Es stammt aus einem abgebrochenen manuellen bzw. agentischen openspec.sh-archive-Lauf, vermutlich aus einer der Sessions, deren PID nicht mehr lief.
+
+Kernbefund und Grund fuer diesen Eintrag: scripts/openspec-half-archive-check.sh existiert genau gegen diesen Zustand, meldete aber die ganze Zeit gruen — er prueft den COMMITTETEN Baum und sieht einen uncommitteten Halbzustand per Konstruktion nicht. Der Guard deckt damit die Phase nicht ab, in der der Fehler entsteht.
+
+Behandelt im Lauf: Dateien nach scratchpad gesichert, Arbeitsbaum auf origin/main zurueckgesetzt (kein Informationsverlust — jede Datei war byteidentisch zu einer getrackten Datei in HEAD), Guard danach weiterhin gruen. Die drei Changes stehen wieder regulaer unter openspec/changes/ und sind ordentlich zu archivieren.
+**6. Delta-Spec nach Change-Slug statt Parent-SSOT-Slug benannt — Archivierung wird scheitern (T002666)** (drift, openspec/changes)
+
+Beobachtet 2026-08-09. Der Change openspec/changes/routes-manifest-stacktrace-fallback-T002666/ traegt seine Delta-Datei unter specs/routes-manifest-stacktrace-fallback-T002666.md — also nach dem CHANGE-Slug benannt, inklusive Ticket-Suffix.
+
+Verifiziert: eine SSOT-Spec openspec/specs/routes-manifest-stacktrace-fallback-T002666.md existiert nicht. Der naechste fachlich passende Parent waere ci-cd.md.
+
+Das verstoesst gegen die Delta-Spec-Konvention T001304 (Delta-Dateien werden nach dem Parent-SSOT-Slug benannt). Praktische Folge: `openspec.sh archive` schlaegt hier ohne --create-new fehl, weil der Ziel-SSOT nicht existiert — und --create-new waere fachlich falsch, da es sich nicht um eine neue Komponente handelt, sondern um einen Fix am routes:manifest-Verhalten.
+
+Faelligkeit: PR #3913 (fix(routes): routes:manifest suppresses tsx stderr stacktrace [T002666]) ist BEREITS GEMERGT. Die Archivierung steht also an, und der Fehler tritt erst zu diesem Zeitpunkt zutage — die Datei liegt seit dem Anlegen des Change falsch benannt da, ohne dass irgendein Gate darauf anspricht.
+
+Denkbar: die Namenskonvention schon bei `openspec.sh propose` pruefen (Delta-Dateiname muss einem existierenden openspec/specs/<slug>.md entsprechen, sonst --target-spec verlangen), statt den Fehler bis zum Archivieren aufzuschieben.
+**7. agent-lock claim ticket returns exit 0 but lock not held** (suspicious, scripts/agent-lock.sh)
+
+During ticket-ops Wave 0+1 dispatch: `agent-lock.sh claim ticket T002781` (and subsequent Wave 1 tickets) returned exit 0 with no output but `check ticket` still showed `free`. The `check-and-claim` variant worked correctly. Observed on 2026-08-09 during T002781 execution in worktree. The silent claim failure creates a race condition where two sessions could believe they both hold the lock.
+**8. Pre-push hook rejects valid push due to stale scope commits from rebased main** (suspicious, scripts/pre-push hook)
+
+When pushing fix/ticket-list-test-data-filter-T002781, the pre-push conventional-commit validator rejected the push because rebased commits from main (ci-cd, mcp-gateway, e2e-testing, routes scopes) were in the push range. These scopes were invalid per T002328 consolidation but the commits were already merged to origin/main — the hook should only check new commits, not the full range being pushed. Required workaround: rebase --onto to isolate only our commits.
+**9. PR #3926 went DIRTY/CONFLICTING immediately after creation — rebase needed 3 attempts** (degraded, devflow/merge pipeline)
+
+T002781 PR #3926 went from clean push to DIRTY/CONFLICTING immediately after creation, requiring 3 rebase cycles: (1) initial rebase with merge conflict on plan files, (2) rebase --onto to fix push rejection, (3) third rebase after auto-merge showed DIRTY. The post-rewrite openspec-status.json regeneration triggered dirty state on most rebases. Main branch was moving during the session with chore:release main commits.
+**10. Planung widersprach einer bestehenden Design-Entscheidung, die erst nach der Nutzerfrage gefunden wurde** (process, dev-flow-plan)
+
+Beim Planen von T002817 (SSOT für ticketlose Branch-Ausnahmen) habe ich dem User die Architekturfrage "gemeinsame Quelle vs. Allowlist spiegeln" gestellt, BEVOR ich geprüft hatte, ob die Frage im Repo schon einmal entschieden wurde. Sie war es: openspec/specs/divergence-guard.md:107-112 (aus T002470) schreibt die Duplikation ausdrücklich fest ("the pre-commit hook stays free of repository file dependencies, so that a missing library file cannot block every commit") und sichert sie mit drei Drift-Tests in tests/spec/divergence-guard/branch-name-guard.bats:114-139 ab.
+
+Gefunden habe ich das erst beim Schreiben des failing Tests, als ich nach bestehenden Hook-Testmustern suchte — also nach der Entscheidung. Der User musste die Frage daraufhin ein zweites Mal beantworten, diesmal mit der vollständigen Faktenlage. Die Entscheidung fiel gleich aus (SSOT, Requirement per RENAMED-Delta ersetzen), das Risiko war aber real: eine unbemerkte Umkehr einer dokumentierten Entscheidung wäre erst im Review oder gar nicht aufgefallen.
+
+ABLEITUNG: Vor einer Architekturfrage an den User gehört eine Suche nach bestehenden Requirements zum selben Gegenstand — grep über openspec/specs/ auf die betroffenen Dateipfade, nicht nur über den Code. Der Fix-Pfad von dev-flow-plan verlangt Ursachen-Verifikation vor dem Brainstorming (T002448-M5), aber nicht die Prüfung, ob die Lösungsrichtung schon einmal verworfen wurde.
+
+NEBENBEFUND, in den Change eingearbeitet: der Drift-Guard aus T002470 hat den Drift, der T002817 auslöste, nicht gefunden. Er vergleicht Ticket-ID-Regex, Exemption-Liste und Typ-Präfixe zwischen Hook und Helper — die _unattended_allowlist (worktree-create.sh:49, mit T002783 hinzugekommen) fällt in keinen der drei Vergleiche. Eine bewusst duplizierte Regel ist nur so vollständig abgesichert wie die Aufzählung der Drift-Tests gepflegt wird.
+
+ZWEITER, KLEINERER BEFUND: Ich habe .githooks/pre-push zunächst als zweiten Blocker der Kette bezeichnet. Der Abschnitt ist advisory (warn + exit 0), blockiert also nicht. Korrigiert, bevor der Plan geschrieben wurde; der Hook bleibt im Scope, weil die Warnung falsch ist, aber er war nie Ursache.
+
+## Verify (RED → GREEN)
+
+- [ ] **Failing-Test-Step (RED).** Fuer den ersten Eintrag oben einen Test schreiben,
+      der das beschriebene Fehlverhalten reproduziert. Er gehoert nach
+      `tests/spec/<spec-slug>.bats` — die Spec, die das Verhalten abdeckt.
+
+```bash
+tests/unit/lib/bats-core/bin/bats -r tests/spec/software-factory/
+# expected: FAIL (rot — der Fix ist noch nicht implementiert)
+```
+
+- [ ] **Fix-Step (GREEN).** Die Eintraege oben abarbeiten.
+
+- [ ] **Final Verification.** Die drei verpflichtenden CI-Gates:
+
+```bash
+task test:changed
+task freshness:regenerate
+task freshness:check
+```

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:26 UTC. Die Eintraege stammen aus den
+2026-08-10 00:29 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:36 UTC. Die Eintraege stammen aus den
+2026-08-09 10:38 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -1,6 +1,6 @@
 ---
 title: "mishap-incident-rollup — Implementation Plan"
-ticket_id: T003067
+ticket_id: T003201
 domains: [factory]
 status: active
 file_locks: []
@@ -12,10 +12,10 @@ depends_on_plans: []
 
 # mishap-incident-rollup — Implementation Plan
 
-_Container-Ticket: T003067_
+_Container-Ticket: T003201_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 02:34 UTC. Die Eintraege stammen aus den
+2026-08-10 18:36 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure
@@ -26,863 +26,496 @@ Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung
 
 ## Mishap-Batches
 
-### Mishap-Rollup — 10 Eintraege (2026-08-09 19:40 UTC)
+### Mishap-Rollup — 10 Eintraege (2026-08-10 04:33 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | suspicious | git-workflow | Teilweise durchgelaufener `git stash pop` nach Rebase sieht aus wie ein erfolgreicher |
-| 2 | degraded | git-workflow | Der Stash-Stack ist worktree-uebergreifend geteilt — als Sicherungsnetz bei Parallelarbeit unbrauchbar |
-| 3 | drift | scripts/factory/mcp-go | Stale factory-mcp binary deployed via systemd (2026-08-04) |
-| 4 | drift | tickets/update-status.sh · Terminal-Guard T002382 | Faelschlich als done angelegtes Ticket ist ueber den sanktionierten Pfad nicht reparierbar |
-| 5 | suspicious | tests/spec · CI-Guards (T002407-M6b, T002500) | Zwei offene PRs scheitern am alten Guard, den ihre eigene Aenderung ersetzt |
-| 6 | drift | skills/references/repo-hygiene-ops | branch-reaper.sh kann den in §2 beschriebenen Sweep gar nicht leisten — filtert hart auf EINE Ticket-ID |
-| 7 | process | repo/pr-hygiene | 4 von 4 offenen PRs scheiterten am Freshness-Gate — test-inventory.json nie mitregeneriert |
-| 8 | drift | repo/worktrees | Zwei verwaiste git-Worktrees im Scratchpad einer fremden, beendeten Session |
-| 9 | degraded | scripts/openspec-embed (post-commit hook) | openspec-embed scheitert bei jedem Commit an Port 15432 — k3d-Port-Forward belegt ihn dauerhaft |
-| 10 | degraded | skills/dev-flow-chore | dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Datenverlustrisiko bei Parallelsessions) |
+| 1 | suspicious | .claude/skills/references/repo-hygiene-ops.md §3 (gh pr checks) | gh pr checks faltet conclusion=cancelled auf "fail" — grüner PR wird als rot gemeldet |
+| 2 | degraded | .claude/skills/references/repo-hygiene-ops.md §3 (Watch-Schleife) | statusCheckRollup mischt Checks mehrerer head-SHAs — Läufe eines Vorgänger-Commits gelten als aktueller Zustand |
+| 3 | drift | Taskfile.yml (ticket-mcp:test) + .github/workflows/ci.yml | Taskfile ticket-mcp:test ist fail-open — fehlende Go-Toolchain deaktiviert das Gate lautlos |
+| 4 | suspicious | .claude/skills/references/repo-hygiene-ops.md §1 | repo-hygiene hat keinen Vorcheck auf laufenden Factory-Tick — Worktrees verändern sich unter dem Lauf |
+| 5 | drift | scripts/branch-reaper.sh + .claude/skills/references/repo-hygiene-ops.md §2 | branch-reaper.sh --dry-run verlangt --ticket — dokumentierter ticketloser Inspektionspfad nicht ausführbar |
+| 6 | degraded | scripts/agent-lock-identity.sh + scripts/vda/ticket/_ticket-core.sh (Lock-Guard, Zeilen 129-183) | ticket-mcp sieht eine andere CLAUDE_CODE_SESSION_ID als die Shell — agent-lock sperrt die eigene Session aus |
+| 7 | suspicious | tests/spec/divergence-guard/main-checkout-foreign-guard.bats + scripts/lib/main-checkout-foreign-guard.sh | Test hing an der PID-Breite der Maschine: lokal grün, CI rot — ps-Spaltenpolsterung als unsichtbare Testvoraussetzung |
+| 8 | drift | dev-flow-plan / commit-msg-hook | superpowers:brainstorming schreibt nach docs/superpowers/specs/, aber der Scope 'specs' ist im commit-msg-Hook verboten |
+| 9 | degraded | factory-mcp / openspec_find_similar | openspec_find_similar zeigt auf eine Cluster-interne Adresse und ist von WSL aus unbenutzbar |
+| 10 | drift | skills/git-workflow (post-merge) | Post-Merge-Ticketabschluss unterblieb bei zwei gemergten PRs — T003120 blieb dadurch in der Factory-Queue |
 
-**1. Teilweise durchgelaufener `git stash pop` nach Rebase sieht aus wie ein erfolgreicher** (suspicious, git-workflow)
+**1. gh pr checks faltet conclusion=cancelled auf "fail" — grüner PR wird als rot gemeldet** (suspicious, .claude/skills/references/repo-hygiene-ops.md §3 (gh pr checks))
 
-Beobachtet beim Abschliessen von T002894 am 2026-08-09. Ablauf nach git-workflow Schritt 0: `git stash -u` → `git rebase origin/main` → `git stash pop`. Der Rebase loeste den post-rewrite-Hook aus, der `website/src/data/openspec-status.json` neu generierte — genau eine der gestashten Dateien. Der anschliessende `pop` konnte deshalb nur teilweise anwenden und meldete am Ende `The stash entry is kept in case you need it again`.
+An PR #4091 meldete `gh pr checks 4091` den Required Check "Factory + OpenSpec + Guards" als **fail**. Tatsaechlich hatte KEIN einziger Job conclusion=failure: `gh run view 31347244592 --json jobs` zeigte 12x success und 1x **cancelled** (eben diesen Aggregat-Job). Sein eigenes Log belegt, dass er sein Urteil bereits gefaellt hatte, bevor er abgebrochen wurde: OPENSPEC_RESULT=success, SHARDS_RESULT=success, "Alle Factory-Gates gruen." — der Abbruch traf ihn NACH dem erfolgreichen Durchlauf. Ein blosser `gh run rerun --failed` machte den PR gruen und Auto-Merge zog ihn durch (mergedAt=2026-08-10T01:48:42Z); es existierte zu keinem Zeitpunkt ein Codefehler. Das ist eine weitere Instanz der §3-Grundregel, aber mit umgekehrtem Vorzeichen: hier meldet ein Signal Krankheit statt Gesundheit, ohne das Attestierte geprueft zu haben. Gegenprobe gehoert nach repo-hygiene-ops.md §3: bei rot gemeldetem Check IMMER `gh run view <run> --json jobs -q '.jobs[]|select(.conclusion=="failure")'` gegenpruefen — kommt nichts zurueck, ist es cancelled/skipped und ein Re-Run genuegt.
+**2. statusCheckRollup mischt Checks mehrerer head-SHAs — Läufe eines Vorgänger-Commits gelten als aktueller Zustand** (degraded, .claude/skills/references/repo-hygiene-ops.md §3 (Watch-Schleife))
 
-Das Tueckische ist der Endzustand: `git status --porcelain` zeigte danach EINE modifizierte Datei (`openspec-status.json`). Das sieht wie ein normaler, erfolgreicher Pop aus. Die eigentliche inhaltliche Arbeit — die Erweiterung von `scripts/one-shot/purge-fn-v8.sql` von einem auf sieben Guards — war NICHT im Arbeitsbaum, sondern lag weiterhin im Stash. Waere sie nicht aufgefallen, haette der PR die halbe Aenderung enthalten und die Verifikation gegen die DB waere trotzdem an einer spaeteren Stelle rot geworden — also mit einem irrefuehrenden Symptom statt mit "deine Aenderung fehlt".
+Beim Beobachten von PR #4092 nach einem Push meldete `gh pr view --json statusCheckRollup` fuenf rote Shards. Der Run auf dem AKTUELLEN head (68991e5dd) lief zu dem Zeitpunkt aber noch (`gh run view 31348198986` -> status=in_progress, logs noch nicht abrufbar) — die roten Eintraege stammten aus dem Lauf des Vorgaenger-Commits. Eine Watch-Schleife auf dem Rollup bricht dadurch mit "ROT" ab, waehrend die eigentliche Messung noch laeuft. Zweite, eigenstaendige Falle im selben Aufruf: in jq ist ein LEERER String truthy (nur null und false sind falsy), deshalb faengt `select(.conclusion?)` auch laufende Checks (conclusion="") und wirft sie in die Fehlerliste. Belastbar ist nur eine Auswertung, die (a) auf `.headSha == <headRefOid>` filtert und (b) laufend/leer explizit von negativ trennt: `select(.conclusion != "" and .conclusion != null and .conclusion != "SUCCESS")`. Kanonisch ist ohnehin `gh run list --branch <b> --json databaseId,name,headSha,status,conclusion` plus Filter auf den head — das ist in §3 bereits als Gegenprobe fuer leere Rollups dokumentiert, aber nicht als Pflicht fuer die Watch-Schleife nach einem Push.
+**3. Taskfile ticket-mcp:test ist fail-open — fehlende Go-Toolchain deaktiviert das Gate lautlos** (drift, Taskfile.yml (ticket-mcp:test) + .github/workflows/ci.yml)
 
-Erkennungs- und Loesungsweg: `git stash list` nach dem Pop pruefen (ein verbliebener Eintrag IST der Befund), Inhalt per `git stash show --stat "stash@{0}"` gegen den Arbeitsbaum halten, fehlende Datei gezielt zurueckholen mit `git checkout "stash@{0}" -- <pfad>`.
+`ticket-mcp:test` (Taskfile.yml:5226) laeuft nur, wenn `command -v go` anschlaegt; sonst gibt es "ticket-mcp:test: Go toolchain not found — skipping (non-fatal)" aus und endet mit Exit 0. Ein Testgate, das sich bei fehlender Toolchain selbst abschaltet, kann nicht zwischen "Tests bestanden" und "Tests nie gelaufen" unterschieden werden — dieselbe Fehlerklasse wie die §3-Grundregel, nur in einem Task statt in einer gh-Abfrage. Konkret sichtbar geworden an PR #4092: der CI-Step "Run ticket-mcp Go tests" war VOR `arduino/setup-task` eingehaengt und brach in allen vier Spec-Shards mit "task: command not found" (Exit 127) ab — der eingebaute Fallback half dort nicht, weil er INNERHALB von task lebt. Nach dem Umsortieren (Commit 9af4e68fe) lief das Gate erstmals und legte sofort einen echten Defekt frei: internal/tools/mishap_konversion_test.go:101:13 "undefined: processBufferAtThreshold". In CI ist Go per setup-go@v5 garantiert vorhanden; der skip-Zweig kann dort also nur ein Setup-Defekt sein und sollte fail-closed werden (z. B. `[ "$CI" = true ] && exit 1`), waehrend lokal der weiche Pfad sinnvoll bleibt.
+**4. repo-hygiene hat keinen Vorcheck auf laufenden Factory-Tick — Worktrees verändern sich unter dem Lauf** (suspicious, .claude/skills/references/repo-hygiene-ops.md §1)
 
-Konventionsluecke (git-workflow Schritt 0): Der Skill schreibt die Sequenz `git stash` / `git pull --rebase` / `git stash pop` vor und warnt bereits vor der Branch-Switch-Race, aber nicht vor dem Teil-Pop. Vorschlag: Nach dem Pop pruefen, dass `git stash list` um genau den eigenen Eintrag kuerzer geworden ist, statt den Exit-Code oder die Statusanzeige als Beleg zu nehmen. Das ist dasselbe Muster wie bei der Merge-Verifikation per `mergedAt` — nicht auf die Abwesenheit eines Fehlers pruefen, sondern auf das positive Signal.
-**2. Der Stash-Stack ist worktree-uebergreifend geteilt — als Sicherungsnetz bei Parallelarbeit unbrauchbar** (degraded, git-workflow)
+Waehrend des repo-hygiene-Laufs am 2026-08-10 aenderten sich die SHAs von FUENF der sieben Worktrees unter dem Skript weg (z. B. .worktrees/mishap-dedupe-konversion-T003120: c193f926a -> 68991e5dd, .worktrees/mishap-rollup-loop-T002931: dc459c351 -> 72aca67a1). Ursache war ein parallel laufender Factory-Tick (`factory_status` -> tick_running=true). Konkrete Folge: der Worktree zu T003116 galt in der Eingangsinventur als sauber (nur Generate abweichend) und trug beim Aufraeumversuch wenige Minuten spaeter eine nicht-allowlistete Abweichung (openspec/specs/active-sessions-hub.md) — die §1-Vorpruefung hatte also einen Zustand gemessen, der zum Zeitpunkt der Entscheidung nicht mehr galt. Nur weil die Pruefung unmittelbar vor dem Remove wiederholt wurde, fiel es auf; die dokumentierte Reihenfolge (einmal inventarisieren, dann pro Worktree entscheiden) erlaubt beliebig viel Zeit dazwischen. repo-hygiene-ops.md §1 kennt keinen Vorcheck auf tick_running und keine Anweisung, die Messung unmittelbar vor dem Remove zu wiederholen. Zuschnitt: §5 (factory_status) VOR §1 ziehen und bei tick_running=true die Worktree-Sektion ueberspringen, oder die --porcelain-Pruefung als Teil des Remove-Schritts vorschreiben statt als Inventur.
+**5. branch-reaper.sh --dry-run verlangt --ticket — dokumentierter ticketloser Inspektionspfad nicht ausführbar** (drift, scripts/branch-reaper.sh + .claude/skills/references/repo-hygiene-ops.md §2)
 
-Beobachtet am 2026-08-09. Vor einer Umstrukturierung im Hauptcheckout legte ich einen benannten Sicherungs-Stash an (`git stash push -u -m "archive-T002894 safety net" -- openspec website/src/data/openspec-status.json`); der Befehl meldete `Saved working directory and index state`. Wenige Minuten spaeter war der Eintrag aus `git stash list` verschwunden, waehrend zwei fremde Eintraege neu darin standen, darunter `On fix/sammel-bats-hygiene-T002925: WIP on fix/purge-test-data-schema-drift-T002894` — also von einer parallel laufenden Session.
+repo-hygiene-ops.md §2 ("Verwaiste Remote-Branches ohne PR") nennt `bash scripts/branch-reaper.sh --ticket T00XXXX --dry-run` als den manuellen Weg zum Nachsehen. Ein reiner Hygiene-Lauf hat aber keine eigene Ticket-ID, und das Skript ist auch im Dry-Run fail-closed: `bash scripts/branch-reaper.sh --dry-run` endet mit Exit 2 und "FEHLER: --ticket ist erforderlich (Format T######)".
 
-Ursache: `refs/stash` liegt im gemeinsamen Git-Verzeichnis (`git rev-parse --git-common-dir`), nicht pro Worktree. Alle 15 Worktrees dieses Repos teilen sich EINEN Stash-Stack. Ein `git stash pop` in irgendeinem davon nimmt `stash@{0}` — und das kann der Eintrag einer anderen Session sein. Die Indizes verschieben sich ausserdem bei jedem fremden Push auf den Stack, sodass selbst ein gemerktes `stash@{N}` nach kurzer Zeit auf etwas anderes zeigt.
+VERIFIKATION: scripts/branch-reaper.sh:77 — `"") echo "FEHLER: --ticket ist erforderlich (Format T######)" >&2; usage; exit 2 ;;`. Kein Default, kein ticketloser Zweig; --dry-run (Zeile 65) setzt nur DRY_RUN=1 und umgeht die Pflichtprüfung nicht.
 
-Konkreter Schaden hier: keiner — der Inhalt war regenerierbar (`scripts/openspec.sh archive` erneut im Worktree ausgefuehrt) und landete in PR #3982. Der Punkt ist die falsche Sicherheitsannahme: ein Stash fuehlt sich wie ein privates Sicherungsnetz an und ist in einem Multi-Worktree-Repo ein geteilter, von fremden Sessions veraenderbarer Stack.
+WIRKUNG: Der Schritt entfällt bei jedem Hygiene-Lauf ohne eigenes Ticket. Am 2026-08-10 wurde er durch Handarbeit ersetzt (git branch -vv + Ticketstatus je Branch) — das prüft nur lokale Branches und deckt die von §2 adressierten verwaisten *Remote*-Branches gar nicht ab. Genau deshalb existiert das Skript: --merged und [gone] erfassen Plan-/Factory-Branches nicht, die über einen Sammel-PR nach main laufen (am 2026-08-01: 24 von 26 Remote-Branches ohne jeden PR).
 
-Konventionsluecke (repo-hygiene §0 und git-workflow Schritt 0): Beide behandeln Stashes als lokalen Zustand. §0 sieht sogar ein "Stash-Inventar" ueber `git stash list` vor, ohne zu erwaehnen, dass die dort gelisteten Eintraege aus beliebigen Worktrees stammen koennen — die Zuordnung "welcher Stash gehoert zu welcher Arbeit" ist allein ueber die Nachricht moeglich, und nur wenn sie benannt wurde. Vorschlag: Bei Parallelarbeit statt `git stash` einen Wegwerf-Commit auf dem eigenen Branch verwenden (`git commit -m wip`, spaeter `reset --soft`) — der ist per Konstruktion an den Branch gebunden. Wo ein Stash noetig bleibt: immer `-m` mit Ticket-ID, und nie ueber den Index `stash@{0}` aufloesen, sondern ueber die Nachricht suchen.
-**3. Stale factory-mcp binary deployed via systemd (2026-08-04)** (drift, scripts/factory/mcp-go)
+ZUSCHNITT (Vorschlag): Die Ticket-ID braucht der Reaper für den Archiv-Tag-Push, also nur im Schreibpfad. Ein Dry-Run schreibt nichts — die Pflichtprüfung gehört hinter die DRY_RUN-Abfrage. Alternativ eine Sammel-ID für Hygiene-Läufe in §2 dokumentieren.
+**6. ticket-mcp sieht eine andere CLAUDE_CODE_SESSION_ID als die Shell — agent-lock sperrt die eigene Session aus** (degraded, scripts/agent-lock-identity.sh + scripts/vda/ticket/_ticket-core.sh (Lock-Guard, Zeilen 129-183))
 
-Der systemd-user-Dienst factory-mcp.service lief mit einem am 2026-08-04 gebauten Binary (scripts/factory/mcp-go/bin/factory-mcp), das den T002830 is_test_data-Filter nicht enthaelt. Die Queue-Reads (factory_status/factory_queue) lieferten deshalb das Test-Fixture-Ticket T003020 (is_test_data=true) zurueck, obwohl alle aktuellen Quell-Pfade (mcp-go/main.go, mcp-server.mjs, queue.sh) den Filter haben. Nachweis: ls bin/factory-mcp (2026-08-04) vs. Quelle mit Filter; nach Rebuild (CGO_ENABLED=0 go build) + systemctl --user restart factory-mcp.service liefert die Queue T003020 nicht mehr. Der agents:factory-mcp:install-Task baut zwar, aber ein laufender Dienst wird nicht automatisch nach Quell-Aenderung neu gebaut/restartet — Drift-Luecke im Deploy-Flow.
-**4. Faelschlich als done angelegtes Ticket ist ueber den sanktionierten Pfad nicht reparierbar** (drift, tickets/update-status.sh · Terminal-Guard T002382)
+BEOBACHTET 2026-08-10 während PR-Handarbeit an #4095. Nach `agent-lock.sh check-and-claim ticket T003078` (Claim korrekt als live gelistet) schlug `mcp__ticket-mcp__transition_status` für dasselbe Ticket mit Exit 7 fehl:
 
-Beobachtet 2026-08-09 waehrend repo-hygiene §3.
+  ERROR: Ticket T003078 ist gesperrt (agent-lock) — Status-Schreibvorgang verweigert.
+         Halter: sid=6bddc378-dc34-4ed5-a67b-7454dd1cd02e
+         Eigene SID: 9b2c77aa-cc3d-43d2-b91c-79fe124b8653 (Shell-PID 1980421)
 
-T003025 wurde bereits als `status=done` mit `resolution=null` angelegt: `created_at == updated_at` (2026-08-09 15:41:36), das Ticket hat also nie einen Lebenszyklus durchlaufen. Ein Merge-Nachweis existiert nicht — `gh pr list --search T003025 --state all` liefert ausschliesslich #4004 mit `state=OPEN` und leerem `mergedAt`, `git log origin/main --grep=T003025` ist leer. PR #4004 ist zudem rot.
+VERIFIKATION (gegengeprüft, kein Fremdsession-Fall):
+- `echo $CLAUDE_CODE_SESSION_ID` in der Arbeits-Shell -> 6bddc378-… (identisch mit dem Halter)
+- `_my_sid()` aus scripts/agent-lock-identity.sh in derselben Shell -> 6bddc378-…
+- Die vom Guard gemeldete "eigene" SID 9b2c77aa-… kommt also NICHT aus der Shell, die den Claim setzte, sondern aus der Umgebung des ticket-mcp-Serverprozesses.
 
-Die Korrektur ist ueber den sanktionierten Pfad NICHT moeglich: `mcp__ticket-mcp__transition_status({id: T003025, status: in_progress})` bricht mit Exit 2 ab — "Cannot transition from 'done' to 'in_progress' — terminal tickets can only transition to 'archived'" (Terminal-Guard T002382).
+URSACHE (soweit belegt): `_AGENT_LOCK_SID_ENVS="CLAUDE_CODE_SESSION_ID CLAUDE_SESSION_ID OPENCODE_SESSION_ID"` (scripts/agent-lock-identity.sh:13) leitet die Identität aus der Prozessumgebung ab. Der ticket-mcp-Server wird einmal gestartet und behält die SID, die zu seinem Startzeitpunkt gesetzt war — sie muss nicht die der aktuell arbeitenden Session sein. Damit ist die Identität nicht an die Session gebunden, sondern an die Lebensdauer des Serverprozesses.
 
-WARUM ES ZAEHLT: Der Terminal-Guard schuetzt gegen das Wiederaufreissen eines echt abgeschlossenen Tickets. Er trifft aber auch den Fall, in dem `done` nie gueltig war, weil es der Anfangszustand war. Damit ist ein per Fehleingabe geschlossenes Ticket nur noch per Direkt-SQL oder ueber `archived` + Neuanlage zu korrigieren; beides umgeht bzw. verliert die Historie. Ein `done` ohne `resolution` und ohne `done_at`-Lebenszyklus ist maschinell von einem gueltigen Abschluss unterscheidbar — der Guard koennte diesen Fall ausnehmen, statt ihn zu zementieren.
+WIRKUNG: Jeder Ticket-Schreibvorgang über ticket-mcp scheitert, sobald die Session den Ticket-Lock hält — also genau im vorgesehenen Ablauf "Lock nehmen, arbeiten, Status setzen". Der Guard schützt hier nichts, er blockiert den Eigentümer. Der reguläre Ausweg (erst `release`, dann schreiben) funktioniert, invertiert aber die Reihenfolge: der Status wird ungeschützt gesetzt, nachdem der Schutz aufgegeben wurde.
 
-Kein Eingriff vorgenommen: der Guard wurde bewusst NICHT per SQL umgangen. Der Widerspruch ist als Kommentar an T003025 dokumentiert.
+WARUM DAS ZÄHLT: Die Fehlermeldung selbst empfiehlt als Alternative `TICKET_LOCK_OVERRIDE=1` und schreibt dazu, dass dies "den Schutz auch gegen echte Fremdsessions deaktiviert". Ein Guard, dessen dokumentierter Ausweg der Generalschlüssel ist, wird unter Reibung genau so benutzt — dann ist er wirkungslos, ohne dass es auffällt.
 
-Angrenzend: T002845 ("18 Tickets stehen auf plan_staged ohne plan-Zeile/Branch") beschreibt dieselbe Klasse — Statuswert ohne den Zustand, den er behauptet.
-**5. Zwei offene PRs scheitern am alten Guard, den ihre eigene Aenderung ersetzt** (suspicious, tests/spec · CI-Guards (T002407-M6b, T002500))
+EINORDNUNG: Der Befund trat Minuten nach dem Merge von T003110/T002826 auf (PR #4094, "cwd-independent lock ownership + claim persistence verification"). Jene Arbeit härtete die Ownership-Erkennung gegen wechselnde Arbeitsverzeichnisse; der Fall "zwei SID-Werte innerhalb einer Session, weil ein langlebiger MCP-Serverprozess seine Startumgebung konserviert" ist davon nicht erfasst. Kandidat für denselben Themenbereich, nicht für ein Rollback.
+**7. Test hing an der PID-Breite der Maschine: lokal grün, CI rot — ps-Spaltenpolsterung als unsichtbare Testvoraussetzung** (suspicious, tests/spec/divergence-guard/main-checkout-foreign-guard.bats + scripts/lib/main-checkout-foreign-guard.sh)
 
-Beobachtet 2026-08-09 waehrend repo-hygiene §3 — zweimal gleichzeitig, gleiches Muster.
+BEOBACHTET 2026-08-10 an PR #4095 (T003078). Zwei Tests in tests/spec/divergence-guard/main-checkout-foreign-guard.bats fielen ausschliesslich auf dem GitHub-Runner. Lokal waren alle vier gruen — auch mit dem CI-identischen Aufruf `bats -j 6 --no-parallelize-within-files`, der Parallelismus war also als Ursache ausgeschlossen.
 
-Beide PRs sind `mergeable=MERGEABLE`, aber rot, und in beiden Faellen ist der Fehlschlag die erwartbare Folge der PR-eigenen Aenderung:
+URSACHE (per Diagnose-Commit im CI belegt, nicht geraten): `ps -eo pid=` richtet die Spalte rechts aus und polstert auf die Breite von /proc/sys/kernel/pid_max (7 Zeichen bei den ueblichen 4194304). In scripts/lib/main-checkout-foreign-guard.sh las `while IFS= read -r _pid` diese Zeilen — das leere IFS schaltet genau das Trimmen ab, das ein blankes `read -r` geleistet haette. Der gepolsterte Wert machte jeden Folgepfad ungueltig (`/proc/   7219/cwd` existiert nicht), `readlink` scheiterte und das nachfolgende `continue` verwarf JEDEN Prozess ungeprueft. Die Erkennung konnte strukturell nie anschlagen.
 
-1. PR #4006 (Branch fix/rollup-container-triage-status-T002876) laesst `ticket.sh rollup-container` den Container als `triage` statt `plan_staged` anlegen. Rot wird `Factory spec shard 4`: `not ok 135 T002407-M6b: ticket.sh rollup-container dokumentiert status=plan_staged (T002783)` — der Guard fordert weiter `plan_staged`.
+WARUM LOKAL GRUEN: Auf einer lang laufenden WSL-Instanz sind die eigenen PIDs bereits 7-stellig (der simulierte Prozess hatte 1613537) — exakt Feldbreite, also keine Polsterung. Ein frischer CI-Runner vergibt 4-stellige PIDs und damit drei Leerzeichen Polsterung. Die Zusicherung hing an der Uptime der ausfuehrenden Maschine, nicht am Code.
 
-2. PR #4004 (Branch chore/ci-shard-balance-T003025) gewichtet die Factory-Spec-Shards nach gemessener Laufzeit (junit-Timing + LPT). Rot wird `Factory spec shard 3`: `not ok 171 T002500: die Shards sind nach @test-Anzahl balanciert (schwerster <= 1.5x leichtester)` — der Guard misst weiter nach @test-Anzahl.
+WAS DIE DIAGNOSE AUSGESCHLOSSEN HAT (alle vier Vorab-Hypothesen waren falsch, jede Sonde meldete den erwarteten Wert): Symlink-Abweichung zwischen $d und /proc/pid/cwd (identisch, auch nach readlink -f), Prozessnamens-Auflösung (`ps -o args=` gab `claude 30`), Sichtbarkeit im Prozess-Scan (in_pslist=1), vorzeitiger Tod des Simulats (alive=yes).
 
-WARUM ES ZAEHLT: In beiden Faellen ist der rote Test kein Defekt-Nachweis, sondern ein nicht mitgezogener Guard. Der PR-Autor sieht einen roten Lauf, dessen Ursache nicht im geaenderten Verhalten liegt, sondern in der Zusicherung des ALTEN Verhaltens. Das ist die teuerste Form von rotem CI: sie sieht aus wie ein Fehler in der Aenderung. Dass es zweimal am selben Tag unabhaengig auftrat, spricht fuer eine strukturelle Luecke, nicht fuer zwei Fluechtigkeitsfehler — es fehlt ein Schritt, der beim Aendern einer Regel die Guards findet, die diese Regel festschreiben (grep auf die Ticket-ID/Regelformulierung in tests/spec/).
+VERALLGEMEINERUNG (der eigentliche Grund fuer diesen Eintrag): Jeder Test, der eine Prozessliste parst, kann auf einer Maschine gruen und auf einer anderen rot sein, ohne dass Code oder Test sich unterscheiden. Das ist dieselbe Klasse wie T002716 (Semantik statt Darstellung), nur eine Ebene tiefer: dort schrieb ein Guard das Ausgabeformat eines Werkzeugs fest, hier setzt ein Test eine Formateigenschaft stillschweigend voraus. Der belastbare Zuschnitt ist, das Format zu ERZWINGEN statt es vorzufinden.
 
-Anmerkung zu PR #4004: dort faellt zusaetzlich `not ok 550 T002721 Daemon raeumt PID- und Token-Datei beim Beenden auf` (31,5 s Laufzeit) — Timing-Verdacht, sachlich unabhaengig von der Shard-Gewichtung und hier nicht mitbewertet.
-**6. branch-reaper.sh kann den in §2 beschriebenen Sweep gar nicht leisten — filtert hart auf EINE Ticket-ID** (drift, skills/references/repo-hygiene-ops)
+BEHOBEN in 4e0f18153 (gemergt als 665f1926e): `while read -r` plus `tr -d '[:blank:]'` an der Quelle. Zusaetzlich ein Regressionstest, der die Polsterung per ps-Stub erzwingt (der Stub polstert ausschliesslich die `-eo pid=`-Form und delegiert alles andere an das echte ps) und damit unabhaengig von der PID-Breite der Maschine ist. Verifiziert gegen die ungefixte Bibliothek: rot ohne Fix, gruen mit Fix; plus Anker im selben Test, der belegt, dass der Stub ueberhaupt greift — sonst waere er stumm gruen.
 
-BEOBACHTET (2026-08-09, repo-hygiene §2)
+OFFEN: Der ursprueglich rote Test 2 bleibt umgebungsabhaengig (er wurde nicht angetastet, weil der neue Test seine Luecke deckt). Wenn die Konvention aufgenommen wird, gehoert sie in die Test-Resultats-Konvention in CLAUDE.md bzw. docs/superpowers/references/gotchas-footguns.md.
+**8. superpowers:brainstorming schreibt nach docs/superpowers/specs/, aber der Scope 'specs' ist im commit-msg-Hook verboten** (drift, dev-flow-plan / commit-msg-hook)
 
-repo-hygiene-ops.md §2 "Verwaiste Remote-Branches (ohne PR) [T002520]" stellt
-scripts/branch-reaper.sh als das Werkzeug vor, das die Klasse verwaister Branches
-abdeckt, und nennt zur Begruendung eine Bestandsaufnahme ueber ALLE Remote-Branches
-("am 2026-08-01: 24 von 26 Remote-Branches ohne jeden PR"). Der Aufruf zum Nachsehen
-steht dort als:
+Die Skill superpowers:brainstorming legt ihr Design-Dokument per Konvention unter
+docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md ab. Der naheliegende Commit-Scope dafuer
+ist 'specs'. Genau den lehnt .githooks/commit-msg ab:
 
-    bash scripts/branch-reaper.sh --ticket T00XXXX --dry-run
+  ✗ unknown scope 'specs': docs(specs): ...
+    ↳ 'specs' wurde zu 'plans' konsolidiert (T002328)
 
-VERIFIZIERT
-scripts/branch-reaper.sh:120-123 selektiert so:
+Kein Blocker — die Meldung nennt die Loesung und 'docs(plans)' geht durch. Aber die
+Verzeichnis-Konvention der Skill und die Scope-Allowlist des Repos zeigen in verschiedene
+Richtungen, und der Fehler tritt bei JEDEM Brainstorming-Durchlauf erneut auf, weil die Skill
+den Pfad vorgibt und niemand den Scope daraus ableiten kann, ohne einmal anzustossen.
 
-    git ls-remote --heads "$REMOTE" | grep -i -- "$TICKET_ID"
+Denkbare Abhilfen (nicht entschieden): 'specs' als Alias auf 'plans' in der Allowlist
+zulassen; oder die Repo-Ueberschreibung des Skill-Pfads in dev-flow-plan dokumentieren
+("Design-Doc nach docs/superpowers/specs/, aber Commit-Scope plans").
 
-und :77 bricht ohne --ticket mit Exit 2 ab. Das Skript kann damit ausschliesslich
-Branches EINES Tickets betrachten — den Bestandssweep, aus dem §2 seine Begruendung
-zieht, leistet es prinzipiell nicht.
+Beobachtet: 2026-08-10 waehrend dev-flow-plan fuer T003203.
+**9. openspec_find_similar zeigt auf eine Cluster-interne Adresse und ist von WSL aus unbenutzbar** (degraded, factory-mcp / openspec_find_similar)
 
-REAL EINGETRETEN
-Der Runbook-Aufruf mit dem woertlichen Platzhalter liefert:
-    $ bash scripts/branch-reaper.sh --ticket T000000 --dry-run
-    Keine Remote-Branches mit Ticket-ID T000000 gefunden.
-Exit 0, keine Zeile. Das ist von "es gibt keine verwaisten Branches" nicht zu
-unterscheiden — dasselbe Muster "leere Antwort ist kein Urteil", das §0 und §3
-bereits an anderer Stelle festhalten. Ich musste den Sweep von Hand fahren
-(git branch -r durchgehen, pro Branch PR-Zustand und Blob-Abweichung pruefen).
+Der MCP-Aufruf mcp__factory-mcp__openspec_find_similar schlaegt vom WSL-Host aus fehl:
 
-MOEGLICHE AUFLOESUNGEN (nicht entschieden)
-a) §2 praeziser fassen: branch-reaper ist der Post-Merge-Aufraeumer FUER EIN TICKET,
-   nicht das Sweep-Werkzeug. Den manuellen Sweep dort als eigenen Block auffuehren.
-b) branch-reaper um einen ticketlosen Modus erweitern (--all/--sweep), der ueber alle
-   Remote-Heads laeuft und je Branch REAP/KEEP mit Begruendung ausgibt.
-Beides ist vertretbar; b) waere die Variante, die den Runbook-Text einloest.
-**7. 4 von 4 offenen PRs scheiterten am Freshness-Gate — test-inventory.json nie mitregeneriert** (process, repo/pr-hygiene)
+  Get "http://website.website.svc.cluster.local:4321/api/openspec/search?q=..."
+  dial tcp: lookup website.website.svc.cluster.local on 127.0.0.53:53: no such host
 
-BEOBACHTET (2026-08-09, repo-hygiene §3)
+Die Adresse ist ein Kubernetes-Service-DNS-Name und nur aus dem Cluster aufloesbar. Vom
+Entwicklungshost — also genau dort, wo dev-flow-plan laeuft und die Duplikatspruefung vor
+einem neuen OpenSpec-Change stattfinden soll — gibt es keinen Weg dorthin.
 
-Alle vier zum Zeitpunkt des Laufs offenen PRs (#4014, #4015, #4016, #4017) scheiterten
-am selben Required Check "BATS Unit + Quality Gates", Step "Ensure freshness artifacts
-are up to date":
+Auswirkung ist begrenzt, aber nicht null: die Duplikatspruefung faellt still aus. In diesem
+Lauf wurde sie manuell per grep ueber openspec/specs/ und tests/spec/ ersetzt, was
+funktionierte, aber nur, weil daran gedacht wurde. Ein Durchlauf, der sich auf das Werkzeug
+verlaesst, uebersieht einen bestehenden Change — und genau das ist hier schon einmal
+passiert: der Change qwen3-coder-loadout (T002645) existierte bereits, waehrend T002753
+dasselbe Loadout unter anderem Slug und Port erneut anlegte.
 
-    ✗ website/src/data/test-inventory.json regenerated but not staged
-    ERROR: 1 generated artifact(s) are not committed
+Denkbare Abhilfen (nicht entschieden): Port-Forward-Unit analog zu bge-forward-*.service;
+oder die Basis-URL konfigurierbar machen und lokal auf einen bestehenden Forward zeigen
+lassen.
 
-Ursache in jedem einzelnen Fall identisch: der PR fuegt neue .bats-Dateien hinzu, ohne
-`task freshness:regenerate` laufen zu lassen und das Inventar mitzucommitten. Belegt
-je PR durch den Diff des nachtraeglichen Regen-Laufs — #4014 fehlten die zwei Eintraege
-ci-cd/spec-test-no-fixed-sleep-polling und ci-cd/spec-test-no-tracked-file-mutation,
-#4017 die zwei Eintraege active-sessions-hub/opencode-session-id-stable und
-ci-cd/devflow-ci-watch-merged-exit.
+Beobachtet: 2026-08-10 waehrend dev-flow-plan fuer T003203.
+**10. Post-Merge-Ticketabschluss unterblieb bei zwei gemergten PRs — T003120 blieb dadurch in der Factory-Queue** (drift, skills/git-workflow (post-merge))
 
-WARUM DAS BEMERKENSWERT IST
-Die Anforderung ist dokumentiert (CLAUDE.md → CI/CD → "Test inventory check") und
-git-workflow Schritt 1 verlangt `task freshness:regenerate` explizit vor dem Commit.
-Trotzdem liegt die Verletzungsquote hier bei 4/4. Eine Regel, die vollstaendig
-dokumentiert ist und trotzdem von jedem PR verletzt wird, ist keine Wissensluecke
-der Ausfuehrenden, sondern eine Luecke in der Durchsetzung: der Fehler faellt erst
-in CI auf, also mehrere Minuten nach dem Push, und kostet dann pro PR eine
-Regen-Commit-Push-Runde.
+Beobachtet am 2026-08-10 während eines repo-hygiene-Laufs.
 
-BEHOBEN IN DIESEM LAUF
-#4014 (Commit e60f343d2) und #4017 (Commit 598f13bd9) regeneriert, gepusht,
-Auto-Merge scharf. #4015/#4016 bewusst nicht angefasst — sie haben zusaetzlich
-echte Testfehler (siehe unten) und gehoeren ihren Ticket-Ownern.
+**Befund:** Zwei PRs waren nach `main` gemergt, ohne dass ihr Ticket geschlossen wurde. Die Konvention „Merge = Abschluss" (T001092) verlangt bei grünem Auto-Merge direkt `done · resolution=fixed/shipped`.
 
-MOEGLICHE AUFLOESUNG (nicht entschieden)
-Der pre-commit-Hook laeuft ohnehin schon (validate-commit-msg, gitleaks). Ein
-`task freshness:check` an derselben Stelle wuerde den Befund vom CI-Zeitpunkt auf
-den Commit-Zeitpunkt vorziehen. Kostenfrage: Laufzeit des Checks im Hook.
-**8. Zwei verwaiste git-Worktrees im Scratchpad einer fremden, beendeten Session** (drift, repo/worktrees)
+| PR | mergedAt (UTC) | Ticket | Status beim Fund |
+|---|---|---|---|
+| #4107 | 2026-08-10T04:29:02Z | T002766 | `in_progress` |
+| #4092 | 2026-08-10T02:26:45Z | T003120 | `plan_staged` |
 
-BEOBACHTET (2026-08-09, repo-hygiene §1)
+**Verifiziert (nicht nur behauptet):** Die Deliverables beider Tickets liegen auf `origin/main`.
+- T002766: `git show origin/main --grep=T002766` zeigt Squash-Commit `6d3d13992` mit `scripts/worktree-git-op-guard.sh` (+116) und `tests/spec/agent-skills/worktree-mid-rebase-guard.bats` (+108).
+- T003120: `git cat-file -e origin/main:<pfad>` für `scripts/vda/ticket/find-similar.sh`, `tests/spec/mishap-tracking/dedupe-korpus.bats`, `tests/spec/mishap-tracking/go-tests-registriert.bats` — alle drei vorhanden.
 
-`git worktree list` im Hauptcheckout fuehrte zwei Eintraege ausserhalb von
-.worktrees/ auf:
+**Warum das mehr ist als ein Statusfeld:** Bei T003120 hatte der offene Status eine sichtbare Zweitwirkung — `mcp__factory-mcp__factory_queue` listete das Ticket weiter als `plan_staged`, also als wartende Arbeit. Die Queue meldete damit einen Vorgang, dessen Arbeit bereits gemergt war. Ein Dispatcher, der diese Queue liest, hätte den Vorgang erneut aufgenommen. Die Queue-Tiefe (86 backlog + 5 plan_staged) ist in dem Maß überzeichnet, in dem dieser Fall auftritt — wie oft, ist mit diesem einen Lauf nicht gemessen.
 
-  /tmp/claude-1000/-home-patrick-Bachelorprojekt/0a75f198-8466-4f3c-bcf5-744a89b9210f/scratchpad/mainwt   23b6061c0 (detached HEAD)
-  /tmp/claude-1000/-home-patrick-Bachelorprojekt/0a75f198-8466-4f3c-bcf5-744a89b9210f/scratchpad/mainwt2  de8d93b6b (detached HEAD)
+**Zusätzliche Beobachtung am selben Ort:** Der lokale Branch `fix/mishap-dedupe-konversion-T003120` stand nur auf dem Anker-Commit (`chore: anchor branch`, 1 Commit), während PR #4092 auf demselben Branch-Namen gemergt war. Die eigentliche Arbeit lief also nicht in diesem Worktree. Der Worktree blieb als Leiche zurück (im Lauf entfernt) — dasselbe galt für T002766.
 
-Die Session-UUID 0a75f198-… gehoert nicht zur laufenden Session. Beide Worktrees
-standen auf detached HEAD auf Commits, die inzwischen in main sind (23b6061c0,
-de8d93b6b), Arbeitsbaum in beiden nachweislich sauber (`git status --porcelain`
-leer). Entfernt per `git worktree remove` (ohne --force) + `git worktree prune`.
+**Behoben:** Beide Tickets im Lauf auf `done · fixed` gesetzt, je mit Kommentar und Merge-Timestamp. Die zwei Worktrees und lokalen Branches entfernt.
 
-WARUM DAS BEMERKENSWERT IST
-Ein Worktree im Scratchpad-Verzeichnis wird beim Aufraeumen leicht uebersehen,
-weil die uebliche Suche in .worktrees/ danebengreift — dieser Runbook-Lauf hat
-sie nur gefunden, weil §1 `git worktree list` verlangt statt eines ls auf
-.worktrees/. Solange die Eintraege liegen bleiben, haelt jeder von ihnen eine
-Ref und verhindert, dass der zugehoerige Commit-Bereich garbage-collected wird;
-ausserdem tauchen sie in jeder kuenftigen Worktree-Inventur als Rauschen auf.
+**Nicht behoben — offene Frage:** Warum der Post-Merge-Abschluss ausblieb, ist nicht ermittelt. Beide PRs entstanden im selben Zeitfenster wie elf weitere Vorgänge, die in der Plan-Phase steckenblieben (kein PR, letzter Commit `chore(plans): stage … for execution`). Ein angehaltener `opencode`-Prozess (Status `Tl`, seit 03:33) legt nahe, dass die Sessions unterbrochen wurden, bevor ihr Abschlussschritt lief — das ist eine Vermutung, keine Messung. Verwandt, aber anderer Sachverhalt: T003003 (dev-flow-execute blockiert auf Hintergrund-Verifikation und schließt nie ab), T002996 (Factory ohne Fortschritt).
 
-Kein Datenverlust, kein akuter Schaden — der Befund ist, dass hier eine Session
-beendet wurde, ohne ihren temporaeren Worktree abzuraeumen, und dass nichts
-diesen Zustand von selbst aufloest.
-**9. openspec-embed scheitert bei jedem Commit an Port 15432 — k3d-Port-Forward belegt ihn dauerhaft** (degraded, scripts/openspec-embed (post-commit hook))
-
-BEOBACHTET (2026-08-09, dev-flow-plan T003045, Stage-Commit b78616a60)
-
-Der post-commit-Hook `openspec-embed` scheiterte dreimal in Folge und gab auf:
-
-  [openspec-embed-local] FEHLER: Port 15432 wird von einem fremden Prozess
-  (PID 50718: kubectl --context k3d-mentolder-dev port-forward -n workspace
-  svc/shared-db 15432:5432) belegt, nicht vom eigenen Port-Forward (PID 1660165).
-  Beende den fremden Prozess oder setze OPENSPEC_EMBED_PF_PORT auf einen freien Port.
-  [openspec-embed] retry 1/3 … retry 2/3 …
-  [openspec-embed] WARN: embed failed for 'main-ci-branch-precondition'
-                   after 3 attempts (non-fatal — see above)
-
-Der Change 'main-ci-branch-precondition' ist damit nicht eingebettet. Die
-Aehnlichkeitssuche (openspec_find_similar) findet ihn nicht — genau die Funktion,
-die Doppelarbeit an derselben Sache verhindern soll.
-
-EINORDNUNG — das Verhalten ist BESSER als frueher, nicht schlechter
-Der Guard erkennt den Fremdprozess und verweigert die Arbeit. Aeltere Notizen
-beschreiben denselben Portkonflikt mit stillem Fallback auf die falsche Datenbank
-(Embedding landete in der Dev-DB, ohne dass etwas auffiel). Fail-loud statt
-fail-silent ist die richtige Richtung; offen bleibt, dass der Konflikt bei jedem
-einzelnen Commit erneut auftritt.
-
-WARUM ES TROTZDEM STOERT
-Der belegende Prozess ist kein Unfall, sondern ein dauerhaft laufender
-Entwicklungs-Port-Forward auf die k3d-Dev-DB. Solange er laeuft — also im
-Normalbetrieb dieser Maschine — schlaegt JEDER Commit mit openspec-Aenderungen
-fehl. Der Hook kostet dabei 3 Versuche a 5 s Wartezeit, bevor er aufgibt.
-
-MOEGLICHE AUFLOESUNGEN (nicht entschieden)
-a) OPENSPEC_EMBED_PF_PORT im Repo auf einen Port ausserhalb des ueblichen
-   Entwicklungsbereichs vorbelegen, statt 15432 zu teilen.
-b) Freien Port dynamisch waehlen, statt einen festen zu belegen — der Hook
-   braucht den Port nur fuer die Dauer seines eigenen Laufs.
-c) Beim erkannten Fremdprozess sofort aufgeben statt 3x5 s zu warten; der
-   Zustand aendert sich innerhalb von 15 s erfahrungsgemaess nicht.
-**10. dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Datenverlustrisiko bei Parallelsessions)** (degraded, skills/dev-flow-chore)
-
-BEOBACHTUNG (T003055, 2026-08-09): Schritt 0 von dev-flow-chore schreibt vor:
-  git stash && git pull --rebase origin main && git stash pop
-Zum Ausfuehrungszeitpunkt liefen im Haupt-Checkout DREI fremde Agent-Sessions (claude PID 1291909 seit 19:49, claude PID 2154793 seit 20:46 — beide mit --dangerously-skip-permissions —, opencode PID 2165174 seit 20:48). Sie hatten 7 uncommittete Dateien offen; .github/workflows/{ai-review,ci,e2e-pr}.yml waren 2 Minuten zuvor (20:49:31) geschrieben worden, tests/spec/ci-cd/fetch-refspec-forced.bats war untracked.
-
-WARUM RELEVANT: git stash ist eine Mutation des Arbeitsbaums, den ein anderer Prozess offen haelt. Schreibt die fremde Session zwischen stash und pop weiter, kollidiert der pop und die Aufloesung ist manuell. Der Skill hat dafuer KEINEN Guard — er setzt implizit voraus, dass der Haupt-Checkout dem ausfuehrenden Agenten allein gehoert.
-
-VERIFIKATION: Skill-Text .claude/skills/dev-flow-chore/SKILL.md Schritt 0; Prozessliste via ps; Datei-mtimes via ls --time-style. Der Schritt wurde in diesem Durchlauf bewusst NICHT ausgefuehrt; stattdessen wurde der Worktree direkt mit `git worktree add -b <branch> <pfad> origin/main` angelegt, was den Haupt-Checkout nicht beruehrt.
-
-VORSCHLAG: Vor dem Stash pruefen, ob der Arbeitsbaum dirty ist UND ein fremder Prozess darin arbeitet; in dem Fall den Stash ueberspringen und direkt von origin/main aus den Worktree anlegen (der Rebase des lokalen main ist fuer die Chore ohnehin nicht noetig — BASE ist origin/main).
-
-Zusammenhang: siehe die beiden weiteren Mishaps dieses Durchlaufs (worktree-create.sh:190, agent-lock Sichtbarkeitsfenster).
-### Mishap-Rollup — 10 Eintraege (2026-08-09 20:54 UTC)
+**Dedupe-Guard (beide Quellen, T002844):** offene Tickets über `factory_queue` (96 Einträge) und `get_mishap_buffer` (9/10) geprüft. Nächstliegende Nachbarn T003179 (done-Tickets ohne `resolution` — betrifft das Feld, nicht den ausbleibenden Übergang) und T002840 (Rollup-Plan nie gepusht) treffen den Sachverhalt nicht.
+### Mishap-Rollup — 10 Eintraege (2026-08-10 10:18 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | degraded | skills/dev-flow-chore | dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Risiko bei Parallelsessions) |
-| 2 | degraded | scripts/worktree-create.sh | worktree-create.sh Divergence-Guard stasht den Haupt-Checkout (gleiche Klasse wie dev-flow-chore Schritt 0) |
-| 3 | degraded | scripts/agent-lock.sh | agent-lock zeigt eine Session erst ab ihrem ersten Commit — Sichtbarkeitsluecke im Vorab-Check |
-| 4 | drift | tests/spec/dev-flow-plan (BATS-Fixture-Erstellung) | printf mit fuehrendem "-" wird als Option statt Format-String interpretiert |
-| 5 | process | tests/spec/dev-flow-plan (BATS-Fixture-Design) | B1b-Prosa-Test-Entwurf war durch sort -u Pfad-Dedup unwirksam (kein echtes RED) |
-| 6 | drift | scripts/openspec-embed (post-commit hook) | openspec-embed post-commit Hook scheitert erneut an Port-15432-Konflikt |
-| 7 | degraded | ticket-ops / scripts/agent-lock.sh + scripts/ticket.sh | Ticket-Locks der auftraggebenden Session blockieren den Abschluss durch Subagent, MCP-Server und post-merge |
-| 8 | drift | scripts/preflight-pr-scope.sh | preflight-pr-scope.sh liest die ERSTE Ticket-ID im PR-Titel — Titel mit zwei IDs faellt faelschlich durch |
-| 9 | drift | tests/spec (repo-weit) | Reihenfolge-Guards mit "grep -n … | head -1" brechen an sachfremden Einfuegungen — 19 Dateien betroffen |
-| 10 | suspicious | skills/git-workflow · .gitattributes merge=ours | Konfliktfreier Rebase verliert mitcommittete Freshness-Artefakte ohne Konfliktmeldung |
+| 1 | drift | scripts/factory/wakeup.sh | Auto-Freshness-Regen generiert auf veralteter main-Basis — PR entfernt existierende Dateien aus repo-index.json, Nachfolger sind Leer-PRs |
+| 2 | suspicious | scripts/factory/mishap-rollup.sh | rollup-publish.sh reset --soft: Divergenz-Rebuild nimmt fremde Remote-Dateien als Deletion mit — Fix als T003240 nur in Worktree, nicht auf main |
+| 3 | degraded | scripts/agent-lock.sh + hooks/worktree-write-guard.sh | agent-lock heartbeat-ttl reapt den Lock während aktiver Arbeit — Worktree-Write-Guard sperrt danach den eigenen Worktree |
+| 4 | suspicious | tests/spec/e2e-test-infrastructure | purge-test-data-missing-table.bats ist auf main rot — mit grünem Positiv-Anker, also kein Umgebungsproblem |
+| 5 | suspicious | ticket-mcp / scripts/factory | ticket-mcp enqueue ändert type=fix unsichtbar zu type=feat |
+| 6 | drift | scripts/openspec.sh + pre-commit guard | Archiv-Commit auf main erforderte SKIP_MAIN_COMMIT_GUARD=1 |
+| 7 | drift | repo/.opencode | .opencode-Plugin-Bump 1.18.11→1.18.16 uncommitted in zwei Factory-Worktrees |
+| 8 | suspicious | repo/CI | PR #4129 (T003267) CI rot an Factory-Spec-Shards — backlog-Ticket mit offenem PR |
+| 9 | drift | scripts/llm-proxy | Spec verlangt /healthz, implementiert ist /health |
+| 10 | suspicious | tests/spec/local-llm-proxy | Slot-Header-Test greppt den Quelltext statt Verhalten zu pruefen |
 
-**1. dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Risiko bei Parallelsessions)** (degraded, skills/dev-flow-chore)
+**1. Auto-Freshness-Regen generiert auf veralteter main-Basis — PR entfernt existierende Dateien aus repo-index.json, Nachfolger sind Leer-PRs** (drift, scripts/factory/wakeup.sh)
 
-BEOBACHTUNG (T003055, 2026-08-09): Schritt 0 von dev-flow-chore schreibt vor:
-    git stash && git pull --rebase origin main && git stash pop
-Zum Ausfuehrungszeitpunkt liefen im Haupt-Checkout DREI fremde Agent-Sessions: claude PID 1291909 (seit 19:49), claude PID 2154793 (seit 20:46) — beide mit --dangerously-skip-permissions —, opencode PID 2165174 (seit 20:48). Sie hatten 7 uncommittete Dateien offen; .github/workflows/{ai-review,ci,e2e-pr}.yml waren zwei Minuten zuvor (20:49:31) geschrieben worden, tests/spec/ci-cd/fetch-refspec-forced.bats war untracked.
+Drei Auto-Freshness-Regen-PRs (4101, 4113, 4114) wurden auf einer VERAULTETEN main-Basis generiert (merge-base 997b2415e, vor dem Merge von #4095). Folge: PR #4101 entfernte drei Testdateien faelschlich aus docs/code-quality/repo-index.json, die auf main existieren (dev-flow-chore-step0-foreign-guard, worktree-mid-rebase-guard, main-checkout-foreign-guard) — ein Merge haette Drift erzeugt. #4113/#4114 waren nach Regen auf aktuellem main Leer-PRs (blob-identisch zu origin/main) und mussten als redundant geschlossen werden. Der Auto-Regen braucht eine frische main-Basis vor der Generierung bzw. eine Pruefung, ob der generierte Diff gegen den AKTUELLEN main noch Substanz hat. Belegt: drei PRs an einem Tag, zwei davon leer.
+**2. rollup-publish.sh reset --soft: Divergenz-Rebuild nimmt fremde Remote-Dateien als Deletion mit — Fix als T003240 nur in Worktree, nicht auf main** (suspicious, scripts/factory/mishap-rollup.sh)
 
-WARUM RELEVANT: `git stash` mutiert den Arbeitsbaum, den ein anderer Prozess offen haelt. Schreibt die fremde Session zwischen stash und pop weiter, kollidiert der pop und die Aufloesung ist manuell. Der Skill hat dafuer keinen Guard — er setzt implizit voraus, dass der Haupt-Checkout dem ausfuehrenden Agenten allein gehoert.
+origin/main hat nach dem T002931-Merge weiterhin `reset -q --soft` in scripts/factory/rollup-publish.sh (Zeile 105). Ein Stash (einzige Kopie) dokumentierte den Bug: --soft laesst den alten Index stehen, der neue Commit nimmt fremde Remote-Dateien (parallel.txt) als Deletion mit. Ein Follow-up-Fix wurde als T003240 geticketed und im Worktree fix/mishap-rollup-divergenz-rebuild-T003240 committet+gepusht. Der Stash wurde nach Sicherung gedroppt. WICHTIG: Der Fix ist noch NICHT auf main — T003240 ist triage/backlog, kein PR.
+**3. agent-lock heartbeat-ttl reapt den Lock während aktiver Arbeit — Worktree-Write-Guard sperrt danach den eigenen Worktree** (degraded, scripts/agent-lock.sh + hooks/worktree-write-guard.sh)
 
-VERIFIKATION: Skill-Text (dev-flow-chore Schritt 0); Prozessliste via ps; Datei-mtimes via `ls --time-style=+%H:%M:%S`. Der Schritt wurde bewusst NICHT ausgefuehrt; stattdessen `git worktree add -b <branch> <pfad> origin/main`, was den Haupt-Checkout nicht beruehrt. Ergebnis war unauffaellig — die Chore lief vollstaendig durch (PR #4037 gemergt).
+Beobachtet am 2026-08-10 während eines dev-flow-execute-Laufs an T003205.
 
-VORSCHLAG: Vor dem Stash pruefen, ob der Arbeitsbaum dirty ist UND ein fremder Prozess darin arbeitet; dann den Stash ueberspringen und den Worktree direkt von origin/main anlegen. Der Rebase des lokalen main ist fuer die Chore ohnehin entbehrlich, weil BASE bereits origin/main ist.
+**Ablauf:** Lock via `agent-lock.sh claim ticket T003205 …` gesetzt, danach im zugehörigen Worktree gearbeitet (Tests, Commit). Beim nächsten `Edit` auf eine Datei **desselben** Worktrees lehnte `scripts/hooks/worktree-write-guard.sh` ab:
 
-Zusammenhang: gleiche Fehlerklasse wie der Divergence-Guard in scripts/worktree-create.sh:190; verschaerft durch das Sichtbarkeitsfenster von agent-lock (beide separat gemeldet).
-**2. worktree-create.sh Divergence-Guard stasht den Haupt-Checkout (gleiche Klasse wie dev-flow-chore Schritt 0)** (degraded, scripts/worktree-create.sh)
+```
+WORKTREE-GUARD: Schreibzugriff abgelehnt.
+  Dieser Session (SID 39e55f79-…) gehoeren:
+    - /home/patrick/Bachelorprojekt/.worktrees/worktree-create-refactor-prefix-T002811
+  Der Pfad liegt ausserhalb — vermutlich im Hauptcheckout oder in einem fremden Worktree.
+```
 
-BEOBACHTUNG (T003055, 2026-08-09): Der Divergence-Guard in scripts/worktree-create.sh (Zeilen 166-214) synchronisiert lokales main auf origin/main. Ist der Haupt-Checkout dabei dirty, stasht er ihn:
-    Zeile 189-199: if ! git diff --quiet HEAD; then git stash push -m "worktree-create-auto-stash" ...
-    Zeile 201:     git pull --rebase origin main
-    Zeile 213:     _wc_stash_pop_or_warn
+Der Pfad lag **nicht** außerhalb — er war der eigene, kurz zuvor geclaimte Worktree. Ursache im Reap-Log (`.git/agent-locks/.reap.log`):
 
-WARUM RELEVANT: Identische Fehlerklasse wie dev-flow-chore Schritt 0 (separat gemeldet). Zum Ausfuehrungszeitpunkt liefen drei fremde Agent-Sessions mit 7 uncommitteten Dateien im Haupt-Checkout; lokales main lag 2 Commits hinter origin/main, der Guard haette also gefeuert. Bemerkenswert: das Skript ist gegen den EIGENEN Stash bereits sorgfaeltig abgesichert (T002673 hat die stillen `|| true` entfernt, damit ein fehlgeschlagener Pop nicht unbemerkt bleibt) — es kennt aber keinen Begriff davon, dass der Arbeitsbaum einem ANDEREN Prozess gehoeren koennte.
+```
+1786338597 ticket/T003205 heartbeat-ttl
+1786338605 ticket/T003205 heartbeat-ttl
+1786338606 ticket/T003205 heartbeat-ttl
+1786338712 ticket/T003205 heartbeat-ttl
+```
 
-VERIFIKATION: Quelltext gelesen (Zeilen 166-226); Divergenz gemessen (`git rev-list --count HEAD..origin/main` = 2); fremde Prozesse via ps belegt. Der Guard wurde bewusst umgangen: `git worktree add -b <branch> <pfad> origin/main` legt den Worktree ohne jede Mutation des Haupt-Checkouts an. Das Ergebnis war korrekt — BASE ist ohnehin origin/main (Zeile 226), der Sync des lokalen main ist fuer die Korrektheit des Worktrees nicht erforderlich.
+**Viermal** in ~2 Minuten wegen abgelaufener Heartbeat-TTL gereapt, während durchgehend an diesem Ticket gearbeitet wurde. In der Lock-Datei sind `created_at` und `heartbeat_at` identisch (`"created_at": "1786335478", "heartbeat_at": "1786335478"`) — der Heartbeat wird nach dem Claim offenbar von nichts fortgeschrieben. Ein Lock, den niemand am Leben hält, läuft bei laufender Arbeit ab.
 
-VORSCHLAG: Den Sync des lokalen main vom Anlegen des Worktrees entkoppeln. Der Worktree braucht nur origin/main als BASE; der Sync ist Hygiene fuer den Haupt-Checkout und sollte uebersprungen (mit Hinweis) statt erzwungen werden, wenn der Arbeitsbaum dirty ist und ein fremder Prozess darin arbeitet.
-**3. agent-lock zeigt eine Session erst ab ihrem ersten Commit — Sichtbarkeitsluecke im Vorab-Check** (degraded, scripts/agent-lock.sh)
+**Warum das mehr ist als eine lästige Meldung:** Der Besitzausweis des Write-Guards hängt am Lock. Läuft der Lock ab, verweigert der Guard Schreibzugriff auf den *eigenen* Worktree — und seine Meldung diagnostiziert das Gegenteil („vermutlich im Hauptcheckout oder in einem fremden Worktree"), also ein Pfadproblem statt eines Zeitproblems. Der angebotene Ausweg ist `WORKTREE_GUARD_BYPASS=1`; wer der Meldung folgt, schaltet damit einen Schutz ab, der gar nicht falsch ausgelöst hat, sondern nur seine Besitzquelle verloren hatte. Das ist derselbe Mechanismus, der `--force` bei `worktree remove` zum Standardgriff gemacht hat (repo-hygiene-ops §1): ein Schutz, der im Normalbetrieb regelmäßig übersprungen werden muss, schützt bald nicht mehr.
 
-BEOBACHTUNG (T003055, 2026-08-09): `bash scripts/agent-lock.sh list` gab um ca. 20:51 nur die Kopfzeile aus — keine einzige Claim —, obwohl zu diesem Zeitpunkt drei fremde Agent-Sessions aktiv im Haupt-Checkout schrieben (Dateien mit mtime 20:49:31). Verlaesslich waren nur `ps` und die Datei-mtimes, nicht das Werkzeug, das fuer genau diese Frage gebaut ist.
+**Umgehung im Lauf:** Vor jedem Schreibzugriff den Claim erneuern. Das ist Symptombehandlung — die eigentliche Frage ist, ob der Heartbeat fortgeschrieben werden soll (dann fehlt der Schreiber) oder ob die TTL für interaktive Läufe zu kurz ist.
 
-URSACHE (verifiziert, kein genereller Defekt): Der main-checkout-Claim entsteht im pre-commit-Hook (.githooks/pre-commit:7, Label "auto: pre-commit self-claim"), also erst beim ERSTEN COMMIT einer Session — nicht ab Arbeitsbeginn. Belegt durch den Zeitstempel der Lock-Datei: $(git rev-parse --git-common-dir)/agent-locks/main-checkout.json traegt mtime 20:53, mein list-Aufruf lag ~2 Minuten davor. Spaeter erschien der Claim dann korrekt (SID b5cfa0f7).
+**Verwandt, aber anderer Sachverhalt:** T003131 (SID-Besitzmodell unterscheidet nebenläufige Subagenten nicht — dort ist die Zuordnung falsch, hier ist sie abgelaufen), T003102 (Locks blockieren Abschluss durch Subagent/MCP), Buffer-Eintrag „ticket-mcp sieht eine andere CLAUDE_CODE_SESSION_ID als die Shell" (im selben Lauf ebenfalls aufgetreten, aber eine andere Ursache: verschiedene SIDs statt abgelaufener TTL).
 
-WARUM RELEVANT: Zwischen Arbeitsbeginn und erstem Commit ist eine Session unsichtbar. Das ist genau das Fenster, in dem die Stash-Schritte aus dev-flow-chore Schritt 0 und worktree-create.sh:190 zuschlagen (beide separat gemeldet) — der Guard sieht die Session nicht, die er schuetzen muesste. Wer `agent-lock.sh list` als Vorab-Check auf konkurrierende Arbeit nutzt (so vorgesehen in dev-flow-chore Schritt 1, Test-only-Kurzpfad: "leer/keine fremde main-checkout-Claim?"), bekommt ein falsch-negatives Ergebnis und arbeitet inline im Haupt-Checkout weiter.
+**Dedupe-Guard (beide Quellen, T002844):** `get_mishap_buffer` (2/10 Einträge) und die offene Ticketliste geprüft — kein Duplikat.
+**4. purge-test-data-missing-table.bats ist auf main rot — mit grünem Positiv-Anker, also kein Umgebungsproblem** (suspicious, tests/spec/e2e-test-infrastructure)
 
-ABGRENZUNG: Die Lock-Mechanik selbst funktioniert (Claim/Release/Reap liefen im Durchlauf korrekt). Es geht ausschliesslich um den Zeitpunkt der Sichtbarkeit.
+Beobachtet am 2026-08-10 bei der Verifikation von T003205.
 
-VORSCHLAG: Entweder die Dokumentation des Vorab-Checks um diese Luecke ergaenzen (eine leere Liste beweist NICHT, dass niemand arbeitet — zusaetzlich Prozess-/mtime-Pruefung), oder den Claim frueher setzen (bei Session-Start statt beim ersten Commit).
-**4. printf mit fuehrendem "-" wird als Option statt Format-String interpretiert** (drift, tests/spec/dev-flow-plan (BATS-Fixture-Erstellung))
+**Befund:** `tests/spec/e2e-test-infrastructure/purge-test-data-missing-table.bats` schlägt fehl — sowohl im Feature-Worktree als auch, per Gegenprobe, im **Hauptcheckout auf `main`**:
 
-Beim Schreiben der BATS-Fixture tests/spec/dev-flow-plan/plan-lint-w3-prose-path.bats: `printf '- [ ] **Step 1: ...**\n\n'` scheitert mit "printf: - : invalid option", weil printf den fuehrenden Bindestrich als Optionsflag liest statt als Formatstring-Zeichen. Fix: `printf -- '...'`. Generisches Bash-Footgun beim Erzeugen von Markdown-Fixtures mit Checklisten-Bullets ("- [ ] ..."), kein Skill-/Repo-Defekt — koennte als Hinweis in die BATS-Fixture-Konventionen (CLAUDE.md) aufgenommen werden, da Markdown-Checklisten-Zeilen in Fixtures haeufig vorkommen.
-**5. B1b-Prosa-Test-Entwurf war durch sort -u Pfad-Dedup unwirksam (kein echtes RED)** (process, tests/spec/dev-flow-plan (BATS-Fixture-Design))
+```
+1..2
+ok 1     T002894: gesaete Testdaten-Zeile existiert vor dem Purge (Positiv-Anker)
+not ok 2 T002894: fn_purge_test_data() raeumt die Zeile ab, obwohl questionnaire_test_status lokal fehlt
+# (line 88)  `[ "$status" -eq 0 ]' failed
+```
 
-Erster Entwurf von tests/spec/dev-flow-plan/plan-lint-b1b-prose-path.bats testete denselben Pfad (InboxApp.svelte) sowohl in der File-Structure-Tabelle als auch zusaetzlich in einem Prosa-Satz. Weil plan-lint.sh Pfad-Tokens vor der Verarbeitung per `sort -u` dedupliziert, war das Ergebnis unabhaengig davon, ob der Fix (struktureller Zeilenfilter) angewendet wurde oder nicht — der Test waere auch bei einem ungefixten Linter gruen gewesen (kein echtes RED, T002448-M4-widrig). Behoben durch Umstellung auf zwei DISTINKTE budget-erschoepfte Dateien: eine echte Tabellenzeile (InboxApp.svelte) und eine reine Prosa-Erwaehnung einer ANDEREN Datei (InboxDetail.svelte), die tatsaechlich nur ueber den ungefilterten Dokumentenscan gefunden werden kann. Lehrreich fuer aehnliche Positiv-/Negativ-Fixtures gegen dedupliziende Linter-Logik.
-**6. openspec-embed post-commit Hook scheitert erneut an Port-15432-Konflikt** (drift, scripts/openspec-embed (post-commit hook))
+**Warum das kein Umgebungsproblem ist:** Test 1 ist der Positiv-Anker — er sät eine Zeile und liest sie zurück. Dass er grün ist, belegt, dass die Datenbank erreichbar ist und das Schema für den Sät-Teil trägt. Ein fehlender Postgres-Socket oder eine fehlende Testdatenbank hätte **beide** Tests rot gefärbt. Der Fehlschlag liegt also im Verhalten von `fn_purge_test_data()`, nicht in der Ausstattung des Läufers. Genau dafür ist der Positiv-Anker gedacht (T002356-M1), und hier trennt er die beiden Fälle sauber.
 
-Beim Commit fuer T002807 (openspec change plan-lint-w3-prose-path) schlug der openspec-embed post-commit Hook dreimal mit "Port 15432 wird von einem fremden Prozess belegt (kubectl port-forward -n workspace svc/shared-db)" fehl, bevor er non-fatal aufgab. Bekanntes, bereits dokumentiertes Verhalten (siehe User-MEMORY openspec-embed-port-collision.md) — kein neuer Defekt, aber weiterhin sichtbares Rauschen bei jedem Commit, solange ein k3d-dev-Port-Forward auf demselben Port laeuft. Nur zur Haeufigkeits-Dokumentation gemeldet, keine Handlungsaufforderung.
-**7. Ticket-Locks der auftraggebenden Session blockieren den Abschluss durch Subagent, MCP-Server und post-merge** (degraded, ticket-ops / scripts/agent-lock.sh + scripts/ticket.sh)
+**Wie er gefunden wurde:** als einer von zwei `not ok` in einem `task test:changed`-Lauf über 3439 Tests. Der zweite (`inventory: committetes JSON …`) war eine echte Folge der eigenen Änderung und wurde behoben. Dieser blieb — die Gegenprobe auf `main` zeigte denselben Fehlschlag, er gehört also nicht zum Vorgang.
 
-Beobachtet 2026-08-09 in einem ticket-ops-Lauf, DREIMAL (Einheiten A, B, F eines Welle-1-Dispatch).
+**Offen:** Ob CI ihn ebenfalls rot sieht, ist mit diesem Lauf nicht gemessen. Wenn CI grün ist, unterscheiden sich lokale und CI-Datenbank in einem Punkt, der genau diese Funktion betrifft — das wäre der eigentliche Befund. Wenn CI ebenfalls rot ist, läuft `main` mit einem roten Test, den die Merges nicht aufhalten. Beide Fälle sind berichtenswert, aber sie zu unterscheiden verlangt einen Blick in einen CI-Lauf, der diesen Test tatsächlich ausgeführt hat (`tests/spec/e2e-test-infrastructure/` steht unter dem Verdacht aus T002922: cluster-abhängige Spec-Tests, die CI nie wirklich ausführt).
 
-ABLAUF
-ticket-ops Phase 3.6 schreibt vor, vor dem Dispatch fuer jedes Wave-Ticket `agent-lock.sh claim ticket <id>` auszufuehren. Das geschah fuer 14 Tickets. Die dispatchten Subagenten mergten ihre PRs erfolgreich — konnten die Tickets danach aber nicht schliessen:
+**Verwandt:** T002922 (cluster-abhängige `tests/spec/*.bats` werden von CI nie ausgeführt) — falls das hier zutrifft, erklärt es, wieso ein auf `main` roter Test unbemerkt bleiben konnte. T002912 (Postgres-Socket nicht erreichbar) ist **nicht** derselbe Fall: dort fehlt die Verbindung, hier steht sie ausweislich des Positiv-Ankers.
 
-    ERROR: Ticket T002825 ist gesperrt (agent-lock) — Status-Schreibvorgang verweigert.
-           Halter: tool=claude, label=ticket-ops, sid=c9c84254-...
-           Eigene SID: 06fb98cf-... (Shell-PID 142734)
-           Falls der Halter diese Session ist, gezielt durchlassen: TICKET_LOCK_OVERRIDE=1
+**Dedupe-Guard (beide Quellen, T002844):** `get_mishap_buffer` (3/10) und die offene Ticketliste geprüft — kein Duplikat.
+**5. ticket-mcp enqueue ändert type=fix unsichtbar zu type=feat** (suspicious, ticket-mcp / scripts/factory)
 
-DREI AKTEURE, DIE AM EIGENEN LOCK SCHEITERN
-(a) Der Subagent: hat gemergt, darf nicht schliessen (fremde SID) — korrektes Verhalten, aber es zerreisst den Vorgang.
-(b) Der Lock-HALTER selbst: `ticket.sh` laeuft im ticket-mcp-Server unter EIGENER SID und sieht den Lock der aufrufenden Session als fremd. Ich hielt den Lock und wurde von ihm ausgesperrt.
-(c) Laut Subagent-Meldung duerfte derselbe Lock auch post-merge.yml blockiert haben.
+Beobachtet bei T003175: `ticket-mcp_enqueue_ticket` änderte den Ticket-Typ von `fix` zu `feat` und den Status von `plan_staged` zu `backlog`. Der API-Rückgabewert sagt "type=feat, status=backlog", aber der Aufrufer hat keine Kontrolle darüber. Für ein Fix-Ticket, das über den normalen dev-flow läuft (PR → CI → Merge), ist die Typ-Änderung unnötig und verwirrend — der Plan war bereits gestaged und der PR bereits erstellt. Der Type-Switch ist nur relevant, wenn das Ticket WIRKLICH von der Factory dispatched werden soll (was bei fix-Tickets mit bereits erstelltem PR nicht der Fall ist).
+**6. Archiv-Commit auf main erforderte SKIP_MAIN_COMMIT_GUARD=1** (drift, scripts/openspec.sh + pre-commit guard)
 
-WARUM DER FEHLERTEXT IN DIE IRRE FUEHRT
-Die Empfehlung "Falls der Halter diese Session ist, TICKET_LOCK_OVERRIDE=1" liest sich wie der vorgesehene Weg. Sie ist hier falsch: der Halter IST dieselbe logische Session, nur unter anderer SID — und ein Override haette den Schutz auch gegenueber echten Fremdsessions abgeschaltet. Der korrekte Ausweg war ein regulaeres `release` NACH getaner Arbeit, ohne Override.
+Nach dem Merge von PR #4128 (T003175) musste der OpenSpec-Change archiviert werden. Der Archivierungs-Commit (chore(plans): archive ...) wurde auf main gebraucht, aber der pre-commit-Hook blockiert Commits auf main. Ein chore-Branch hätte angelegt werden müssen, aber der Workflow (merge → archive → commit → push) ist auf main ausgelegt. Der Bypass per SKIP_MAIN_COMMIT_GUARD=1 umgeht den Schutz, ist aber die einzige praktikable Lösung ohne separaten Chore-Branch + PR nur für den Archiv-Commit.
+**7. .opencode-Plugin-Bump 1.18.11→1.18.16 uncommitted in zwei Factory-Worktrees** (drift, repo/.opencode)
 
-STRUKTURELLER KERN
-Der Mechanismus gegen Doppelbearbeitung verhindert hier nicht die Doppelbearbeitung, sondern den ABSCHLUSS — und zwar fuer drei verschiedene Prozesse derselben Arbeit. Die Annahme "eine Session = eine SID" haelt nicht, sobald MCP-Server, Subagenten und CI-Workflows im selben Vorgang schreiben.
+In .worktrees/agent-lock-claim-help-T003107-reuse und .worktrees/ticket-sh-subcommand-help-T002843-reuse liegt identischer uncommitteter Bump (.opencode/package.json + package-lock.json), während origin/main und Hauptcheckout auf 1.18.11 stehen. Verifiziert via git show origin/main:.opencode/package.json. Systematischer Nebeneffekt (vermutlich opencode-Plugin-Install im Worktree), blockiert Worktree-Remove in repo-hygiene §1, Herkunft ungeklärt.
+**8. PR #4129 (T003267) CI rot an Factory-Spec-Shards — backlog-Ticket mit offenem PR** (suspicious, repo/CI)
 
-ZU ERWAEGEN (nicht entschieden)
-- ticket-ops Phase 3.6: Lock nach dem Dispatch freigeben statt bis zum Abschluss halten — der Worktree ist dann der Kollisionsschutz.
-- Oder eine Vererbungskennung (Parent-SID), damit Subagent und MCP-Server als derselbe Halter gelten.
-- Mindestens: den Fehlertext um den regulaeren Release-Pfad ergaenzen, statt nur den Override zu nennen.
+PR #4129 feature/cross-harness-plan-guardrails-T003267: mergeStateStatus=DIRTY, 4 Jobs failed (Factory spec shard 1/2/4, Factory + OpenSpec + Guards) bei headRefOid == remote tip (kein nachträglicher Push; verifiziert via gh pr view + gh run list). Ticket steht auf backlog, PR existiert bereits — kein Merge nach Runbook. Bekannte Fehlerklasse (T002997, T002922) — hier nur dokumentiert, kein neues Ticket.
+**9. Spec verlangt /healthz, implementiert ist /health** (drift, scripts/llm-proxy)
 
-VERWANDT: T002849 (Lebendigkeitserkennung in agent-lock.sh), T002826 (stiller claim-Fehlschlag), Buffer-Eintrag "agent-lock zeigt eine Session erst ab ihrem ersten Commit" vom selben Tag.
-**8. preflight-pr-scope.sh liest die ERSTE Ticket-ID im PR-Titel — Titel mit zwei IDs faellt faelschlich durch** (drift, scripts/preflight-pr-scope.sh)
+openspec/specs/local-llm-proxy.md verlangt an zwei Stellen einen Endpunkt /healthz mit HTTP 200 (Szenario "Cutover replaces the legacy proxy in place"). Der Proxy kennt diesen Pfad nicht.
 
-Beobachtet 2026-08-09 beim Anlegen von PR #4043.
+VERIFIZIERT am laufenden Dienst:
+  for p in /healthz /health /livez; do printf '%-10s ' "$p"; curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:18235$p"; echo; done
+  -> /healthz 404 | /health 503 | /livez 200
+  grep -oE "path === '/[a-z]+'" scripts/llm-proxy/server.mjs | sort -u
+  -> nur /admin, /health, /livez
 
-VERIFIZIERT (scripts/preflight-pr-scope.sh:46 und :52):
-    TICKET_ID="$(echo "$TITLE" | grep -oP '\[T\d{6}\]|T\d{6}' | tr -d '[]' | head -n 1 || true)"
-    ...
-    if [[ "$BRANCH_LC" != *"$TICKET_LC"* ]]; then
-      echo "preflight-pr-scope: FATAL: PR title ticket ID '$TICKET_ID' does not match current branch name ..."
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-`head -n 1` nimmt die erste ID im Titel — unabhaengig davon, ob sie das bearbeitete Ticket bezeichnet. Ein Titel, der ein anderes Ticket ERWAEHNT bevor er das eigene nennt (hier: eine Referenz auf T002629 vor dem eigentlichen [T002825]), scheitert mit FATAL, obwohl Branch und Arbeitsticket zusammenpassen.
+Es handelt sich NICHT um einen kaputten Endpunkt, sondern um Spec-Drift: der Pfad heisst /health, der Spec-Text nennt /healthz. Die 503 auf /health ist korrektes Verhalten laut T002336 (kein Prio-1-Backend aktiv) und kein Mangel.
 
-WARUM DAS ZAEHLT
-Der Guard prueft nicht, was er zu pruefen vorgibt. Seine Aussage soll sein "der PR gehoert zum Branch"; gemessen wird "die erste Zeichenkette im Titel, die wie eine Ticket-ID aussieht, steht im Branchnamen". Die Fehlermeldung schlaegt dann eine Branch-Umbenennung auf das FALSCHE Ticket vor (`_suggested_branch="${CURRENT_BRANCH}-${TICKET_LC}"`) — wer ihr folgt, benennt den Branch nach dem nur erwaehnten Ticket um.
+Behebung: entweder den Spec-Text auf /health ziehen oder /healthz als Alias ergaenzen. Die erste Variante ist vorzuziehen, weil ein zweiter Name fuer dieselbe Sache nur die naechste Divergenz vorbereitet.
+**10. Slot-Header-Test greppt den Quelltext statt Verhalten zu pruefen** (suspicious, tests/spec/local-llm-proxy)
 
-Der Workaround (Zweitticket in den Body statt in den Titel) funktioniert, ist aber unsichtbar, solange man den Guard nicht liest.
+tests/spec/local-llm-proxy.bats:451-454 prueft die Zusicherung "response includes x-llm-proxy-slot header when slot present" mit einem grep auf die Implementierungsdatei:
 
-ZU ERWAEGEN: alle IDs im Titel einsammeln und den Guard bestehen lassen, wenn IRGENDEINE davon zum Branch passt — statt nur der ersten. Das ist dieselbe Klasse wie die Reihenfolge-Guards mit `grep -n … | head -1`: der erste Treffer ist nicht der gemeinte Treffer.
+  @test "T002483: response includes x-llm-proxy-slot header when slot present" {
+    run grep -q "x-llm-proxy-slot" "${BATS_TEST_DIRNAME}/../../scripts/llm-proxy/server.mjs"
+    [ "$status" -eq 0 ]
+  }
 
-Gefunden waehrend eines ticket-ops-Welle-1-Dispatch (Einheit F).
-**9. Reihenfolge-Guards mit "grep -n … | head -1" brechen an sachfremden Einfuegungen — 19 Dateien betroffen** (drift, tests/spec (repo-weit))
+Das widerspricht der Test-Resultats-Konvention T002448-M4 (Output- statt Source-Verifikation). Der Test belegt nur, dass die Zeichenkette in der Datei steht — er wuerde gruen bleiben, wenn der Header in einem Zweig gesetzt wird, der nie erreicht wird, oder wenn er nur in einem Kommentar vorkommt.
 
-Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit A, PR #4046).
+Der Fall ist hier nicht theoretisch: derselbe Vorgang hat gezeigt, dass der korrespondierende Eingang x-slot-id von KEINEM Aufrufer gesetzt wird (siehe separaten Mishap). Der Test hat die Wirkungslosigkeit der Funktion also nicht bemerkt, weil er das Verhalten nie ausfuehrt.
 
-WAS PASSIERTE
-Der bestehende Guard tests/spec/dev-flow-chore-ticket-ops-mishaps.bats (aus T001210) prueft, dass eine Dedupe-Regel hinter der Ueberschrift "## 4." in repo-hygiene-ops.md steht. Er sucht dazu den ERSTEN `dedup`-Treffer im GANZEN Dokument und vergleicht dessen Zeilennummer. Ein neu hinzugefuegter Verweis in §3 kam ihm zuvor — der Guard wurde rot, obwohl §4 voellig unveraendert blieb.
-
-Gefixt durch Einschraenkung der Suche auf den Bereich ab "## 4." — das ist die Aussage, die der Guard treffen wollte.
-
-REICHWEITE (verifiziert)
-    $ grep -rlE 'grep -n[^|]*\| *head -1' tests/spec/ | wc -l
-    19
-Neunzehn Guard-Dateien tragen dasselbe Muster, darunter tests/spec/dev-flow-plan.bats, ticket-system.bats, openspec-workflow.bats, mishap-categorize-erden.bats. Nicht jeder davon ist zwangslaeufig defekt — aber jeder, der eine Reihenfolge- oder Positionsaussage trifft, ist gegen unverwandte Einfuegungen oberhalb der gemeinten Stelle nicht robust.
-
-STRUKTURELLER KERN
-Der Guard misst die Position des ersten Zufallstreffers statt der Aussage, die er treffen will. Ein solcher Test wird rot, ohne dass das Geprueefte sich geaendert hat, und meldet damit einen Defekt, den es nicht gibt — er kostet Diagnosezeit an der falschen Stelle und erzeugt Druck, die eigentlich korrekte Aenderung zurueckzunehmen.
-
-Das ist dieselbe Familie wie die Konvention T002716 ("Semantik statt Darstellung"): dort bricht eine Zusicherung am Ausgabeformat eines Werkzeugs, hier an der Dokumentposition eines beliebigen anderen Treffers. Die Regel deckt diesen Fall bislang nicht ausdruecklich ab.
-
-ZU ERWAEGEN: die Suche in solchen Guards grundsaetzlich auf den relevanten Abschnitt eingrenzen (awk-Bereichsmuster oder sed-Range), statt eine dokumentweite Suche mit `head -1` zu beschneiden. Und T002716 um den Positions-Fall erweitern.
-**10. Konfliktfreier Rebase verliert mitcommittete Freshness-Artefakte ohne Konfliktmeldung** (suspicious, skills/git-workflow · .gitattributes merge=ours)
-
-Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit B, PR #4050).
-
-WAS PASSIERTE
-Ein `git rebase` gegen origin/main lief KONFLIKTFREI durch. Dabei wurden die mitcommitteten generierten Artefakte website/src/data/test-inventory.json und docs/code-quality/repo-index.json ohne jede Konfliktmeldung auf die main-Version aufgeloest und fielen damit aus dem Commit. `task freshness:check` wurde daraufhin erneut rot — nachdem er vor dem Rebase gruen war.
-
-Ursache ist der merge=ours-Treiber in .gitattributes fuer die Freshness-Generate: er loest zugunsten einer Seite auf, statt einen Konflikt zu melden. Das ist fuer den Merge-Fall gewollt (sonst konfligierte jeder PR an diesen Dateien), hat im Rebase-Fall aber die Nebenwirkung, dass eigene, absichtlich mitgefuehrte Regenerate still verschwinden.
-
-STRUKTURELLER KERN
-Ein gruener Rebase belegt NICHT, dass die Artefakte noch im Commit sind. Das Erfolgssignal des Rebase sagt nichts ueber die Vollstaendigkeit seines Ergebnisses — dieselbe Familie wie "der Erfolg des LETZTEN Kommandos in einer Kette sagt nichts ueber den Erfolg des vorherigen" (T002815) und wie die soeben in repo-hygiene-ops §3 aufgenommene Regel "ein leeres Signal ist kein Urteil".
-
-Besonders tueckisch, weil die Gegenprobe billig ist und trotzdem niemand sie faehrt: nach dem Rebase `git show --stat HEAD` auf die Artefaktpfade oder schlicht `task freshness:check` erneut laufen lassen.
-
-ZU ERWAEGEN: in git-workflow nach jedem Rebase eine Freshness-Nachpruefung vorschreiben, bevor gepusht wird — und explizit benennen, dass merge=ours hier ohne Konfliktmarker zuschlaegt.
-
-VERWANDT: T002823 (merge=ours-Phantomkonflikt gegenueber GitHub — dieselbe .gitattributes-Ursache, andere Richtung).
-## Kanonischer Rollup-Container (Entscheidung ticket-ops 2026-08-09)
-
-**Dieses Ticket NICHT schliessen.** Der Hinweis stammt aus dem Vorgaenger-Container T002784 und gilt hier unveraendert weiter:
-
-Ein geschlossener oder blockierter Container laesst den Mishap-Flush ins Leere laufen, **ohne dass es auffaellt**. Genau diese Kette ist bereits zweimal gerissen:
-
-- T002783: die Vorgaenger T002597 und T002601 standen beide auf `done` und waren damit fuer `scripts/factory/mishap-rollup.sh` unsichtbar.
-- 2026-08-09: T002784 stand auf `blocked` und wurde ebenfalls nicht mehr aufgeloest; dieser Container hier musste manuell angelegt werden, weil `ticket.sh rollup-container` zusaetzlich am Leerfall-Defekt T003068 scheiterte.
-
-Konsequenz: Der Container muss auf einem **offenen, nicht-terminalen** Status stehen (`triage`). T002784 wurde als `done/obsolete` geschlossen, `duplicate_of` → T003067.
-
-Verwandt: T003068 (rollup-container kann sich bei leerer Trefferliste nicht selbst heilen) — solange dieser Defekt besteht, ist der Container hier die einzige Absicherung des Mishap-Meldewegs.
-### Mishap-Rollup — 10 Eintraege (2026-08-09 21:40 UTC)
+Behebung: echten Request gegen einen Fake-Backend absetzen und den Antwort-Header pruefen. T003277/p6 baut die dafuer noetige Testinfrastruktur ohnehin auf.
+### Mishap-Rollup — 10 Eintraege (2026-08-10 12:10 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | drift | tests/spec (repo-weit) · Shell-Konventionen | grep -qF schuetzt NICHT vor Options-Parsing — jeder Guard, der auf ein CLI-Flag im Text greppt, scheitert |
-| 2 | suspicious | skills/repo-hygiene · gh-Warteschleifen | gh pr checks --jq 'all(...)' ist auf der leeren Checkliste vakuos true — CI-Warteschleife bricht sofort ab |
-| 3 | degraded | scripts/agent-lock.sh | agent-lock.sh check detektiert SID nicht aus Worktree-Pfaden — TICKET_LOCK_OVERRIDE als Workaround nötig |
-| 4 | process | dev-flow-plan | dev-flow-plan Schritt 5 verlangt ticket-scoped agent-lock, den der ticket-ops-Dispatch verbietet |
-| 5 | suspicious | scripts/plan-qa-check.sh | plan-qa-check.sh liefert Parse-Fehler statt inhaltlicher QA-Rückmeldung |
-| 6 | drift | scripts/plan-touched-files.sh | touched_files-Ableitung nimmt reine Lesebefehl-Pfade als geänderte Dateien auf |
-| 7 | suspicious | skills/dev-flow-plan · scripts/hooks/worktree-write-guard.sh | worktree-write-guard blockiert Sub-Agenten in vom Orchestrator vorbereiteten Worktrees ohne eigenen agent-lock-Claim |
-| 8 | drift | scripts/openspec-embed-local.sh | openspec-embed-local.sh scheitert weiterhin an Port-15432-Kollision bei Plan-Stage-Commits (bekanntes Muster, erneut bestaetigt) |
-| 9 | degraded | skills/ticket-ops + skills/dev-flow-plan + scripts/hooks/worktree-write-guard.sh | Drei Regelwerke widersprechen sich beim agent-lock-Scope — Planungsagenten kommen ohne bewusste Abweichung nicht durch |
-| 10 | suspicious | skills/ticket-ops Phase 1 (Dedupe-Guard) | ticket-ops-Dedupe-Guard vergleicht Titel exakt und fand 1 von 6 Dubletten — die dominante Dublettenklasse entgeht ihm strukturell |
+| 1 | degraded | scripts/llm-proxy/slot-queue.mjs | Per-Slot-Queue-Isolation seit T002483 wirkungslos — kein Aufrufer sendet x-slot-id |
+| 2 | suspicious | scripts/plan-qa-check.sh | plan-qa-check widerspricht plan-lint bei identischer Eingabe |
+| 3 | degraded | scripts/openspec-embed.mjs | openspec-embed scheitert bei jedem Commit an belegtem Port 15432 |
+| 4 | suspicious | scripts/branch-reaper.sh | Reuse-Worktrees sammeln npm-Install-Rauschen in .opencode/package.json — §1-Allowlist greift nicht |
+| 5 | process | factory | PR #4129 (T003267) offen mit rotem CI, Ticket weiterhin backlog — Implementation vor Factory-Dispatch gepusht |
+| 6 | suspicious | repo/git-state | .git/shallow-Boundary am main-Tip blockierte pre-push-Validierung (Ursache ungeklärt) |
+| 7 | suspicious | repo/worktrees | Scratchpad-Worktree wt-order-guards-head-first-match: leerer Index + Teil-Snapshot, nicht sicherbar |
+| 8 | drift | repo/.opencode | Identischer uncommitteter @opencode-ai/plugin-Bump (1.18.11→1.18.16) in zwei -reuse-Worktrees fremd zu deren Tickets |
+| 9 | drift | skills/repo-hygiene | repo-hygiene-SKILL.md verweist auf nicht existierenden SSOT-Relativpfad |
+| 10 | degraded | mcp-postgres | mcp-postgres fleet copy returned 98 'open' tickets, live DB had 58 — 40 already done |
 
-**1. grep -qF schuetzt NICHT vor Options-Parsing — jeder Guard, der auf ein CLI-Flag im Text greppt, scheitert** (drift, tests/spec (repo-weit) · Shell-Konventionen)
+**1. Per-Slot-Queue-Isolation seit T002483 wirkungslos — kein Aufrufer sendet x-slot-id** (degraded, scripts/llm-proxy/slot-queue.mjs)
 
-Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit B) beim Schreiben eines Guards, der die Erwaehnung von `--draft` in einem Skill-Dokument pruefen sollte.
+scripts/llm-proxy/slot-queue.mjs isoliert Warteschlangen pro Slot, damit "slot 0 does not block slot 1" (Kopfkommentar). Der Schluessel entsteht in enqueue() aus `${name}:slot${slotId}`, wobei slotId aus extractSlotId(req) stammt und den Header x-slot-id liest.
 
-VERIFIZIERT (Output-Verifikation, im Hauptcheckout nachgestellt):
-    $ echo "text mit --draft drin" | grep -qF '--draft'; echo "exit=$?"
-    ugrep: invalid option --draft, did you mean --decompress, --delay=, --depth=, ...
-    exit=2
+VERIFIZIERT: kein produktiver Aufrufer setzt diesen Header.
+  git grep -c "x-slot-id" -- . ':!tests' ':!scripts/llm-proxy'
+  -> nur Treffer in den neuen Plandateien von T003277, sonst keine
+  git grep -n 'x-slot-id' -- scripts .opencode
+  -> nur slot-queue.mjs (Leser) und server.test.mjs (Testfixtures)
 
-    $ echo "text mit --draft drin" | grep -qF -e '--draft'; echo "exit=$?"
-    mit -e: exit=0
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-`-F` macht das Muster nur zu einer festen Zeichenkette statt einer Regex — es verhindert NICHT, dass das Argument zuvor als Option geparst wird. Nur `-e` (oder `--`) markiert es als Muster.
+Folge: slotId ist immer null, der Schluessel faellt auf backend.name zurueck, und alle Slots teilen sich dieselbe Semaphore — genau der Zustand, den die Datei laut ihrem Kopfkommentar verhindern soll. scripts/factory/sandbox-run.sh kennt zwar eine SLOT_ID, reicht sie aber nie als HTTP-Header weiter.
 
-WARUM DAS ZAEHLT
-Der Exit-Code ist 2, nicht 1. Ein Guard der Form `grep -qF '--flag' datei || fail` bricht damit nicht mit "nicht gefunden" ab, sondern mit einem Werkzeugfehler — und in einer `if`-Bedingung sind beide ununterscheidbar falsch. Der Test meldet dann "das Flag fehlt im Dokument", obwohl es dasteht. Betrifft jeden Guard, der ein CLI-Flag, einen Long-Option-Namen oder irgendein mit `-` beginnendes Token im Text sucht — und das ist in einem Repo mit dokumentierten Runbooks kein Randfall.
+T003277/p3 setzt den Header und weist die Wirksamkeit mit zwei gleichzeitigen Anfragen nach. Dieser Mishap haelt fest, dass die Funktion seit T002483 unbemerkt tot war — der zugehoerige Test konnte es nicht bemerken, weil er den Quelltext greppt statt Verhalten zu messen (separater Mishap).
+**2. plan-qa-check widerspricht plan-lint bei identischer Eingabe** (suspicious, scripts/plan-qa-check.sh)
 
-NEBENBEFUND ZUM UMFELD: Die Fehlermeldung stammt von `ugrep`, nicht von GNU grep — auf diesem Host ist `grep` ein ugrep-Alias. Der Wortlaut der Meldung unterscheidet sich damit zwischen lokaler Shell und CI-Runner; ein Guard, der auf den Meldungstext prueft, waere aus genau diesem Grund unzuverlaessig (T002716).
+scripts/plan-qa-check.sh (advisory, LLM-gestuetzt) beanstandete an openspec/changes/llm-proxy-dispatch-capture/tasks.md zu Kriterium 5, der letzte Task sei "nicht explizit als Teil eines Tasks definiert, der die Schritte test:changed, freshness:regenerate und freshness:check enthaelt".
 
-VERWANDT: Buffer-Eintrag "printf mit fuehrendem '-' wird als Option statt Format-String interpretiert" vom selben Tag — dieselbe Klasse bei einem anderen Werkzeug. Es lohnt, das als eine Regel zu fassen statt als zwei Einzelfaelle.
-**2. gh pr checks --jq 'all(...)' ist auf der leeren Checkliste vakuos true — CI-Warteschleife bricht sofort ab** (suspicious, skills/repo-hygiene · gh-Warteschleifen)
+Das ist ein Fehlurteil. Die drei Befehle stehen als Checkbox-Task ("Abschliessende Pruefung") im Index, und das fail-closed Hard Gate wertet dieselbe Datei als konform:
+  bash scripts/plan-lint.sh openspec/changes/llm-proxy-dispatch-capture/tasks.md
+  -> PLAN-LINT: PASS (0 hard, 0 warn)   # STRUCT3 geprueft und bestanden
 
-Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit B, PR #4050).
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-WAS PASSIERTE
-Der PR stand auf mergeStateStatus=DIRTY. Bei einem Konflikt startet GitHub die CI gar nicht erst — die Checkliste bleibt LEER. Eine Warteschleife der Form
+Warum das zaehlt: plan-qa laeuft mit "|| true" und blockiert nichts, aber es durchlaeuft bis zu zwei Auto-Fix-Iterationen, in denen es Vorschlaege an die Plandatei anhaengt ("Auto-fix attempt 1/2: appending suggestions"). Ein falsch-positives Kriterium kann damit einen Plan veraendern, der bereits konform ist. In diesem Lauf blieb die Datei unveraendert (nachgeprueft), aber die Moeglichkeit besteht.
 
-    gh pr checks <n> --json bucket --jq 'all(.bucket != "pending")'
+Ein zweiter Punkt derselben Meldung war dagegen berechtigt: die S1-Budgets standen nur in den Partials, nicht im Index. Das wurde uebernommen. Der Befund richtet sich also gegen Kriterium 5, nicht gegen das Werkzeug insgesamt.
+**3. openspec-embed scheitert bei jedem Commit an belegtem Port 15432** (degraded, scripts/openspec-embed.mjs)
 
-liefert auf der leeren Liste `true`. Das ist die korrekte jq-Semantik (`all` ueber eine leere Menge ist wahr), aber die Schleife liest daraus "keine Checks mehr pending" und bricht sofort ab. Der Zustand liest sich als "CI durchgelaufen", waehrend in Wahrheit nie eine Pruefung stattgefunden hat.
+Der post-commit-Hook scripts/openspec-embed.mjs schlug bei BEIDEN Commits dieses Vorgangs nach drei Versuchen fehl:
 
-BELASTBAR IST ERST: `mergeStateStatus != DIRTY` UND eine NICHTLEERE Checkliste. Nach einem Rebase erschienen 15 Checks.
+  [openspec-embed] post-commit: embedding slug='llm-proxy-dispatch-capture'...
+  [openspec-embed] retry 1/3 ... retry 2/3 ...
+  [openspec-embed] WARN: embed failed after 3 attempts (non-fatal)
 
-VERHAELTNIS ZU T002822 (im SELBEN Lauf behoben, PR #4046)
-T002822 beschrieb dieselbe Ursache (CONFLICTING PR unterdrueckt CI) und wurde in repo-hygiene-ops.md §3 unter der neuen Regel "ein leeres Signal ist kein Urteil" aufgenommen, mit der Gegenprobe ueber mergeStateStatus und einen lokalen Probe-Merge.
+Ursache ist die bekannte Portkollision: openspec-embed.mjs oeffnet einen pg.Pool auf localhost:15432, den auf dieser Maschine der k3d-Portforward belegt.
 
-GEPRUEFT, OB BEREITS ABGEDECKT — NEIN: Die neue §3-Fassung auf origin/main enthaelt keine Stelle zu `all(...)`, `jq` in diesem Zusammenhang oder zum vakuosen Wahrheitswert ueber leeren Mengen. Sie warnt davor, eine leere Checkliste als Urteil zu LESEN; sie deckt nicht den Fall, dass ein AUTOMATISIERTES Praedikat sie stillschweigend als Erfolg auswertet. Das ist die schaerfere Variante: bei der manuellen Lesart sieht man wenigstens die leere Liste, bei der Warteschleife sieht man nur `true`.
+Beobachtet an den Commits d041220e6 und 64f07d0fc.
 
-ZU ERWAEGEN: §3 um eine Zeile zum vakuosen `all()` ergaenzen und, wo im Repo solche Warteschleifen existieren (devflow-ci-watch.sh, Auto-Merge-Wartepfade), die Nichtleere-Bedingung ergaenzen. Allgemeiner: jedes Praedikat ueber einer moeglicherweise leeren Menge braucht eine vorgeschaltete Nichtleere-Pruefung — dieselbe Struktur wie die Positiv-Anker-Pflicht bei Negativtests (T002356-M1), wo ein Test ueber einer leeren Kandidatenliste ebenfalls vakuos besteht.
-**3. agent-lock.sh check detektiert SID nicht aus Worktree-Pfaden — TICKET_LOCK_OVERRIDE als Workaround nötig** (degraded, scripts/agent-lock.sh)
+Der Fehlschlag ist als non-fatal markiert und bricht den Commit nicht ab — die Folge ist still: die Proposals dieses Vorgangs sind nicht eingebettet und damit ueber die semantische Suche (openspec_find_similar) nicht auffindbar. Wer spaeter nach aehnlichen Vorhaben sucht, bekommt ein unvollstaendiges Ergebnis, ohne dass etwas darauf hinweist.
 
-BEOBACHTUNG (2026-08-09, T002807 + T002849): `agent-lock.sh check ticket <id>` meldet stets `Eigene SID: <nicht gesetzt>` bei Aufrufen aus einem `.worktrees/`-Pfad, obwohl `check-and-claim` (gleiche Session, gleicher Worktree-Pfad) den Lock erfolgreich anlegt. `ticket.sh update-status` bricht deshalb mit Exit 7 ab (`Ticket X ist gesperrt`). Workaround: `TICKET_LOCK_OVERRIDE=1 bash scripts/ticket.sh update-status ...`.
+Beitrag zum Design von T003277: genau dieser Mechanismus war der Grund, einen direkten pg-Client im llm-proxy zu verwerfen (design.md D1a) — ein langlaufender Dienst haette sich dieses Ausfallmuster eingehandelt.
+**4. Reuse-Worktrees sammeln npm-Install-Rauschen in .opencode/package.json — §1-Allowlist greift nicht** (suspicious, scripts/branch-reaper.sh)
 
-VERIFIZIERT: sowohl in `.worktrees/plan-lint-w3-prosa-T002807` als auch in `.worktrees/agent-lock-liveness-T002849` reproduziert. Der Hauptcheckout (`/home/patrick/Bachelorprojekt`) zeigt das Problem nicht — `check` meldet dort `mine`.
+Drei reuse-Worktrees (T002908, T002843, T002934) trugen uncommittete @opencode-ai/plugin-Bumps 1.18.11→1.18.16 in .opencode/package.json + package-lock.json — identisches npm-Install-Artefakt, in keinem Git-Objekt, auf main nicht vorhanden. Die §1-Allowlist (maßgeblich: ALLOWLIST in scripts/branch-reaper.sh) deckt .opencode/ ab nicht ab, also blockierte ein Nicht-Allowlist-Pfad die Worktree-Removal als scheinbarer Befund. Workaround: git checkout -- auf die committeden Versionen, dann remove. Kein Datenverlust, aber: (a) Allowlist kennt den Pfad nicht, obwohl reines Generat-Rauschen, (b) jede Worktree-Removal von reuse-Worktrees braucht künftig denselben Zwei-Schritt.
+**5. PR #4129 (T003267) offen mit rotem CI, Ticket weiterhin backlog — Implementation vor Factory-Dispatch gepusht** (process, factory)
 
-URSACHE VERMUTET: `_my_sid()` in `agent-lock.sh` nutzt `git rev-parse --show-toplevel` o.Ä. als Pfadanker, der in Worktrees (deren `.git` eine Datei mit `gitdir:`-Verweis ist) anders auflöst. Die `check-and-claim`-Funktion ermittelt die SID über einen anderen Code-Pfad (`scripts/agent-lock-identity.sh`).
-**4. dev-flow-plan Schritt 5 verlangt ticket-scoped agent-lock, den der ticket-ops-Dispatch verbietet** (process, dev-flow-plan)
+Auf dem Branch feature/cross-harness-plan-guardrails-T003267 liegt ein offener PR (#4129, erstellt 08:23Z) mit voller Implementation, während das Ticket T003267 status=backlog ist (noch nie dispatched). CI rot in 4 Jobs: Factory spec shards 1/2/4 + Aggregate. Ursache: echte Spec-Regressionen — die Checks "do not commit on main / clean status / Pre-Commit-Guard lock-file / branch__<slug>.json / stage-plan auto-emit" wurden aus .claude/skills/dev-flow-plan/SKILL.md nach scripts/plan-preflight.sh verschoben, die greppenden Tests (agent-lock-session-identity.bats, catalog-eval-telemetry.bats T001444, agent-lock-scope-regelwerk.bats T003102) laufen dagegen ins Leere. stage-plan --hold/--no-hold-Pflicht bricht den T001444-Aufruf ohne Hold-Flag. Befund auf T003267 kommentiert. Merge blockiert, bis die Tests an den plan-preflight-Umbau angepasst sind.
+**6. .git/shallow-Boundary am main-Tip blockierte pre-push-Validierung (Ursache ungeklärt)** (suspicious, repo/git-state)
 
-Bei T002999 (Welle-1-Dispatch) standen zwei Vorgaben gegeneinander:
+Während des repo-hygiene-Laufs (2026-08-10, ~11:46Z) tauchte in .git/shallow ein Boundary-Eintrag für den main-Tip 1c6b90028 auf (mtime 13:46:54 +0200 — mitten in der Session). Kein Hook im Repo erzeugt Shallow-State (geprüft: grep -rln 'shallow|--depth' .githooks/ scripts/hooks/ = leer). Wirkung: die pre-push-Validierung (validate-commit-msg.sh range origin/main..HEAD) zog wegen der gebrochenen Ancestry 6724 Commits statt 3 in den Range und blockierte den Push des T003107-Merge-Commits mit "unknown scope"-Fehlern auf alten main-Commits — dieselbe Fehlerklasse wie T002827, aber andere Ursache. Der vollständige Commit-Graph war im Objektstore vorhanden (merge-base 47d25bb7 bcf14d546 = 8d77df268 mit ignoriertem Shallow); die Boundary wurde entfernt (Backup /tmp/opencode/shallow.bak), Historie danach vollständig (rev-list count main = 6805), Push erfolgreich. VERIFIZIERT.
+**7. Scratchpad-Worktree wt-order-guards-head-first-match: leerer Index + Teil-Snapshot, nicht sicherbar** (suspicious, repo/worktrees)
 
-1. Der Dispatch verbietet ausdruecklich einen agent-lock im **ticket**-Scope (T003102 — blockiert den spaeteren Abschluss).
-2. `dev-flow-plan` Schritt 5 (Pre-Commit Guard, Punkt 3) verlangt genau diese Lock-Datei: `$(git rev-parse --git-common-dir)/agent-locks/ticket__<ID>.json` — fehlt sie, soll der Commit mit FATAL abbrechen.
+/tmp/claude-1000/.../scratchpad/wt-order-guards-head-first-match (Branch fix/order-guards-head-first-match-T003104, backlog): git status --porcelain zeigt leeren Index (ls-files = 0), HEAD tracked 9857 Dateien, Arbeitsbaum enthält nur 1812 (Teil-Snapshot eines abgebrochenen Checkouts), davon 139 Dateien mit vom HEAD abweichenden Blobs. Branch ist exakt == origin/main (1c6b90028). Es existiert kein git-artefaktierter Zwischenstand (Index leer, 0 Commits auf dem Branch) — es ist nicht entscheidbar, ob die 139 abweichenden Dateien echte Arbeit enthalten (mtimes/Herleitung unklar). Fail-closed: Worktree NICHT entfernt, Befund gelassen. VERIFIZIERT (empty index, 1812 untracked, 139 blob-abweichend).
+**8. Identischer uncommitteter @opencode-ai/plugin-Bump (1.18.11→1.18.16) in zwei -reuse-Worktrees fremd zu deren Tickets** (drift, repo/.opencode)
 
-Zusaetzlich blockierte `scripts/hooks/worktree-write-guard.sh` jeden Write im eigenen Worktree, solange gar kein Claim existierte. Aufloesung war ein **branch**-scoped Claim (`agent-lock.sh claim branch`) — Regel 2 des Guards greift auf den Branch-Claim, nicht auf den Ticket-Claim. Damit sind beide Vorgaben erfuellbar, aber das steht nirgends: Schritt 5 nennt nur den Ticket-Claim.
+.worktrees/ticket-guard-diff-scope-T002934-reuse und .worktrees/worktree-status-check-existence-T002932-reuse tragen beide denselben uncommitteten Dependency-Bump in .opencode/package.json + package-lock.json (@opencode-ai/plugin 1.18.11 → 1.18.16). Die touched_files beider Tickets (T002934, T002932) decken .opencode/ nicht ab; origin/main hat weiterhin 1.18.11. Unerklärter Fremdstand in Worktrees aktiver Tickets — nicht revertiert (könnte Absicht sein), nicht committet (gehört zu keinem Ticket), liegt gelassen. VERIFIZIERT (diff in beiden Worktrees identisch, main=1.18.11).
+**9. repo-hygiene-SKILL.md verweist auf nicht existierenden SSOT-Relativpfad** (drift, skills/repo-hygiene)
 
-Nebenbefund zur Meldung des Guards: unter "Dieser Session gehoeren:" listet er die Worktrees **fremder** Sessions (hier zwei andere T003xxx-Worktrees, doppelt). Das liest sich, als besaesse die eigene Session diese Verzeichnisse, und fuehrt beim Debuggen in die falsche Richtung.
+.agents/skills/repo-hygiene/SKILL.md referenziert die Mechanik-SSOT als file:///home/patrick/Bachelorprojekt/.claude/skills/references/repo-hygiene-ops.md (absoluter Pfad) — der im Skill-Base-Kontext genutzte relative Pfad .agents/skills/repo-hygiene/references/repo-hygiene-ops.md existiert nicht (glob leer); die Datei liegt korrekt unter .claude/skills/references/. Beim Laden musste der Pfad per glob aufgelöst werden. VERIFIZIERT.
+**10. mcp-postgres fleet copy returned 98 'open' tickets, live DB had 58 — 40 already done** (degraded, mcp-postgres)
 
-Vorschlag: Schritt 5 Punkt 3 auf "ticket- ODER branch-scoped Claim" lockern und die Guard-Meldung auf "Geclaimt von anderen Sessions" umformulieren.
-**5. plan-qa-check.sh liefert Parse-Fehler statt inhaltlicher QA-Rückmeldung** (suspicious, scripts/plan-qa-check.sh)
-
-Beim Plan-Stage für T003077 (openspec-embed-dynamic-port) lieferte die advisory LLM-QA (scripts/plan-qa-check.sh) in Iteration 2 "FAIL — Missing criteria: Could not parse missing items" statt einer inhaltlichen Rückmeldung — ein Parse-Fehler des LLM-Antwortformats, keine echte Lücke (das harte Gate scripts/plan-lint.sh war zu diesem Zeitpunkt bereits PASS). Nicht blockierend (Skill-Konvention: bricht nie, `|| true`), aber Rauschen, das potenziell bei jedem Plan-Stage-Lauf auftritt und den Nutzen der advisory QA mindert.
-**6. touched_files-Ableitung nimmt reine Lesebefehl-Pfade als geänderte Dateien auf** (drift, scripts/plan-touched-files.sh)
-
-scripts/ticket.sh stage-plan (Ableitung via plan-touched-files.sh) trug für T003077 (openspec-embed-dynamic-port) docs/code-quality/baseline.json und docs/code-quality/gates.yaml als touched_files ein, obwohl der Plan diese Dateien nur per jq/grep-Lesebefehl referenziert (zur S1-Budget-Ermittlung in der Plan-Prosa), nicht verändert. touched_files zeigt dadurch zwei Dateien, die dieser Fix nicht anfasst — die Ableitung unterscheidet nicht zwischen "im Plan als MODIFIED/NEW markierter Pfad" und "im Plan als Lesebefehl-Argument zitierter Pfad".
-**7. worktree-write-guard blockiert Sub-Agenten in vom Orchestrator vorbereiteten Worktrees ohne eigenen agent-lock-Claim** (suspicious, skills/dev-flow-plan · scripts/hooks/worktree-write-guard.sh)
-
-Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch fuer T003075. Der Dispatch-Prompt wies an, ausschliesslich im vom Orchestrator vorab angelegten Worktree /home/patrick/Bachelorprojekt/.worktrees/freshness-gate-artifacts-T003075 zu arbeiten, und untersagte explizit einen ticket-scoped agent-lock-Claim ("KEIN agent-lock im ticket-Scope (T003102)"). Der erste Write-Tool-Aufruf auf einen Pfad unter diesem Worktree wurde dennoch von scripts/hooks/worktree-write-guard.sh abgelehnt: der Guard erlaubt Schreibzugriffe nur unter Pfaden, die per agent-lock.sh claim branch/ticket IN DIESER SESSION geclaimt wurden — ein vom Orchestrator vorab angelegter Worktree ohne eigenen Claim der Sub-Agenten-Session zaehlt nicht als "eigener" Pfad. Geloest durch `bash scripts/agent-lock.sh claim branch "fix/freshness-gate-artifacts-T003075" --worktree "$PWD" --label dev-flow-plan` vor dem ersten Write — das ist ein BRANCH-Scope-Claim, kein TICKET-Scope-Claim, widerspricht also der Anweisung nicht direkt, aber die Unterscheidung war im Dispatch-Prompt nicht klar genug: der Fehler musste erst live gegen den Write-Guard reproduziert werden, um zu verstehen, welcher Claim fehlte. Vorschlag: Dispatch-Prompts fuer ticket-ops-Wellen, die einen vorab angelegten Worktree uebergeben, sollten explizit nennen, ob/welcher agent-lock-Claim (branch vs. ticket) vom Sub-Agenten selbst noch zu setzen ist, um Write-Zugriff zu erhalten.
-**8. openspec-embed-local.sh scheitert weiterhin an Port-15432-Kollision bei Plan-Stage-Commits (bekanntes Muster, erneut bestaetigt)** (drift, scripts/openspec-embed-local.sh)
-
-Beim Plan-Stage-Commit fuer T003075 (2026-08-09) loeste der post-commit-Hook openspec-embed-local.sh aus, welches 3x mit "Port 15432 wird von einem fremden Prozess belegt (kubectl port-forward svc/shared-db)" scheiterte, bevor es non-fatal aufgab. Kein neuer Befund — deckt sich mit dem bereits dokumentierten Muster (openspec-embed scheitert an Port 15432, k3d-Forward belegt ihn). Bestaetigt lediglich, dass das Problem in Multi-Session-Umgebungen mit parallelen kubectl-Port-Forwards weiterhin regelmaessig auftritt und bei jedem betroffenen Plan-Stage-Commit sichtbare Fehlermeldungen erzeugt (non-fatal, aber Rauschen im Session-Log).
-**9. Drei Regelwerke widersprechen sich beim agent-lock-Scope — Planungsagenten kommen ohne bewusste Abweichung nicht durch** (degraded, skills/ticket-ops + skills/dev-flow-plan + scripts/hooks/worktree-write-guard.sh)
-
-Beobachtet 2026-08-09 in einem ticket-ops-Welle-1-Dispatch mit 6 parallelen dev-flow-plan-Agenten. VERIFIZIERT durch Code-Lesung, nicht nur berichtet.
-
-DER WIDERSPRUCH (drei Stellen, paarweise unvereinbar):
-
-(a) ticket-ops Step 3.6 (.claude/skills/references/ticket-ops-procedures.md) schreibt vor:
-    `agent-lock.sh claim ticket <ext-id> --branch <b> --worktree <wt> --label ticket-ops`
-
-(b) T003102 belegt (dort dreimal in einem einzigen Lauf beobachtet), dass genau dieser
-    ticket-scoped Lock danach den ABSCHLUSS blockiert: Subagent, ticket-mcp-Server und
-    post-merge.yml schreiben je unter eigener SID und sehen den Lock der aufrufenden
-    Session als fremd. Der Halter sperrt sich selbst aus.
-
-(c) dev-flow-plan/SKILL.md:217 fordert dieselbe Datei fail-closed als Vorbedingung des
-    Stage-Commits:
-        LOCK_FILE="$(git rev-parse --git-common-dir)/agent-locks/ticket__${TICKET_EXT_ID}.json"
-        [ -f "$LOCK_FILE" ] || { echo "FATAL: kein ticket-scoped agent-lock-Claim ..."; exit 1; }
-
-(d) scripts/hooks/worktree-write-guard.sh Regel 2 (Zeile 147-165) verweigert ohne
-    irgendeinen eigenen Claim jeden Write im zugewiesenen Worktree — exit 2.
-
-WAS TATSAECHLICH PASSIERTE: Der Orchestrator untersagte den Agenten wegen (b) den
-ticket-Lock. Daraufhin blockierte (d) bei 4 von 6 Agenten den ersten Testdatei-Write.
-Alle vier loesten es unabhaengig voneinander identisch auf — branch-scoped Claim, auf
-den Regel 2 ebenfalls greift. Zwei weitere Agenten (T003068, T003077) setzten entgegen
-der Anweisung doch ticket-Locks; diese mussten nach dem Lauf manuell freigegeben werden,
-um die (b)-Blockade zu vermeiden.
-
-DIE AUFLOESUNG, DIE NIRGENDS DOKUMENTIERT IST:
-    bash scripts/agent-lock.sh claim branch <branch> --worktree <pfad> --branch <branch>
-Der branch-scoped Claim befriedigt (d), erfuellt den Zweck des Kollisionsschutzes und
-erzeugt die Abschluss-Blockade aus (b) NICHT. Er steht derzeit in keinem der drei
-Regelwerke — jeder Agent musste ihn neu herleiten.
-
-ZU AENDERN:
-1. ticket-ops Step 3.6: claim branch statt claim ticket vorschreiben.
-2. dev-flow-plan Schritt 5 Punkt 3: branch-scoped Lock-Datei akzeptieren
-   (branch__<slug>.json) statt ticket__<id>.json fail-closed zu fordern.
-3. Beide Stellen mit einem Verweis auf T003102 versehen, damit die Begruendung nicht
-   erneut hergeleitet werden muss.
-
-Hinweis: WORKTREE_GUARD_BYPASS=1 per Bash-Export wirkt NICHT — der Hook laeuft pro
-Tool-Aufruf in einem eigenen Prozess (von einem Agenten geprueft).
-**10. ticket-ops-Dedupe-Guard vergleicht Titel exakt und fand 1 von 6 Dubletten — die dominante Dublettenklasse entgeht ihm strukturell** (suspicious, skills/ticket-ops Phase 1 (Dedupe-Guard))
-
-Beobachtet 2026-08-09 im ticket-ops-Vollduchlauf ueber 88 offene Tickets. GEMESSEN, nicht vermutet: die Exakt-Titel-Query fand genau ein Paar, die manuelle semantische Durchsicht fuenf weitere.
-
-DIE QUERY (Skill-Body-Invariante "Dedupe-Guard vor jeder Intake-Zeile"):
-    GROUP BY lower(regexp_replace(title,'\s+',' ','g')) HAVING count(*) > 1
-Sie findet nur Tickets mit WORTGLEICHEM Titel.
-
-GEFUNDEN: 1 Paar (T002784 / T003067, beide "Mishap Rollup — fortlaufende Sammlung").
-
-UEBERSEHEN: 5 Paare, alle semantisch identisch, alle mit unterschiedlichem Titel:
-- T002765 / T002911 — beide scripts/plan-touched-files.sh nimmt Prosa-Pfade auf.
-  Beide nennen sogar DASSELBE Beispiel: docs/code-quality/gates.yaml.
-- T003077 / T003101 — beide openspec-embed scheitert an Port-15432-Kollision.
-- T002877 / T002910 — beide openspec-embed completeness gate (12/57 bzw. 14/58 Dokumente).
-- T003001 / T003006 — beide spec-tracked-file-guard.bats unter bats -j, beide aus PR #3974.
-- T003078 / T003096 — wortgleiche BESCHREIBUNG, minimal abweichender Titel (der Guard
-  vergleicht nur den Titel, deshalb entging auch dieses Paar).
-
-WARUM DAS STRUKTURELL IST: Die dominante Dublettenquelle in diesem Repo sind
-Mishap-Reports. Jeder wird unabhaengig formuliert — dieselbe Beobachtung, andere Worte.
-Ein Titelvergleich kann diese Klasse per Konstruktion nicht fassen. Waehrend dieses
-Laufs meldete ein Planungsagent den plan-touched-files-Defekt zum VIERTEN Mal als
-vermeintlich neuen Befund.
-
-VORHANDENE BAUSTEINE FUER EINEN BESSEREN GUARD:
-- mcp__factory-mcp__openspec_find_similar (semantische Aehnlichkeitssuche, bereits im Einsatz)
-- bge-mcp (bge_embed + bge_rerank)
-- Als billige Naeherung ohne Embedding: Gleichheit von (component, areas) plus
-  Ueberlappung der in der Beschreibung genannten Dateipfade. Alle fuenf uebersehenen
-  Paare teilen Komponente UND mindestens einen Dateipfad — diese Heuristik allein
-  haette sie gefunden.
-
-FOLGEKOSTEN, falls unveraendert: Beinahe-Duplikate werden getrennt geplant und getrennt
-dispatcht. In diesem Lauf haette das drei Agenten gleichzeitig an denselben roten
-Shard-4-Guard gesetzt (T002941 / T003001 / T003006).
-### Mishap-Rollup — 10 Eintraege (2026-08-09 23:49 UTC)
+Triage run used mcp-postgres (fleet copy, port 13001) which returned 98 tickets. Switched to kubectl exec psql (live DB) which returned 58. 40 tickets in the fleet copy were already done/archived. Known issue T002785-4.
+### Mishap-Rollup — 10 Eintraege (2026-08-10 12:10 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | degraded | scripts/hooks/worktree-write-guard.sh | worktree-write-guard: SID-basiertes Besitzmodell unterscheidet nebenlaeufige Subagenten einer Session nicht — Meldung fuehrt in die Irre |
-| 2 | suspicious | skills/ticket-ops Step 3.6 (Dispatch-Prompt) | ticket-ops-Dispatchvorlage sagt nicht, welchen Lock-Scope der Subagent selbst setzen soll |
-| 3 | process | skills/repo-hygiene (repo-hygiene-ops.md §1) | repo-hygiene §1: Freshness-Generat macht jeden fertigen Worktree dauerhaft dirty — `worktree remove` ohne `--force` schlägt regelhaft fehl |
-| 4 | process | scripts/ticket.sh + ticket-mcp (mishap-buffer) | Mishap-Buffer kennt keinen Rücknahmepfad — ein behobener Befund erscheint beim Flush trotzdem als offener Punkt im Rollup |
-| 5 | drift | scripts/openspec.sh | Half-archived change mcp-config-mutation-race detected during repo-hygiene |
-| 6 | suspicious | ci/freshness-gate | Archive PR #4083 failed freshness gate — openspec-status.json not committed after archive |
-| 7 | suspicious | scripts/factory/babysit-prs.sh | babysit-prs.sh entfernt Worktrees ohne den live-Lock-Guard aus T002896 |
-| 8 | degraded | Taskfile.yml:test:changed | test:changed startet Live-E2E gegen korczewski bei reiner openspec/-Aenderung |
-| 9 | drift | scripts/validate-commit-msg.sh | Commit-Scope 'openspec' abgelehnt, obwohl das ganze Repo von OpenSpec spricht |
-| 10 | degraded | scripts/openspec.sh | openspec.sh archive skaliert nicht im Batch (~3s pro Change, Node-Start je Delta) |
+| 1 | degraded | scripts/llm-proxy/slot-queue.mjs | Per-Slot-Queue-Isolation seit T002483 wirkungslos — kein Aufrufer sendet x-slot-id |
+| 2 | suspicious | scripts/plan-qa-check.sh | plan-qa-check widerspricht plan-lint bei identischer Eingabe |
+| 3 | degraded | scripts/openspec-embed.mjs | openspec-embed scheitert bei jedem Commit an belegtem Port 15432 |
+| 4 | suspicious | scripts/branch-reaper.sh | Reuse-Worktrees sammeln npm-Install-Rauschen in .opencode/package.json — §1-Allowlist greift nicht |
+| 5 | process | factory | PR #4129 (T003267) offen mit rotem CI, Ticket weiterhin backlog — Implementation vor Factory-Dispatch gepusht |
+| 6 | suspicious | repo/git-state | .git/shallow-Boundary am main-Tip blockierte pre-push-Validierung (Ursache ungeklärt) |
+| 7 | suspicious | repo/worktrees | Scratchpad-Worktree wt-order-guards-head-first-match: leerer Index + Teil-Snapshot, nicht sicherbar |
+| 8 | drift | repo/.opencode | Identischer uncommitteter @opencode-ai/plugin-Bump (1.18.11→1.18.16) in zwei -reuse-Worktrees fremd zu deren Tickets |
+| 9 | drift | skills/repo-hygiene | repo-hygiene-SKILL.md verweist auf nicht existierenden SSOT-Relativpfad |
+| 10 | degraded | ticket-mcp | ticket-mcp export_tickets returns insufficient fields for triage |
 
-**1. worktree-write-guard: SID-basiertes Besitzmodell unterscheidet nebenlaeufige Subagenten einer Session nicht — Meldung fuehrt in die Irre** (degraded, scripts/hooks/worktree-write-guard.sh)
+**1. Per-Slot-Queue-Isolation seit T002483 wirkungslos — kein Aufrufer sendet x-slot-id** (degraded, scripts/llm-proxy/slot-queue.mjs)
 
-Beobachtet 2026-08-09 bei einem ticket-ops-Dispatch mit 6 parallelen Subagenten. WICHTIG: Der urspruengliche Agentenbericht war ungenau; die hier beschriebene Fassung ist gegen den Quellcode korrigiert.
+scripts/llm-proxy/slot-queue.mjs isoliert Warteschlangen pro Slot, damit "slot 0 does not block slot 1" (Kopfkommentar). Der Schluessel entsteht in enqueue() aus `${name}:slot${slotId}`, wobei slotId aus extractSlotId(req) stammt und den Header x-slot-id liest.
 
-BERICHTET WURDE: "Die Meldung listet unter 'Dieser Session gehoeren:' die Worktrees FREMDER Sessions auf."
+VERIFIZIERT: kein produktiver Aufrufer setzt diesen Header.
+  git grep -c "x-slot-id" -- . ':!tests' ':!scripts/llm-proxy'
+  -> nur Treffer in den neuen Plandateien von T003277, sonst keine
+  git grep -n 'x-slot-id' -- scripts .opencode
+  -> nur slot-queue.mjs (Leser) und server.test.mjs (Testfixtures)
 
-TATSAECHLICH (scripts/hooks/worktree-write-guard.sh:132-157): `MY_WTS` sammelt alle
-Worktrees, deren Lock-Owner dieselbe SID traegt. Alle sechs Subagenten liefen unter
-DERSELBEN Session-SID (im Lock-Bestand nachgeprueft: sechs branch-Claims, identisches
-owner_sid). Aus Sicht des Guards gehoerten die Worktrees also korrekt "dieser Session".
-Die Meldung ist im Modell des Guards richtig — sie wurde nur als "fremd" gelesen.
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-DER EIGENTLICHE DEFEKT liegt eine Ebene tiefer: das SID-basierte Besitzmodell kann
-NEBENLAEUFIGE SUBAGENTEN einer Session nicht voneinander unterscheiden. Fuer Regel 2
-(Zeile 147-152) heisst das: Agent A darf in Agent B's Worktree schreiben, weil beide
-dieselbe SID tragen. Der Guard schuetzt gegen fremde SESSIONS, nicht gegen paralleles
-Arbeiten INNERHALB einer Session — genau das Szenario, das ticket-ops erzeugt.
+Folge: slotId ist immer null, der Schluessel faellt auf backend.name zurueck, und alle Slots teilen sich dieselbe Semaphore — genau der Zustand, den die Datei laut ihrem Kopfkommentar verhindern soll. scripts/factory/sandbox-run.sh kennt zwar eine SLOT_ID, reicht sie aber nie als HTTP-Header weiter.
 
-DAS IST DIESELBE GEBROCHENE ANNAHME WIE IN T003102: "eine Session = eine SID" haelt
-nicht, sobald MCP-Server, Subagenten und CI-Workflows im selben Vorgang schreiben.
-Dort verhindert sie den Abschluss, hier den Schutz. Beide Tickets sollten gemeinsam
-betrachtet werden — eine Vererbungskennung (Parent-SID plus Actor-Kennung) wuerde
-beide Faelle adressieren.
+T003277/p3 setzt den Header und weist die Wirksamkeit mit zwei gleichzeitigen Anfragen nach. Dieser Mishap haelt fest, dass die Funktion seit T002483 unbemerkt tot war — der zugehoerige Test konnte es nicht bemerken, weil er den Quelltext greppt statt Verhalten zu messen (separater Mishap).
+**2. plan-qa-check widerspricht plan-lint bei identischer Eingabe** (suspicious, scripts/plan-qa-check.sh)
 
-ZUSATZBEFUND: In der Auflistung erschienen Worktrees doppelt. Ursache ist plausibel,
-dass mehrere Locks unterschiedlichen Scopes (branch- und worktree-Scope) auf denselben
-Pfad zeigen und die Schleife jeden Treffer anhaengt, ohne zu deduplizieren
-(Zeile 138: `MY_WTS+=("$wt")` ohne Existenzpruefung).
+scripts/plan-qa-check.sh (advisory, LLM-gestuetzt) beanstandete an openspec/changes/llm-proxy-dispatch-capture/tasks.md zu Kriterium 5, der letzte Task sei "nicht explizit als Teil eines Tasks definiert, der die Schritte test:changed, freshness:regenerate und freshness:check enthaelt".
 
-KLEINE VERBESSERUNG UNABHAENGIG DAVON: Die Meldezeile "Dieser Session gehoeren:" sollte
-sagen, WOHER der Besitz stammt (z. B. "Claims dieser SID (auch anderer Subagenten):"),
-damit sie nicht als Eigenbesitz des aufrufenden Akteurs gelesen wird. Genau diese
-Fehllesung kostete beim Debuggen Zeit.
-**2. ticket-ops-Dispatchvorlage sagt nicht, welchen Lock-Scope der Subagent selbst setzen soll** (suspicious, skills/ticket-ops Step 3.6 (Dispatch-Prompt))
+Das ist ein Fehlurteil. Die drei Befehle stehen als Checkbox-Task ("Abschliessende Pruefung") im Index, und das fail-closed Hard Gate wertet dieselbe Datei als konform:
+  bash scripts/plan-lint.sh openspec/changes/llm-proxy-dispatch-capture/tasks.md
+  -> PLAN-LINT: PASS (0 hard, 0 warn)   # STRUCT3 geprueft und bestanden
 
-Beobachtet 2026-08-09, von einem der sechs Welle-1-Agenten ausdruecklich als Verbesserungswunsch zurueckgemeldet ("Dispatch-Prompt sollte kuenftig klarstellen, welcher Claim (branch vs. ticket) vom Sub-Agenten selbst zu setzen ist").
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-BEFUND: ticket-ops Step 3.6 beschreibt die Lock-Vergabe ausschliesslich aus Sicht des
-ORCHESTRATORS ("agent-lock.sh claim ticket <ext-id> ... --label ticket-ops"). Was der
-dispatchte Subagent in seinem Worktree selbst claimen muss, steht nirgends — obwohl
-scripts/hooks/worktree-write-guard.sh Regel 2 ohne eigenen Claim jeden Write ablehnt.
+Warum das zaehlt: plan-qa laeuft mit "|| true" und blockiert nichts, aber es durchlaeuft bis zu zwei Auto-Fix-Iterationen, in denen es Vorschlaege an die Plandatei anhaengt ("Auto-fix attempt 1/2: appending suggestions"). Ein falsch-positives Kriterium kann damit einen Plan veraendern, der bereits konform ist. In diesem Lauf blieb die Datei unveraendert (nachgeprueft), aber die Moeglichkeit besteht.
 
-FOLGE IN DIESEM LAUF: Vier von sechs Agenten liefen in die Guard-Blockade und mussten
-den richtigen Claim selbst herleiten. Zwei setzten den falschen (ticket-scoped), der
-nach T003102 den spaeteren Abschluss blockiert und vom Orchestrator manuell wieder
-freigegeben werden musste. Sechs Agenten, vier unabhaengige Herleitungen desselben
-Schrittes, zwei Fehlgriffe — das ist ein Vorlagen-Problem, kein Agenten-Problem.
+Ein zweiter Punkt derselben Meldung war dagegen berechtigt: die S1-Budgets standen nur in den Partials, nicht im Index. Das wurde uebernommen. Der Befund richtet sich also gegen Kriterium 5, nicht gegen das Werkzeug insgesamt.
+**3. openspec-embed scheitert bei jedem Commit an belegtem Port 15432** (degraded, scripts/openspec-embed.mjs)
 
-ZU ERGAENZEN in der Dispatch-Vorlage von Step 3.6, woertlich als Prompt-Baustein:
-    "Setze zu Beginn im Worktree:
-       bash scripts/agent-lock.sh claim branch <branch> --worktree <pfad> --branch <branch>
-     Setze KEINEN ticket-scoped Lock (T003102 — blockiert den spaeteren Abschluss durch
-     Subagent, ticket-mcp und post-merge.yml).
-     Gib den Branch-Lock am Ende deiner Arbeit wieder frei."
+Der post-commit-Hook scripts/openspec-embed.mjs schlug bei BEIDEN Commits dieses Vorgangs nach drei Versuchen fehl:
 
-Haengt inhaltlich am Mishap "Drei Regelwerke widersprechen sich beim agent-lock-Scope"
-aus demselben Lauf — dort liegt die Ursache, hier die konkrete Textstelle, die sie
-weitertraegt.
-**3. repo-hygiene §1: Freshness-Generat macht jeden fertigen Worktree dauerhaft dirty — `worktree remove` ohne `--force` schlägt regelhaft fehl** (process, skills/repo-hygiene (repo-hygiene-ops.md §1))
+  [openspec-embed] post-commit: embedding slug='llm-proxy-dispatch-capture'...
+  [openspec-embed] retry 1/3 ... retry 2/3 ...
+  [openspec-embed] WARN: embed failed after 3 attempts (non-fatal)
 
-BEOBACHTET (repo-hygiene-Lauf 2026-08-09/10, Worktree .worktrees/factory-worktree-reaper-T002896)
+Ursache ist die bekannte Portkollision: openspec-embed.mjs oeffnet einen pg.Pool auf localhost:15432, den auf dieser Maschine der k3d-Portforward belegt.
 
-repo-hygiene-ops.md §1 schreibt vor, `git worktree remove <pfad>` OHNE `--force` aufzurufen, und begründet das ausdrücklich als "Schutz bei ungetrackten Dateien". Dieser Schutz greift in der Praxis nicht, weil er regelhaft am falschen Signal scheitert.
+Beobachtet an den Commits d041220e6 und 64f07d0fc.
 
-BEFUND
-Der Worktree war inhaltlich vollständig abgeschlossen: PR #4068 gemergt (mergedAt 2026-08-09T21:55:02Z), Squash-Commit e78a30777 in origin/main, Upstream [gone]. Der Blob-Vergleich pro Datei gegen origin/main (§2-Form) zeigte genau EINE Abweichung: website/src/data/openspec-status.json — ein reines Freshness-Generat. Der Inhalt der Abweichung war ausschliesslich regenerierter Archivstatus FREMDER Tickets (T002814 plan_staged -> archived, T002849 zusaetzlicher archived-Eintrag), also kein Byte eigener Arbeit.
+Der Fehlschlag ist als non-fatal markiert und bricht den Commit nicht ab — die Folge ist still: die Proposals dieses Vorgangs sind nicht eingebettet und damit ueber die semantische Suche (openspec_find_similar) nicht auffindbar. Wer spaeter nach aehnlichen Vorhaben sucht, bekommt ein unvollstaendiges Ergebnis, ohne dass etwas darauf hinweist.
 
-`git status --porcelain` meldet dafuer ` M website/src/data/openspec-status.json`. Nach der woertlichen Regel aus §1 ("MUSS leer sein — sonst kein Remove") ist der Worktree damit nicht entfernbar, und `git worktree remove` ohne `--force` verweigert.
+Beitrag zum Design von T003277: genau dieser Mechanismus war der Grund, einen direkten pg-Client im llm-proxy zu verwerfen (design.md D1a) — ein langlaufender Dienst haette sich dieses Ausfallmuster eingehandelt.
+**4. Reuse-Worktrees sammeln npm-Install-Rauschen in .opencode/package.json — §1-Allowlist greift nicht** (suspicious, scripts/branch-reaper.sh)
 
-WARUM DAS STOERT
-Das ist keine Ausnahme, sondern der Normalfall: jeder Worktree, in dem ein Plan gestaged oder archiviert wurde, traegt danach ein regeneriertes openspec-status.json. Der Aufraeumpfad landet damit routinemaessig im `--force`-Zweig — also in genau der Eskalation, die §1 als bewusste Ausnahme kennzeichnet. Ein Schutzmechanismus, der bei fast jedem legitimen Aufruf uebersprungen werden muss, schuetzt nicht mehr: er trainiert `--force` als Standardgriff an, und dann faellt echte ungesicherte Arbeit im selben Zweig nicht mehr auf.
+Drei reuse-Worktrees (T002908, T002843, T002934) trugen uncommittete @opencode-ai/plugin-Bumps 1.18.11→1.18.16 in .opencode/package.json + package-lock.json — identisches npm-Install-Artefakt, in keinem Git-Objekt, auf main nicht vorhanden. Die §1-Allowlist (maßgeblich: ALLOWLIST in scripts/branch-reaper.sh) deckt .opencode/ ab nicht ab, also blockierte ein Nicht-Allowlist-Pfad die Worktree-Removal als scheinbarer Befund. Workaround: git checkout -- auf die committeden Versionen, dann remove. Kein Datenverlust, aber: (a) Allowlist kennt den Pfad nicht, obwohl reines Generat-Rauschen, (b) jede Worktree-Removal von reuse-Worktrees braucht künftig denselben Zwei-Schritt.
+**5. PR #4129 (T003267) offen mit rotem CI, Ticket weiterhin backlog — Implementation vor Factory-Dispatch gepusht** (process, factory)
 
-ABGRENZUNG
-Der Vorcheck selbst ist nicht falsch — er misst nur zu grob. Die verlaessliche Messung stand im selben Runbook bereits daneben (§2, Blob-Vergleich pro Datei gegen origin/main); sie unterscheidet Generat von Arbeit, `git status --porcelain` nicht.
+Auf dem Branch feature/cross-harness-plan-guardrails-T003267 liegt ein offener PR (#4129, erstellt 08:23Z) mit voller Implementation, während das Ticket T003267 status=backlog ist (noch nie dispatched). CI rot in 4 Jobs: Factory spec shards 1/2/4 + Aggregate. Ursache: echte Spec-Regressionen — die Checks "do not commit on main / clean status / Pre-Commit-Guard lock-file / branch__<slug>.json / stage-plan auto-emit" wurden aus .claude/skills/dev-flow-plan/SKILL.md nach scripts/plan-preflight.sh verschoben, die greppenden Tests (agent-lock-session-identity.bats, catalog-eval-telemetry.bats T001444, agent-lock-scope-regelwerk.bats T003102) laufen dagegen ins Leere. stage-plan --hold/--no-hold-Pflicht bricht den T001444-Aufruf ohne Hold-Flag. Befund auf T003267 kommentiert. Merge blockiert, bis die Tests an den plan-preflight-Umbau angepasst sind.
+**6. .git/shallow-Boundary am main-Tip blockierte pre-push-Validierung (Ursache ungeklärt)** (suspicious, repo/git-state)
 
-MOEGLICHE AUFLOESUNG (nicht entschieden)
-a) §1-Vorcheck um eine Generat-Allowlist ergaenzen (dieselbe, die scripts/branch-reaper.sh bereits fuehrt): Abweichungen ausschliesslich in Plan-/Generat-Pfaden gelten als sauber, `--force` ist dann keine Eskalation mehr, sondern der belegte Normalfall.
-b) Vor dem Remove `git checkout -- <generat-pfade>` im Worktree, damit der Vorcheck wieder eine echte Aussage trifft.
-**4. Mishap-Buffer kennt keinen Rücknahmepfad — ein behobener Befund erscheint beim Flush trotzdem als offener Punkt im Rollup** (process, scripts/ticket.sh + ticket-mcp (mishap-buffer))
+Während des repo-hygiene-Laufs (2026-08-10, ~11:46Z) tauchte in .git/shallow ein Boundary-Eintrag für den main-Tip 1c6b90028 auf (mtime 13:46:54 +0200 — mitten in der Session). Kein Hook im Repo erzeugt Shallow-State (geprüft: grep -rln 'shallow|--depth' .githooks/ scripts/hooks/ = leer). Wirkung: die pre-push-Validierung (validate-commit-msg.sh range origin/main..HEAD) zog wegen der gebrochenen Ancestry 6724 Commits statt 3 in den Range und blockierte den Push des T003107-Merge-Commits mit "unknown scope"-Fehlern auf alten main-Commits — dieselbe Fehlerklasse wie T002827, aber andere Ursache. Der vollständige Commit-Graph war im Objektstore vorhanden (merge-base 47d25bb7 bcf14d546 = 8d77df268 mit ignoriertem Shallow); die Boundary wurde entfernt (Backup /tmp/opencode/shallow.bak), Historie danach vollständig (rev-list count main = 6805), Push erfolgreich. VERIFIZIERT.
+**7. Scratchpad-Worktree wt-order-guards-head-first-match: leerer Index + Teil-Snapshot, nicht sicherbar** (suspicious, repo/worktrees)
 
-BEOBACHTET (2026-08-09/10, repo-hygiene-Lauf + anschliessende Chore T003121)
+/tmp/claude-1000/.../scratchpad/wt-order-guards-head-first-match (Branch fix/order-guards-head-first-match-T003104, backlog): git status --porcelain zeigt leeren Index (ls-files = 0), HEAD tracked 9857 Dateien, Arbeitsbaum enthält nur 1812 (Teil-Snapshot eines abgebrochenen Checkouts), davon 139 Dateien mit vom HEAD abweichenden Blobs. Branch ist exakt == origin/main (1c6b90028). Es existiert kein git-artefaktierter Zwischenstand (Index leer, 0 Commits auf dem Branch) — es ist nicht entscheidbar, ob die 139 abweichenden Dateien echte Arbeit enthalten (mtimes/Herleitung unklar). Fail-closed: Worktree NICHT entfernt, Befund gelassen. VERIFIZIERT (empty index, 1812 untracked, 139 blob-abweichend).
+**8. Identischer uncommitteter @opencode-ai/plugin-Bump (1.18.11→1.18.16) in zwei -reuse-Worktrees fremd zu deren Tickets** (drift, repo/.opencode)
 
-ABLAUF
-1. 22:02Z: Befund als Mishap gemeldet — "repo-hygiene §1: Freshness-Generat macht jeden fertigen Worktree dauerhaft dirty" (Buffer-Eintrag 3/10).
-2. Direkt danach in derselben Sitzung behoben: Ticket T003121, PR #4075, gemergt 22:35Z. Der Befund existiert seit 33 Minuten nicht mehr.
-3. Der Buffer-Eintrag steht unveraendert weiter drin. `get_mishap_buffer` zeigt ihn, `report_mishap` kann nur anfuegen, `flush_mishap_buffer` schreibt ALLE Eintraege in den Rollup-Container.
+.worktrees/ticket-guard-diff-scope-T002934-reuse und .worktrees/worktree-status-check-existence-T002932-reuse tragen beide denselben uncommitteten Dependency-Bump in .opencode/package.json + package-lock.json (@opencode-ai/plugin 1.18.11 → 1.18.16). Die touched_files beider Tickets (T002934, T002932) decken .opencode/ nicht ab; origin/main hat weiterhin 1.18.11. Unerklärter Fremdstand in Worktrees aktiver Tickets — nicht revertiert (könnte Absicht sein), nicht committet (gehört zu keinem Ticket), liegt gelassen. VERIFIZIERT (diff in beiden Worktrees identisch, main=1.18.11).
+**9. repo-hygiene-SKILL.md verweist auf nicht existierenden SSOT-Relativpfad** (drift, skills/repo-hygiene)
 
-WIRKUNG
-Beim naechsten Flush (spaetestens bei 10 Eintraegen oder nach 7 Tagen) landet ein bereits geschlossener Befund als offener Punkt im Rollup-Ticket. Wer den Rollup abarbeitet, untersucht etwas, das auf main schon behoben ist — im Zweifel inklusive erneutem Fix. Das Fenster ist genau die Spanne zwischen Erfassung und Flush, also bis zu 7 Tage; in dieser Spanne liegt jeder Befund, den eine Sitzung selbst behebt, und "selbst beheben" ist der Normalfall, nicht die Ausnahme.
+.agents/skills/repo-hygiene/SKILL.md referenziert die Mechanik-SSOT als file:///home/patrick/Bachelorprojekt/.claude/skills/references/repo-hygiene-ops.md (absoluter Pfad) — der im Skill-Base-Kontext genutzte relative Pfad .agents/skills/repo-hygiene/references/repo-hygiene-ops.md existiert nicht (glob leer); die Datei liegt korrekt unter .claude/skills/references/. Beim Laden musste der Pfad per glob aufgelöst werden. VERIFIZIERT.
+**10. ticket-mcp export_tickets returns insufficient fields for triage** (degraded, ticket-mcp)
 
-ABGRENZUNG — das ist NICHT der Dedupe-Fall aus T002844
-T002844 beschreibt die umgekehrte Richtung: der Buffer ist fuer die Ticket-Suche unsichtbar, deshalb entsteht ein DUPLIKAT. Hier ist der Eintrag sichtbar und korrekt erfasst — er ist nur inzwischen GEGENSTANDSLOS, und dafuer gibt es keinen Weg. Beide Faelle teilen die Ursache (Buffer und Tickets sind zwei Zustandsraeume ohne Verbindung), aber nicht die Auswirkung.
-
-UMGEHUNG im aktuellen Lauf
-Hinweis als Kommentar an T003121 gehaengt, damit die Spur beim Rollup auffindbar ist. Das ist Handarbeit und traegt nur, solange jemand daran denkt.
-
-MOEGLICHE AUFLOESUNGEN (nicht entschieden)
-a) `resolve_mishap`/`withdraw_mishap` mit Index oder Titel-Match, das den Eintrag mit Verweis auf das loesende Ticket aus dem Buffer nimmt.
-b) Beim Flush jeden Eintrag gegen die Tickets pruefen und geschlossene als "bereits behoben durch T00XXXX" markieren statt sie als offenen Punkt zu fuehren — loest zugleich die Richtung aus T002844, weil beide Quellen dann in EINEM Aufruf zusammenkommen.
-c) Nichts tun und die Handarbeit als Konvention im mishap-tracker-Skill festhalten (schwaechste Variante, aber billig).
-**5. Half-archived change mcp-config-mutation-race detected during repo-hygiene** (drift, scripts/openspec.sh)
-
-During repo-hygiene run, mcp-config-mutation-race was found in a half-archived state: the archive target 2026-08-10-mcp-config-mutation-race already existed in openspec/changes/archive/ while the source directory was still present in openspec/changes/. openspec.sh archive refuses to re-archive an existing target. The half-archive-check.sh script detected it correctly. Manual cleanup: verify delta was in SSOT, then rm -rf the source. Root cause unknown — possibly a prior archive that crashed after moving files but before removing source.
-**6. Archive PR #4083 failed freshness gate — openspec-status.json not committed after archive** (suspicious, ci/freshness-gate)
-
-PR #4083 (archive-only, no code changes) failed CI because website/src/data/openspec-status.json was regenerated by task freshness:check but not committed to the PR branch. The pre-commit hook did not catch this because the archive work was done in a worktree where the artifact was staged but the commit didn't include it. The openspec archive operation (moving/deleting change dirs) changes the openspec status map, which in turn triggers a freshness regeneration — but the regenerated artifact wasn't added to the commit.
-**7. babysit-prs.sh entfernt Worktrees ohne den live-Lock-Guard aus T002896** (suspicious, scripts/factory/babysit-prs.sh)
-
-Beobachtung (T003129): Ein aktiver Worktree unter .worktrees/openspec-archive-backlog-T003129 verschwand mitten in einem laufenden Batch ("getcwd: cannot access parent directories"), obwohl der Branch einen frisch geclaimten, lebenden agent-lock trug. 41 bereits verarbeitete Archivierungen gingen verloren, der Lauf musste komplett neu aufgesetzt werden.
-
-Verifikation korrigiert die naheliegende Hypothese: .git/agent-locks/.reap.log zeigt fuer 01:27:45 den Eintrag "branch/chore/openspec-archive-backlog-T003129 worktree-missing". Der Lock wurde also stale, WEIL der Worktree fehlte — nicht umgekehrt. agent-lock hat korrekt gearbeitet; "agent-lock.sh reap" ruft ohnehin nur "git worktree prune" auf und entfernt keine existierenden Verzeichnisse.
-
-Wer den Worktree entfernt hat, bleibt ungeklaert. Bei der Suche nach Kandidaten faellt aber eine reale Inkonsistenz auf, unabhaengig davon ob sie hier zugeschlagen hat:
-
-- scripts/factory/cleanup.sh prueft VOR dem Removal "agent-lock.sh check-branch-live" und ueberspringt dann (Guard aus T002896, an zwei Stellen: EXIT-Trap Zeile 29 und Hauptpfad Zeile 43). Begruendung im Kommentar: "Der Factory-Autopilot darf aktiv geclaimte Fremd-Worktrees nicht entfernen."
-- scripts/factory/watchdog.sh Zeile 76 prueft wenigstens auf uncommitted changes und ueberspringt dann mit Kommentar am Ticket.
-- scripts/factory/babysit-prs.sh Zeile 222 hat WEDER das eine noch das andere: "git worktree remove "$WT" --force >/dev/null 2>&1 || rm -rf "$WT"". Kein check-branch-live, keine Dirty-Pruefung, und der rm -rf-Fallback setzt sich sogar ueber ein fehlgeschlagenes git worktree remove hinweg.
-
-Der Guard aus T002896 wurde offenbar nur in cleanup.sh eingezogen, obwohl babysit-prs.sh dieselbe Operation ausfuehrt. Vorschlag: check-branch-live auch dort vorschalten, und den rm -rf-Fallback entfernen oder ebenfalls hinter den Guard legen.
-
-Praktischer Workaround bis dahin: Worktrees fuer laengere Batch-Laeufe ausserhalb von .worktrees/ anlegen (z.B. im Session-Scratchpad). Der zweite Anlauf lief dort unbehelligt durch.
-**8. test:changed startet Live-E2E gegen korczewski bei reiner openspec/-Aenderung** (degraded, Taskfile.yml:test:changed)
-
-Beobachtung (T003129): Ein Diff, der ausschliesslich openspec/ und das generierte website/src/data/openspec-status.json beruehrt (kein einziger ausfuehrbarer Code), loeste in "task test:changed" den Teiltask test:e2e:korczewski aus. Der scheiterte am Auth-Setup gegen die Live-Site (korczewski-auth-setup.spec.ts:44, "authenticate korczewski website admin"), 48 Tests liefen gar nicht erst. Exit 201.
-
-Der Taskfile-Kommentar beschreibt genau diesen Fall als bereits geloest (T002255): "Generierte Artefakte (linguist-generated in .gitattributes) vor der Selektion entfernen: sie liegen im Diff JEDES Changes mit OpenSpec-Artefakt und wuerden sonst Playwright fuer Changes ohne Website-Bezug starten." Der Filter greift hier nicht — vermutlich weil openspec/specs/website-core.md im Diff liegt und als website-Bezug gewertet wird, obwohl es eine Spezifikationsdatei ist.
-
-Warum das mehr als kosmetisch ist: derselbe Taskfile-Kommentar haelt fest, dass CI fuer PRs nur test:spec:changed plus manifests.bats faehrt, NICHT das volle test:changed — "der lokale Lauf war also strenger als das Gate, das er simuliert". Ein Agent, der den Verifikationsblock woertlich befolgt, steht damit vor einem roten Ergebnis, das keine Regression ist, und muss zwischen "falsche Regression melden", "blind weitermachen" und "Zeit an einem Umgebungsproblem verbrennen" waehlen. Genau diese Wahl beschreibt der Kommentar zu T002375-p4 bereits fuer den k3d-Fall, wo daraufhin ein sichtbarer Skip eingebaut wurde.
-
-Bestaetigung, dass es ein Fehlalarm war: test:spec:changed lief mit 220 ok / 0 Fehlschlaegen, task openspec:validate 11/11 gruen, freshness:check exit 0, und PR #4086 ging mit 18/18 gruenen Checks durch.
-
-Vorschlag: dieselbe Erreichbarkeits-/Relevanzpruefung wie fuer die k3d-Gruppe auch fuer die E2E-Gruppe, oder openspec/specs/*.md aus der Website-Domain-Zuordnung nehmen — eine Spec-Datei ist kein Website-Code.
-**9. Commit-Scope 'openspec' abgelehnt, obwohl das ganze Repo von OpenSpec spricht** (drift, scripts/validate-commit-msg.sh)
-
-Beobachtung (T003129): "chore(openspec): 54 gemergte Changes archivieren [T003129]" wurde vom commit-msg-Hook abgelehnt: "unknown scope 'openspec' — 'openspec' wurde zu 'plans' konsolidiert (T002328)". Korrekt ist chore(plans).
-
-Warum das wiederholt Zeit kostet: der abgelehnte Scope ist ueberall sonst der etablierte Begriff. Das Verzeichnis heisst openspec/, die Tasks heissen openspec:validate / openspec:propose / openspec:apply / openspec:archive, die Slash-Commands heissen /opsx:*, die Skills heissen openspec-propose / openspec-apply-change / openspec-archive-change, und CLAUDE.md hat einen eigenen Abschnitt "OpenSpec native change workflow". Ein Agent, der einen Commit fuer eine openspec/-Aenderung schreibt, waehlt den naheliegenden Scope — und der ist der falsche.
-
-Der Hook selbst weist darauf hin, dass CI hier nicht schuetzt: "Der CI-PR-Titel-Check (amannn/action-semantic-pull-request) prueft keinen Scope — ein gruener PR-Titel ist keine Garantie fuer diesen Scope." Der Fehler faellt also erst lokal beim Commit auf, nach dem Verfassen der vollstaendigen Message.
-
-Kosten pro Vorfall gering (ein Fehlversuch), Haeufigkeit aber strukturell: jede openspec-Aenderung eines Agenten, der die Konsolidierung nicht auswendig kennt.
-
-Vorschlag (eines von beiden, nicht beide):
-(a) 'openspec' als Alias auf 'plans' in validate-commit-msg.sh zulassen — die Konsolidierung bliebe inhaltlich bestehen, nur der naheliegende Name wuerde nicht mehr bestrafen; oder
-(b) einen Satz in CLAUDE.md beim OpenSpec-Abschnitt: "Commits zu openspec/ tragen den Scope 'plans', nicht 'openspec' (T002328)."
-**10. openspec.sh archive skaliert nicht im Batch (~3s pro Change, Node-Start je Delta)** (degraded, scripts/openspec.sh)
-
-Beobachtung (T003129): Beim Abbau des Archivierungsrueckstands (98 offene Changes) brauchte "scripts/openspec.sh archive <slug>" rund 3 Sekunden pro Change. Ursache: _merge_delta startet fuer jede einzelne Delta-Datei einen eigenen Node-Prozess ("node scripts/openspec-merge.mjs apply ..."), der Prozessstart dominiert die eigentliche Arbeit.
-
-Praktische Folge: eine Schleife ueber 59 Changes laeuft rund drei Minuten und schlaegt damit in jedes Default-Kommandotimeout (2 Minuten). Der erste Lauf brach nach 41 verarbeiteten Changes ab und musste gestueckelt bzw. mit erhoehtem Timeout wiederholt werden. Fuer den Normalfall — ein Change am Ende eines dev-flow-execute — ist das irrelevant; relevant wird es genau dann, wenn ein Rueckstand aufgeholt werden soll, also im Wartungsfall.
-
-Das ist kein Fehlverhalten, nur schlechte Batch-Ergonomie. Zwei denkbare Wege:
-(a) ein Batch-Modus, der mehrere Slugs in EINEM Node-Prozess abarbeitet (openspec-merge.mjs bekaeme eine Liste statt eines Paares); oder
-(b) schlicht dokumentieren, dass Block-Archivierungen im Hintergrund oder in Portionen zu fahren sind.
-
-Randnotiz aus demselben Lauf, gleiche Ursachenklasse: openspec.sh archive prueft den Ticket-Status fail-closed (done/archived) und verweigert sonst — das hat sauber funktioniert und mehrere nicht abgeschlossene Changes korrekt abgewiesen. Der Guard ist nicht das Problem, nur die Wiederholrate.
-### Mishap-Rollup — 10 Eintraege (2026-08-10 01:56 UTC)
+export_tickets returns status/type/priority/attention_mode but omits areas, depends_on, readiness, component, desc_len — insufficient for computing missing[] list. Had to use raw SQL via kubectl exec psql.
+### Mishap-Rollup — 10 Eintraege (2026-08-10 12:10 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | degraded | skills/references/ticket-ops-procedures.md | ticket-ops Step 1.1: Triage-Query überschreitet bei ~96 offenen Tickets das mcp-postgres-Token-Limit |
-| 2 | degraded | skills/references/ticket-ops-procedures.md | ticket-ops Step 1.1 dokumentiert einen jq-Ausdruck, der am MCP-Ergebnis scheitert |
-| 3 | degraded | skills/references/ticket-ops-procedures.md (Step 3.1/3.2) | ticket-ops Wellenbildung: areas-Konfliktheuristik erkennt Kollisionen über generierte Artefakte nicht |
-| 4 | suspicious | .githooks/post-commit (openspec-embed) | openspec-embed post-commit meldet "Backend nicht erreichbar" auf :8081, das Backend antwortet aber mit 200 |
-| 5 | suspicious | repo/git | 4 Stashes verschwanden während repo-hygiene §0-Inventur — refs/stash komplett weg, Mechanismus ungeklärt |
-| 6 | drift | tickets | 285 von 881 done-Tickets ohne resolution (32%) — darunter T003121/T003129 von heute |
-| 7 | process | scripts/branch-reaper.sh + skills/references/repo-hygiene-ops.md §2 | branch-reaper.sh --dry-run ohne --ticket nicht aufrufbar, Runbook dokumentiert ihn als manuellen Inspektionsblick |
-| 8 | process | .claude/skills/references/repo-hygiene-ops.md §3 (Konfliktprobe) | repo-hygiene-ops §3: dokumentierte Konfliktprobe ist im Normalfall nicht gangbar (invasiver Arbeitsbaum-Merge in dirty Worktree) |
-| 9 | process | scripts/branch-reaper.sh | branch-reaper.sh meldet "DELETED", löscht aber nur den Remote-Ref — lokaler Branch überlebt |
-| 10 | process | .claude/skills/references/repo-hygiene-ops.md §2 | repo-hygiene §2: [gone]-Prune läuft VOR branch-reaper, der selbst neue [gone]-Refs erzeugt |
+| 1 | degraded | scripts/llm-proxy/slot-queue.mjs | Per-Slot-Queue-Isolation seit T002483 wirkungslos — kein Aufrufer sendet x-slot-id |
+| 2 | suspicious | scripts/plan-qa-check.sh | plan-qa-check widerspricht plan-lint bei identischer Eingabe |
+| 3 | degraded | scripts/openspec-embed.mjs | openspec-embed scheitert bei jedem Commit an belegtem Port 15432 |
+| 4 | suspicious | scripts/branch-reaper.sh | Reuse-Worktrees sammeln npm-Install-Rauschen in .opencode/package.json — §1-Allowlist greift nicht |
+| 5 | process | factory | PR #4129 (T003267) offen mit rotem CI, Ticket weiterhin backlog — Implementation vor Factory-Dispatch gepusht |
+| 6 | suspicious | repo/git-state | .git/shallow-Boundary am main-Tip blockierte pre-push-Validierung (Ursache ungeklärt) |
+| 7 | suspicious | repo/worktrees | Scratchpad-Worktree wt-order-guards-head-first-match: leerer Index + Teil-Snapshot, nicht sicherbar |
+| 8 | drift | repo/.opencode | Identischer uncommitteter @opencode-ai/plugin-Bump (1.18.11→1.18.16) in zwei -reuse-Worktrees fremd zu deren Tickets |
+| 9 | drift | skills/repo-hygiene | repo-hygiene-SKILL.md verweist auf nicht existierenden SSOT-Relativpfad |
+| 10 | drift | tickets/lifecycle | 45 of 58 'open' tickets were already done — post-merge closure gap (T003233 symptom) |
 
-**1. ticket-ops Step 1.1: Triage-Query überschreitet bei ~96 offenen Tickets das mcp-postgres-Token-Limit** (degraded, skills/references/ticket-ops-procedures.md)
+**1. Per-Slot-Queue-Isolation seit T002483 wirkungslos — kein Aufrufer sendet x-slot-id** (degraded, scripts/llm-proxy/slot-queue.mjs)
 
-Beobachtet 2026-08-10 im ticket-ops-Lauf (96 offene Tickets, is_test_data=false).
+scripts/llm-proxy/slot-queue.mjs isoliert Warteschlangen pro Slot, damit "slot 0 does not block slot 1" (Kopfkommentar). Der Schluessel entsteht in enqueue() aus `${name}:slot${slotId}`, wobei slotId aus extractSlotId(req) stammt und den Header x-slot-id liest.
 
-BEFUND: Die in ticket-ops-procedures.md §Step 1.1 vorgeschriebene json_agg-Query liefert 52.548 Zeichen und wird von mcp__mcp-postgres__query mit "exceeds maximum allowed tokens" abgewiesen. Das Ergebnis landet stattdessen in einer Datei im Tool-Results-Verzeichnis; die Query ist über MCP nicht mehr direkt konsumierbar.
+VERIFIZIERT: kein produktiver Aufrufer setzt diesen Header.
+  git grep -c "x-slot-id" -- . ':!tests' ':!scripts/llm-proxy'
+  -> nur Treffer in den neuen Plandateien von T003277, sonst keine
+  git grep -n 'x-slot-id' -- scripts .opencode
+  -> nur slot-queue.mjs (Leser) und server.test.mjs (Testfixtures)
 
-VERIFIZIERT: Die Abweisung trat beim ersten Aufruf auf, Zeichenzahl aus der Fehlermeldung.
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-WARUM RELEVANT: Der Skalierungsbruch ist nicht dokumentiert. Die Prozedur wurde erkennbar für kleinere Ticketmengen geschrieben (das Beispiel im Entscheidungsbaum nennt "Open Tickets (N=17)"). Ein Agent, der sie wörtlich befolgt, läuft bei wachsendem Backlog in einen Fehlschlag und muss den Umweg selbst herleiten — hier über die Ergebnisdatei plus jq/python.
+Folge: slotId ist immer null, der Schluessel faellt auf backend.name zurueck, und alle Slots teilen sich dieselbe Semaphore — genau der Zustand, den die Datei laut ihrem Kopfkommentar verhindern soll. scripts/factory/sandbox-run.sh kennt zwar eine SLOT_ID, reicht sie aber nie als HTTP-Header weiter.
 
-VORSCHLAG: Entweder die Query von vornherein in eine Datei schreiben lassen und dort weiterverarbeiten, oder sie chunken (LIMIT/OFFSET nach Priorität), oder die Feldliste kürzen — 'readiness' und 'depends_on' machen einen erheblichen Teil der Nutzlast aus und werden in Phase 1 nur aggregiert gebraucht.
+T003277/p3 setzt den Header und weist die Wirksamkeit mit zwei gleichzeitigen Anfragen nach. Dieser Mishap haelt fest, dass die Funktion seit T002483 unbemerkt tot war — der zugehoerige Test konnte es nicht bemerken, weil er den Quelltext greppt statt Verhalten zu messen (separater Mishap).
+**2. plan-qa-check widerspricht plan-lint bei identischer Eingabe** (suspicious, scripts/plan-qa-check.sh)
 
-ABGRENZUNG: Kein Defekt von mcp-postgres — das Limit ist gewollt. Der Defekt liegt in der Prozedur, die ihn nicht berücksichtigt.
-**2. ticket-ops Step 1.1 dokumentiert einen jq-Ausdruck, der am MCP-Ergebnis scheitert** (degraded, skills/references/ticket-ops-procedures.md)
+scripts/plan-qa-check.sh (advisory, LLM-gestuetzt) beanstandete an openspec/changes/llm-proxy-dispatch-capture/tasks.md zu Kriterium 5, der letzte Task sei "nicht explizit als Teil eines Tasks definiert, der die Schritte test:changed, freshness:regenerate und freshness:check enthaelt".
 
-Beobachtet 2026-08-10 im ticket-ops-Lauf.
+Das ist ein Fehlurteil. Die drei Befehle stehen als Checkbox-Task ("Abschliessende Pruefung") im Index, und das fail-closed Hard Gate wertet dieselbe Datei als konform:
+  bash scripts/plan-lint.sh openspec/changes/llm-proxy-dispatch-capture/tasks.md
+  -> PLAN-LINT: PASS (0 hard, 0 warn)   # STRUCT3 geprueft und bestanden
 
-BEFUND: ticket-ops-procedures.md Zeile 79 schreibt zur Weiterverarbeitung der Triage-Query vor: "das Ergebnis wird mit `jq -r '.result[]'` verarbeitet, nicht mit Split-by-Pipe".
+Gemessen gegen Branch-Stand 64f07d0fc.
 
-Das mcp-postgres-Ergebnis hat aber die Form `[{"result": "<json-string>"}]` — ein Array mit einem Objekt, dessen Feld 'result' einen JSON-STRING enthält (nicht ein Array). Der dokumentierte Ausdruck scheitert; korrekt ist `jq -r '.[0].result'`, dessen Ausgabe dann erneut als JSON geparst wird.
+Warum das zaehlt: plan-qa laeuft mit "|| true" und blockiert nichts, aber es durchlaeuft bis zu zwei Auto-Fix-Iterationen, in denen es Vorschlaege an die Plandatei anhaengt ("Auto-fix attempt 1/2: appending suggestions"). Ein falsch-positives Kriterium kann damit einen Plan veraendern, der bereits konform ist. In diesem Lauf blieb die Datei unveraendert (nachgeprueft), aber die Moeglichkeit besteht.
 
-VERIFIZIERT: `grep -n "result\[\]" .claude/skills/references/ticket-ops-procedures.md` → Treffer in Zeile 79. Der erste Parse-Versuch dieses Laufs scheiterte entsprechend mit einem JSONDecodeError; `jq -r '.[0].result'` lief durch.
+Ein zweiter Punkt derselben Meldung war dagegen berechtigt: die S1-Budgets standen nur in den Partials, nicht im Index. Das wurde uebernommen. Der Befund richtet sich also gegen Kriterium 5, nicht gegen das Werkzeug insgesamt.
+**3. openspec-embed scheitert bei jedem Commit an belegtem Port 15432** (degraded, scripts/openspec-embed.mjs)
 
-WARUM RELEVANT: Die Zeile stammt aus T002422, wo sie die Umstellung von Pipe-Spalten auf JSON begründet — die Begründung ist richtig, nur der konkrete Ausdruck stimmt nicht mit dem Ausgabeformat überein. Kostet jeden Nutzer der Prozedur einen Fehlschlag.
+Der post-commit-Hook scripts/openspec-embed.mjs schlug bei BEIDEN Commits dieses Vorgangs nach drei Versuchen fehl:
 
-VORSCHLAG: Zeile 79 auf `jq -r '.[0].result'` korrigieren und den doppelten Parse-Schritt benennen. Hängt inhaltlich am separat gemeldeten Skalierungsbruch derselben Query — beide Korrekturen betreffen denselben Absatz.
-**3. ticket-ops Wellenbildung: areas-Konfliktheuristik erkennt Kollisionen über generierte Artefakte nicht** (degraded, skills/references/ticket-ops-procedures.md (Step 3.1/3.2))
+  [openspec-embed] post-commit: embedding slug='llm-proxy-dispatch-capture'...
+  [openspec-embed] retry 1/3 ... retry 2/3 ...
+  [openspec-embed] WARN: embed failed after 3 attempts (non-fatal)
 
-Beobachtet 2026-08-10 im ticket-ops-Welle-1-Dispatch mit 4 parallelen dev-flow-plan-Einheiten.
+Ursache ist die bekannte Portkollision: openspec-embed.mjs oeffnet einen pg.Pool auf localhost:15432, den auf dieser Maschine der k3d-Portforward belegt.
 
-BEFUND: Die Soft-Conflict-Kante aus Step 3.1 serialisiert zwei Tickets, wenn sie einen `areas`-Eintrag teilen. Sie fängt nicht, dass ALLE VIER Welle-1-Branches dieselbe generierte Datei ändern: website/src/data/openspec-status.json. Jede dev-flow-plan-Einheit legt ein openspec/changes/<slug>/ an, woraus die Statuskarte regeneriert und mitcommittet wird.
+Beobachtet an den Commits d041220e6 und 64f07d0fc.
 
-VERIFIZIERT (alle vier Branches, nicht nur eine Stichprobe):
-  git diff --name-only origin/main..fix/agent-lock-scope-regelwerk-T003116   -> Treffer
-  git diff --name-only origin/main..fix/agent-lock-sid-detection-T003110     -> Treffer
-  git diff --name-only origin/main..fix/no-unasked-stash-T003078             -> Treffer
-  git diff --name-only origin/main..fix/babysit-prs-live-lock-guard-T003137  -> Treffer
+Der Fehlschlag ist als non-fatal markiert und bricht den Commit nicht ab — die Folge ist still: die Proposals dieses Vorgangs sind nicht eingebettet und damit ueber die semantische Suche (openspec_find_similar) nicht auffindbar. Wer spaeter nach aehnlichen Vorhaben sucht, bekommt ein unvollstaendiges Ergebnis, ohne dass etwas darauf hinweist.
 
-WARUM DIE HEURISTIK VERSAGT: Keine der vier Einheiten trägt `website` in ihren areas — die areas lauten scripts/agent-lock.sh, skills/dev-flow-chore, scripts/factory/babysit-prs.sh usw. Die Kollision entsteht nicht über die inhaltlich berührten Bereiche, sondern über ein GENERIERTES Artefakt, das jeder Planlauf als Nebenwirkung anfasst. Eine areas-basierte Heuristik kann das strukturell nicht sehen.
+Beitrag zum Design von T003277: genau dieser Mechanismus war der Grund, einen direkten pg-Client im llm-proxy zu verwerfen (design.md D1a) — ein langlaufender Dienst haette sich dieses Ausfallmuster eingehandelt.
+**4. Reuse-Worktrees sammeln npm-Install-Rauschen in .opencode/package.json — §1-Allowlist greift nicht** (suspicious, scripts/branch-reaper.sh)
 
-FOLGE: Die vier PRs sind nicht gleichzeitig merge-fähig. Sie müssen seriell durch, jede nach dem Merge der vorigen mit `task freshness:regenerate`. Das war beim Aufstellen des Masterplans nicht sichtbar und fiel erst beim Nachprüfen der fertigen Branches auf.
+Drei reuse-Worktrees (T002908, T002843, T002934) trugen uncommittete @opencode-ai/plugin-Bumps 1.18.11→1.18.16 in .opencode/package.json + package-lock.json — identisches npm-Install-Artefakt, in keinem Git-Objekt, auf main nicht vorhanden. Die §1-Allowlist (maßgeblich: ALLOWLIST in scripts/branch-reaper.sh) deckt .opencode/ ab nicht ab, also blockierte ein Nicht-Allowlist-Pfad die Worktree-Removal als scheinbarer Befund. Workaround: git checkout -- auf die committeden Versionen, dann remove. Kein Datenverlust, aber: (a) Allowlist kennt den Pfad nicht, obwohl reines Generat-Rauschen, (b) jede Worktree-Removal von reuse-Worktrees braucht künftig denselben Zwei-Schritt.
+**5. PR #4129 (T003267) offen mit rotem CI, Ticket weiterhin backlog — Implementation vor Factory-Dispatch gepusht** (process, factory)
 
-VORSCHLAG: Freshness-Generate (openspec-status.json, test-inventory.json) als implizite geteilte area der Wellenbildung behandeln — oder schlichter: Wellen aus dev-flow-plan grundsätzlich als seriell-mergend kennzeichnen und das im Masterplan-Format ausweisen, statt Merge-Parallelität zu suggerieren, die es nicht gibt.
+Auf dem Branch feature/cross-harness-plan-guardrails-T003267 liegt ein offener PR (#4129, erstellt 08:23Z) mit voller Implementation, während das Ticket T003267 status=backlog ist (noch nie dispatched). CI rot in 4 Jobs: Factory spec shards 1/2/4 + Aggregate. Ursache: echte Spec-Regressionen — die Checks "do not commit on main / clean status / Pre-Commit-Guard lock-file / branch__<slug>.json / stage-plan auto-emit" wurden aus .claude/skills/dev-flow-plan/SKILL.md nach scripts/plan-preflight.sh verschoben, die greppenden Tests (agent-lock-session-identity.bats, catalog-eval-telemetry.bats T001444, agent-lock-scope-regelwerk.bats T003102) laufen dagegen ins Leere. stage-plan --hold/--no-hold-Pflicht bricht den T001444-Aufruf ohne Hold-Flag. Befund auf T003267 kommentiert. Merge blockiert, bis die Tests an den plan-preflight-Umbau angepasst sind.
+**6. .git/shallow-Boundary am main-Tip blockierte pre-push-Validierung (Ursache ungeklärt)** (suspicious, repo/git-state)
 
-ABGRENZUNG: T003133 (Freshness-Generat macht Worktrees dirty), T003136 (Archive-PR am Freshness-Gate gescheitert) und T003105 (Rebase verliert Freshness-Artefakte) beschreiben Folgen desselben Generats. Dieser Befund ist ein anderer: die fehlende ERKENNUNG in der Wellenbildung von ticket-ops.
-**4. openspec-embed post-commit meldet "Backend nicht erreichbar" auf :8081, das Backend antwortet aber mit 200** (suspicious, .githooks/post-commit (openspec-embed))
+Während des repo-hygiene-Laufs (2026-08-10, ~11:46Z) tauchte in .git/shallow ein Boundary-Eintrag für den main-Tip 1c6b90028 auf (mtime 13:46:54 +0200 — mitten in der Session). Kein Hook im Repo erzeugt Shallow-State (geprüft: grep -rln 'shallow|--depth' .githooks/ scripts/hooks/ = leer). Wirkung: die pre-push-Validierung (validate-commit-msg.sh range origin/main..HEAD) zog wegen der gebrochenen Ancestry 6724 Commits statt 3 in den Range und blockierte den Push des T003107-Merge-Commits mit "unknown scope"-Fehlern auf alten main-Commits — dieselbe Fehlerklasse wie T002827, aber andere Ursache. Der vollständige Commit-Graph war im Objektstore vorhanden (merge-base 47d25bb7 bcf14d546 = 8d77df268 mit ignoriertem Shallow); die Boundary wurde entfernt (Backup /tmp/opencode/shallow.bak), Historie danach vollständig (rev-list count main = 6805), Push erfolgreich. VERIFIZIERT.
+**7. Scratchpad-Worktree wt-order-guards-head-first-match: leerer Index + Teil-Snapshot, nicht sicherbar** (suspicious, repo/worktrees)
 
-Beobachtet 2026-08-10, bei DREI von vier parallel laufenden dev-flow-plan-Agenten.
+/tmp/claude-1000/.../scratchpad/wt-order-guards-head-first-match (Branch fix/order-guards-head-first-match-T003104, backlog): git status --porcelain zeigt leeren Index (ls-files = 0), HEAD tracked 9857 Dateien, Arbeitsbaum enthält nur 1812 (Teil-Snapshot eines abgebrochenen Checkouts), davon 139 Dateien mit vom HEAD abweichenden Blobs. Branch ist exakt == origin/main (1c6b90028). Es existiert kein git-artefaktierter Zwischenstand (Index leer, 0 Commits auf dem Branch) — es ist nicht entscheidbar, ob die 139 abweichenden Dateien echte Arbeit enthalten (mtimes/Herleitung unklar). Fail-closed: Worktree NICHT entfernt, Befund gelassen. VERIFIZIERT (empty index, 1812 untracked, 139 blob-abweichend).
+**8. Identischer uncommitteter @opencode-ai/plugin-Bump (1.18.11→1.18.16) in zwei -reuse-Worktrees fremd zu deren Tickets** (drift, repo/.opencode)
 
-BERICHTET WURDE: Der post-commit-Hook openspec-embed schlug fehl, weil kein Embedding-Backend erreichbar sei — genannt wurden 127.0.0.1:8081 (bge-mcp) und, von einem weiteren Agenten, der bekannte Port-15432-Konflikt. Non-fatal, kein Commit wurde blockiert.
+.worktrees/ticket-guard-diff-scope-T002934-reuse und .worktrees/worktree-status-check-existence-T002932-reuse tragen beide denselben uncommitteten Dependency-Bump in .opencode/package.json + package-lock.json (@opencode-ai/plugin 1.18.11 → 1.18.16). Die touched_files beider Tickets (T002934, T002932) decken .opencode/ nicht ab; origin/main hat weiterhin 1.18.11. Unerklärter Fremdstand in Worktrees aktiver Tickets — nicht revertiert (könnte Absicht sein), nicht committet (gehört zu keinem Ticket), liegt gelassen. VERIFIZIERT (diff in beiden Worktrees identisch, main=1.18.11).
+**9. repo-hygiene-SKILL.md verweist auf nicht existierenden SSOT-Relativpfad** (drift, skills/repo-hygiene)
 
-NACHERHEBUNG WIDERSPRICHT DER MELDUNG (das ist der eigentliche Befund):
-  curl http://127.0.0.1:8081/health   -> HTTP 200
-  ss -ltnp | grep -E ':(8081|15432)'  -> beide Ports haben einen Lauscher
-      127.0.0.1:8081  kubectl pid=753980
-      127.0.0.1:15432 kubectl pid=50718
+.agents/skills/repo-hygiene/SKILL.md referenziert die Mechanik-SSOT als file:///home/patrick/Bachelorprojekt/.claude/skills/references/repo-hygiene-ops.md (absoluter Pfad) — der im Skill-Base-Kontext genutzte relative Pfad .agents/skills/repo-hygiene/references/repo-hygiene-ops.md existiert nicht (glob leer); die Datei liegt korrekt unter .claude/skills/references/. Beim Laden musste der Pfad per glob aufgelöst werden. VERIFIZIERT.
+**10. 45 of 58 'open' tickets were already done — post-merge closure gap (T003233 symptom)** (drift, tickets/lifecycle)
 
-Die Port-Forwards standen also zum Zeitpunkt der Nacherhebung. Ob sie während der Agentenläufe kurzzeitig weg waren, lässt sich nachträglich nicht klären — deshalb ist die naheliegende Lesart ("Backend war tot") NICHT belegt, und die Meldung des Hooks bleibt fragwürdig: sie behauptet Nichterreichbarkeit als Ursache, obwohl das Backend erreichbar ist.
-
-WARUM RELEVANT: Eine Fehlermeldung, die eine falsche Ursache nennt, kostet beim Debuggen mehr als gar keine. Dasselbe Muster ist im Bestand bereits zweimal erfasst — T002909 (plan-qa-check.sh meldet "Gateway not reachable", obwohl der Gateway erreichbar ist) und T002912 (Postgres-Socket-Meldung trotz erreichbarer DB). Drei Werkzeuge mit demselben Fehlbild deuten auf eine gemeinsame Ursache im Erreichbarkeits-Check, nicht auf drei unabhängige Defekte.
-
-VORSCHLAG: Prüfen, ob die drei Stellen denselben Probe-Code teilen. Falls ja, dort ansetzen statt dreimal einzeln. Mindestens sollte der Hook den tatsächlichen Fehler (Timeout? HTTP-Status? DNS?) ausgeben statt ihn zu "nicht erreichbar" zu verallgemeinern.
-
-[Teilweise UNVERIFIED — der Zustand während der Agentenläufe ist nachträglich nicht rekonstruierbar; verifiziert ist nur der Widerspruch zur Nacherhebung.]
-**5. 4 Stashes verschwanden während repo-hygiene §0-Inventur — refs/stash komplett weg, Mechanismus ungeklärt** (suspicious, repo/git)
-
-Während repo-hygiene §0 (2026-08-10 ~02:30Z) wurden 4 Stashes inventarisiert (stash@{0} worktree-create-auto-stash 02:06, stash@{1} wip-before-chore T002649 01:48, stash@{2} WIP auf 7815d6592 (#4082) 01:19, stash@{3} WIP auf 0cee50e43 [T002896] 00:04). Minuten später war refs/stash vollständig weg — weder git stash list noch reflog show refs/stash liefern etwas. Kein Hook, kein Script im Repo droppt Stashes (grep über scripts/ + .git/hooks/ leer). Inhalte sind verifiziert NICHT verloren: stash@{2}/stash@{3}-Inhalt steht in origin/main (Archiv-Commits #4083 + factory-reclaim-lock-respect-Delta), stash@{0} enthielt keine unikaten Bytes (nur Deletionen eines aktiven Changes, T002658 planning), stash@{1} war ein regenerierbarer openspec-status.json-Generat. Commit-Objekte hängen noch (dangling, via git fsck auffindbar) und wären bis GC wiederherstellbar. Befund: unerklärte Fremd-Drop-Aktion (vermutlich parallele Session/Workflow mit git stash clear) — Problemraum T003078 (ungefragtes Stashen). Kein Datenverlust, aber Mechanismus ungeklärt und Folge-Läufe können echte Arbeit treffen.
-**6. 285 von 881 done-Tickets ohne resolution (32%) — darunter T003121/T003129 von heute** (drift, tickets)
-
-SELECT count FILTER (status='done' AND resolution IS NULL) über tickets.tickets ergibt 285/881 (32%). Die Konvention (repo-hygiene-ops §3, mishap-tracker) verlangt bei status=done eine resolution (fixed für fix/*, shipped für feature/*). Heute gemergte PRs #4075 (T003121) und #4086 (T003129) wurden als done ohne resolution abgeschlossen — auch frische Tickets betroffen, nicht nur Altbestand. Kein offenes Ticket dazu vorhanden. Empfehlung: Backfill-Regel (z.B. per Post-Merge-Hook oder cockpit_audit) für done ohne resolution, oder resolution bei done-Writes verpflichtend erzwingen.
-**7. branch-reaper.sh --dry-run ohne --ticket nicht aufrufbar, Runbook dokumentiert ihn als manuellen Inspektionsblick** (process, scripts/branch-reaper.sh + skills/references/repo-hygiene-ops.md §2)
-
-`.claude/skills/references/repo-hygiene-ops.md` §2 ("Verwaiste Remote-Branches") dokumentiert:
-
-    bash scripts/branch-reaper.sh --ticket T00XXXX --dry-run   # zeigt REAP-/KEEP-Zeilen mit Begründung
-
-und rahmt das als "im Post-Merge-Workflow läuft er automatisch, manuell zum Nachsehen". Der Nachsehen-Fall braucht aber gerade kein Ticket — man will die Kandidatenliste sehen, nicht eine Löschung einem Vorgang zuordnen.
-
-BELEG: `bash scripts/branch-reaper.sh --dry-run` bricht mit Exit 2 ab: "FEHLER: --ticket ist erforderlich (Format T######)". Usage: `branch-reaper.sh --ticket T###### [--dry-run] [--remote <name>] [--repo <pfad>]`.
-
-FOLGE: Wer §2 zum reinen Nachsehen befolgt, muss eine Ticketnummer erfinden oder eine fremde einsetzen. Beides ist unerwünscht — eine erfundene Nummer erzeugt im Zweifel einen Archiv-Tag unter falscher Zuordnung, eine fremde hängt die Aktion an einen unbeteiligten Vorgang.
-
-Beobachtet im repo-hygiene-Lauf 2026-08-10: 17 Remote-Branches außer main, davon 5 mit lokalem Worktree — die Kandidatenliste blieb ungeprüft, weil der Dry-Run nicht ohne Ticket lief.
-
-ZUSCHNITT: Entweder `--dry-run` das `--ticket` erlassen (der Dry-Run schreibt per Definition nichts, ein Archiv-Tag entsteht dabei nicht), oder die Runbook-Zeile so korrigieren, dass sie den Zwang nennt statt einen ticketlosen Blick zu suggerieren.
-**8. repo-hygiene-ops §3: dokumentierte Konfliktprobe ist im Normalfall nicht gangbar (invasiver Arbeitsbaum-Merge in dirty Worktree)** (process, .claude/skills/references/repo-hygiene-ops.md §3 (Konfliktprobe))
-
-Beobachtet 2026-08-10 während eines repo-hygiene-Laufs an PR #4091. VERIFIZIERT durch Messung, nicht nur berichtet.
-
-DER WIDERSPRUCH (zwei Stellen desselben Runbooks):
-
-(a) §3 „Leere Checkliste kann auch Konflikt heißen" [T002822] schreibt als Gegenprobe einen
-    invasiven Arbeitsbaum-Merge vor:
-        git merge origin/main --no-commit --no-ff   # danach: git merge --abort
-        git diff --name-only --diff-filter=U
-
-(b) §1 „Generat-Abweichungen sind kein Befund" hält an anderer Stelle desselben Dokuments fest,
-    dass jeder Worktree, in dem ein Plan gestaged oder archiviert wurde, dauerhaft ein
-    abweichendes website/src/data/openspec-status.json trägt — das ist ausdrücklich der
-    NORMALFALL, nicht die Ausnahme.
-
-Ein PR-Worktree erfüllt (b) praktisch immer. Damit läuft (a) auf einen Merge in einen dirty
-Arbeitsbaum hinaus, und zwar genau in der Datei, die main ebenfalls fortschreibt.
-
-GEMESSEN:
-- git -C .worktrees/agent-lock-scope-regelwerk-T003116 status --porcelain
-  → " M website/src/data/openspec-status.json"
-- PR #4091: mergeStateStatus=DIRTY, statusCheckRollup=[] (0 Einträge),
-  gh run list --branch … → [] (null Runs) — exakt das T002822-Symptom.
-
-DIE NICHT-INVASIVE ALTERNATIVE, die dieselbe Frage beantwortet:
-    git merge-tree --write-tree --name-only origin/main <branch>
-Exit 0 + Tree-SHA  = konfliktfrei → Phantomkonflikt aus merge=ours (T002823)
-Exit != 0 + Dateiliste = echter Konflikt
-Der Aufruf fasst weder Working Tree noch Index an, braucht also keinen sauberen Worktree und
-kein anschließendes --abort (dessen Vergessen im dokumentierten Weg einen halbfertigen Merge
-hinterlässt — verwandt mit T002766).
-
-Hier lieferte er sofort: exit=0, Tree a9984a261215047e18e3322a3f4d75db609fb891 → Phantomkonflikt.
-Auf dieser Grundlage wurde der lokale Merge-Weg aus §3 gefahren (merge + freshness:regenerate +
-push); PR #4091 wechselte danach von DIRTY auf BLOCKED mit 15 Checks, CI lief an, Auto-Merge ist
-aktiv.
-
-ZU ÄNDERN (Vorschlag, nicht präjudiziert):
-In §3 die merge-tree-Form als primäre Gegenprobe nennen und den Arbeitsbaum-Merge auf den Fall
-zurücknehmen, in dem man die Konfliktmarker tatsächlich sehen will. Die Reihenfolge
-„mergeStateStatus lesen → bei UNKNOWN/DIRTY probe-mergen" bleibt unverändert richtig; nur das
-Werkzeug des zweiten Schritts passt nicht zum dokumentierten Normalzustand der Worktrees.
-
-Kein Defekt an einem Skript — eine Runbook-Lücke: der empfohlene Weg kollidiert mit einer
-Bedingung, die dasselbe Runbook 200 Zeilen weiter oben als Regelfall beschreibt.
-**9. branch-reaper.sh meldet "DELETED", löscht aber nur den Remote-Ref — lokaler Branch überlebt** (process, scripts/branch-reaper.sh)
-
-`bash scripts/branch-reaper.sh --ticket T002623` gab "DELETED chore/adr006-sdlc-topologie-T002623 (archiviert als refs/tags/reaped/...)" aus. Danach war der Remote-Branch weg und der Archiv-Tag lokal wie remote gesetzt — der LOKALE Branch-Ref existierte aber unverändert weiter (`git rev-parse --verify` lieferte 3c600d7bf). Belegt in scripts/branch-reaper.sh Zeilen 189-205: die Schleife führt ausschliesslich `git push $REMOTE $sha:refs/tags/...` und `git push $REMOTE --delete $branch` aus; ein `git branch -d/-D` kommt im gesamten Skript nicht vor (`grep -nE 'branch -D|git branch'` findet nur die echo-Zeile). Die Meldung "DELETED $branch" ist unqualifiziert und liest sich als vollstaendige Loeschung — sie beschreibt aber nur die Remote-Haelfte. Folge: nach jedem Reap bleiben lokale Leichen liegen, deren Upstream ab da [gone] ist. Zuschnitt eines Fixes: entweder Meldung auf "DELETED remote/$branch" praezisieren, oder den lokalen Ref mitloeschen, wenn er auf denselben SHA zeigt wie der Archiv-Tag.
-**10. repo-hygiene §2: [gone]-Prune läuft VOR branch-reaper, der selbst neue [gone]-Refs erzeugt** (process, .claude/skills/references/repo-hygiene-ops.md §2)
-
-In repo-hygiene-ops.md §2 steht der [gone]-Aufraeumpfad (git fetch --prune + force-delete gemergter Branches) VOR dem Unterabschnitt "Verwaiste Remote-Branches (ohne PR)", der branch-reaper.sh aufruft. Der Reaper loescht aber Remote-Branches und erzeugt damit GENAU die [gone]-Refs, die der vorangegangene Schritt haette aufraeumen sollen. Real beobachtet am 2026-08-10: der Prune zu Beginn fand null [gone]-Branches, nach dem Reap von chore/adr006-sdlc-topologie-T002623 war dieser eine [gone] — im selben Lauf raeumte ihn nichts mehr weg. Erschwerend: der §2-[gone]-Pfad verlangt einen nachweislich gemergten PR, und Reaper-Kandidaten haben per Definition KEINEN PR (deshalb greift der Reaper ueberhaupt). Der [gone]-Pfad haette ihn also auch beim naechsten Lauf uebersprungen ("SKIP — upstream gone but no merged PR found"). Manuell aufgeraeumt ueber den Archiv-Tag als Sicherheitsanker (`git rev-parse --verify refs/tags/reaped/$b` vorhanden -> `git branch -D` belegt sicher). Zuschnitt: entweder Reihenfolge umdrehen, oder den Archiv-Tag als zweites zulaessiges Positiv-Signal im [gone]-Pfad dokumentieren.
+Phase 3 masterplan started with 53 ready tickets. After checking git history for [Txxxxxx] references in commit subjects, 45 had merged PRs but ticket status was never updated to done. Symptom of T003233 (Post-Merge-Ticketabschluss unterblieb). Closed 45 tickets with resolution=fixed.
+Watchdog: pipeline stale > 30min (no phase progress write, class=INFRA). Plan already staged (FACTORY-PLAN-REF branch=chore/mishap-incident-rollup plan=openspec/changes/mishap-incident-rollup/tasks.md) — resuming via plan_staged instead of restarting from Scout. [INFRA 1/3 | tier=haiku]
 
 ## Verify (RED → GREEN)
 

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:19 UTC. Die Eintraege stammen aus den
+2026-08-10 01:22 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:05 UTC. Die Eintraege stammen aus den
+2026-08-10 01:10 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:31 UTC. Die Eintraege stammen aus den
+2026-08-09 10:33 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:03 UTC. Die Eintraege stammen aus den
+2026-08-09 05:04 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:27 UTC. Die Eintraege stammen aus den
+2026-08-10 01:31 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:21 UTC. Die Eintraege stammen aus den
+2026-08-10 00:26 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:06 UTC. Die Eintraege stammen aus den
+2026-08-09 05:07 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -1,6 +1,6 @@
 ---
 title: "mishap-incident-rollup — Implementation Plan"
-ticket_id: T002784
+ticket_id: T003067
 domains: [factory]
 status: active
 file_locks: []
@@ -12,10 +12,10 @@ depends_on_plans: []
 
 # mishap-incident-rollup — Implementation Plan
 
-_Container-Ticket: T002784_
+_Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:49 UTC. Die Eintraege stammen aus den
+2026-08-09 23:31 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure
@@ -26,1374 +26,540 @@ Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung
 
 ## Mishap-Batches
 
-_Uebernommen von T002601 (status=done, fuer den Rollup-Treiber unsichtbar) — Defekt T002783._
-
-### Mishap-Rollup — 9 Eintraege (2026-08-09 01:55 UTC)
+### Mishap-Rollup — 10 Eintraege (2026-08-09 19:40 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | degraded |  | ticket.sh --attempts-Validierung scheitert bei regulaerer Nutzung |
-| 2 | degraded |  | Agent-Lock schuetzt nicht: zweiter Akteur arbeitete ohne Lock im selben Worktree |
-| 3 | degraded |  | Abgebrochener CI-Lauf ist in der Aggregation nicht von echtem Fehlschlag unterscheidbar |
-| 4 | drift | mcp/mcp-postgres · docs | mcp-postgres liest eingefrorene fleet-Kopie statt lokaler SSOT — Triage las 3 bereits-done Tickets als offen |
-| 5 | drift | factory · tickets/lifecycle | 7 Tickets plan_staged ohne Plan-Artefakte (T002768–T002774) — dev-flow-execute kann sie nicht verarbeiten |
-| 6 | drift | repo | Main-Checkout dirty — Post-T002753-Docs, stale Fixture, untracked Hook |
-| 7 | drift | factory | T002762 (SF-TEST-*, is_test_data=true) im Factory-Backlog |
-| 8 | suspicious | skills/repo-hygiene | Hauptcheckout wurde mitten im repo-hygiene-Lauf von fremder Hand gestasht — §0-Befund veraltete unbemerkt |
-| 9 | drift | scripts/agent-lock.sh | Branch-Lock überlebt Reap trotz totem PID und fehlendem Worktree — plus Korrektur zum vorigen Mishap |
+| 1 | suspicious | git-workflow | Teilweise durchgelaufener `git stash pop` nach Rebase sieht aus wie ein erfolgreicher |
+| 2 | degraded | git-workflow | Der Stash-Stack ist worktree-uebergreifend geteilt — als Sicherungsnetz bei Parallelarbeit unbrauchbar |
+| 3 | drift | scripts/factory/mcp-go | Stale factory-mcp binary deployed via systemd (2026-08-04) |
+| 4 | drift | tickets/update-status.sh · Terminal-Guard T002382 | Faelschlich als done angelegtes Ticket ist ueber den sanktionierten Pfad nicht reparierbar |
+| 5 | suspicious | tests/spec · CI-Guards (T002407-M6b, T002500) | Zwei offene PRs scheitern am alten Guard, den ihre eigene Aenderung ersetzt |
+| 6 | drift | skills/references/repo-hygiene-ops | branch-reaper.sh kann den in §2 beschriebenen Sweep gar nicht leisten — filtert hart auf EINE Ticket-ID |
+| 7 | process | repo/pr-hygiene | 4 von 4 offenen PRs scheiterten am Freshness-Gate — test-inventory.json nie mitregeneriert |
+| 8 | drift | repo/worktrees | Zwei verwaiste git-Worktrees im Scratchpad einer fremden, beendeten Session |
+| 9 | degraded | scripts/openspec-embed (post-commit hook) | openspec-embed scheitert bei jedem Commit an Port 15432 — k3d-Port-Forward belegt ihn dauerhaft |
+| 10 | degraded | skills/dev-flow-chore | dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Datenverlustrisiko bei Parallelsessions) |
 
-**1. ticket.sh --attempts-Validierung scheitert bei regulaerer Nutzung** (degraded, )
+**1. Teilweise durchgelaufener `git stash pop` nach Rebase sieht aus wie ein erfolgreicher** (suspicious, git-workflow)
 
-Gefunden am 2026-08-09 bei der Umsetzung von T002620 (Reparatur der FA-SF-26-Watchdog-Tests).
+Beobachtet beim Abschliessen von T002894 am 2026-08-09. Ablauf nach git-workflow Schritt 0: `git stash -u` → `git rebase origin/main` → `git stash pop`. Der Rebase loeste den post-rewrite-Hook aus, der `website/src/data/openspec-status.json` neu generierte — genau eine der gestashten Dateien. Der anschliessende `pop` konnte deshalb nur teilweise anwenden und meldete am Ende `The stash entry is kept in case you need it again`.
 
-Beim Versuch, den vollstaendigen watchdog.sh-Pfad live zu verifizieren, lief der Agent in einen vorbestehenden Fehler in der --attempts-Validierung von scripts/ticket.sh. Der Fehler ist unabhaengig von T002620 und war der Grund, warum stattdessen auf einen read-only RED->GREEN-Nachweis ausgewichen wurde.
+Das Tueckische ist der Endzustand: `git status --porcelain` zeigte danach EINE modifizierte Datei (`openspec-status.json`). Das sieht wie ein normaler, erfolgreicher Pop aus. Die eigentliche inhaltliche Arbeit — die Erweiterung von `scripts/one-shot/purge-fn-v8.sql` von einem auf sieben Guards — war NICHT im Arbeitsbaum, sondern lag weiterhin im Stash. Waere sie nicht aufgefallen, haette der PR die halbe Aenderung enthalten und die Verifikation gegen die DB waere trotzdem an einer spaeteren Stelle rot geworden — also mit einem irrefuehrenden Symptom statt mit "deine Aenderung fehlt".
 
-WARUM DAS ZAEHLT: Der Watchdog-Eskalationspfad fuehrt einen Attempt-Counter (Status-Reset, Slot-Freigabe, Comment, Worktree-Cleanup, Attempt-Counter — siehe T002620-Beschreibung). Wenn dessen CLI-Einstiegspunkt bei regulaerer Nutzung scheitert, ist der Zaehler-Teil des Eskalationspfads praktisch nicht bedienbar und auch nicht live pruefbar. Das ist dieselbe Struktur wie der Befund von T002620 selbst: ein Pfad, der als getestet gilt, ist es nicht.
+Erkennungs- und Loesungsweg: `git stash list` nach dem Pop pruefen (ein verbliebener Eintrag IST der Befund), Inhalt per `git stash show --stat "stash@{0}"` gegen den Arbeitsbaum halten, fehlende Datei gezielt zurueckholen mit `git checkout "stash@{0}" -- <pfad>`.
 
-ZUSATZBEFUND aus demselben Lauf, bereits mitbehoben: seed_test_feature war in der setup() von tests/spec/software-factory/scheduling.bats nicht gesourced — ein latenter Defekt unabhaengig vom updated_at-Backdating.
+Konventionsluecke (git-workflow Schritt 0): Der Skill schreibt die Sequenz `git stash` / `git pull --rebase` / `git stash pop` vor und warnt bereits vor der Branch-Switch-Race, aber nicht vor dem Teil-Pop. Vorschlag: Nach dem Pop pruefen, dass `git stash list` um genau den eigenen Eintrag kuerzer geworden ist, statt den Exit-Code oder die Statusanzeige als Beleg zu nehmen. Das ist dasselbe Muster wie bei der Merge-Verifikation per `mergedAt` — nicht auf die Abwesenheit eines Fehlers pruefen, sondern auf das positive Signal.
+**2. Der Stash-Stack ist worktree-uebergreifend geteilt — als Sicherungsnetz bei Parallelarbeit unbrauchbar** (degraded, git-workflow)
 
-NAECHSTER SCHRITT: Die genaue Fehlermeldung reproduzieren (bash scripts/ticket.sh … --attempts <n>) und die Validierung gegen die tatsaechlich vorgesehenen Aufrufformen pruefen. Test nach Repo-Konvention mit Output-Verifikation, eigene Datei unter tests/spec/software-factory/.</description>
-<parameter name="component">scripts/ticket.sh
-**2. Agent-Lock schuetzt nicht: zweiter Akteur arbeitete ohne Lock im selben Worktree** (degraded, )
+Beobachtet am 2026-08-09. Vor einer Umstrukturierung im Hauptcheckout legte ich einen benannten Sicherungs-Stash an (`git stash push -u -m "archive-T002894 safety net" -- openspec website/src/data/openspec-status.json`); der Befehl meldete `Saved working directory and index state`. Wenige Minuten spaeter war der Eintrag aus `git stash list` verschwunden, waehrend zwei fremde Eintraege neu darin standen, darunter `On fix/sammel-bats-hygiene-T002925: WIP on fix/purge-test-data-schema-drift-T002894` — also von einer parallel laufenden Session.
 
-Beobachtet am 2026-08-09 bei der Ausfuehrung von T002679.
+Ursache: `refs/stash` liegt im gemeinsamen Git-Verzeichnis (`git rev-parse --git-common-dir`), nicht pro Worktree. Alle 15 Worktrees dieses Repos teilen sich EINEN Stash-Stack. Ein `git stash pop` in irgendeinem davon nimmt `stash@{0}` — und das kann der Eintrag einer anderen Session sein. Die Indizes verschieben sich ausserdem bei jedem fremden Push auf den Stack, sodass selbst ein gemerktes `stash@{N}` nach kurzer Zeit auf etwas anderes zeigt.
 
-HERGANG: ticket-ops hielt einen gueltigen Lock (scope=ticket, id=T002679, state=live, label=ticket-ops-execute) und dispatchte einen Agenten in .worktrees/brain-ingest-chunking-T002679. Parallel arbeitete ein opencode-Lauf (drei Prozesse plus scripts/factory/wakeup.sh) IM SELBEN WORKTREE: er editierte Dateien, committete den Stand des ersten Agenten, pushte und oeffnete PR #3892. Zwischenzeitlich setzte er brain-ingest-transform.sh auf die head -c-Fassung zurueck und den lokalen Branch auf einen frischen Scaffold-Commit — aus Sicht des ersten Agenten war die Implementierung damit lokal verschwunden.
+Konkreter Schaden hier: keiner — der Inhalt war regenerierbar (`scripts/openspec.sh archive` erneut im Worktree ausgefuehrt) und landete in PR #3982. Der Punkt ist die falsche Sicherheitsannahme: ein Stash fuehlt sich wie ein privates Sicherungsnetz an und ist in einem Multi-Worktree-Repo ein geteilter, von fremden Sessions veraenderbarer Stack.
 
-Der zweite Akteur hielt KEINEN Lock. Der Lock-Mechanismus ist kooperativ: er meldet Besitz, verhindert aber keinen Zugriff. Wer ihn nicht abfragt, ist von ihm nicht betroffen.
+Konventionsluecke (repo-hygiene §0 und git-workflow Schritt 0): Beide behandeln Stashes als lokalen Zustand. §0 sieht sogar ein "Stash-Inventar" ueber `git stash list` vor, ohne zu erwaehnen, dass die dort gelisteten Eintraege aus beliebigen Worktrees stammen koennen — die Zuordnung "welcher Stash gehoert zu welcher Arbeit" ist allein ueber die Nachricht moeglich, und nur wenn sie benannt wurde. Vorschlag: Bei Parallelarbeit statt `git stash` einen Wegwerf-Commit auf dem eigenen Branch verwenden (`git commit -m wip`, spaeter `reset --soft`) — der ist per Konstruktion an den Branch gebunden. Wo ein Stash noetig bleibt: immer `-m` mit Ticket-ID, und nie ueber den Index `stash@{0}` aufloesen, sondern ueber die Nachricht suchen.
+**3. Stale factory-mcp binary deployed via systemd (2026-08-04)** (drift, scripts/factory/mcp-go)
 
-AUSGANG (verifiziert, kein Schaden): Der erste Agent brach ab statt einen Push-Wettlauf zu fuehren und sicherte seinen Stand als origin/backup/T002679-infra-agent-a2ee6146f. Der Diff Sicherung -> origin/feature/brain-ingest-chunking-T002679 enthaelt ausschliesslich HINZUGEKOMMENE Dateien (die gemergten T002659/T002709-Aenderungen plus Release-Artefakte); alle vier neuen Skripte sind vorhanden und der fail-closed MAX_SOURCE_CHARS-Guard steht. Der aktuelle Stand ist eine Obermenge.
+Der systemd-user-Dienst factory-mcp.service lief mit einem am 2026-08-04 gebauten Binary (scripts/factory/mcp-go/bin/factory-mcp), das den T002830 is_test_data-Filter nicht enthaelt. Die Queue-Reads (factory_status/factory_queue) lieferten deshalb das Test-Fixture-Ticket T003020 (is_test_data=true) zurueck, obwohl alle aktuellen Quell-Pfade (mcp-go/main.go, mcp-server.mjs, queue.sh) den Filter haben. Nachweis: ls bin/factory-mcp (2026-08-04) vs. Quelle mit Filter; nach Rebuild (CGO_ENABLED=0 go build) + systemctl --user restart factory-mcp.service liefert die Queue T003020 nicht mehr. Der agents:factory-mcp:install-Task baut zwar, aber ein laufender Dienst wird nicht automatisch nach Quell-Aenderung neu gebaut/restartet — Drift-Luecke im Deploy-Flow.
+**4. Faelschlich als done angelegtes Ticket ist ueber den sanktionierten Pfad nicht reparierbar** (drift, tickets/update-status.sh · Terminal-Guard T002382)
 
-WARUM DAS TROTZDEM ZAEHLT: Der Ausgang war Glueck plus die Umsicht des ersten Agenten, nicht Wirkung eines Schutzmechanismus. Zwei nicht koordinierte Schreiber in einem Worktree koennen einander Arbeit vernichten; ein Backup-Branch entsteht nur, wenn ein Agent auf die Idee kommt.
+Beobachtet 2026-08-09 waehrend repo-hygiene §3.
 
-VORSCHLAG: Beim Betreten eines Worktrees pruefen, ob ein fremder Lock auf dem zugehoerigen Ticket oder Branch liegt, und bei Treffer abbrechen — auf BEIDEN Wegen (Claude-Code-Agenten und opencode/factory-Laeufe). Alternativ eine Lockdatei IM Worktree, die jeder Schreiber sieht, statt nur einer zentralen Liste, die abgefragt werden muss.
+T003025 wurde bereits als `status=done` mit `resolution=null` angelegt: `created_at == updated_at` (2026-08-09 15:41:36), das Ticket hat also nie einen Lebenszyklus durchlaufen. Ein Merge-Nachweis existiert nicht — `gh pr list --search T003025 --state all` liefert ausschliesslich #4004 mit `state=OPEN` und leerem `mergedAt`, `git log origin/main --grep=T003025` ist leer. PR #4004 ist zudem rot.
 
-VERWANDT: T002498-M6 (Lock-Scope-Vollstaendigkeit), T002422 (Pre-Check vor claim).</description>
-<parameter name="component">scripts/agent-lock.sh · Worktree-Koordination
-**3. Abgebrochener CI-Lauf ist in der Aggregation nicht von echtem Fehlschlag unterscheidbar** (degraded, )
+Die Korrektur ist ueber den sanktionierten Pfad NICHT moeglich: `mcp__ticket-mcp__transition_status({id: T003025, status: in_progress})` bricht mit Exit 2 ab — "Cannot transition from 'done' to 'in_progress' — terminal tickets can only transition to 'archived'" (Terminal-Guard T002382).
 
-Beobachtet am 2026-08-09 an PR #3892 (T002679).
+WARUM ES ZAEHLT: Der Terminal-Guard schuetzt gegen das Wiederaufreissen eines echt abgeschlossenen Tickets. Er trifft aber auch den Fall, in dem `done` nie gueltig war, weil es der Anfangszustand war. Damit ist ein per Fehleingabe geschlossenes Ticket nur noch per Direkt-SQL oder ueber `archived` + Neuanlage zu korrigieren; beides umgeht bzw. verliert die Historie. Ein `done` ohne `resolution` und ohne `done_at`-Lebenszyklus ist maschinell von einem gueltigen Abschluss unterscheidbar — der Guard koennte diesen Fall ausnehmen, statt ihn zu zementieren.
 
-BEFUND: Der CI-Lauf 31286855491 auf Head a2ad33bc2 wurde als Ganzes abgebrochen (cancelled). In der PR-Aggregation erschien das als "10 failed" — zehn FAILURE/CANCELLED-Eintraege. Der eine echte failure-Eintrag, "Factory + OpenSpec + Guards", war ein 5-Sekunden-Job, dessen Log woertlich SHARDS_RESULT: cancelled als Ursache nennt. Ein abgebrochener Lauf sieht in der Aggregation also aus wie ein Fehlschlag.
+Kein Eingriff vorgenommen: der Guard wurde bewusst NICHT per SQL umgangen. Der Widerspruch ist als Kommentar an T003025 dokumentiert.
 
-KOSTEN: Die Verwechslung hat zwei Agenten Zeit gekostet. Der erste erklaerte die roten Eintraege als Supersede-Artefakt und schloss daraus faelschlich auf "im Grunde gruen" — der Lauf war aber kein Nachweis, sondern gar KEIN Ergebnis. Nach einem Neustart lagen darunter zwei echte Fehlschlaege (Freshness-Drift in openspec-status.json/repo-index.json sowie die Race aus T002779). Beide Fehlurteile — "rot, also kaputt" und "abgebrochen, also harmlos" — folgen aus derselben nicht unterscheidbaren Anzeige.
+Angrenzend: T002845 ("18 Tickets stehen auf plan_staged ohne plan-Zeile/Branch") beschreibt dieselbe Klasse — Statuswert ohne den Zustand, den er behauptet.
+**5. Zwei offene PRs scheitern am alten Guard, den ihre eigene Aenderung ersetzt** (suspicious, tests/spec · CI-Guards (T002407-M6b, T002500))
 
-UNGEKLAERT UND EIGENSTAENDIG VERDAECHTIG: Was den Lauf abgebrochen hat, liess sich nicht feststellen. Es gab KEINEN neueren Lauf fuer dieselbe SHA (die Concurrency-Gruppe ci-CI-refs/pull/3892/merge hatte nichts zu verdraengen), arbitration.yml cancelt nichts, und ein aelterer Lauf auf 173ec2869 lief zu dem Zeitpunkt noch weiter. Das deutet auf ein externes gh run cancel. Wenn das haeufiger vorkommt, bricht jemand oder etwas fremde CI-Laeufe ab.
+Beobachtet 2026-08-09 waehrend repo-hygiene §3 — zweimal gleichzeitig, gleiches Muster.
 
-VORSCHLAG: (1) In der CI-Fix-Schleife (.claude/skills/references/) festhalten, dass ein cancelled-Lauf KEIN Ergebnis ist und neu gestartet werden muss, statt interpretiert zu werden — weder als gruen noch als rot. (2) Den Aggregat-Job so gestalten, dass er cancelled sichtbar von failure trennt, statt SHARDS_RESULT: cancelled als failure zu melden. (3) Bei Wiederholung die Herkunft der Cancel-Ereignisse untersuchen.
+Beide PRs sind `mergeable=MERGEABLE`, aber rot, und in beiden Faellen ist der Fehlschlag die erwartbare Folge der PR-eigenen Aenderung:
 
-VERWANDT: T002779 (Race auf docs/agent-guide/registry/mcp.yaml unter bats -j).</description>
-<parameter name="component">.github/workflows/ci.yml · CI-Fix-Schleife
-**4. mcp-postgres liest eingefrorene fleet-Kopie statt lokaler SSOT — Triage las 3 bereits-done Tickets als offen** (drift, mcp/mcp-postgres · docs)
+1. PR #4006 (Branch fix/rollup-container-triage-status-T002876) laesst `ticket.sh rollup-container` den Container als `triage` statt `plan_staged` anlegen. Rot wird `Factory spec shard 4`: `not ok 135 T002407-M6b: ticket.sh rollup-container dokumentiert status=plan_staged (T002783)` — der Guard fordert weiter `plan_staged`.
 
-mcp__mcp-postgres__query (127.0.0.1:13001) wird per kubectl --context fleet port-forward auf svc/claude-code-mcp-monolith (default ns) bedient — also die per ADR-006 E3 EINGEFRORENE fleet-Kopie des tickets-Schemas (SELECT ja, INSERT/UPDATE/DELETE nein). Die lokale SSOT liegt auf k3d-mentolder-dev/workspace/shared-db (Default von scripts/ticket.sh). Verifiziert: ss zeigt Port 13001 an kubectl --context fleet; ticket.sh-Header dokumentiert die Freeze-Situation nur dort, nicht im MCP-Tool-Guide §mcp-postgres. Folge: der erste Triage-Lauf las T002714 als plan_staged (lokal: in_progress), T002722/T002679/T002709 als offen (lokal: bereits done) und loeste redundante Closure-Writes aus. Empfehlung: MCP-Tool-Guide §mcp-postgres um den Freeze-Hinweis ergaenzen oder 13001 auf die lokale shared-db umziehen.
-**5. 7 Tickets plan_staged ohne Plan-Artefakte (T002768–T002774) — dev-flow-execute kann sie nicht verarbeiten** (drift, factory · tickets/lifecycle)
+2. PR #4004 (Branch chore/ci-shard-balance-T003025) gewichtet die Factory-Spec-Shards nach gemessener Laufzeit (junit-Timing + LPT). Rot wird `Factory spec shard 3`: `not ok 171 T002500: die Shards sind nach @test-Anzahl balanciert (schwerster <= 1.5x leichtester)` — der Guard misst weiter nach @test-Anzahl.
 
-T002768, T002769, T002770, T002771, T002772, T002773, T002774 haben lokal status=plan_staged, aber KEINEN gestagten Plan: keine FACTORY-PLAN-REF-Kommentarzeile, keine ticket_plans-Zeile, kein Branch (lokal/remote), kein openspec/changes/-Dir, kein Commit. Verifiziert: ticket_plans-Join leer, git log --all leer, Change-Dir-Suche leer. Die plan_staged-Statuszahl (9) speist die Factory-Kommissionierung — dispatcher-bridge wuerde dev-flow-execute auf Plan-lose Tickets loslassen und scheitern. Ursache vermutlich die parallele ticket-ops-Welle (Sid fa33ecd9), die Mishap-Fix-Tickets anlegte und Status setzte ohne Staging-Ceremonie. Empfehlung: entweder stage-plan fuer die 7 nachziehen oder Status auf triage zuruecksetzen; solange ungeklaert, sind sie KEIN Execution-Wave-Kandidat.
-**6. Main-Checkout dirty — Post-T002753-Docs, stale Fixture, untracked Hook** (drift, repo)
+WARUM ES ZAEHLT: In beiden Faellen ist der rote Test kein Defekt-Nachweis, sondern ein nicht mitgezogener Guard. Der PR-Autor sieht einen roten Lauf, dessen Ursache nicht im geaenderten Verhalten liegt, sondern in der Zusicherung des ALTEN Verhaltens. Das ist die teuerste Form von rotem CI: sie sieht aus wie ein Fehler in der Aenderung. Dass es zweimal am selben Tag unabhaengig auftrat, spricht fuer eine strukturelle Luecke, nicht fuer zwei Fluechtigkeitsfehler — es fehlt ein Schritt, der beim Aendern einer Regel die Guards findet, die diese Regel festschreiben (grep auf die Ticket-ID/Regelformulierung in tests/spec/).
 
-git status --porcelain zeigt: M .opencode/agent-models.jsonc (Quants-Doku-Update), M AGENTS.md (gemma26-factory statt alter Loadouts), D openspec/changes/tcc-fixture-3511572/* (stale Test-Fixture, 1092 Zeilen), ?? .githooks/post-rewrite (neuer Hook, ungetrackt). Alle Änderungen sind Maintenance-Reste ohne funktionalen Patch — kein laufendes Ticket, in dessen Worktree sie gezogen werden könnten. Aufgefallen während repo-hygiene §0.
-**7. T002762 (SF-TEST-*, is_test_data=true) im Factory-Backlog** (drift, factory)
+Anmerkung zu PR #4004: dort faellt zusaetzlich `not ok 550 T002721 Daemon raeumt PID- und Token-Datei beim Beenden auf` (31,5 s Laufzeit) — Timing-Verdacht, sachlich unabhaengig von der Shard-Gewichtung und hier nicht mitbewertet.
+**6. branch-reaper.sh kann den in §2 beschriebenen Sweep gar nicht leisten — filtert hart auf EINE Ticket-ID** (drift, skills/references/repo-hygiene-ops)
 
-factory_queue zeigt T002762 im Backlog. Das ist ein E2E-Testdaten-Ticket mit is_test_data=true. T002781 (ticket.sh list filtert is_test_data nicht) adressiert den Root-Cause, ist aber noch in triage. Der Backlog-Slot ist faktisch blockiert, bis T002781 implementiert ist. Aufgefallen während repo-hygiene §5.
-**8. Hauptcheckout wurde mitten im repo-hygiene-Lauf von fremder Hand gestasht — §0-Befund veraltete unbemerkt** (suspicious, skills/repo-hygiene)
+BEOBACHTET (2026-08-09, repo-hygiene §2)
 
-BEOBACHTUNG (verifiziert, repo-hygiene-Lauf 2026-08-09)
+repo-hygiene-ops.md §2 "Verwaiste Remote-Branches (ohne PR) [T002520]" stellt
+scripts/branch-reaper.sh als das Werkzeug vor, das die Klasse verwaister Branches
+abdeckt, und nennt zur Begruendung eine Bestandsaufnahme ueber ALLE Remote-Branches
+("am 2026-08-01: 24 von 26 Remote-Branches ohne jeden PR"). Der Aufruf zum Nachsehen
+steht dort als:
 
-Zu Beginn des Laufs (§0 Arbeitsbaum und Stashes), eigene Messung:
-    git status --porcelain  ->  M .opencode/agent-models.jsonc
-                                M AGENTS.md
-                                ?? .githooks/post-rewrite
-    git stash list          ->  LEER
-    git worktree list       ->  main + 3 Worktrees
-
-Am Ende desselben Laufs, dieselben Befehle:
-    git status --porcelain  ->  nur noch ?? .githooks/post-rewrite
-    git stash list          ->  stash@{0}: On main: repo-hygiene: pre-T002769-plan
-                                dirty main checkout
-    git worktree list       ->  zusaetzlich .worktrees/plan-staged-guard-T002769
-
-Zeitstempel (git log -g refs/stash bzw. stat): Stash 2026-08-09T03:36:03+02:00, Worktree
-03:37:21 — beide innerhalb dieses Laufs.
-
-URHEBER IST NICHT BELEGT [UNVERIFIED]
-
-Die naheliegende Erklaerung waere der Factory-Tick — mcp__factory-mcp__factory_status
-meldete tick_running=true, und T002769 stand als plan_staged in der Queue. Diese
-Zuschreibung haelt der Pruefung aber NICHT stand: eine repo-weite Suche nach der
-Stash-Nachricht ("dirty main checkout") findet keinen Treffer, und der einzige
-git-stash-push im Repo steht in scripts/worktree-create.sh:154 mit der abweichenden
-Nachricht "worktree-create-auto-stash". Die Nachricht "repo-hygiene: pre-T002769-plan
-dirty main checkout" ist von Hand formuliert — also von einer nebenlaeufigen
-Agenten-Session, nicht von versioniertem Code. ListAgents meldete 53 Peer-Sessions.
-Welche es war, ist offen.
-
-Kein Verzeichnis .agent-locks/ vorhanden — zum Zeitpunkt der Kollision hielt niemand
-einen Lock auf den Hauptcheckout, auch ich nicht.
-
-FOLGE
-
-Kein Datenverlust: der Stash-Inhalt wurde per git diff "stash@{0}^" "stash@{0}"
-verifiziert und ist mit dem urspruenglich gefundenen Diff identisch; er ist in Ticket
-T002782 samt Wiederauffind-Anleitung ueber die Stash-Nachricht dokumentiert
-(stash@{0} ist relativ und verschiebt sich bei weiteren Stashes).
-
-Der Schaden ist ein anderer: der §0-Befund, auf dem eine Nutzerentscheidung beruhte
-(Routing der drei ungeticketen Aenderungen in ein chore-Ticket), war zum Zeitpunkt des
-Berichts nicht mehr der Ist-Zustand. Aufgefallen ist es nur, weil am Ende zufaellig noch
-einmal git status lief. Ohne diese Wiederholung haette der Bericht einen Arbeitsbaum
-beschrieben, den es nicht mehr gab — und der Nutzer haette die Aenderungen an der
-genannten Stelle nicht gefunden.
-
-STRUKTURELLER KERN
-
-repo-hygiene §0 liest den Hauptcheckout und leitet daraus Entscheidungen ab, haelt aber
-keinen Lock dagegen und prueft nicht, ob nebenlaeufige Schreiber aktiv sind. Der
-Factory-Status wird erst in §5 abgefragt, also NACH der Auswertung — obwohl ein laufender
-Tick eine Vorbedingung fuer §0 ist, nicht eine Randnotiz am Schluss.
-
-DENKBARE ABHILFE (nicht entschieden)
-- §0 fragt Factory-Status und aktive Sessions VOR der Arbeitsbaum-Inspektion ab und
-  meldet einen laufenden Schreiber als ausdruecklichen Vorbehalt am Befund.
-- Oder: §0 wiederholt die Inspektion am Ende und vergleicht; eine Abweichung wird
-  gemeldet statt stillschweigend ueberschrieben.
-- Oder: repo-hygiene nimmt fuer die Dauer des Laufs einen agent-lock auf den
-  Hauptcheckout (scripts/agent-lock.sh).
-Welche davon traegt, ist eine eigene Untersuchung — insbesondere weil der Urheber hier
-gerade NICHT der Factory-Tick war und ein Lock gegen fremde Agenten-Sessions nur wirkt,
-wenn diese ihn auch lesen.
-**9. Branch-Lock überlebt Reap trotz totem PID und fehlendem Worktree — plus Korrektur zum vorigen Mishap** (drift, scripts/agent-lock.sh)
-
-KORREKTUR ZUM VORHERGEHENDEN EINTRAG (gleiche Session, 2026-08-09)
-
-Der Mishap "Hauptcheckout wurde mitten im repo-hygiene-Lauf von fremder Hand gestasht"
-enthaelt eine falsche Behauptung: "Kein Verzeichnis .agent-locks/ vorhanden — zum
-Zeitpunkt der Kollision hielt niemand einen Lock". Das ist falsch. Ich hatte im
-Repo-Wurzelverzeichnis nachgesehen; der Lock-Store liegt aber laut _lock_dir() in
-scripts/agent-lock.sh unter "$(git rev-parse --git-common-dir)/agent-locks", also
-.git/agent-locks/. Dort lagen sechs lebende Claims.
-
-Damit klaert sich auch der offene Punkt "Urheber ist nicht belegt": ticket/T002769 war
-mit Label "opencode-flow-plan" (sid 289461) geclaimt. Die Stash-Nachricht
-"repo-hygiene: pre-T002769-plan dirty main checkout" passt dazu. Der Urheber war eine
-opencode-Planungssession — nicht der Factory-Tick, wie zuerst vermutet, und nicht
-"niemand mit Lock", wie danach behauptet. Wer den vorigen Eintrag liest, muss diesen
-mitlesen.
-
-EIGENSTAENDIGER BEFUND: Branch-Lock ueberlebt zwei Reap-Laeufe
-
-    $ cat .git/agent-locks/branch__fix-ticket-read-path-T002781.json
-    { "scope": "branch", "id": "fix/ticket-read-path-T002781",
-      "owner_sid": "fa33ecd9-...", "owner_pid": "127574",
-      "worktree": "/home/patrick/Bachelorprojekt/.worktrees/ticket-read-path-T002781",
-      "created_at": "1786238180", "heartbeat_at": "1786238180" }
-
-Zustand zum Pruefzeitpunkt:
-  - PID 127574: ps -p 127574 -> nicht vorhanden (tot)
-  - worktree-Pfad: von mir entfernt, existiert nicht mehr
-  - owner_sid: fremde Session, nicht meine (ffe41dfa-...)
-  - heartbeat_at == created_at, rund 28 Minuten alt
-
-Trotzdem meldet agent-lock.sh list den Eintrag nach ZWEI aufeinanderfolgenden reap-Laeufen
-weiterhin als STATE=live. Im selben Lauf wurden andere Locks sehr wohl geerntet
-(.reap.log: ticket/T002767 heartbeat-ttl, ticket/T002781 heartbeat-ttl), und der Reaper
-kennt worktree-missing nachweislich als Grund — er hat ticket/T002645 genau damit geerntet
-(1786239054 ticket/T002645 worktree-missing).
-
-VERMUTUNG (nicht verifiziert): worktree-missing und/oder pid-dead werden fuer scope=ticket
-ausgewertet, fuer scope=branch aber nicht — oder der Branch-Scope hat eine deutlich
-laengere Heartbeat-TTL. Welche der beiden zutrifft, ist ohne Lesen der Reap-Bedingungen in
-scripts/agent-lock.sh nicht entschieden.
-
-FOLGE: Ein Claim auf branch "fix/ticket-read-path-T002781" wird blockiert, obwohl der
-Halter tot und sein Worktree weg ist. T002781 ist ein offenes Ticket in triage — die
-naechste Session, die daran arbeiten will, laeuft in den toten Lock.
-
-TEST (Output-Verifikation, T002448-M4): Einen Branch-Lock mit totem PID und fehlendem
-Worktree anlegen, reap AUSFUEHREN und pruefen, dass der Lock danach WEG ist (bzw. list ihn
-nicht mehr als live fuehrt) — nicht die Reap-Bedingungen im Quelltext greppen. Positiv-Anker
-(T002356-M1): im selben Test zeigen, dass ein Branch-Lock mit LEBENDEM Halter den Reap
-ueberlebt, sonst besteht der Test auch bei einem Reaper, der wahllos alles loescht.
-### Mishap-Rollup — kuratierte Uebernahme aus 14 gestrandeten Batches (2026-08-09)
-
-Nachgezogen aus den Containern T002557/T002575/T002597/T002601 (alle `done`, fuer den Rollup-Treiber unsichtbar — Defekt T002783). Quelle: 14 unverarbeitete Batch-Kommentare vom 2026-08-02 bis 2026-08-09 mit 128 Eintragszeilen, davon 109 eindeutig.
-
-**Auswahl:** 44 Eintraege hatten bereits ein eigenes Ticket (Titelabgleich gegen 2079 Tickets), 24 waren einmalige Zustandsbeobachtungen, 9 sind anderweitig dokumentiert oder abgedeckt. Es bleiben die folgenden strukturellen Befunde ohne eigenes Ticket. Die Klassifikation erfolgte auf Titelebene mit Stichproben-Verifikation, nicht als Einzelaudit jedes Eintrags.
-
-| # | Typ | Befund |
-|---|---|---|
-| 1 | degraded | KORREKTUR zum vorigen Eintrag: task pr:refresh verweigert Branches, die in einem Worktree ausgecheckt sind |
-| 2 | degraded | Offener PR wird durch parallelen OpenSpec-Archive-Merge rot, ohne automatisches Nachziehen |
-| 3 | degraded | Ticket-Auto-Close bei Mehr-PR-Vorgaengen: done bei 1/7 Fortschritt |
-| 4 | degraded | Vitest-Dateien liegen zwischen node:test-Suiten und machen Sammellaeufe strukturell rot |
-| 5 | degraded | branch-reaper.sh: fehlende Merge-Base wird als "keine Abweichung" gewertet |
-| 6 | degraded | dev-flow-execute-Subagenten beenden sich beim Warten auf Hintergrundlaeufe — Arbeit bleibt halbfertig liegen |
-| 7 | degraded | devflow-ci-watch.sh meldet nach Force-Push (Rebase) stale Check-Ergebnisse der alten SHA statt der neuen |
-| 8 | degraded | freshness:check misst lokal gegen den Branch, CI gegen den Merge-Commit |
-| 9 | degraded | llm-proxy haelt loadouts.mjs im Speicher — kennt nach einem Merge neue Felder nicht |
-| 10 | degraded | openspec-status.json ist per Konstruktion blind fuer plan_staged-Tickets |
-| 11 | degraded | plan-context.sh --with-openspec liefert 170+ Proposals, Direktive nicht befolgbar |
-| 12 | degraded | post-commit openspec-embed-Hook meldet "fetch failed" — Changes bleiben unindiziert |
-| 13 | degraded | repo-hygiene-ops §2 setzt volle Historie voraus — Hauptcheckout war shallow |
-| 14 | degraded | repo-hygiene-ops.md §3 umgeht vier vorhandene PR-Werkzeuge zugunsten handgeschriebener gh/git-Kommandos |
-| 15 | degraded | worktree-create.sh prueft die erste Ticket-ID im Branchnamen, nicht die eigene |
-| 16 | degraded | worktree-create.sh: lokale Aenderungen an Dateien im FF-Bereich gehen beim main-Sync still verloren |
-| 17 | degraded | worktree-write-guard erfasst keine Bash-Schreibzugriffe |
-| 18 | drift | Doku-Drift: ticket_links traegt 340+ PR-Selbstkanten, Skill-Referenz schliesst das aus |
-| 19 | drift | G-AGENTIC07 auf main rot: ein verwaister aktiver Skill ohne Referenzquelle |
-| 20 | drift | dev-flow-plan Fix-Pfad: stage-plan (Schritt 4.5) steht vor Commit (Schritt 5), ist so aber nicht ausfuehrbar |
-| 21 | process | "behind N" gegen den eigenen Feature-Remote ist kein Beleg fuer fehlende Arbeit |
-| 22 | process | Subagent-Abbruch: letzte Ausgabezeile suggerierte Fortschritt, Dateien waren leer |
-| 23 | process | dev-flow-e2e empfiehlt test/*-Branch, pre-commit verlangt feature/fix/chore/docs + T###### |
-| 24 | process | mishap-tracker erzeugt Duplikat-Incident zu einem bereits gestagten Plan |
-| 25 | suspicious | agent-lock list zeigt Lock mit "--label" als Scope-Wert (Argument-Parsing) |
-| 26 | suspicious | branch-reaper.sh erzwingt --ticket auch im reinen --dry-run-Inventarlauf |
-| 27 | suspicious | browser.newContext() im storageState-Projekt lieferte authentifizierten Kontext |
-| 28 | suspicious | devflow-ci-watch meldet "Keine CI-Checks gefunden", nachdem es zehn gruene Checks gelistet hat |
-| 29 | suspicious | mcp-sync-Guard meldet auf veralteter Branch-Basis roten Drift, der lokal nicht existiert |
-| 30 | suspicious | test:spec:changed uebersieht staged-aber-uncommittete Tests und meldet "No matching spec tests" |
-| 31 | suspicious | ticket.sh list --status <unbekannt> liefert still [] statt eines Fehlers |
-
-Volltext der Einzeleintraege: Batch-Kommentare 9913, 10114, 10273, 10413, 10672, 10718, 10839, 10840, 11241, 11242, 13115, 13249, 13429, 13727 in `tickets.ticket_comments`.
-### Volltexte der 31 uebernommenen Befunde (Archiv vor Loeschung der Altcontainer)
-
-Gesichert am 2026-08-09, bevor T002541/T002557/T002575/T002597/T002601 entfernt wurden. Die Zeiger auf die urspruenglichen Kommentar-IDs im vorigen Kommentar verfallen mit der Loeschung — dies hier ist der Ersatz.
-
----
-
-#### 1. KORREKTUR zum vorigen Eintrag: task pr:refresh verweigert Branches, die in einem Worktree ausgecheckt sind
-
-_(degraded, skills/references/repo-hygiene-ops)_
-
-Korrigiert den unmittelbar vorhergehenden Buffer-Eintrag "repo-hygiene-ops.md §3 umgeht vier vorhandene PR-Werkzeuge". Dessen Fix-Richtung ("Heilpfad auf `task pr:refresh -- <pr>` als Primaerweg umstellen, manuelle Prozedur zum Fallback degradieren") ist in dieser Form FALSCH und darf nicht so umgesetzt werden.
-
-BEOBACHTUNG:
-    $ task pr:refresh -- --dry-run 3856
-    pr-refresh: PR 3856: Branch feature/e3-sdlc-tickets-lokal-T002626 ist ausgecheckt in
-                /home/patrick/Bachelorprojekt/.worktrees/e3-sdlc-tickets-lokal — abgebrochen.
-    pr-refresh: Bilanz — 0 geheilt, 0 uebersprungen, 1 abgelehnt.
-    exit status 1
-
-scripts/pr-refresh.sh lehnt einen PR ab, sobald dessen Branch in einem Worktree ausgecheckt ist. Das ist plausibel als Schutz (das Skript will den Branch selbst auschecken/rebasen und wuerde sonst mit dem Worktree kollidieren), aber es trifft den Regelfall von repo-hygiene: die offenen PRs dieses Repos haben typischerweise genau einen zugehoerigen Worktree unter .worktrees/. In diesem Lauf galt das fuer beide offenen PRs.
-
-FOLGE FUER DIE FIX-RICHTUNG:
-Die manuelle Prozedur in §3 (git merge origin/main → task freshness:regenerate → task test:inventory → commit → push) ist NICHT obsolet — sie ist der korrekte Weg fuer worktree-ausgecheckte Branches, und PR #3856 wurde in diesem Lauf zweimal so geheilt. Der eigentliche Mangel ist enger als zuerst formuliert: §3 nennt weder das Werkzeug noch seine Vorbedingung. Richtige Ergaenzung waere eine Fallunterscheidung:
-  - Branch NICHT in einem Worktree ausgecheckt → `task pr:refresh -- <pr>`
-  - Branch in einem Worktree ausgecheckt (Regelfall) → manuelle Prozedur, im Worktree ausgefuehrt
-Zusaetzlich waere zu pruefen, ob pr-refresh.sh den Worktree-Fall selbst bedienen koennte (im vorhandenen Worktree mergen statt den Branch andernorts auszuchecken) — dann entfiele die Fallunterscheidung.
-
-Der Teilbefund zu scripts/ci-pr-health.sh aus dem vorigen Eintrag bleibt unveraendert gueltig: es erkennt "CI nie gestartet" via Exit 2 und hat keine Worktree-Vorbedingung, ist also uneingeschraenkt als Triage-Schritt in §3 aufnehmbar.
-
-ZUSATZBEOBACHTUNG (belegt die Wiederkehr): Nach dem Merge von PR #3867 nach main fiel PR #3856 sofort wieder auf mergeStateStatus=DIRTY zurueck, weil beide PRs dieselben generierten Artefakte (test-inventory.json, repo-index.json) beruehren. Die Heilung musste im selben Lauf zweimal ausgefuehrt werden. Das ist die in T002347 beschriebene Ursache, hier mit Messpunkt.
-
----
-
-#### 2. Offener PR wird durch parallelen OpenSpec-Archive-Merge rot, ohne automatisches Nachziehen
-
-_(degraded, ci/openspec-validate)_
-
-PR #3669 war 5 Commits hinter main und CI rot (Factory OpenSpec + Guards, Factory spec shard 3), weil der Branch noch das inzwischen von PR #3671 archivierte OpenSpec-Change-Verzeichnis openspec/changes/fix-plan-intel-merge unarchiviert trug. Kollateralschaden: jeder offene PR mit eigenem OpenSpec-Change kann durch einen fremden Archive-Merge auf main rot werden, ohne dass etwas am PR selbst falsch ist. Kein automatischer Rebase-Trigger dafür vorhanden. Manuell per REST-Update behoben.
-
----
-
-#### 3. Ticket-Auto-Close bei Mehr-PR-Vorgaengen: done bei 1/7 Fortschritt
-
-_(degraded, scripts/factory/pipeline.js)_
-
-T002569 (OpenSpec-Rueckstau, 7 geplante Chargen) wurde nach dem Merge von PR #3694 ("archive OpenSpec-Charge 1 [T002569]") automatisch auf done gesetzt. Zu dem Zeitpunkt standen 166 von urspruenglich 181 Changes noch unarchiviert — der Vorgang war zu etwa 1/7 erledigt.
-
-Ursache: der Merge-Automatismus schliesst jede im PR-Titel referenzierte Ticket-ID, unabhaengig vom tatsaechlichen Fortschritt. Bei einem Vorgang, der per Plan bewusst ueber mehrere PRs laeuft, ist das strukturell falsch.
-
-VERSCHAERFEND: Der Rueckweg ist per Wrapper versperrt. `mcp__ticket-mcp__transition_status` lehnt ab mit "Cannot transition from 'done' to 'in_progress' — terminal tickets can only transition to 'archived'". Die Korrektur ging nur per direktem psql-UPDATE am Guard vorbei. Wer den Fehlzustand bemerkt, muss also eine Schutzregel umgehen, um ihn zu beheben.
-
-VERIFIZIERT 2026-08-02: PR #3693 und #3694 gemergt, `git ls-tree -d origin/main openspec/changes/` zaehlt 166 unarchivierte Verzeichnisse, Ticket stand auf done/resolution=NULL. Zurueckgesetzt auf in_progress per psql.
-
-VORSCHLAG: Entweder der Auto-Close prueft eine Fortschritts-Bedingung (z.B. Plan-Tasks alle abgehakt), oder mehrteilige Vorgaenge markieren sich als solche und sind vom Auto-Close ausgenommen. Alternativ ein dokumentierter, nicht-SQL Rueckweg fuer genau diesen Fall.
-
----
-
-#### 4. Vitest-Dateien liegen zwischen node:test-Suiten und machen Sammellaeufe strukturell rot
-
-_(degraded, scripts/llm-proxy)_
-
-scripts/llm-proxy/mcp-bridge.test.mjs und scripts/llm/ui-config-seed.test.mjs importieren aus 'vitest', liegen aber im selben Verzeichnis wie echte node:test-Suiten (loadouts/runner/server/models.test.mjs).
-
-Unter `node --test` geben sie irrefuehrende Fehler, die nach Produktionsfehlern aussehen statt nach falschem Runner:
-  mcp-bridge:      "Vitest mocker was not initialized in this environment. vi.queueMock() is forbidden."
-  ui-config-seed:  "TypeError: Cannot read properties of undefined (reading 'config')"
-
-Folge: `node --test scripts/llm-proxy/` ist per Konstruktion rot, obwohl alle vier echten Suiten gruen sind. Beide Dateien verhalten sich auf main genauso — vorbestehend, nicht durch einen aktuellen PR verursacht. Unter `npx vitest run` laufen sie sauber (3/3 geprueft).
-
-Kostete zweimal Diagnosezeit: einmal beim Sammellauf, einmal bei der Frage, ob eine eigene Aenderung sie gebrochen hatte.
-
-Vorschlag: Namenskonvention (*.vitest.mjs) oder ein Kommentarheader in Zeile 1, der den zustaendigen Runner nennt — die Dateien sagen es derzeit erst im Import.
-
----
-
-#### 5. branch-reaper.sh: fehlende Merge-Base wird als "keine Abweichung" gewertet
-
-_(degraded, scripts/branch-reaper.sh)_
-
-VERIFIZIERT (2026-08-02, repo-hygiene-Lauf).
-
-BEFUND: scripts/branch-reaper.sh:109 in _diverging_files():
-  mb="$(git merge-base "$REMOTE/main" "$ref" 2>/dev/null)" || return 0
-Schlaegt git merge-base fehl (keine gemeinsame Historie), kehrt die Funktion mit Exit 0 und OHNE jede Ausgabe zurueck. Der Aufrufer kann eine leere Abweichungsliste nicht von einer nie durchgefuehrten Messung unterscheiden — beides sieht aus wie "Branch weicht nicht von main ab" und damit wie eine Reap-Freigabe.
-
-Damit faellt genau das zweite der beiden Sicherheitssignale aus, die der Reaper laut Dokumentation verlangt ("Blob-Diff leer" UND "Ticket done"). Uebrig bleibt "Ticket done" allein — und die SSOT-Referenz repo-hygiene-ops.md haelt ausdruecklich fest, dass dieses Signal allein bei T002431 die einzige Kopie eines nie gemergten Deliverables geloescht haette.
-
-REAL AUFGETRETEN: origin/chore/mishap-t002408 hatte heute keine gemeinsame Merge-Base mit origin/main (git merge-base exit 1). Der Branch war nach manueller Pruefung tatsaechlich harmlos (beide Plan-Dateien blob-identisch in main, Ticket T002408 done, kein PR) und wurde geloescht — die Freigabe kam aber aus einer Pruefung, die in diesem Pfad nichts geprueft haette.
-
-GLEICHES MUSTER, ZWEITE STELLE: Der in repo-hygiene-ops.md §2 dokumentierte Handbetrieb-Schnipsel hat denselben Defekt ohne den kaschierenden Exit-Code:
-  mb=$(git merge-base origin/main "$b")
-  for f in $(git diff --name-only "$mb" "$b"); do ...
-Bei leerem $mb meldet git "fatal: ambiguous argument ''" auf stderr und die Schleife laeuft null Runden — auf stdout nicht von einem sauberen Ergebnis unterscheidbar.
-
-VORSCHLAG: In beiden Faellen die leere Antwort explizit vom negativen Befund trennen, statt aus Abwesenheit auf Unbedenklichkeit zu schliessen:
-  mb="$(git merge-base "$REMOTE/main" "$ref" 2>/dev/null)" || { printf 'KEINE-MERGE-BASE\n'; return 0; }
-Der Marker faellt dann in die Abweichungsliste, faellt durch die Allowlist und fuehrt zu KEEP statt REAP. Das ist dieselbe Korrektur, die repo-hygiene-ops.md §3 fuer gh-Antworten bereits vorschreibt ("Leere Antwort ist KEIN Urteil", T002498-M5) — hier fehlt sie auf der git-Seite.
-
----
-
-#### 6. dev-flow-execute-Subagenten beenden sich beim Warten auf Hintergrundlaeufe — Arbeit bleibt halbfertig liegen
-
-_(degraded, .claude/skills/dev-flow-execute)_
-
-BEFUND (2026-08-02, Fan-out von 6 dev-flow-execute-Subagenten aus ticket-ops Phase 3): DREI VON DREI Agenten, die sich bis dahin beendet hatten, stoppten im selben Zustand — sie hatten einen Lauf im Hintergrund gestartet und beendeten sich in Erwartung einer Benachrichtigung, die einen Subagenten nicht mehr erreicht.
-
-Belegte Faelle, je woertlich aus der Abschlussmeldung:
-- T002504: "Waiting for the background `task test:changed` run (and the completion watcher) to finish — I'll resume once notified."
-- T002435: "Waiting for the background CI-watch loop to complete before continuing."
-- T002467: "I'll pause here and wait for the background verification task to complete."
-
-AUSWIRKUNG: Der Agent meldet sich als `completed`, ohne fertig zu sein. T002504 hatte zu diesem Zeitpunkt weder Commit noch PR. Ohne einen Orchestrator, der die Abschlussmeldungen gegenliest und per SendMessage nachfasst, waeren die Branches halbfertig liegen geblieben und haetten von aussen wie erledigte Arbeit ausgesehen — der gefaehrlichere Fall, weil nichts rot wird. Bei allen drei genuegte eine Aufforderung, den Stand selbst nachzusehen; danach liefen sie sauber bis Auto-Merge durch (T002435 → PR #3677).
-
-URSACHE (Hypothese, nicht verifiziert): Das Warte-Idiom von dev-flow-execute (Hintergrundlauf starten, auf Notification warten) setzt einen Lebenszyklus voraus, den ein Subagent nicht hat. Im Hauptloop funktioniert es, im Fan-out nicht.
-
-MOEGLICHE ABHILFEN, zu bewerten: (a) dev-flow-execute weist an, Verifikationslaeufe im Fan-out-Kontext im VORDERGRUND mit Timeout zu fahren statt im Hintergrund; (b) die Subagent-Provisionierung ergaenzt eine Direktive "warte nie auf eine Notification, pruefe den Stand selbst"; (c) der Dispatcher prueft jede `completed`-Meldung gegen den tatsaechlichen Branch-Zustand (Commit vorhanden? PR vorhanden? Auto-Merge gesetzt?), bevor er sie als fertig wertet. Variante (c) ist unabhaengig von der Ursache wirksam und deshalb der robusteste Kandidat.
-
----
-
-#### 7. devflow-ci-watch.sh meldet nach Force-Push (Rebase) stale Check-Ergebnisse der alten SHA statt der neuen
-
-_(degraded, scripts)_
-
-T002561: Nach `git push --force-with-lease` (Rebase gegen origin/main wegen eines konkurrierenden Merges) lief `devflow-ci-watch.sh` erneut und meldete "18 CI-Checks, alle grün" — aber mit denselben Run-/Job-IDs wie vor dem Force-Push. Ein direkter Abgleich über `gh api repos/.../commits/<neue-SHA>/check-runs` zeigte die Checks noch als `in_progress` für die neue SHA. Das Skript scheint gecachte Rollup-Daten zu nutzen, die kurz nach einem Force-Push die alte SHA widerspiegeln, statt gegen die aktuelle `headRefOid` zu verifizieren. Ohne manuellen Gegencheck wäre ein Merge auf Basis stale gemeldeter grüner Checks versucht worden. Vorschlag: Skript soll die aktuelle `headRefOid` explizit gegen die Check-Run-SHA abgleichen und bei Mismatch neu pollen.
-
----
-
-#### 8. freshness:check misst lokal gegen den Branch, CI gegen den Merge-Commit
-
-_(degraded, Taskfile.yml)_
-
-PR #3658 scheiterte dreimal an "docs/code-quality/repo-index.json regenerated but not staged", waehrend lokal `task freshness:check` durchgehend "All generated artifacts are fresh" meldete. Auch ein direkter Aufruf von scripts/code-quality/emit-index.mjs erzeugte lokal keinen Diff.
-
-URSACHE (nach dem Rebase belegt): CI prueft den MERGE-Commit aus PR-Head und aktuellem main, nicht den Branch allein. Zwischen Abzweig und Pruefung waren mehrere PRs auf main gelandet; der gemergte Zustand enthielt also mehr Dateien. Der Index-Generator scannt `git ls-files` PLUS untracked-but-not-ignored (scripts/code-quality/scan.mjs), das Ergebnis haengt damit direkt an der Dateimenge.
-
-Nach `git rebase origin/main` aenderten sich prompt beide Artefakte: repo-index.json +2/-1, test-inventory.json +6 Zeilen. Genau die Differenz, die CI sah und die lokale Messung nicht sehen konnte.
-
-WARUM ES ZEIT KOSTETE: Beide Messungen waren korrekt, sie massen nur Verschiedenes. Ein Re-Run des Jobs half deshalb nicht — es war kein Flake, sondern eine veraltete Basis. Diagnostiziert wurde erst, nachdem der PR zusaetzlich auf DIRTY ging und ein Rebase ohnehin faellig war.
-
-VORSCHLAG: Die Fehlermeldung von freshness:check koennte nennen, gegen welche Basis gemessen wurde, oder der Task koennte warnen, wenn der Branch hinter origin/main liegt ("HEAD ist N Commits hinter origin/main — CI misst gegen den Merge-Commit, das Ergebnis kann abweichen"). Der Hinweis kostet eine Zeile und haette hier drei Anlaeufe gespart.
-
-VERWANDT, gleiche Fehlerklasse in derselben Session: `git show origin/main:<pfad>` im Worktree lieferte einen veralteten Stand, woraufhin gueltige Tests als verwaist geloescht wurden (Mishap bereits erfasst). Beide Male war die Referenz falsch, nicht die Messung.
-
----
-
-#### 9. llm-proxy haelt loadouts.mjs im Speicher — kennt nach einem Merge neue Felder nicht
-
-_(degraded, scripts/llm-proxy/server.mjs)_
-
-Beim Stop/Start von llama-gemma26-factory ueber den llm-proxy (POST /admin/loadouts/<slug>/start) antwortete dieser:
-
-  {"error":{"code":"start_error","message":"loadouts.json: loadouts[4]: unbekanntes Feld 'tools'"}}
-
-Das Feld 'tools' ist seit PR #3640 im Validator (scripts/llm-proxy/loadouts.mjs). Der llm-proxy-Prozess lief seit 08:26:39 aus /home/patrick/Bachelorprojekt; #3640 wurde gegen 08:50 gemergt. Die Datei auf der Platte war also neu, der Prozess hielt die alte Fassung im Speicher.
-
-FOLGE, nicht bloss kosmetisch: Das Loadout war zu dem Zeitpunkt bereits GESTOPPT (der Stop lief ueber denselben Proxy und gelang). Der fehlgeschlagene Start liess gemma26-factory unten — die Factory hatte kein Modell, bis der Proxy neu gestartet und das Loadout erneut hochgefahren war. Insgesamt rund 10 Minuten.
-
-Die Reihenfolge macht es gefaehrlich: Stop gelingt (alter Code reicht dafuer), Start scheitert (neuer Code noetig). Wer beides als Paar denkt, steht danach ohne laufendes Modell da.
-
-VORSCHLAG: Nach einem Merge, der scripts/llm-proxy/* beruehrt, gehoert systemctl --user restart llm-proxy.service in den post-merge-Pfad — analog zu dem, was devflow-post-merge-deploy.sh fuer Cluster-Pfade tut. Alternativ koennte der Proxy seine Modul-Memoisierung beim Erkennen einer geaenderten loadouts.mjs verwerfen; das ist aber der groessere Eingriff.
-
-Verwandt: der Proxy memoisiert auch die Backend-Tabelle (loadBackendsOnce in backends.mjs) — dieselbe Klasse Problem fuer Aenderungen an tickets.llm_proxy_backends.
-
----
-
-#### 10. openspec-status.json ist per Konstruktion blind fuer plan_staged-Tickets
-
-_(degraded, scripts/openspec-status-map.sh)_
-
-ticket-ops-procedures Step 1.3 schreibt den Lookup `get_openspec_status` gegen website/src/data/openspec-status.json vor. Am 2026-08-02 lieferte er fuer ALLE 14 offenen Tickets einen leeren Status. VERIFIZIERT: Die Datei ist nicht defekt — 41663 Bytes, 379 Top-Level-Keys. Sie enthaelt aber keinen der aktuellen Changes, weil diese in Feature-Branches liegen und der Index aus main gebaut wird (`grep -rl` auf openspec/changes/*/.ticket findet auf main keinen der Slugs zu T002433-T002438, waehrend die Changes in den jeweiligen Branches committet vorliegen). Damit ist der Lookup strukturell wirkungslos fuer genau die Ticketklasse, fuer die Step 1.3 ihn abfragt: plan_staged-Tickets haben ihren Change definitionsgemaess noch nicht auf main. Entweder muss scripts/openspec-status-map.sh Branch-Changes mitindizieren, oder Step 1.3 muss den Branch-Stand direkt lesen. Nebenbefund: die Datei war im Hauptcheckout uncommitted modifiziert.
-
----
-
-#### 11. plan-context.sh --with-openspec liefert 170+ Proposals, Direktive nicht befolgbar
-
-_(degraded, scripts/plan-context.sh)_
-
-CLAUDE.md schreibt vor, den Output von `bash scripts/plan-context.sh <role> --with-openspec` vor JEDEM Agent-Dispatch in den Prompt zu injizieren. Der Output umfasst derzeit ueber 170 Proposals, weil plan-context.sh `openspec/changes/` als Menge der AKTIVEN Vorhaben liest und dort der Archivierungs-Rueckstau liegt.
-
-WIRKUNG: Die Direktive ist fuer Multi-Agent-Dispatches praktisch nicht befolgbar — der Block wuerde den Prompt dominieren. In diesem ticket-ops-Lauf wurde sie fuer beide Welle-1-Dispatches bewusst uebergangen und die Abweichung im jeweiligen Agent-Prompt begruendet.
-
-STATUS DER BEHEBUNG: T002569 baut den Rueckstau ab. Stand 2026-08-02 sind PR #3693 (Guard-Fix) und #3694 (Charge 1) gemergt, 166 von urspruenglich 181 Changes stehen noch. Nach Abschluss aller 7 Chargen schrumpft der Feed auf die real offenen Vorhaben und die Direktive wird wieder sinnvoll.
-
-Kein eigener Fix noetig — hier festgehalten, damit die bewusste Abweichung nachvollziehbar ist und damit sichtbar bleibt, dass eine dokumentierte Pflicht derzeit nicht erfuellbar ist.
-
----
-
-#### 12. post-commit openspec-embed-Hook meldet "fetch failed" — Changes bleiben unindiziert
-
-_(degraded, hooks/openspec-embed)_
-
-Beim Commit des T002569-Plans meldete der post-commit-Hook `openspec-embed` "fetch failed" (Embedding-Backend nicht erreichbar). Der Hook ist nicht-fatal, der Commit ging durch.
-
-WIRKUNG: Der neue Change ist nicht in pgvector indiziert. Die semantische Suche ueber OpenSpec-Changes (u.a. `openspec_find_similar` in factory-mcp, das vor dem Anlegen eines Proposals auf Duplikate prueft) sieht ihn nicht. Da der Hook still fail-open ist, faellt das nur auf, wenn man die Hook-Ausgabe liest — die Luecke waechst unbemerkt mit jedem Commit, der bei nicht erreichbarem Backend entsteht.
-
-Zusammenhang mit T002570: dort wurde gerade das Embedding-Routing korrigiert (bge-m3 primaer statt Voyage-Default, tote :8095-Fallbacks entfernt). Ob der Hook denselben Endpunkt nutzt und der Fehler nach dem Merge von PR #3692 verschwindet, ist NICHT geprueft — waere aber der erste Verdacht.
-
-VORSCHLAG: Pruefen, ob openspec-embed nach T002570 wieder durchlaeuft; falls ja, einen Nachindizierungs-Lauf fuer die zwischenzeitlich unindizierten Changes anstossen. Falls nein, eigene Ursachensuche.
-
----
-
-#### 13. repo-hygiene-ops §2 setzt volle Historie voraus — Hauptcheckout war shallow
-
-_(degraded, skills/references/repo-hygiene-ops)_
-
-Beobachtet 2026-08-03 beim /repo-hygiene-Lauf. Der Hauptcheckout /home/patrick/Bachelorprojekt war ein Shallow Clone (.git/shallow vorhanden, `git log --oneline origin/main | wc -l` = 12).
-
-Folge: `git merge-base origin/main <branch>` scheiterte mit rc=1 fuer JEDEN der 7 Feature-Branches ("keine gemeinsame Historie"). Die in repo-hygiene-ops.md §2 dokumentierte Blob-Vergleichsschleife baut auf `mb=$(git merge-base ...)` auf und lief damit mit leerem $mb ins `fatal: ambiguous argument ''`. Der naheliegende Ausweichweg `git diff --name-only origin/main <branch>` (Zwei-Punkt) meldete stattdessen hunderte Phantom-Loeschungen unter .claude/skills/unsloth-buddy/** — die Branches lagen dort lediglich hinter main. Eine Reap-Entscheidung auf dieser Basis haette die Diff-Signatur falsch gelesen.
-
-Nach `git fetch --unshallow` lieferte dieselbe Schleife das korrekte Bild: alle 7 Branches tragen echte ungemergte Dateien, kein einziger war Reap-Kandidat.
-
-Vorschlag: in repo-hygiene-ops.md §2 einen Vorcheck aufnehmen, z.B.
-  [ -f "$(git rev-parse --git-dir)/shallow" ] && git fetch --unshallow
-Auch `git branch --merged main` ist im Shallow-Zustand strukturell unbrauchbar, ohne dass es das anzeigt.
-
----
-
-#### 14. repo-hygiene-ops.md §3 umgeht vier vorhandene PR-Werkzeuge zugunsten handgeschriebener gh/git-Kommandos
-
-_(degraded, skills/references/repo-hygiene-ops)_
-
-BEOBACHTUNG (/repo-hygiene-Lauf 2026-08-08)
-
-Die SSOT-Referenz .claude/skills/references/repo-hygiene-ops.md §3 ("PR-Triage") schreibt eine manuelle Prozedur vor: rohes `gh pr list --json statusCheckRollup`, und zum Heilen eines CONFLICTING-PR `git merge origin/main` + `task freshness:regenerate` + commit + push, mit REST-`update-branch` als Eskalation. Sie nennt keines der vier Werkzeuge, die das Repo für genau diesen Zweck bereits hat.
-
-VERIFIKATION (grep -c gegen repo-hygiene-ops.md):
-  task pr:refresh              → 0 Treffer
-  scripts/ci-pr-health.sh      → 0 Treffer
-  scripts/factory/babysit-prs.sh → 0 Treffer
-  scripts/devflow-ci-watch.sh  → 0 Treffer
-
-Belege, dass die Werkzeuge existieren und passen:
-- `task --list` zeigt: "pr:refresh: Rebase konfliktbehaftete PRs auf origin/main und heilt Konflikte in generierten Artefakten. Usage: task pr:refresh -- [--dry-run] <pr-nummer>..." (entstanden aus T002413, Status done).
-- scripts/ci-pr-health.sh dokumentiert im Kopf und implementiert in Zeile 216 den Exit-Code 2 = "no checks found at all (CI never started)".
-
-KONKRETER SCHADEN IN DIESEM LAUF:
-1. PR #3856 (T002626) stand auf mergeStateStatus=CONFLICTING. GitHub startet auf solchen PRs keine Workflows: statusCheckRollup hatte 0 Einträge. In `gh pr list` sah der PR dadurch nicht rot aus, sondern unauffällig — er war schlicht ungetestet. Nach dem Heilen sprang die Zahl von 0 auf 15 Checks. Ein Aufruf von scripts/ci-pr-health.sh hätte das mit Exit 2 sofort gemeldet; §3 sieht ihn nicht vor.
-2. Ich habe #3856 anschließend von Hand geheilt (git merge origin/main, task freshness:regenerate, task test:inventory, commit, push), obwohl `task pr:refresh -- 3856` denselben Vorgang automatisiert.
-
-MITURSACHE (Verhalten des Agenten): CLAUDE.md verlangt "Never look up or hardcode task commands. Use the task oracle instead: bash scripts/vda.sh oracle '<goal>'". Ich habe den Oracle nicht befragt, sondern die in der Skill-Referenz hartkodierten Kommandos ausgeführt — genau deshalb blieben die vier Werkzeuge unentdeckt. Die Referenz macht diesen Fehler leicht, weil sie fertige Kommandozeilen anbietet, gegen die der Oracle-Vorrang nicht sichtbar konkurriert.
-
-FIX-RICHTUNG:
-- §3 um `scripts/ci-pr-health.sh --pr <n>` als ersten Triage-Schritt ergänzen und Exit 2 ausdrücklich als "CI nie gestartet, meist CONFLICTING" ausdeuten.
-- Heilpfad auf `task pr:refresh -- <pr>` als Primärweg umstellen; die manuelle merge+regenerate-Prozedur zum dokumentierten Fallback degradieren (sie bleibt wertvoll, wenn pr:refresh scheitert).
-- Prüfen, ob dieselbe Lücke in anderen Skill-Referenzen besteht, die rohe gh-Kommandos einbetten.
-
-ABGRENZUNG (bewusst NICHT als eigener Mishap gemeldet, Dedupe):
-- Uncommittete Einzelkopie-Arbeit im Worktree fix/flux-artifact-versioning-T002706 und Drift im main-Checkout → gedeckt von T002709 (plan_staged).
-- Wiederkehrende Reibung durch committete generierte Artefakte → gedeckt von T002347.
-
----
-
-#### 15. worktree-create.sh prueft die erste Ticket-ID im Branchnamen, nicht die eigene
-
-_(degraded, scripts/worktree-create.sh)_
-
-`bash scripts/worktree-create.sh fix/restore-t002549-rollback-T002552 …` wurde abgelehnt mit:
-  "ERROR: Ticket-ID im Branch-Namen ist kleingeschrieben. Verwende T002549 statt t002549."
-
-Die Branch-eigene ID T002552 stand korrekt grossgeschrieben am Ende; t002549 war nur ein Kontextverweis auf das zurueckgerollte Ticket.
-
-Ursache verifiziert (scripts/worktree-create.sh:226):
-  _ticket_id=$(echo "$BRANCH" | grep -oE '[tT][0-9]{6,}' | head -1 || true)
-
-`head -1` nimmt die ERSTE ID im Namen, unabhaengig davon, ob sie die des Branches ist. Der Fehlertext benennt dadurch die falsche ID als Problem und fuehrt in die Irre — er verlangt T002549 dort, wo T002552 gemeint ist.
-
-Kein Schaden, umgangen durch Umbenennen auf fix/restore-rollback-T002552. Sinnvoll waere, die letzte statt der ersten ID zu nehmen (Konvention: die eigene ID steht am Ende) oder mehrere IDs zu tolerieren, solange mindestens eine korrekt geschrieben ist.
-
----
-
-#### 16. worktree-create.sh: lokale Aenderungen an Dateien im FF-Bereich gehen beim main-Sync still verloren
-
-_(degraded, scripts/worktree-create.sh)_
-
-BEOBACHTUNG (2026-08-08, dev-flow-plan fuer T002729)
-Vor dem Aufruf standen im Haupt-Checkout drei uncommittete Aenderungen:
-  M scripts/llm/loadouts.json
-  D tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts
-  M website/src/data/test-inventory.json
-
-scripts/worktree-create.sh meldete "local main synced to origin/main" und fuehrte dabei einen
-Fast-Forward von ba0040c8c auf 11969ff50 aus (4 Commits). Danach:
-  M scripts/llm/loadouts.json          -> ueberlebt
-  tests/e2e/specs/fa-59-...spec.ts     -> Loeschung rueckgaengig, Datei wieder auf Platte (23:04)
-  website/src/data/test-inventory.json -> Aenderung verworfen
-`git stash list` ist leer, es liegt also kein Stash zur Wiederherstellung bereit.
-
-MUSTER
-Genau die beiden Dateien verschwanden, die im FF-Bereich ebenfalls geaendert wurden:
-`git diff --stat ba0040c8c 11969ff50 -- website/src/data/test-inventory.json` meldet
-+30 Zeilen aus 8a0e518f2 (#3856) und 2dbaef3b5 (#3867). loadouts.json war im FF-Bereich
-nicht betroffen und blieb erhalten. Die Vermutung ist daher, dass der Stash-Pop bei
-Kollision zugunsten des Remote-Stands aufloest, statt abzubrechen.
-
-WARUM DAS ZAEHLT
-Das Skript besitzt einen Stash-Mechanismus (_needs_pop / _wc_stash_pop_or_warn, Zeile 177),
-der genau diesen Fall abdecken soll. Wer ihn kennt, verlaesst sich darauf und committet
-vorher nicht. Der Verlust ist still: die Zusammenfassungszeile meldet Erfolg
-("local main synced to origin/main"), und ohne Stash-Eintrag gibt es keinen offensichtlichen
-Wiederherstellungspfad.
-
-Erschwerend: der Sync laeuft, obwohl der Aufrufer nur einen Worktree anlegen wollte. In
-dieser Session war ausdruecklich angekuendigt, main NICHT zu bewegen, weil fremde
-uncommittete Arbeit im Baum lag — das Skript tat es intern trotzdem.
-
-EINSCHRAENKUNG DER BEOBACHTUNG
-Die Skriptausgabe wurde mit `tail -15` abgeschnitten. Eine Warnung aus
-_wc_stash_pop_or_warn koennte weiter oben gestanden haben und uebersehen worden sein. Der
-Datenverlust selbst ist unabhaengig davon belegt (git status vorher/nachher, leere
-stash list).
-
-SCHADEN IM KONKRETEN FALL: gering. test-inventory.json ist ein generiertes Artefakt
-(`task test:inventory`), und die rueckgaengig gemachte Spec-Loeschung stellt den
-origin/main-Stand wieder her. Der Pfad selbst ist aber allgemein und trifft beim
-naechsten Mal handgeschriebenen Code.
-
-VORSCHLAG ZUR PRUEFUNG
-Entweder fail-closed abbrechen, wenn der Arbeitsbaum schmutzig ist und der FF-Bereich
-dieselben Dateien beruehrt, oder den Konflikt beim Pop stehen lassen statt aufzuloesen —
-in beiden Faellen mit einer Meldung, die den Sync als das benennt, was er ist.
-
----
-
-#### 17. worktree-write-guard erfasst keine Bash-Schreibzugriffe
-
-_(degraded, scripts/hooks/worktree-write-guard.sh)_
-
-scripts/hooks/worktree-write-guard.sh blockierte einen Edit auf einen fremd geclaimten Worktree korrekt. Ein `cat >> datei` im selben Worktree lief unmittelbar davor ungehindert durch — in einem zweiten, ebenfalls geclaimten Worktree wurde dadurch committet UND gepusht, bevor der Lock ueberhaupt sichtbar wurde.
-
-Ursache belegt: der Hook zieht den Zielpfad aus `file_path`/`notebook_path` der Tool-Eingabe (Zeile 48-49). Bash-Aufrufe haben kein solches Feld, fallen also durch. Der Guard schuetzt damit genau den Pfad, den ein disziplinierter Agent ohnehin nimmt, und nicht den, ueber den die Umgehung faktisch passiert.
-
-Verifiziert: `grep -c worktree-write-guard .githooks/pre-commit` = 0 — der Guard ist dort NICHT verankert, der Vorschlag ist also noch offen.
-
-Vorschlag: Aufruf im pre-commit-Hook ergaenzen (dort ist er werkzeugunabhaengig und faengt auch Bash-Schreibzugriffe ab), oder mindestens im Hook-Kopf dokumentieren, dass Bash ungeprueft bleibt — derzeit liest sich der Guard wie ein vollstaendiger Schutz.
-
----
-
-#### 18. Doku-Drift: ticket_links traegt 340+ PR-Selbstkanten, Skill-Referenz schliesst das aus
-
-_(drift, skills/references/ticket-ops-procedures)_
-
-KORREKTUR EINER EIGENEN FEHLBEOBACHTUNG — beim Verifizieren widerlegt, deshalb umklassifiziert statt gemeldet wie urspruenglich notiert.
-
-Beobachtet: tickets.ticket_links enthaelt Kanten mit from_id = to_id und kind='pr'. Zuerst als Datenmuell fuer zwei Tickets notiert. Die Gegenpruefung (`WHERE f.id = l.to_id`) zeigt: es sind ueber 340 solcher Zeilen, durchgehend seit T000099. Das ist also das REGULAERE Muster, wie eine PR-Verknuepfung am Ticket vermerkt wird — kein Fehler.
-
-DER EIGENTLICHE BEFUND ist eine Doku-Diskrepanz: `.claude/skills/references/ticket-ops-procedures.md` sagt woertlich "Never use ticket_links for PR references — it is ticket→ticket only", und der ticket-ops-Skill-Body wiederholt "ticket_links ist ticket→ticket, **nie** fuer PR-Referenzen". Die gelebte Praxis widerspricht dem seit hunderten Zeilen.
-
-WIRKUNG: gering, aber irrefuehrend. Wer die Doku liest und die Tabelle sieht, haelt den Bestand fuer korrupt und koennte "aufraeumen". Fuer den Phase-3-Graphenaufbau ist es folgenlos, weil dort auf kind IN ('blocks','blocked_by') gefiltert wird.
-
-VORSCHLAG: Doku an die Praxis angleichen — kind='pr' als legitime Selbstkante beschreiben und klarstellen, dass fuer Abhaengigkeitsgraphen nur blocks/blocked_by zaehlen. Alternativ die Praxis aendern, was aber 340+ Zeilen migrieren hiesse und keinen erkennbaren Nutzen haette.
-
----
-
-#### 19. G-AGENTIC07 auf main rot: ein verwaister aktiver Skill ohne Referenzquelle
-
-_(drift, skills/OVERVIEW.md)_
-
-`bash scripts/health-goals-check.sh` meldet auf `main` `🔴 G-AGENTIC07 1 (Ziel =0)` — „Verwaiste aktive Skills (keine Referenzquelle, nur getrackte)".
-
-Verifiziert: sowohl im Hauptcheckout auf altem main-Stand als auch im Chore-Worktree derselbe Wert 1, unverändert vor und nach dem Vendoring von `unsloth-buddy` (das Gate blieb bei 1, der neue Skill ist über den Vendor-Block in `.claude/skills/OVERVIEW.md` referenziert). Bestandsbefund, nicht durch T002590 verursacht.
-
-Zum Vergleich: das benachbarte G-AGENTIC06 (Skill-Zähler 28 behauptet vs. 29 real getrackte SKILL.md) war ebenfalls seit längerem rot und wurde in PR #3716 nebenbei mitkorrigiert (Zähler jetzt 30, Gate grün). G-AGENTIC07 blieb bewusst unangetastet, weil die Ursachenanalyse — welcher Skill ist verwaist und soll er entfernt oder referenziert werden — außerhalb der Chore lag.
-
----
-
-#### 20. dev-flow-plan Fix-Pfad: stage-plan (Schritt 4.5) steht vor Commit (Schritt 5), ist so aber nicht ausfuehrbar
-
-_(drift, skills/dev-flow-plan)_
-
-Beobachtet bei T002595.
-
-Die Schrittfolge des Fix-Pfads in .claude/skills/references/dev-flow-plan-phases.md lautet:
-  Schritt 4.5: Plan stagen (ticket.sh stage-plan ...)
-  Schritt 5:   Commit & Push
-
-In dieser Reihenfolge ausgefuehrt bricht Schritt 4.5 ab:
-  ERROR: Plan file 'openspec/changes/<slug>/tasks.md' does not exist on branch
-  '<branch>' or in HEAD.
-  Die Datei muss committed sein, bevor stage-plan sie referenzieren kann.
-
-stage-plan liest die Plandatei aus dem Commit, nicht aus dem Arbeitsbaum. Die dokumentierte Reihenfolge ist daher nicht durchfuehrbar; korrekt ist commit -> push -> stage-plan.
-
-Bemerkenswert: der Fehler ist gutartig (klare Meldung, exit 0, kein Datenverlust) und kostet nur einen Durchlauf. Er trifft aber jeden, der den Fix-Pfad wortgetreu abarbeitet, und ist in der SKILL.md-Fassung des Feature-Pfads ebenfalls in dieser Reihenfolge notiert (dort Schritt 4.5 vor Schritt 5).
-
-Moegliche Richtung (nicht umgesetzt): die beiden Schritte in dev-flow-plan-phases.md und dev-flow-plan/SKILL.md tauschen, oder in Schritt 4.5 den Hinweis ergaenzen, dass der Plan-Commit vorausgehen muss.
-
----
-
-#### 21. "behind N" gegen den eigenen Feature-Remote ist kein Beleg fuer fehlende Arbeit
-
-_(process, skills/ticket-ops)_
-
-EIGENER MESSFEHLER, dokumentiert damit er nicht wiederkehrt.
-
-`git status -sb` meldete fuer fix/bge-embed-routing-T002570: "ahead 22, behind 3". Ich las das als fehlende Arbeit und gab es als Auftragspraemisse an einen Subagenten weiter ("die 3 fehlenden Commits einholen"). Der Subagent pruefte nach und widerlegte es: die 3 Commits auf dem Remote waren stale Vor-Rebase-Duplikate mit IDENTISCHEN patch-ids zu bereits lokal vorhandenen Commits, und `merge-base HEAD origin/main == origin/main`. Ein Merge haette doppelte Commits erzeugt. Richtige Aufloesung war ein --force-with-lease-Push.
-
-WIRKUNG: Eine falsche Praemisse im Agent-Prompt haette ohne die Gegenpruefung des Subagenten zu einer verdoppelten Historie gefuehrt. Der Subagent hat die Anweisung korrekt in Frage gestellt, statt sie auszufuehren.
-
-LEHRE: "behind N" gegenueber dem Remote des EIGENEN Feature-Branch (nicht gegenueber main) entsteht regelmaessig nach einem lokalen Rebase und bedeutet dann gerade NICHT fehlende Arbeit. Vor dem Einholen pruefen: `git patch-id` auf beide Seiten bzw. `git merge-base HEAD origin/main`. Nur wenn merge-base VOR origin/main liegt, fehlt wirklich etwas.
-
-VORSCHLAG: In die Verifikations-Referenz aufnehmen — die Formulierung "X behind" ist im Repo-Alltag haeufig und wird verlaesslich falsch gelesen.
-
----
-
-#### 22. Subagent-Abbruch: letzte Ausgabezeile suggerierte Fortschritt, Dateien waren leer
-
-_(process, skills/ticket-ops)_
-
-Ein Planungs-Subagent brach an einem API-Stream-Stall ab ("Response stalled mid-stream"). Seine letzte Ausgabezeile lautete "Now generating the frozen batch manifest" und las sich, als sei die Analyse abgeschlossen und nur die Ausgabe offen.
-
-TATSAECHLICHER ZUSTAND nach dem Abbruch (gemessen, nicht angenommen): proposal.md 73 Bytes mit leeren "## Why"/"## What"-Abschnitten, tasks.md nur mit dem Template-Platzhalter "<author fills this in — list of new/changed files>", specs/-Delta 135 Bytes Skelett, nichts committed, alles untracked. Die gesamte Analyse war verloren.
-
-WIRKUNG: Haette ich den Bericht des Agenten fuer bare Muenze genommen, waere ein leeres Skelett als fertiger Plan durchgegangen. Beim Fortsetzen musste dem Agenten der gemessene Dateizustand ausdruecklich mitgegeben werden ("verlass dich nicht auf deine Erinnerung") — ein wieder aufgenommener Agent haelt seinen abgebrochenen Kontext sonst fuer gueltigen Fortschritt.
-
-LEHRE fuer alle Runbook-Skills, die Subagenten dispatchen: Nach JEDEM failed-Notification den Arbeitsstand auf der Platte MESSEN (git log, git status, Dateigroessen), bevor der Agent fortgesetzt oder sein Ergebnis bewertet wird. Die letzte Ausgabezeile eines abgebrochenen Agenten ist kein Fortschrittsbeleg.
-
-ZUSATZ: Ein per SendMessage fortgesetzter Agent behaelt seinen Kontext — das ist bei Transport-Fehlern (Stream-Stall) die richtige Wahl gegenueber einem Neustart. Bei einem vom Nutzer GESTOPPTEN Agenten ist die Fortsetzung dagegen gesperrt ("was stopped by the user and won't be resumed"); dort muss ein neuer Agent mit dem gemessenen Stand gebrieft werden.
-
----
-
-#### 23. dev-flow-e2e empfiehlt test/*-Branch, pre-commit verlangt feature/fix/chore/docs + T######
-
-_(process, skills/dev-flow-e2e)_
-
-dev-flow-e2e SKILL.md Schritt "AUSSTIEG" empfiehlt "test/*-Branch". Der pre-commit-Hook des Repos lehnt test/* ab: "kein gueltiges Typ-Praefix. Erlaubt: feature/ fix/ chore/ docs/", zusätzlich zwingend Ticket-ID im Branch (T002600 statt t002600). Erster Commit wurde blockiert; Workaround: Ticket angelegt (T002600) + Branch auf chore/fa-58-admin-cockpit-e2e-T002600 umbenannt. Friction: Skill-Doku divergiert von Repo-Hook — SSOT (dev-flow-e2e SKILL.md AUSSTIEG) sollte auf die Branch-Konvention des git-workflow-Skills zeigen.
-
----
-
-#### 24. mishap-tracker erzeugt Duplikat-Incident zu einem bereits gestagten Plan
-
-_(process, skills/mishap-tracker)_
-
-Ich meldete die kaputten Ziele G-LLM01/G-LLM02 mit `type=broken` an `report_mishap`. Der Tracker legte daraufhin sofort das Incident-Ticket T002583 an (`needs_human`, `hoch`, `major`).
-
-Der Fix war zu diesem Zeitpunkt BEREITS GEPLANT: der T002442-Plan (gestaged auf `chore/zielfamilie-llm-stack-T002442`, Commit 492e0cf41, Task 4) ersetzt den Messblock beider Ziele durch `scripts/lib/llm-stack-measure.sh` und deckt alle vier gemeldeten Defekte ab. T002583 war also ein Duplikat zu einem Vorgang, der wenige Minuten zuvor in derselben Sitzung gestagt wurde.
-
-URSACHE: Der `incident`/`broken`/`security`-Pfad umgeht den Buffer und legt sofort ein Ticket an — ohne Abgleich gegen bestehende Tickets oder gestagte Pläne. Der Dedupe-Guard des ticket-ops-Skills greift nur beim Intake neuer Ticketzeilen, nicht bei diesem Pfad.
-
-AUFLOESUNG im konkreten Fall: `T002442 --[fixes]--> T002583` verknuepft, T002583 auf `blocked` gesetzt und sein Scope per Kommentar auf den verbleibenden eigenstaendigen Rest reduziert (systematischer Audit aller 21 Zielfamilien auf dieselbe Fehlerklasse). Das Ticket bleibt also sinnvoll, aber nur weil es einen Rest gab — ohne den waere es reiner Muell gewesen.
-
-VORSCHLAG: Vor dem Anlegen eines Incident-Tickets die offenen Tickets und die gestagten Plaene (`openspec/changes/*/tasks.md`, `ticket_plans`) auf die betroffene Komponente pruefen. Mindestens: die eigene Meldung mit einem Hinweis versehen, wenn ein Ticket mit ueberlappender Komponente in `plan_staged` steht.
-
-EIGENANTEIL: Ich haette vor dem `report_mishap`-Aufruf pruefen koennen, dass ich denselben Defekt gerade selbst habe einplanen lassen — der Agent hatte ihn in seinem Bericht genannt. Der Tracker macht es einem aber auch nicht leicht: `type=broken` fuehlt sich fuer einen echten Defekt richtig an, und dass diese Wahl den Dedupe umgeht, steht nicht im Aufrufpfad.
-
----
-
-#### 25. agent-lock list zeigt Lock mit "--label" als Scope-Wert (Argument-Parsing)
-
-_(suspicious, scripts/agent-lock.sh)_
-
-`bash scripts/agent-lock.sh list` gibt aus:
-
-  SCOPE          ID                       TOOL     SID        STATE  LABEL
-  --label        devflow-T002569          claude   263874bd-193f-419e-88f7-f10deb99ca08 live
-
-Das Flag `--label` wurde als Scope-POSITIONSARGUMENT gelesen, der eigentliche Label-Wert ("devflow-T002569") landete im ID-Feld. Der Aufrufer hat vermutlich `claim --label devflow-T002569 ...` ohne vorangehende scope/id-Positionsargumente aufgerufen, und cmd_claim nimmt $1/$2 ungeprueft als scope/id.
-
-WIRKUNG: Der Lock ist ueber `check ticket T002569` NICHT auffindbar — er haengt an einem Phantom-Scope. Eine Session, die den regulaeren Pre-Check faehrt, sieht das Ticket als frei und koennte parallel darauf zugreifen. Das ist genau die Luecke, die T002498-M6 fuer den branch-Scope beschreibt, hier aber durch einen Parsing-Fehler statt durch Scope-Wahl entsteht.
-
-VERIFIZIERT 2026-08-02: Ausgabe oben reproduziert; der Lock gehoert einer fremden Session (nicht meiner SID) und wurde deshalb nicht angefasst.
-
-VORSCHLAG: cmd_claim sollte ablehnen, wenn das Scope-Argument mit "-" beginnt — ein Scope ist immer eines aus {ticket, branch, worktree, ...}. Eine Allowlist-Pruefung auf $1 faengt den ganzen Fehlerfall ab.
-
----
-
-#### 26. branch-reaper.sh erzwingt --ticket auch im reinen --dry-run-Inventarlauf
-
-_(suspicious, scripts/branch-reaper.sh)_
-
-VERIFIZIERT (2026-08-02, repo-hygiene-Lauf): `bash scripts/branch-reaper.sh --dry-run` endet mit "FEHLER: --ticket ist erforderlich (Format T######)".
-
-WARUM DAS STOERT: Die SSOT-Referenz repo-hygiene-ops.md §2 fuehrt den Reaper unter "Verwaiste Remote-Branches (ohne PR)" als das Werkzeug ein, das genau jene Faelle abdeckt, die --merged und [gone] nicht erfassen — und nennt den Dry-Run ausdruecklich "manuell zum Nachsehen". Beim Housekeeping ist der Ticketbezug aber gerade das Unbekannte: man hat eine Liste verwaister Branches und sucht zu jedem das Ticket. Die Kandidatenauswahl im Skript laeuft ueber `grep -i -- "$TICKET_ID"` gegen die Remote-Branch-Namen (Zeile 119-125), setzt die gesuchte Antwort also als Eingabe voraus.
-
-FOLGE IM HEUTIGEN LAUF: Der Inventarschritt musste von Hand nachgebaut werden (git for-each-ref + gh pr list + Blob-Vergleich pro Branch) — also genau die Logik, die im Skript bereits steht und dort besser geprueft ist. Der handgebaute Nachbau traf dabei prompt den Merge-Base-Defekt aus dem Schwester-Mishap.
-
-VORSCHLAG: Einen ticketlosen Inventarmodus ergaenzen (z.B. `--all --dry-run`), der ueber alle Remote-Branches iteriert und pro Branch REAP/KEEP mit Begruendung ausgibt, ohne zu loeschen. Die Ticket-Aufloesung kann dabei aus dem Branch-Namen abgeleitet werden (dieselbe T[0-9]{6}-Extraktion, die repo-hygiene-ops.md §3 fuer PRs beschreibt); Branches ohne ableitbare ID werden als KEEP mit Begruendung "keine Ticket-ID im Namen" gemeldet. Loeschen bleibt an --ticket gebunden.
-
----
-
-#### 27. browser.newContext() im storageState-Projekt lieferte authentifizierten Kontext
-
-_(suspicious, tests/e2e)_
-
-In fa-58-admin-cockpit.spec.ts T20 (mentolder-Projekt mit use.storageState) sollte browser.newContext({ ignoreHTTPSErrors: true }) einen unauthentifizierten Kontext ergeben. Der Test schlug fehl: page.url() blieb auf /admin/cockpit (authentifizierte Seite). curl bestätigt unauthentifiziert → 302 nach /login. Workaround: playwright.request.newContext({ storageState: { cookies: [], origins: [] } }) + maxRedirects:0 → erwartetes 302. Ursache unklar — vermutlich StorageState-Vererbung über die Browser-Instanz bei manuell erzeugten Kontexten in Playwright Test 1.61.
-
----
-
-#### 28. devflow-ci-watch meldet "Keine CI-Checks gefunden", nachdem es zehn gruene Checks gelistet hat
-
-_(suspicious, scripts/devflow-ci-watch.sh)_
-
-Bei PR #3843 (T002704) endete scripts/devflow-ci-watch.sh mit Exit 5 und der Meldung "⚠ Keine CI-Checks gefunden (total_count=0) — CI wurde nie gestartet oder laeuft noch." — unmittelbar NACHDEM dieselbe Ausgabe zehn Checks mit Status "pass" aufgelistet hatte.
-
-Ursache ist eine voruebergehend leere API-Antwort: ein direkt danach abgesetztes 'gh pr view --json statusCheckRollup' lieferte 'null' statt der Liste. GitHub berechnet das Rollup zeitweise neu; die Checks waren nicht verschwunden.
-
-Das ist genau die Verwechslung, gegen die die Konvention aus T002498-M5 geschrieben wurde: die auswertende Logik muss eine LEERE Antwort von einer NEGATIVEN unterscheiden. Hier fuehrt total_count=0 zu der Aussage "CI wurde nie gestartet", was in diesem Fall nachweislich falsch war — und die Meldung ist zusaetzlich irrefuehrend, weil sie zwei sich ausschliessende Deutungen ("nie gestartet ODER laeuft noch") in einem Satz anbietet und daraus einen Fehler-Exit macht.
-
-Der eigentliche Merge-Blocker war ein anderer und wurde von der Meldung verdeckt: mergeStateStatus=DIRTY / mergeable=CONFLICTING. Lokal rebaste der Branch konfliktfrei — das bekannte merge=ours-Phantommuster. Wer der Skriptmeldung glaubt, sucht den Fehler in der CI statt im Merge-Status.
-
-Vorschlag: bei total_count=0 nicht urteilen, sondern erneut abfragen und erst nach mehreren leeren Antworten in Folge eskalieren — und die Meldung um den aktuellen mergeStateStatus ergaenzen.
-
----
-
-#### 29. mcp-sync-Guard meldet auf veralteter Branch-Basis roten Drift, der lokal nicht existiert
-
-_(suspicious, scripts/mcp-sync.sh)_
-
-Beobachtet 2026-08-03 an PR #3723 (chore/toolset-divergenzen-T002596).
-
-CI rot: "Factory spec shard 4" → `not ok 36 mcp-sync.sh check stays green — headers are generated, not hand-edited`, Diff-Ausgabe "1,49d0" gegen .mcp.json. Im zugehoerigen Worktree meldete `bash scripts/mcp-sync.sh check` jedoch 4x OK (.mcp.json, .opencode/opencode.jsonc, mcp_config.json, scripts/llm/mcp-servers.json).
-
-Der PR aenderte .mcp.json ueberhaupt nicht (Diff: .claude/settings.json, AGENTS.md, CLAUDE.md, toolset-map.md, capabilities.yaml). Tatsaechliche Ursache war reine Branch-Staleness — die Basis lag 9 Commits hinter main. Nach `gh api --method PUT repos/.../pulls/3723/update-branch` lief CI durch und Auto-Merge feuerte (mergedAt 2026-08-03T04:01:16Z).
-
-Reibung: weder das Job-Log noch mergeStateStatus=BLOCKED unterschieden "echter Registry-Drift" von "Basis veraltet". Die Fehlausgabe zeigt einen kompletten .mcp.json-Inhalt als geloescht und liest sich wie ein realer Drift; die Diagnose kostete drei Log-Abrufe plus einen lokalen Gegencheck. Ein Hinweis im Guard-Fehlertext ("Basis vs. origin/main pruefen") oder ein vorgelagerter Staleness-Check im CI wuerde diesen Umweg sparen.
-
----
-
-#### 30. test:spec:changed uebersieht staged-aber-uncommittete Tests und meldet "No matching spec tests"
-
-_(suspicious, scripts/find-changed-tests.sh)_
-
-Beobachtet bei T002593. Nach `git add` einer NEUEN Datei tests/spec/dev-flow-plan/plan-lint-task-count.bats (10 Tests) meldete `task test:spec:changed`: "No matching spec tests for this diff" — und lief exit 0 durch.
-
-Ursache (verifiziert): scripts/find-changed-tests.sh:17 baut die Dateiliste aus
-  git diff --name-only HEAD origin/main
-Das vergleicht COMMITS, nicht den Index. Staged-aber-uncommittete Dateien sind darin nicht enthalten.
-
-Warum das mehr ist als eine Reihenfolge-Frage: der Verify-Block (references/verification-block.md) sieht `task test:spec:changed` VOR dem Commit vor, und die Meldung ist positiv formuliert ("No matching spec tests for this diff") statt als Warnung. Sie liest sich damit wie eine Aussage ueber die CI-Abdeckung ("meine neuen Tests laufen auf keinem PR" — vgl. den bekannten Fall aus pr-testabdeckung-unterverzeichnisse) statt wie "du hast noch nicht committed". Nach dem Commit lief dieselbe Suite mit 110/110 gruen, die neuen Tests darunter.
-
-Moegliche Richtungen (nicht umgesetzt):
-- Die Diff-Basis um den Index erweitern (`git diff --name-only HEAD` erfasst unstaged, `--cached` den Index) oder
-- die Meldung um einen Hinweis ergaenzen, wenn `git diff --cached --name-only` Testdateien enthaelt, die in der Auswahl fehlen.
-
-Kein Datenverlust, kein CI-Risiko — CI selbst arbeitet immer gegen Commits und ist korrekt.
-
----
-
-#### 31. ticket.sh list --status <unbekannt> liefert still [] statt eines Fehlers
-
-_(suspicious, scripts/ticket.sh)_
-
-Beobachtet bei T002595, mit Folgeschaden.
-
-`./scripts/ticket.sh list --status open` liefert `[]`. "open" ist kein gueltiger Status-Wert (gueltig sind triage, backlog, plan_staged, done, ...). Statt den unbekannten Filterwert abzulehnen, gibt der Befehl eine leere Liste zurueck.
-
-Folgeschaden (real eingetreten): Die Duplikatssuche vor dem Anlegen eines Bug-Tickets lief mit genau diesem Aufruf. Die leere Antwort las sich als "es gibt kein passendes Ticket", woraufhin T002594 (bge-embed OOMKilled) angelegt wurde - ein Duplikat des seit 2026-08-02 bestehenden T002580, das auf status=backlog steht und deshalb aus dem Filter fiel. T002594 musste als resolution=duplicate wieder geschlossen werden. Eine fremde Session arbeitete zu dem Zeitpunkt bereits auf fix/bge-embed-oom-T002580.
-
-Warum das mehr ist als ein Tippfehler: eine leere Liste ist ein legitimes Ergebnis. Der Aufrufer kann "kein Treffer" nicht von "Filter ungueltig" unterscheiden. Bei einer Duplikatssuche ist das die gefaehrlichste Verwechslung, weil beide Faelle zur selben falschen Handlung fuehren (neues Ticket anlegen).
-
-Moegliche Richtung (nicht umgesetzt): unbekannte --status-Werte gegen die Enum pruefen und mit exit != 0 plus Auflistung der gueltigen Werte ablehnen. Analog fuer andere Filter-Flags mit Enum-Domaene.
-Watchdog: pipeline stale > 30min (no phase progress write, class=INFRA). Returned to queue (triage); slot released. [INFRA 1/3 | tier=haiku]
-### Mishap-Rollup — 10 Eintraege (2026-08-09 03:52 UTC)
-
-| # | Typ | Komponente | Titel |
-|---|---|---|---|
-| 1 | drift | scripts/plan-lint.sh | plan-lint W3 zaehlt einen in der Prosa erwaehnten Pfad als gelistete Datei |
-| 2 | drift | skills/openspec-flow-plan, skills/openspec-propose | Delta-Spec-Header-Format in openspec-flow-plan/openspec-propose nicht explizit dokumentiert |
-| 3 | suspicious | scripts/agent-lock.sh | Agent-Lock auto-reset blockiert Branch-Wechsel im main-Checkout |
-| 4 | drift | tests/lib/factory-test-fixtures.sh | seed_test_feature dokumentiert TICKET_TEST_DB_OK nicht — Fehlschlag liest sich als fehlender DB-Pod |
-| 5 | process | scripts/worktree-create.sh | worktree-create.sh: refactor-Präfix nicht in Branch-Allowlist (nur feature/fix/chore/docs) |
-| 6 | suspicious | tests/spec/ticket-system | Pre-existing T002732 backfill-id-sequence test failures (3 tests) sichtbar in test:changed |
-| 7 | degraded | skills/openspec-archive-change | Plan archiviert, Deliverable nie gemergt — archivierter Change ohne seine Implementierung auf main |
-| 8 | drift | repo/githooks | Zwei Commit-Message-Validatoren mit unterschiedlichem Scope-Vokabular |
-| 9 | suspicious | skills/git-workflow | Abgelehnter Commit gefolgt von erfolgreichem Push sieht aus wie ein erfolgreicher Push |
-| 10 | degraded | skills/dev-flow-plan | Gestagter, nie implementierter Plan stand als roter PR in der Queue |
-
-**1. plan-lint W3 zaehlt einen in der Prosa erwaehnten Pfad als gelistete Datei** (drift, scripts/plan-lint.sh)
-
-BEOBACHTUNG (Planungslauf T002783, 2026-08-09)
-
-Der Plan enthielt unterhalb der File-Structure-Tabelle einen Fliesstext-Satz:
-
-    Positiv-Kontrolle: `scripts/agent-lock.sh` gibt unter demselben Aufruf 265 zurueck,
-    der Messpfad funktioniert also.
-
-Der Linter meldete daraufhin:
-
-    ⚠ W3: `scripts/agent-lock.sh` is listed in File Structure but no task references it
-    PLAN-LINT: PASS (0 hard, 1 warn)
-
-Die Datei stand NICHT in der Tabelle. Sie war Beleg dafuer, dass der residual_budget-Pfad
-ueberhaupt misst — genau die Gegenprobe, die die Konvention "leere Antwort ist kein Urteil"
-verlangt, wenn zwei Zieldateien ein leeres Budget liefern. W3 scheint jeden
-Backtick-Pfad im Abschnitt als Tabelleneintrag zu lesen, statt nur die Tabellenzeilen.
-
-FOLGE: gering, aber in eine unerwuenschte Richtung. Die Warnung verschwand erst, als ich
-den Pfad aus dem Satz entfernte ("ein gemessenes Shell-Skript (agent-lock)"). Der Linter
-draengt damit dazu, Belege UNSPEZIFISCHER zu formulieren — waehrend derselbe Regelsatz an
-anderer Stelle konkrete, nachpruefbare Angaben verlangt. Wer die Warnung schnell loswerden
-will, loescht eher den Beleg als ihn zu praezisieren.
-
-NICHT GEPRUEFT: ob W3 nur Backtick-Pfade im Umfeld der Tabelle erfasst oder im ganzen
-Dokument, und ob dieselbe Verwechslung auch B1a/B1b betrifft. Das waere der erste Schritt
-einer Umsetzung.
-
-TEST (Output-Verifikation, T002448-M4): plan-lint.sh gegen einen Plan AUSFUEHREN, dessen
-File-Structure-Tabelle Datei A listet und dessen Prosa Datei B in Backticks erwaehnt,
-wobei B von keiner Task referenziert wird. Erwartung: keine W3-Warnung zu B. Positiv-Anker
-(T002356-M1): im selben Test ein tatsaechlich in der TABELLE gelistetes, unreferenziertes
-A verwenden und zeigen, dass W3 dafuer sehr wohl anschlaegt — sonst besteht der Test auch
-bei einem Linter, der W3 gar nicht mehr auswertet.
-**2. Delta-Spec-Header-Format in openspec-flow-plan/openspec-propose nicht explizit dokumentiert** (drift, skills/openspec-flow-plan, skills/openspec-propose)
-
-Fünf Mishap-Fix-PRs (#3905-#3909) waren alle durch CI blockiert, weil ihre Delta-Spec-Dateien nicht dem validierten Format entsprachen:
-
-1. `## ADDED:` / `## MODIFIED:` statt `## ADDED Requirements` / `## MODIFIED Requirements` (ohne "Requirements" im Header)
-2. Keine `#### Scenario:`-Blöcke unter den `### Requirement:`-Blöcken
-
-Der CI-Check `scripts/openspec-validate.test.ts` → `validateTree` verlangt exakt das Pattern `## (ADDED|MODIFIED|REMOVED|RENAMED) Requirements` und mindestens einen `#### Scenario:`-Block pro Requirement.
-
-Root Cause: Die `openspec-flow-plan` und `openspec-propose` Skills dokumentierten das Pflicht-Format nicht explizit genug — `openspec-propose` nannte zwar `## ADDED Requirements` aber nicht den Scenario-Zwang; `openspec-flow-plan` verwies nur auf die T001304-Delta-Konvention ohne Format-Details.
-
-Fix: PR #3910 ergänzt beide Skills um explizite Format-Vorgaben inkl. der vier gültigen Header-Varianten, dem Requirement→Scenario-Pattern und dem Hinweis auf die CI-Blockade.
-**3. Agent-Lock auto-reset blockiert Branch-Wechsel im main-Checkout** (suspicious, scripts/agent-lock.sh)
-
-Beim ticket-ops-Durchlauf am 2026-08-09: Beim Versuch, von `fix/openspec-flow-plan-delta-header-format` auf `main` zu wechseln, setzte AGENT-LOCK den Checkout wiederholt auf den alten Branch zurück.
-
-Beobachtete Meldung (mehrfach): `AGENT-LOCK: main-Checkout auf 'fix/openspec-flow-plan-delta-header-format' zurückgesetzt (Lock-Halter aktiv)`.
-
-Dies passierte trotz `git checkout -B fix/delta-spec-header-doc-T002772 origin/main` — der Lock-Mechanismus überschrieb den Branch-Wechsel.
-
-Workaround: `git worktree add` umging das Problem; der Commit für PR #3910 wurde im isolierten Worktree durchgeführt.
-**4. seed_test_feature dokumentiert TICKET_TEST_DB_OK nicht — Fehlschlag liest sich als fehlender DB-Pod** (drift, tests/lib/factory-test-fixtures.sh)
-
-BEOBACHTUNG (Planungslauf T002781, 2026-08-09)
-
-Ein neuer BATS-Test rief seed_test_feature "mentolder" auf. Ergebnis:
-
-    ERROR: no shared-db pod found in namespace workspace
-           (context bats-no-cluster-t002224)
-
-Die Meldung liest sich wie ein Infrastrukturproblem — kein Pod, Cluster weg. Tatsaechlich
-lief der Cluster, und derselbe kubectl-Aufruf mit --context k3d-mentolder-dev fand den Pod
-sofort. Der Kontext bats-no-cluster-t002224 ist ein ABSICHTLICHER Sentinel aus
-scripts/vda/ticket/_ticket-core.sh:31: unter BATS zeigt ticket.sh bewusst ins Leere, damit
-Tests keine echten Ticketzeilen schreiben. Der Kommentar dort ist ausfuehrlich und nennt den
-Anlass — rund 130 Geisterzeilen zwischen dem 2026-07-03 und dem 2026-07-26. Das Opt-in
-heisst TICKET_TEST_DB_OK=1.
-
-DER DEFEKT IST NICHT DER SCHUTZ, SONDERN WO ER DOKUMENTIERT IST
-
-seed_test_feature in tests/lib/factory-test-fixtures.sh ist die Funktion, die ein
-Testautor aufruft. Ihr Kopfkommentar lautet vollstaendig:
-
-    # seed_test_feature <brand> [touched_file ...] → echoes the new external_id
-
-Kein Wort zu TICKET_TEST_DB_OK. Die Begruendung steht in _ticket-core.sh — einer Datei,
-die der Testautor nicht liest, weil sie zwei Ebenen unter dem aufgerufenen Werkzeug liegt.
-Wer den Hinweis nicht kennt, diagnostiziert einen Cluster- oder Namespace-Fehler; genau
-das ist hier passiert und hat einen Debug-Zyklus gekostet.
-
-Verschaerfend: die Meldung nennt zwar den Kontextnamen, aber "bats-no-cluster-t002224"
-liest sich wie ein verunglueckter Default, nicht wie eine absichtliche Sperre. Ein Hinweis
-im Fehlertext ("unter BATS gesperrt — TICKET_TEST_DB_OK=1 zum Opt-in") haette gereicht.
-
-VORSCHLAG (nicht entschieden)
-- Den Kopfkommentar von seed_test_feature um die Vorbedingung ergaenzen.
-- Oder die Sperre selbst sprechen lassen: wenn CTX der Sentinel ist und _pgpod scheitert,
-  eine eigene Meldung ausgeben statt der generischen "no shared-db pod"-Zeile.
-Die zweite Variante wirkt an jeder Aufrufstelle, nicht nur an der, die man gerade liest.
-
-TEST (Output-Verifikation, T002448-M4): seed_test_feature unter BATS OHNE
-TICKET_TEST_DB_OK AUSFUEHREN und pruefen, dass die Fehlermeldung das Opt-in benennt.
-Positiv-Anker (T002356-M1): im selben Test mit gesetztem TICKET_TEST_DB_OK=1 zeigen, dass
-der Seed durchlaeuft und eine external_id liefert — sonst besteht der Test auch bei einer
-Fixture, die immer fehlschlaegt.
-**5. worktree-create.sh: refactor-Präfix nicht in Branch-Allowlist (nur feature/fix/chore/docs)** (process, scripts/worktree-create.sh)
-
-Beim Dispatch von T002627 (type=refactor) wurde der Branch refactor/sdlc-routes-remove-T002627 von worktree-create.sh abgelehnt. Erlaubt sind nur feature/fix/chore/docs. Workaround: feature/ statt refactor/ verwendet. Ticket-Typ "refactor" sollte entweder ein erlaubtes Branch-Präfix bekommen oder beim Anlegen automatisch auf feature/chore normalisiert werden.
-**6. Pre-existing T002732 backfill-id-sequence test failures (3 tests) sichtbar in test:changed** (suspicious, tests/spec/ticket-system)
-
-Während test:changed für T002783 liefen 3 Tests in tests/spec/ticket-system/backfill-id-sequence.bats (T002732) rot. Nicht durch T002783 verursacht, aber sie erscheinen in jedem test:changed-Lauf, der ticket.sh-Änderungen enthält, und kosten jedes Mal Diagnosezeit. Sollten entweder gefixt oder als known-flaky markiert werden.
-**7. Plan archiviert, Deliverable nie gemergt — archivierter Change ohne seine Implementierung auf main** (degraded, skills/openspec-archive-change)
-
-Beobachtet 2026-08-09 während repo-hygiene. PR #3919 archivierte den Change nach openspec/changes/archive/2026-08-09-fa-59-e2e-spec-positive-assertion und merged das Delta in openspec/specs/e2e-testing.md. Die eigentliche Implementierung von T002730 — die positive Assertion toBe(403) in tests/e2e/specs/fa-59-systemtest-purge-endpoint.spec.ts sowie die beiden BATS-Guards in tests/spec/e2e-testing.bats — lag jedoch ausschliesslich auf dem noch OFFENEN Branch von PR #3914. main trug damit einen als erledigt geltenden, archivierten Change ohne sein Deliverable; die Spec enthielt weiterhin das negative not.toBe(404), das der Change gerade beseitigen sollte.
-
-Verschaerfend: PR #3914 haette in seiner damaligen Fassung den bereits archivierten Change unter openspec/changes/ wieder auferstehen lassen (alle 8 Plan-Dateien als Additions), zusaetzlich mit einer Delta-Spec nach Change-Slug statt Parent-SSOT-Slug benannt.
-
-Der Check aus CLAUDE.md M10 (T002506) beschreibt genau diesen Fall — vor dem Abschluss per git show origin/main:<pfad> belegen, dass die Deliverable-Dateien wirklich auf main liegen. Er lief nicht. Bemerkenswert ist, dass hier keine manuelle Closure vorlag, sondern ein Archive-PR: die M10-Regel ist heute auf manuelle done/shipped-Faelle formuliert und deckt den Archive-Pfad nicht ab.
-
-Behoben im Lauf: #3914 traegt jetzt nur noch das Deliverable, die auferstandene Kopie ist entfernt, PR umbenannt zu fix(e2e-testing). Verifiziert nach Merge: origin/main enthaelt 2x toBe(403) und 3x T002730-Referenzen.
-**8. Zwei Commit-Message-Validatoren mit unterschiedlichem Scope-Vokabular** (drift, repo/githooks)
-
-Beobachtet 2026-08-09. `fix(mcp-gateway): …` besteht den PR-Titel-Check "Conventional Commits" (grün auf PR #3918, dessen Titel genau so lautet), wird aber vom lokalen .githooks/commit-msg abgelehnt: "✗ unknown scope 'mcp-gateway' — did you mean 'mcp'?". Dasselbe bei `chore(tickets):`.
-
-Verifiziert: `bash .githooks/commit-msg` gegen eine Testnachricht liefert reproduzierbar die Ablehnung; `bash scripts/validate-commit-msg.sh scopes` fuehrt mcp, plans, ci und test, aber kein mcp-gateway und kein tickets.
-
-Die Folge ist nicht nur Reibung: der PR-Titel ist die naheliegendste Vorlage fuer die Commit-Message auf demselben Branch, und er ist nachweislich gruen. Wer ihn uebernimmt, laeuft in die Ablehnung. Kostete in diesem Lauf zwei verworfene Commits.
-
-Denkbar: dieselbe Scope-Allowlist auch auf den PR-Titel anwenden, oder die Ablehnungsmeldung um den Hinweis ergaenzen, dass der PR-Titel-Check ein anderes Vokabular nutzt.
-**9. Abgelehnter Commit gefolgt von erfolgreichem Push sieht aus wie ein erfolgreicher Push** (suspicious, skills/git-workflow)
-
-Beobachtet 2026-08-09, zweimal (PR #3918 und PR #3915). Ablauf: `git commit …` wird vom commit-msg-Hook abgelehnt ("No commit was created — commit-msg hook rejected the message (conventional-commit format check)"), der im selben Kommando nachfolgende `git push` laeuft daraufhin durch und meldet ganz normal "   <alt>..<neu>  HEAD -> <branch>".
-
-Uebertragen wurde in beiden Faellen nur der zuvor erzeugte Merge-Commit — der eigentliche Fix blieb liegen. Die Push-Ausgabe ist von einem erfolgreichen Push nicht zu unterscheiden: sie nennt einen echten SHA-Bereich und einen echten Branch.
-
-Zwei Faktoren verstaerken das: (a) die Ablehnungsmeldung erscheint weit oben in der Ausgabe und wird von der nachfolgenden Hook- und Push-Ausgabe verdraengt; (b) `git push` hat keinen Grund zu scheitern, weil der Branch ja tatsaechlich Commits hat.
-
-Verallgemeinerbar und deshalb notiert: der Erfolg des LETZTEN Kommandos in einer Kette sagt nichts ueber den Erfolg des vorherigen. Konsequenz fuer Runbooks: nach einem Commit den erzeugten SHA per `git log -1 --oneline` pruefen, statt die Push-Ausgabe als Bestaetigung zu lesen — oder commit und push mit && verketten (so macht es scripts/factory/mishap-rollup.sh laut eigenem Skriptkopf bereits bewusst).
-**10. Gestagter, nie implementierter Plan stand als roter PR in der Queue** (degraded, skills/dev-flow-plan)
-
-Beobachtet 2026-08-09 an PR #3918 (T002719). Der Branch trug ausschliesslich die Commits "chore: anchor branch" und "chore(plans): add failing test + stage plan" — also den dev-flow-plan-Ausgang, ohne dev-flow-execute. Trotzdem existierte ein offener PR mit dem Titel eines fertigen Fixes ("fix(mcp-gateway): agy headless mcp tool permissions via --dangerously-skip-permissions").
-
-Der PR hatte vier rote Checks. Zwei davon stammten allein daraus, dass die Implementierung nicht committet war: die Delta-Spec openspec/changes/agy-headless-mcp-permissions/specs/mcp-gateway.md existierte im Worktree als UNTRACKED (daher "missing specs/ delta dir" in der OpenSpec-validateTree-Pruefung), und die zugehoerige SSOT-Ergaenzung in openspec/specs/mcp-gateway.md lag dort uncommittet (daher der rote BATS-Guard, der genau dieses Requirement greppt).
-
-Die Arbeit war also getan, nur nie festgeschrieben — im Worktree einer Session, deren PID nicht mehr lief.
-
-Das Problem ist die Lesart von aussen: ein roter PR mit Fix-Titel liest sich als "kaputter Fix, Diagnose noetig", nicht als "Plan gestagt, Implementierung ausstehend". In einer Queue mit mehreren PRs kostet das gezielt Zeit an der falschen Stelle. Denkbar: Plan-only-Branches gar nicht als PR oeffnen, oder als Draft mit erkennbarem Titel-Praefix.
-### Mishap-Rollup — 10 Eintraege (2026-08-09 04:24 UTC)
-
-| # | Typ | Komponente | Titel |
-|---|---|---|---|
-| 1 | drift | skills/dev-flow-plan | Von dev-flow-plan erzeugter Failing-Test war strukturell CI-untauglich (Drittanbieter-Binary) |
-| 2 | suspicious | skills/repo-hygiene | gh pr checks meldet "no checks reported", obwohl Runs für denselben HEAD-SHA existieren |
-| 3 | drift | skills/repo-hygiene | CONFLICTING PR unterdrückt CI — Symptom ist von "noch nicht gestartet" nicht unterscheidbar |
-| 4 | drift | skills/repo-hygiene | merge=ours-Phantomkonflikt: update-branch antwortet 422, lokaler Merge läuft konfliktfrei |
-| 5 | suspicious | scripts/openspec-half-archive-check.sh | Halb archivierter Zustand im Hauptcheckout — uncommittet, vom half-archive-Guard nicht erfasst |
-| 6 | drift | openspec/changes | Delta-Spec nach Change-Slug statt Parent-SSOT-Slug benannt — Archivierung wird scheitern (T002666) |
-| 7 | suspicious | scripts/agent-lock.sh | agent-lock claim ticket returns exit 0 but lock not held |
-| 8 | suspicious | scripts/pre-push hook | Pre-push hook rejects valid push due to stale scope commits from rebased main |
-| 9 | degraded | devflow/merge pipeline | PR #3926 went DIRTY/CONFLICTING immediately after creation — rebase needed 3 attempts |
-| 10 | process | dev-flow-plan | Planung widersprach einer bestehenden Design-Entscheidung, die erst nach der Nutzerfrage gefunden wurde |
-
-**1. Von dev-flow-plan erzeugter Failing-Test war strukturell CI-untauglich (Drittanbieter-Binary)** (drift, skills/dev-flow-plan)
-
-Beobachtet 2026-08-09 an PR #3918. Der von dev-flow-plan als TDD-Rotphase erzeugte Test tests/spec/mcp-gateway/agy-mcp-permissions.bats enthielt:
-
-    @test "agy binary supports --dangerously-skip-permissions flag" {
-      run agy --help
-      [ "$status" -eq 0 ]
-      ...
-    }
-
-`agy` ist ein lokal installiertes Drittanbieter-CLI. Verifiziert: `grep -rn 'agy' .github/workflows/*.yml` liefert 0 Treffer — kein Workflow installiert es. Der Test waere in CI also DAUERHAFT rot gewesen, ohne je eine Aussage ueber das Repository zu treffen; er misst die Ausstattung des Runners, nicht den Zustand des Codes.
-
-Das ist keine Kleinigkeit im Rotphasen-Kontext: ein Test, der aus Umgebungsgruenden nie gruen werden kann, ist von einem Test, der wegen fehlender Implementierung rot ist, in der CI-Ausgabe nicht zu unterscheiden. Die Rotphase verliert damit ihre Aussagekraft.
-
-Behoben im Lauf mit dem im Repo etablierten Muster (tests/spec/sealed-secret-cluster-drift.bats: kein erreichbarer Cluster -> skip):
-    command -v agy >/dev/null 2>&1 || skip "agy binary not installed"
-Verifiziert in beiden Richtungen: mit agy im PATH laeuft der Test durch, mit PATH=/usr/bin:/bin skippt er sauber.
-
-Denkbar als Konvention: wenn ein geplanter Test ein externes Binary oder einen Dienst voraussetzt, gehoert der Verfuegbarkeits-Guard schon in die Rotphase.
-**2. gh pr checks meldet "no checks reported", obwohl Runs für denselben HEAD-SHA existieren** (suspicious, skills/repo-hygiene)
-
-Beobachtet 2026-08-09 an PR #3916. `gh pr checks 3916` antwortete "no checks reported on the 'fix/main-checkout-freshness-cleanup-T002664' branch", und `gh pr view 3916 --json statusCheckRollup` lieferte ein LEERES Array.
-
-Gleichzeitig zeigte `gh run list --branch fix/main-checkout-freshness-cleanup-T002664` fuenf abgeschlossene Runs, darunter einen CI-Run mit conclusion=failure (databaseId 31291991475). Der PR-HEAD (9b4fb48cbdb3ee604c65fc5f8c720dbbe9436a24) war identisch mit dem Remote-Branch-Tip — es lag also kein nachtraeglicher Push vor, der den Rollup entwertet haette.
-
-Die Fehldiagnose, in die das fuehrt: "keine Checks" liest sich als "Workflows noch nicht gestartet / Queue klemmt" und lenkt die Untersuchung auf die Actions-Infrastruktur, waehrend der PR in Wahrheit an zwei konkreten BATS-Tests scheiterte. Gefunden nur, weil zusaetzlich `gh run list` abgefragt wurde.
-
-Konsequenz fuer repo-hygiene §3: eine leere Checkliste ist KEIN Urteil ueber den CI-Zustand — dasselbe Muster, das der Abschnitt bereits fuer mergedAt festhaelt. Bei leerem Rollup immer gegen `gh run list --branch <b>` gegenpruefen, bevor "noch keine Checks" berichtet wird.
-**3. CONFLICTING PR unterdrückt CI — Symptom ist von "noch nicht gestartet" nicht unterscheidbar** (drift, skills/repo-hygiene)
-
-Beobachtet 2026-08-09 an PR #3915. Der PR hatte NULL Workflow-Runs (`gh run list --branch fix/ticket-mcp-update-fields-T002714` war komplett leer), weil er mit main konfligierte.
-
-Dass ein CONFLICTING PR die CI unterdrueckt, ist in docs/superpowers/references/gotchas-footguns.md dokumentiert. Sein SYMPTOM ist es nicht: `gh pr checks` liefert exakt dieselbe Meldung "no checks reported on the branch" wie bei einem noch nicht gestarteten Lauf. Ohne einen lokalen Merge-Versuch ist der Konflikt als Ursache nicht erkennbar — und `mergeStateStatus` stand zu dem Zeitpunkt auf UNKNOWN, half also auch nicht.
-
-Der Konflikt selbst war trivial: ein Append-Konflikt in der Commands-Zeile von scripts/ticket.sh (`update-fields` auf dem Branch, `rollup-container` aus main). Aufloesung durch Behalten BEIDER Kommandos, verifiziert nach Merge auf origin/main (5x update-fields, 4x rollup-container).
-
-Vorschlag fuer repo-hygiene §3: bei leerer Checkliste zuerst `mergeStateStatus` pruefen und, falls UNKNOWN oder DIRTY, lokal `git merge origin/main --no-commit` gegen den Branch versuchen — das trennt "Konflikt" von "noch nicht gestartet" eindeutig.
-**4. merge=ours-Phantomkonflikt: update-branch antwortet 422, lokaler Merge läuft konfliktfrei** (drift, skills/repo-hygiene)
-
-Beobachtet 2026-08-09 an PR #3915, zweiter Durchgang (nach vier zwischenzeitlichen Merges nach main). GitHub meldete mergeStateStatus=DIRTY, und
-
-    gh api --method PUT repos/Paddione/Bachelorprojekt/pulls/3915/update-branch \
-      -f expected_head_sha=<head>
-
-antwortete mit HTTP 422 "merge conflict between base and head".
-
-Lokal war davon nichts zu sehen: `git merge origin/main` in einem frischen Worktree auf denselben Branch lief glatt durch, `git diff --name-only --diff-filter=U` blieb LEER. Ursache ist der dokumentierte merge=ours-Effekt — die Freshness-Generate (website/src/data/openspec-status.json, test-inventory.json) tragen in .gitattributes einen Custom-Merge-Driver, den GitHub nicht ausfuehrt.
-
-Bestaetigung eines bekannten Gotchas, hier mit einem Zusatz, der die Diagnose beschleunigt haette: der REST-Fallback aus repo-hygiene-ops ("PR-Branch auf main nachziehen") HILFT IN DIESEM FALL NICHT — er scheitert an genau demselben Phantomkonflikt mit 422. Der Abschnitt liest sich heute so, als sei update-branch der Weg und der lokale Merge nur die Nachbereitung. Tatsaechlich ist bei merge=ours-Konflikten der lokale Merge der EINZIGE Weg: mergen, Artefakte regenerieren, Merge-Commit pushen.
-**5. Halb archivierter Zustand im Hauptcheckout — uncommittet, vom half-archive-Guard nicht erfasst** (suspicious, scripts/openspec-half-archive-check.sh)
-
-Beobachtet 2026-08-09 im Hauptcheckout /home/patrick/Bachelorprojekt. `git status` zeigte 19 Zeilen: drei Change-Verzeichnisse (agy-headless-mcp-permissions, qwen3-coder-loadout, routes-manifest-stacktrace-fallback-T002666) als geloescht unter openspec/changes/, dieselben Inhalte als UNTRACKED unter openspec/changes/archive/2026-08-09-*, plus regeneriertes openspec-status.json.
-
-Die Verschiebung war inhaltlich getreu (alle 15 Dateien byteidentisch, gleiche Dateizahlen je Change — geprueft gegen HEAD). Sie war aber UNVOLLSTAENDIG: die Delta-Specs waren nicht in die SSOT-Specs gemerged. Fuer qwen3-coder-loadout haette ein Commit das Requirement "Qwen3-Coder is available as an additive chat loadout" aus dem aktiven Baum entfernt, ohne dass es je in openspec/specs/local-llm-proxy.md ankommt — stiller Verlust eines Requirements.
-
-Herkunft: KEIN post-merge-Hook erzeugt das (.githooks/post-merge enthaelt nichts zu archive/openspec). Es stammt aus einem abgebrochenen manuellen bzw. agentischen openspec.sh-archive-Lauf, vermutlich aus einer der Sessions, deren PID nicht mehr lief.
-
-Kernbefund und Grund fuer diesen Eintrag: scripts/openspec-half-archive-check.sh existiert genau gegen diesen Zustand, meldete aber die ganze Zeit gruen — er prueft den COMMITTETEN Baum und sieht einen uncommitteten Halbzustand per Konstruktion nicht. Der Guard deckt damit die Phase nicht ab, in der der Fehler entsteht.
-
-Behandelt im Lauf: Dateien nach scratchpad gesichert, Arbeitsbaum auf origin/main zurueckgesetzt (kein Informationsverlust — jede Datei war byteidentisch zu einer getrackten Datei in HEAD), Guard danach weiterhin gruen. Die drei Changes stehen wieder regulaer unter openspec/changes/ und sind ordentlich zu archivieren.
-**6. Delta-Spec nach Change-Slug statt Parent-SSOT-Slug benannt — Archivierung wird scheitern (T002666)** (drift, openspec/changes)
-
-Beobachtet 2026-08-09. Der Change openspec/changes/routes-manifest-stacktrace-fallback-T002666/ traegt seine Delta-Datei unter specs/routes-manifest-stacktrace-fallback-T002666.md — also nach dem CHANGE-Slug benannt, inklusive Ticket-Suffix.
-
-Verifiziert: eine SSOT-Spec openspec/specs/routes-manifest-stacktrace-fallback-T002666.md existiert nicht. Der naechste fachlich passende Parent waere ci-cd.md.
-
-Das verstoesst gegen die Delta-Spec-Konvention T001304 (Delta-Dateien werden nach dem Parent-SSOT-Slug benannt). Praktische Folge: `openspec.sh archive` schlaegt hier ohne --create-new fehl, weil der Ziel-SSOT nicht existiert — und --create-new waere fachlich falsch, da es sich nicht um eine neue Komponente handelt, sondern um einen Fix am routes:manifest-Verhalten.
-
-Faelligkeit: PR #3913 (fix(routes): routes:manifest suppresses tsx stderr stacktrace [T002666]) ist BEREITS GEMERGT. Die Archivierung steht also an, und der Fehler tritt erst zu diesem Zeitpunkt zutage — die Datei liegt seit dem Anlegen des Change falsch benannt da, ohne dass irgendein Gate darauf anspricht.
-
-Denkbar: die Namenskonvention schon bei `openspec.sh propose` pruefen (Delta-Dateiname muss einem existierenden openspec/specs/<slug>.md entsprechen, sonst --target-spec verlangen), statt den Fehler bis zum Archivieren aufzuschieben.
-**7. agent-lock claim ticket returns exit 0 but lock not held** (suspicious, scripts/agent-lock.sh)
-
-During ticket-ops Wave 0+1 dispatch: `agent-lock.sh claim ticket T002781` (and subsequent Wave 1 tickets) returned exit 0 with no output but `check ticket` still showed `free`. The `check-and-claim` variant worked correctly. Observed on 2026-08-09 during T002781 execution in worktree. The silent claim failure creates a race condition where two sessions could believe they both hold the lock.
-**8. Pre-push hook rejects valid push due to stale scope commits from rebased main** (suspicious, scripts/pre-push hook)
-
-When pushing fix/ticket-list-test-data-filter-T002781, the pre-push conventional-commit validator rejected the push because rebased commits from main (ci-cd, mcp-gateway, e2e-testing, routes scopes) were in the push range. These scopes were invalid per T002328 consolidation but the commits were already merged to origin/main — the hook should only check new commits, not the full range being pushed. Required workaround: rebase --onto to isolate only our commits.
-**9. PR #3926 went DIRTY/CONFLICTING immediately after creation — rebase needed 3 attempts** (degraded, devflow/merge pipeline)
-
-T002781 PR #3926 went from clean push to DIRTY/CONFLICTING immediately after creation, requiring 3 rebase cycles: (1) initial rebase with merge conflict on plan files, (2) rebase --onto to fix push rejection, (3) third rebase after auto-merge showed DIRTY. The post-rewrite openspec-status.json regeneration triggered dirty state on most rebases. Main branch was moving during the session with chore:release main commits.
-**10. Planung widersprach einer bestehenden Design-Entscheidung, die erst nach der Nutzerfrage gefunden wurde** (process, dev-flow-plan)
-
-Beim Planen von T002817 (SSOT für ticketlose Branch-Ausnahmen) habe ich dem User die Architekturfrage "gemeinsame Quelle vs. Allowlist spiegeln" gestellt, BEVOR ich geprüft hatte, ob die Frage im Repo schon einmal entschieden wurde. Sie war es: openspec/specs/divergence-guard.md:107-112 (aus T002470) schreibt die Duplikation ausdrücklich fest ("the pre-commit hook stays free of repository file dependencies, so that a missing library file cannot block every commit") und sichert sie mit drei Drift-Tests in tests/spec/divergence-guard/branch-name-guard.bats:114-139 ab.
-
-Gefunden habe ich das erst beim Schreiben des failing Tests, als ich nach bestehenden Hook-Testmustern suchte — also nach der Entscheidung. Der User musste die Frage daraufhin ein zweites Mal beantworten, diesmal mit der vollständigen Faktenlage. Die Entscheidung fiel gleich aus (SSOT, Requirement per RENAMED-Delta ersetzen), das Risiko war aber real: eine unbemerkte Umkehr einer dokumentierten Entscheidung wäre erst im Review oder gar nicht aufgefallen.
-
-ABLEITUNG: Vor einer Architekturfrage an den User gehört eine Suche nach bestehenden Requirements zum selben Gegenstand — grep über openspec/specs/ auf die betroffenen Dateipfade, nicht nur über den Code. Der Fix-Pfad von dev-flow-plan verlangt Ursachen-Verifikation vor dem Brainstorming (T002448-M5), aber nicht die Prüfung, ob die Lösungsrichtung schon einmal verworfen wurde.
-
-NEBENBEFUND, in den Change eingearbeitet: der Drift-Guard aus T002470 hat den Drift, der T002817 auslöste, nicht gefunden. Er vergleicht Ticket-ID-Regex, Exemption-Liste und Typ-Präfixe zwischen Hook und Helper — die _unattended_allowlist (worktree-create.sh:49, mit T002783 hinzugekommen) fällt in keinen der drei Vergleiche. Eine bewusst duplizierte Regel ist nur so vollständig abgesichert wie die Aufzählung der Drift-Tests gepflegt wird.
-
-ZWEITER, KLEINERER BEFUND: Ich habe .githooks/pre-push zunächst als zweiten Blocker der Kette bezeichnet. Der Abschnitt ist advisory (warn + exit 0), blockiert also nicht. Korrigiert, bevor der Plan geschrieben wurde; der Hook bleibt im Scope, weil die Warnung falsch ist, aber er war nie Ursache.
-### Mishap-Rollup — 10 Eintraege (2026-08-09 06:49 UTC)
-
-| # | Typ | Komponente | Titel |
-|---|---|---|---|
-| 1 | drift | scripts/factory/mishap-rollup.sh · tickets/lifecycle | Rollup-Plan lokal committet, nie gepusht — Container blieb triage mit plan_ref=null |
-| 2 | degraded | scripts/bge-mcp · systemd-user-units · openspec-embed-hook | bge-forward-embed: Unit active, Socket lauscht, Tunnel tot — openspec-embed schlägt bei jedem Commit still fehl |
-| 3 | degraded | k3d/llm-gpu.yaml · bge-embed · scripts/bge-mcp | KORREKTUR zum bge-forward-embed-Mishap: Restart wirkungslos, Ursache liegt cluster-seitig — readiness=true bei totem Endpoint |
-| 4 | degraded | scripts/ticket.sh | ticket.sh: --help auf Subkommando-Ebene fuehrt in eine Fehlermeldung statt zur Optionsliste |
-| 5 | drift | .claude/skills/references/repo-hygiene-ops.md §4 · mishap-tracker | Dedupe-Guard prueft nur offene Tickets, nicht den Mishap-Buffer — Doppelerfassung real eingetreten |
-| 6 | suspicious | tickets/plan_staged | 18 Tickets stehen auf plan_staged ohne plan-Zeile/Branch — halbgestagte Plans |
-| 7 | suspicious | tickets/t002629 | T002629-Beschreibung behauptet offenen Blocker, PR #3745 ist seit 4 Tagen gemergt |
-| 8 | process | skills/repo-hygiene | Probe-Schleife mit 2>/dev/null macht harten Fehler zu stillem Leerergebnis |
-| 9 | degraded | llm/gateway | Alle vier lokalen LLM-Backends am Gateway degraded (/health 503) |
-| 10 | suspicious | scripts/agent-lock.sh | Tote agent-locks blockieren bis zu 30 min, obwohl beide PIDs nachweislich tot sind |
-
-**1. Rollup-Plan lokal committet, nie gepusht — Container blieb triage mit plan_ref=null** (drift, scripts/factory/mishap-rollup.sh · tickets/lifecycle)
-
-Beobachtet 2026-08-09 in .worktrees/mishap-incident-rollup waehrend eines repo-hygiene-Laufs.
-
-Der Branch chore/mishap-incident-rollup trug den Commit 7b3916970 ("chore(plans): update mishap-incident-rollup from container batches [T002784]") mit einem vollstaendigen 1092-zeiligen Plan (proposal.md + tasks.md). VERIFIZIERT: `git ls-remote --heads origin` kannte KEIN refs/heads/chore/mishap-incident-rollup, und Container T002784 stand auf status=triage mit plan_ref=null. Der Lauf ist zwischen `git commit` (erfolgreich) und `git push`/`stage-plan` gestorben.
-
-WARUM DAS ZAEHLT: Wie bei T002817 endet die Mishap-Auswertung blind — der Plan wird korrekt erzeugt und gelintet, ist fuer die Factory aber unsichtbar (kein Remote-Ref, kein plan_ref, Container nicht plan_staged). Unterschied zu T002817: dort scheiterte der COMMIT am pre-commit-Branch-Guard, hier war der Commit erfolgreich und PUSH/stage-plan blieben aus. Naechster Blocker derselben Kette, nicht derselbe.
-
-BESONDERS TUECKISCH: Der lokale Branch trug origin/main als Upstream statt seines eigenen Remote-Refs. `git status` meldet dann "ahead 2" — das liest sich wie normaler unveroeffentlichter Fortschritt, obwohl der designierte Remote-Branch gar nicht existiert. Das Signal, das den Defekt anzeigen muesste, sieht aus wie der Normalzustand.
-
-BEHOBEN IN DIESEM LAUF (Symptom, nicht Ursache): Branch nach origin gepusht (pre-push gruen, T002817-Allowlist greift jetzt), danach `ticket.sh stage-plan --id T002784 --branch chore/mishap-incident-rollup --plan openspec/changes/mishap-incident-rollup/tasks.md --partials 1`. Container steht wieder auf plan_staged mit gueltigem plan_ref. Der Defekt im Treiber-Pfad selbst ist NICHT behoben.
-
-VORSCHLAG: Der Treiber sollte nach dem Push verifizieren, dass der Remote-Ref existiert (`git ls-remote --heads origin "$BRANCH"`), statt sich auf den Exit-Code von `git push -q` zu verlassen — dieselbe Struktur wie die mergedAt-Regel in repo-hygiene-ops §3 ("eine leere Antwort ist kein Urteil"). Zusaetzlich ein Nachlauf-Check, der einen committeten aber nicht gepushten Plan beim naechsten Tick aufgreift, statt ihn liegen zu lassen.
-
-VERWANDT: T002817 (pre-commit-Guard, PR #3929 gemergt), T002783 (Container-Aufloesung), T002407 (Treiber).
-**2. bge-forward-embed: Unit active, Socket lauscht, Tunnel tot — openspec-embed schlägt bei jedem Commit still fehl** (degraded, scripts/bge-mcp · systemd-user-units · openspec-embed-hook)
-
-Beobachtet 2026-08-09 waehrend eines repo-hygiene-Laufs, aufgefallen an einer WARN-Zeile des post-commit-Hooks von scripts/factory/mishap-rollup.sh.
-
-BEFUND (drei Signale gruen, Dienst unbenutzbar):
-- `systemctl --user is-active bge-forward-embed` -> active (running), seit 8 h
-- `ss -tlnp | grep 8081` -> LISTEN auf 127.0.0.1:8081 und [::1]:8081, gehalten von kubectl pid 318
-- `/proc/318/cmdline` -> `kubectl --context fleet port-forward -n workspace svc/llm-gateway-embed 8081:8081`
-- `curl -m 8 http://127.0.0.1:8081/v1/embeddings` -> HTTP 000 nach 8,02 s (Timeout), zweimal reproduziert
-
-Der lokale Socket nimmt Verbindungen an, aber der Tunnel dahinter transportiert nichts. Ein Zombie-Port-Forward: der kubectl-Prozess lebt weiter, seine Cluster-Verbindung ist weg.
-
-WARUM DAS ZAEHLT: Der Kommentarkopf von scripts/bge-mcp/bge-mcp.service dokumentiert unter T002604 ausdruecklich, dass die Port-Forwards zu eigenen Units gemacht wurden, damit systemd sie ueberwacht und neu startet — "statt wie bisher `active` zu melden, waehrend [der Tunnel tot ist]". Genau dieser Zustand ist eingetreten. Die Massnahme kann ihn nicht verhindern: systemd sieht Prozess-Liveness, nicht Tunnel-Gesundheit. Ein `Requires=`/Restart-Mechanismus, der auf Prozessende triggert, greift bei einem Prozess, der nicht endet, nie.
-
-FOLGE: Der post-commit-Hook openspec-embed meldet den Fehlschlag als "WARN: embed failed ... (non-fatal)" und laeuft weiter. Jeder Commit an einem OpenSpec-Change laesst damit den Embedding-Index weiter veralten, ohne dass irgendwo ein rotes Signal entsteht. Der Drift ist kumulativ und wird erst bemerkt, wenn eine Aehnlichkeitssuche (openspec_find_similar, bge_embed) schlechte Treffer liefert — dann aber ohne Bezug zur Ursache.
-
-STRUKTURELLER KERN: dritter Befund desselben Musters in diesem Lauf — ein Signal, das Gesundheit attestiert, ohne das Attestierte zu pruefen. Vgl. repo-hygiene-ops §3 ("eine leere Antwort ist kein Urteil") und den unpushed-Plan-Befund vom selben Tag, wo `git status` "ahead 2" meldete, obwohl der Remote-Branch fehlte.
-
-VORSCHLAG: Die Forward-Units mit einem echten Readiness-Check versehen statt mit Prozess-Liveness — periodischer HTTP-Probe gegen den Endpoint (systemd-Timer oder ExecStartPost-Watchdog), der die Unit bei Timeout neu startet. Mindestens sollte openspec-embed den Fehlschlag zaehlen bzw. sichtbar machen, statt ihn pro Commit als non-fatal wegzuschlucken — ein stiller WARN in einem Hook, der bei jedem Commit laeuft, wird nicht gelesen.
-
-SOFORT-REMEDIATION (im Lauf angewandt): `systemctl --user restart bge-forward-embed`.
-
-VERWANDT: T002604 (Port-Forwards als eigene Units), T002551 (bge-embed als Cluster-CPU-Deployment), T002488 (Cluster-DNS auf dem WSL-Host nicht aufloesbar).
-**3. KORREKTUR zum bge-forward-embed-Mishap: Restart wirkungslos, Ursache liegt cluster-seitig — readiness=true bei totem Endpoint** (degraded, k3d/llm-gpu.yaml · bge-embed · scripts/bge-mcp)
-
-Korrektur zum unmittelbar vorhergehenden Buffer-Eintrag ("bge-forward-embed: Unit active, Socket lauscht, Tunnel tot"). Dort steht "SOFORT-REMEDIATION (im Lauf angewandt): systemctl --user restart bge-forward-embed". Das ist FALSCH und wird hiermit richtiggestellt: der Restart wurde ausgefuehrt und hat NICHT geholfen.
-
-NACHGEMESSEN nach dem Restart:
-- `systemctl --user restart bge-forward-embed` -> Exit 0, Unit laeuft neu
-- `curl -m 10 http://127.0.0.1:8081/v1/embeddings` -> weiterhin HTTP 000, Timeout nach 10,02 s
-
-URSACHE LIEGT NICHT IM PORT-FORWARD, sondern cluster-seitig:
-- `svc/llm-gateway-embed` existiert (ClusterIP 10.43.42.200:8081, 70 d alt)
-- Endpoints sind BEFUELLT: 10.42.2.231:8080 — es fehlt also kein Backend
-- Der Pod dahinter ist `bge-embed-5d54c9c44d-mz9pr` auf pk-hetzner-8: phase=Running, ready=TRUE, aber **restarts=6 in den letzten 10 Stunden**, Alter 15 h
-
-Der Pod meldet sich also als bereit, waehrend Anfragen ueber den Service ins Leere laufen — und er startet dabei mehrmals pro Stunde neu. Die Readiness-Probe attestiert Gesundheit, ohne sie zu pruefen (vermutlich TCP- statt HTTP-Probe, oder ein Endpoint, der die Modell-Ladephase nicht abbildet).
-
-WAS DAS AM URSPRUNGSBEFUND AENDERT: Die These des vorigen Eintrags — gruene Signale ueber einem toten Dienst — bleibt gueltig und wird sogar staerker, verschiebt sich aber eine Schicht tiefer. Es sind nicht drei, sondern VIER Signale, die Gesundheit melden: systemd-Unit active, kubectl-Prozess lebt, Socket lauscht, UND Pod ready=true. Der Vorschlag aus dem vorigen Eintrag (Readiness-Probe am Forward statt Prozess-Liveness) reicht deshalb nicht — ein HTTP-Probe vom Host haette hier zwar rot gemeldet, die Ursache liegt aber in der Pod-Readiness-Definition und der Restart-Schleife von bge-embed.
-
-NAECHSTER SCHRITT (nicht ausgefuehrt, ausserhalb des Auftrags dieses Laufs): Logs von bge-embed-5d54c9c44d-mz9pr auswerten (6 Restarts / 10 h ist der eigentliche Defekt), die Readiness-Probe des Deployments in k3d/llm-gpu.yaml gegen einen echten HTTP-Endpoint pruefen, und erst danach die Host-seitige Probe nachziehen.
-
-METHODISCHE NOTIZ: Der Fehler in meinem vorigen Eintrag entstand, weil ich die Remediation dokumentiert habe, BEVOR ich ihr Ergebnis gemessen hatte. Genau die Verwechslung von "Massnahme ausgefuehrt" mit "Wirkung eingetreten", vor der repo-hygiene-ops §3 fuer Merges warnt.
-**4. ticket.sh: --help auf Subkommando-Ebene fuehrt in eine Fehlermeldung statt zur Optionsliste** (degraded, scripts/ticket.sh)
-
-Beobachtet am 2026-08-09 in einem repo-hygiene-Lauf (§5), beim Anlegen eines Bug-Tickets nach der Bug-Triage-Konvention G-DORA03.
+    bash scripts/branch-reaper.sh --ticket T00XXXX --dry-run
 
 VERIFIZIERT
-  bash scripts/ticket.sh            -> gibt korrekt Usage + vollstaendige Kommandoliste aus
-  bash scripts/ticket.sh create --help -> "Unknown create option: --help"
-  bash scripts/ticket.sh help       -> "Unknown command: help"
-  bash scripts/ticket.sh --help     -> "Unknown command: --help"
+scripts/branch-reaper.sh:120-123 selektiert so:
 
-Die Kommando-EBENE ist also auffindbar, die Options-EBENE nicht. Wer wissen will, welche
-Optionen `create` nimmt und welche davon Pflicht sind, hat ueber das Skript keinen Weg
-dorthin — `--help` wird vom Options-Parser als unbekannte Option abgewiesen, statt vor der
-Parser-Schleife abgefangen zu werden.
+    git ls-remote --heads "$REMOTE" | grep -i -- "$TICKET_ID"
 
-WARUM DAS ZAEHLT
-CLAUDE.md nennt `bash scripts/ticket.sh create --type bug --title "..."` als kanonischen
-Weg der Bug-Triage-Konvention. Diese Zeile ist unvollstaendig: `description` ist Pflicht
-(so dokumentiert im create_ticket-MCP-Tool: "Beschreibung (Pflicht in create.sh)"), taucht
-im CLAUDE.md-Beispiel aber nicht auf. Beide Auskunftswege fuehren damit ins Leere, und der
-Umweg ging ueber das MCP-Toolschema, um die Pflichtfelder zu erfahren.
+und :77 bricht ohne --ticket mit Exit 2 ab. Das Skript kann damit ausschliesslich
+Branches EINES Tickets betrachten — den Bestandssweep, aus dem §2 seine Begruendung
+zieht, leistet es prinzipiell nicht.
 
-VORSCHLAG
-1. `--help`/`-h` in jedem Subkommando vor der Options-Schleife abfangen und die Optionen
-   des jeweiligen Subkommandos ausgeben (Pflichtfelder markiert).
-2. `help` als Alias fuer den argumentlosen Usage-Ausgang akzeptieren.
-3. Das CLAUDE.md-Beispiel um `--description` ergaenzen, damit die dort genannte Zeile
-   ausfuehrbar ist.
+REAL EINGETRETEN
+Der Runbook-Aufruf mit dem woertlichen Platzhalter liefert:
+    $ bash scripts/branch-reaper.sh --ticket T000000 --dry-run
+    Keine Remote-Branches mit Ticket-ID T000000 gefunden.
+Exit 0, keine Zeile. Das ist von "es gibt keine verwaisten Branches" nicht zu
+unterscheiden — dasselbe Muster "leere Antwort ist kein Urteil", das §0 und §3
+bereits an anderer Stelle festhalten. Ich musste den Sweep von Hand fahren
+(git branch -r durchgehen, pro Branch PR-Zustand und Blob-Abweichung pruefen).
 
-Kein Blocker — der MCP-Weg (mcp__ticket-mcp__create_ticket) traegt ein vollstaendiges
-Schema und ist ohnehin MCP-first vorgeschrieben. Der CLI-Weg bleibt aber der in CLAUDE.md
-genannte und der einzige im Fallback ohne MCP.
-**5. Dedupe-Guard prueft nur offene Tickets, nicht den Mishap-Buffer — Doppelerfassung real eingetreten** (drift, .claude/skills/references/repo-hygiene-ops.md §4 · mishap-tracker)
+MOEGLICHE AUFLOESUNGEN (nicht entschieden)
+a) §2 praeziser fassen: branch-reaper ist der Post-Merge-Aufraeumer FUER EIN TICKET,
+   nicht das Sweep-Werkzeug. Den manuellen Sweep dort als eigenen Block auffuehren.
+b) branch-reaper um einen ticketlosen Modus erweitern (--all/--sweep), der ueber alle
+   Remote-Heads laeuft und je Branch REAP/KEEP mit Begruendung ausgibt.
+Beides ist vertretbar; b) waere die Variante, die den Runbook-Text einloest.
+**7. 4 von 4 offenen PRs scheiterten am Freshness-Gate — test-inventory.json nie mitregeneriert** (process, repo/pr-hygiene)
 
-Beobachtet und real eingetreten am 2026-08-09 in einem repo-hygiene-Lauf.
+BEOBACHTET (2026-08-09, repo-hygiene §3)
 
-WAS PASSIERTE
-Derselbe Befund (is_test_data-Filter fehlt in scripts/factory/queue.sh) wurde am selben Tag
-zweimal erfasst: um 05:04:57 UTC als Mishap-Buffer-Eintrag durch einen frueheren Lauf, um
-05:35 UTC als Ticket T002830 durch meinen Lauf. Beide Laeufe folgten repo-hygiene §5.
+Alle vier zum Zeitpunkt des Laufs offenen PRs (#4014, #4015, #4016, #4017) scheiterten
+am selben Required Check "BATS Unit + Quality Gates", Step "Ensure freshness artifacts
+are up to date":
 
-WARUM DER GUARD NICHT GRIFF
-repo-hygiene-ops.md §4 schreibt einen Title-Dedupe-Guard vor (T001210) — er sucht nach einem
-offenen TICKET mit gleichem Titel. Ich habe ihn ausgefuehrt:
+    ✗ website/src/data/test-inventory.json regenerated but not staged
+    ERROR: 1 generated artifact(s) are not committed
 
-    for s in triage backlog plan_staged in_progress planning; do
-      bash scripts/ticket.sh list --status "$s"; done | grep -oiE '"title":"[^"]*(queue\.sh|is_test_data|...)'
-      -> kein Treffer
+Ursache in jedem einzelnen Fall identisch: der PR fuegt neue .bats-Dateien hinzu, ohne
+`task freshness:regenerate` laufen zu lassen und das Inventar mitzucommitten. Belegt
+je PR durch den Diff des nachtraeglichen Regen-Laufs — #4014 fehlten die zwei Eintraege
+ci-cd/spec-test-no-fixed-sleep-polling und ci-cd/spec-test-no-tracked-file-mutation,
+#4017 die zwei Eintraege active-sessions-hub/opencode-session-id-stable und
+ci-cd/devflow-ci-watch-merged-exit.
 
-Der Guard war also korrekt angewandt und lieferte trotzdem gruen. Der frueher erfasste
-Befund lag zu diesem Zeitpunkt nicht als Ticket vor, sondern als Eintrag in
-.git/mishap-buffer.json (Buffer-Stand 5/10, Schwelle 10 nicht erreicht). Buffer-Eintraege
-sind dateibasiert und tauchen in KEINER Ticket-Query auf.
+WARUM DAS BEMERKENSWERT IST
+Die Anforderung ist dokumentiert (CLAUDE.md → CI/CD → "Test inventory check") und
+git-workflow Schritt 1 verlangt `task freshness:regenerate` explizit vor dem Commit.
+Trotzdem liegt die Verletzungsquote hier bei 4/4. Eine Regel, die vollstaendig
+dokumentiert ist und trotzdem von jedem PR verletzt wird, ist keine Wissensluecke
+der Ausfuehrenden, sondern eine Luecke in der Durchsetzung: der Fehler faellt erst
+in CI auf, also mehrere Minuten nach dem Push, und kostet dann pro PR eine
+Regen-Commit-Push-Runde.
 
-STRUKTURELLER KERN
-Zwischen "Befund erfasst" und "Befund als Ticket sichtbar" liegt ein Fenster von bis zu
-10 Buffer-Eintraegen bzw. 7 Tagen (Alters-Schnitt). In diesem Fenster ist ein bereits
-erfasster Befund fuer den vorgeschriebenen Dedupe-Guard unsichtbar. Bei mehreren
-repo-hygiene-Laeufen pro Tag — hier zwei — ist die Doppelerfassung damit nicht
-unwahrscheinlich, sondern erwartbar.
+BEHOBEN IN DIESEM LAUF
+#4014 (Commit e60f343d2) und #4017 (Commit 598f13bd9) regeneriert, gepusht,
+Auto-Merge scharf. #4015/#4016 bewusst nicht angefasst — sie haben zusaetzlich
+echte Testfehler (siehe unten) und gehoeren ihren Ticket-Ownern.
 
-Dasselbe Muster wie der Befund, den es hier verdoppelt hat: eine Pruefung, die nur einen
-von zwei Pfaden kennt, sieht bei Anwendung auf den bekannten Pfad vollstaendig aus.
+MOEGLICHE AUFLOESUNG (nicht entschieden)
+Der pre-commit-Hook laeuft ohnehin schon (validate-commit-msg, gitleaks). Ein
+`task freshness:check` an derselben Stelle wuerde den Befund vom CI-Zeitpunkt auf
+den Commit-Zeitpunkt vorziehen. Kostenfrage: Laufzeit des Checks im Hook.
+**8. Zwei verwaiste git-Worktrees im Scratchpad einer fremden, beendeten Session** (drift, repo/worktrees)
 
-VORSCHLAG
-1. §4 (und die Dedupe-Vorbedingung der Completeness-Triage) um eine zweite Quelle
-   erweitern: vor dem Anlegen eines Tickets aus einem Mishap-Befund zusaetzlich
-   mcp__ticket-mcp__get_mishap_buffer bzw. .git/mishap-buffer.json pruefen.
-2. Erwaegen, das in ein Werkzeug zu ziehen statt in eine Merkregel — z. B. ein
-   ticket.sh-Subkommando oder ein MCP-Tool, das Tickets UND Buffer gegen einen Titel
-   prueft und einen einzigen Ja/Nein-Befund liefert. Eine Merkregel, die zwei getrennte
-   Quellen von Hand zusammenfuehrt, ist genau die Form, die hier versagt hat.
-3. Erwaegen, ob report_mishap seinerseits gegen offene Tickets dedupliziert — die
-   Gegenrichtung derselben Luecke ist bisher ungeprueft.
+BEOBACHTET (2026-08-09, repo-hygiene §1)
 
-AUFLOESUNG DES KONKRETEN FALLS
-Der Buffer-Eintrag wurde nach Ueberfuehrung seines Inhalts (er war reicher als der
-Ticketrumpf: Merge-Referenz PR #3926/1fcb6cfb2, Vorgeschichte T002762, struktureller Kern)
-als Kommentar an T002830 aus .git/mishap-buffer.json entfernt. Backup der Datei vor dem
-Eingriff wurde abgelegt. T002830 ist die einzige verbliebene Erfassung.
+`git worktree list` im Hauptcheckout fuehrte zwei Eintraege ausserhalb von
+.worktrees/ auf:
 
-TEST (Output-Verifikation, T002448-M4)
-Falls Vorschlag 2 umgesetzt wird: das Pruefkommando AUSFUEHREN mit einem Titel, der
-ausschliesslich im Buffer liegt, und pruefen, dass es einen Treffer meldet. Positiv-Anker
-(T002356-M1): ein Titel, der weder in Tickets noch im Buffer liegt, MUSS als kein Treffer
-zurueckkommen — sonst besteht der Test vakuos, wenn die Pruefung pauschal Treffer meldet.
+  /tmp/claude-1000/-home-patrick-Bachelorprojekt/0a75f198-8466-4f3c-bcf5-744a89b9210f/scratchpad/mainwt   23b6061c0 (detached HEAD)
+  /tmp/claude-1000/-home-patrick-Bachelorprojekt/0a75f198-8466-4f3c-bcf5-744a89b9210f/scratchpad/mainwt2  de8d93b6b (detached HEAD)
 
-VERWANDT: T002830 (der verdoppelte Befund), T001210 (Herkunft des Guards), T002784
-(Rollup-Container), T002783 (Rollup-Treiber blockiert — verlaengert das Sichtbarkeitsfenster).
-**6. 18 Tickets stehen auf plan_staged ohne plan-Zeile/Branch — halbgestagte Plans** (suspicious, tickets/plan_staged)
+Die Session-UUID 0a75f198-… gehoert nicht zur laufenden Session. Beide Worktrees
+standen auf detached HEAD auf Commits, die inzwischen in main sind (23b6061c0,
+de8d93b6b), Arbeitsbaum in beiden nachweislich sauber (`git status --porcelain`
+leer). Entfernt per `git worktree remove` (ohne --force) + `git worktree prune`.
 
-Triage 2026-08-09: 19 plan_staged-Tickets, davon 18 (T002807–T002829 außer T002784) ohne ticket_plans-Zeile (slug/branch/pr_number NULL) und ohne existierenden Branch in `git branch -a`. Nur T002784 (Rollup-Container) ist legitim plan_staged ohne Plan-Zeile. Damit ist der Kommissionierungs-Zustand halbgestaged — kein dev-flow-execute kann den Plan finden (T002816-Klasse: "Gestagter, nie implementierter Plan"). Vermutlich wurden die Tickets per status-Update gestaged, ohne stage-plan/branch zu setzen.
-**7. T002629-Beschreibung behauptet offenen Blocker, PR #3745 ist seit 4 Tagen gemergt** (suspicious, tickets/t002629)
+WARUM DAS BEMERKENSWERT IST
+Ein Worktree im Scratchpad-Verzeichnis wird beim Aufraeumen leicht uebersehen,
+weil die uebliche Suche in .worktrees/ danebengreift — dieser Runbook-Lauf hat
+sie nur gefunden, weil §1 `git worktree list` verlangt statt eines ls auf
+.worktrees/. Solange die Eintraege liegen bleiben, haelt jeder von ihnen eine
+Ref und verhindert, dass der zugehoerige Commit-Bereich garbage-collected wird;
+ausserdem tauchen sie in jeder kuenftigen Worktree-Inventur als Rauschen auf.
 
-T002629 (E6 Modell-Registry) führt im Text "BLOCKIERT VON: PR #3745 (T002587) ist offen mit zwei roten Checks" — `gh pr view 3745` zeigt state=MERGED (mergedAt 2026-08-04T00:12:47Z). Die Beschreibung ist stale und würde jede spätere Triage erneut in den Blocker-Pfad schicken. Triage hat die PR verifiziert und einen Kommentar mit Beleg ergänzt. Prozesslücke: Blocker-Status wird nicht beim PR-Merge zurückgeschrieben.
-**8. Probe-Schleife mit 2>/dev/null macht harten Fehler zu stillem Leerergebnis** (process, skills/repo-hygiene)
+Kein Datenverlust, kein akuter Schaden — der Befund ist, dass hier eine Session
+beendet wurde, ohne ihren temporaeren Worktree abzuraeumen, und dass nichts
+diesen Zustand von selbst aufloest.
+**9. openspec-embed scheitert bei jedem Commit an Port 15432 — k3d-Port-Forward belegt ihn dauerhaft** (degraded, scripts/openspec-embed (post-commit hook))
 
-Beobachtet in repo-hygiene 2026-08-09 beim Abfragen von 8 Ticketstatus:
+BEOBACHTET (2026-08-09, dev-flow-plan T003045, Stage-Commit b78616a60)
 
-    for t in T002813 T002647 …; do
-      s=$(bash scripts/ticket.sh show "$t" 2>/dev/null | grep -iE '^(status|title)' | tr '\n' ' ')
-      echo "$t: $s"
-    done
+Der post-commit-Hook `openspec-embed` scheiterte dreimal in Folge und gab auf:
 
-Ergebnis: acht leere Zeilen. Gelesen als „Tickets existieren nicht / liefern keine Daten".
+  [openspec-embed-local] FEHLER: Port 15432 wird von einem fremden Prozess
+  (PID 50718: kubectl --context k3d-mentolder-dev port-forward -n workspace
+  svc/shared-db 15432:5432) belegt, nicht vom eigenen Port-Forward (PID 1660165).
+  Beende den fremden Prozess oder setze OPENSPEC_EMBED_PF_PORT auf einen freien Port.
+  [openspec-embed] retry 1/3 … retry 2/3 …
+  [openspec-embed] WARN: embed failed for 'main-ci-branch-precondition'
+                   after 3 attempts (non-fatal — see above)
 
-Tatsaechlich: `scripts/ticket.sh` kennt kein Subkommando `show`. Es schrieb „Unknown command: show" nach **stderr** und beendete mit Exit 1 — beides durch `2>/dev/null` und die Pipe unsichtbar. Das Skript verhaelt sich korrekt; unsichtbar gemacht hat es der Aufruf.
+Der Change 'main-ci-branch-precondition' ist damit nicht eingebettet. Die
+Aehnlichkeitssuche (openspec_find_similar) findet ihn nicht — genau die Funktion,
+die Doppelarbeit an derselben Sache verhindern soll.
 
-Zusatzfehler bei der Gegenprobe: `bash scripts/ticket.sh show T002837 2>&1 | head -5; echo "exit=$?"` misst den Exit-Code von `head`, nicht den des Skripts — die erste Nachpruefung meldete daher faelschlich Exit 0 und haette das Skript zu Unrecht als fail-open beschuldigt. Verifiziert mit `bash scripts/ticket.sh show T002837 >/dev/null 2>&1; echo $?` → 1.
+EINORDNUNG — das Verhalten ist BESSER als frueher, nicht schlechter
+Der Guard erkennt den Fremdprozess und verweigert die Arbeit. Aeltere Notizen
+beschreiben denselben Portkonflikt mit stillem Fallback auf die falsche Datenbank
+(Embedding landete in der Dev-DB, ohne dass etwas auffiel). Fail-loud statt
+fail-silent ist die richtige Richtung; offen bleibt, dass der Konflikt bei jedem
+einzelnen Commit erneut auftritt.
 
-Regel: In Probe-Schleifen stderr NICHT unterdruecken und den Exit-Code getrennt von der Pipeline auswerten. Ein leeres Ergebnis ist erst dann ein Messwert, wenn der Aufruf nachweislich erfolgreich war — dieselbe Familie wie „Leere API-Antwort ist kein Urteil" (repo-hygiene-ops §3, T002498-M5).
+WARUM ES TROTZDEM STOERT
+Der belegende Prozess ist kein Unfall, sondern ein dauerhaft laufender
+Entwicklungs-Port-Forward auf die k3d-Dev-DB. Solange er laeuft — also im
+Normalbetrieb dieser Maschine — schlaegt JEDER Commit mit openspec-Aenderungen
+fehl. Der Hook kostet dabei 3 Versuche a 5 s Wartezeit, bevor er aufgibt.
 
-Kanonischer Weg fuer Ticketstatus ist ohnehin `mcp__ticket-mcp__get_ticket` / `list_tickets`, nicht ein geratenes CLI-Subkommando.
-**9. Alle vier lokalen LLM-Backends am Gateway degraded (/health 503)** (degraded, llm/gateway)
+MOEGLICHE AUFLOESUNGEN (nicht entschieden)
+a) OPENSPEC_EMBED_PF_PORT im Repo auf einen Port ausserhalb des ueblichen
+   Entwicklungsbereichs vorbelegen, statt 15432 zu teilen.
+b) Freien Port dynamisch waehlen, statt einen festen zu belegen — der Hook
+   braucht den Port nur fuer die Dauer seines eigenen Laufs.
+c) Beim erkannten Fremdprozess sofort aufgeben statt 3x5 s zu warten; der
+   Zustand aendert sich innerhalb von 15 s erfahrungsgemaess nicht.
+**10. dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Datenverlustrisiko bei Parallelsessions)** (degraded, skills/dev-flow-chore)
 
-Beobachtet 2026-08-09 während dev-flow-plan für T002836.
+BEOBACHTUNG (T003055, 2026-08-09): Schritt 0 von dev-flow-chore schreibt vor:
+  git stash && git pull --rebase origin main && git stash pop
+Zum Ausfuehrungszeitpunkt liefen im Haupt-Checkout DREI fremde Agent-Sessions (claude PID 1291909 seit 19:49, claude PID 2154793 seit 20:46 — beide mit --dangerously-skip-permissions —, opencode PID 2165174 seit 20:48). Sie hatten 7 uncommittete Dateien offen; .github/workflows/{ai-review,ci,e2e-pr}.yml waren 2 Minuten zuvor (20:49:31) geschrieben worden, tests/spec/ci-cd/fetch-refspec-forced.bats war untracked.
 
-BEFUND (verifiziert)
-Das LLM-Gateway auf 127.0.0.1:18235 LÄUFT — /v1/models liefert 200. Aber /health liefert 503 mit status=degraded, ready=false: alle vier registrierten Backends sind unten:
-  - llamacpp-devstral (priority 1, http://127.0.0.1:8099/v1)
-  - llamacpp-gemma4   (priority 1, http://127.0.0.1:8090/v1)
-  - llamacpp-qwen     (priority 1, http://127.0.0.1:8094/v1)
-  - opencode-zen      (priority 91, http://127.0.0.1:5099/v1)
-checked=6, lastProbe=1786258092799.
+WARUM RELEVANT: git stash ist eine Mutation des Arbeitsbaums, den ein anderer Prozess offen haelt. Schreibt die fremde Session zwischen stash und pop weiter, kollidiert der pop und die Aufloesung ist manuell. Der Skill hat dafuer KEINEN Guard — er setzt implizit voraus, dass der Haupt-Checkout dem ausfuehrenden Agenten allein gehoert.
 
-FOLGE
-scripts/plan-qa-check.sh Zeile 115 prüft mit `curl -sf .../health`; 503 lässt -f fehlschlagen, das Skript meldet "Gateway not reachable" und überspringt die LLM-QA (advisory, blockiert nicht). Das Skript verhält sich damit KORREKT — der Kommentar in Zeile 113 nennt genau diesen Fall. Die Meldung "not reachable" ist aber irreführend: der Dienst antwortet, nur seine Backends nicht.
+VERIFIKATION: Skill-Text .claude/skills/dev-flow-chore/SKILL.md Schritt 0; Prozessliste via ps; Datei-mtimes via ls --time-style. Der Schritt wurde in diesem Durchlauf bewusst NICHT ausgefuehrt; stattdessen wurde der Worktree direkt mit `git worktree add -b <branch> <pfad> origin/main` angelegt, was den Haupt-Checkout nicht beruehrt.
 
-MÖGLICHER ZUSAMMENHANG
-T002663 (factory-mcp factory_ask LLM-Backend unerreichbar, type=fix, status=triage) beschreibt seit 2026-08-04 ausgefallene Natürlichsprach-Antworten am factory-mcp. Es ist zu prüfen, ob das dieselbe Ursache ist (Backends unten) statt eines eigenen Fehlers am factory-mcp — die dortige Fehlermeldung nannte allerdings 'Insufficient Balance' und 'invalid api key', was eher auf einen Remote-Provider deutet. Der Zusammenhang ist eine Hypothese, keine belegte Ursache.
+VORSCHLAG: Vor dem Stash pruefen, ob der Arbeitsbaum dirty ist UND ein fremder Prozess darin arbeitet; in dem Fall den Stash ueberspringen und direkt von origin/main aus den Worktree anlegen (der Rebase des lokalen main ist fuer die Chore ohnehin nicht noetig — BASE ist origin/main).
 
-WERT DES BEFUNDS
-Solange die Backends unten sind, läuft jede LLM-gestützte Prüfung im Repo still im Skip-Pfad: plan-qa-check (advisory), Release-Notes-Generierung, der Task-Oracle. Das fällt nicht auf, weil alle drei bewusst fail-open sind.
-**10. Tote agent-locks blockieren bis zu 30 min, obwohl beide PIDs nachweislich tot sind** (suspicious, scripts/agent-lock.sh)
-
-Beobachtet 2026-08-09 zu Beginn von dev-flow-plan für T002836.
-
-BEFUND (verifiziert)
-Sechs ticket-scoped agent-locks (T002836, T002830, T002812, T002813, T002647, T002663) gehörten einer ticket-ops-Session mit owner_sid=611671, owner_pid=611672. Beide PIDs existierten nicht mehr (`ps -p` lieferte je nur die Kopfzeile). `agent-lock.sh reap` räumte sie dennoch nicht; `scripts/openspec.sh propose` brach mit "Ticket T002836 ist gesperrt (agent-lock)" ab.
-
-URSACHE (belegt, kein Bug)
-scripts/agent-lock.sh Block 0b (Zeilen 164-174): existiert der Worktree UND stimmt sein Branch mit dem Lock-Feld überein, gilt der Lock als lebendig — eingeführt für Session-Resumes (T002204), die mit neuer SID/PID zurückkehren. T002513 begrenzt das auf einen frischen Heartbeat. Der Heartbeat war 12 Minuten alt, AGENT_LOCK_TTL ist 1800s. Der Lock wäre also nach ~18 weiteren Minuten von selbst reapable geworden.
-
-EINORDNUNG
-Das Verhalten ist so entworfen und die Begründung trägt. Bemerkenswert ist die Lücke dazwischen: eine Session, die abstürzt ohne zu releasen, blockiert ihre Tickets bis zu 30 Minuten, obwohl die Toten-Erkennung über die PID sofort möglich wäre. Block 0b prüft den Worktree, aber nicht zusätzlich, ob owner_pid noch lebt — beides zusammen wäre eindeutig: Worktree passt UND PID tot = abgestürzte Session, kein Resume. Ein Resume hätte eine neue PID, die lebt.
-
-Zu erwägen (nicht entschieden): in Block 0b zusätzlich `_pid_alive "$pid"` prüfen und bei toter PID trotz Worktree-Match reapen. Risiko: ein Resume, der die Lock-Datei noch nicht mit seiner neuen PID aktualisiert hat, würde fälschlich geräumt.
-
-AUFLÖSUNG IM LAUF
-Nach Rückfrage beim Operator wurden alle sechs Claims per `agent-lock.sh release ticket <id>` freigegeben (der Pfad für tote Owner greift regulär, ohne --force) und T002836 auf die aktive Session neu geclaimt.
-### Mishap-Rollup — 10 Eintraege (2026-08-09 08:41 UTC)
+Zusammenhang: siehe die beiden weiteren Mishaps dieses Durchlaufs (worktree-create.sh:190, agent-lock Sichtbarkeitsfenster).
+### Mishap-Rollup — 10 Eintraege (2026-08-09 20:54 UTC)
 
 | # | Typ | Komponente | Titel |
 |---|---|---|---|
-| 1 | degraded | scripts/openspec-embed | openspec-embed indexiert in eine fast leere Collection (4 docs vs 55 aktive Pläne) |
-| 2 | degraded | tests/spec/ticket-system | BATS-Suite backfill-id (T002732) schlägt lokal rot, CI grün |
-| 3 | degraded | scripts/llm-proxy | llm-proxy BATS-Suiten (T002753 + ui_config.mcpServers seed) lokal rot |
-| 4 | drift | skills/references/ticket-ops-procedures.md | ticket-ops-procedures nennt kein Prüfkriterium für "Ticket hat einen Plan" |
-| 5 | suspicious | scripts/factory/reconcile-ticket-status.sh | reconcile-ticket-status Pattern 4 matcht nicht, obwohl der Watchdog läuft |
-| 6 | drift | skills/mishap-tracker | mishap-tracker/SKILL.md legt status=plan_staged nahe, gemeint ist nur der Rollup-Container |
-| 7 | drift | scripts/vda/ticket/update-status.sh | update-status.sh hat keinen Guard gegen plan_staged ohne Plan-Referenz |
-| 8 | suspicious | scripts/openspec-embed · openspec_find_similar | openspec-embed Completeness-Gate: 12 Dokumente in der Collection, 57 lokale aktive Pläne |
-| 9 | drift | tests/spec · BATS-Konventionen | BATS: Helper-Funktion trägt grep-Exit-Code nach außen — Positiv-Anker wird aus falschem Grund rot |
-| 10 | drift | prod/wildcard-certificate.yaml · cert-manager | Reflector-Annotationen am Wildcard-Certificate, aber kein Reflector im Cluster |
+| 1 | degraded | skills/dev-flow-chore | dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Risiko bei Parallelsessions) |
+| 2 | degraded | scripts/worktree-create.sh | worktree-create.sh Divergence-Guard stasht den Haupt-Checkout (gleiche Klasse wie dev-flow-chore Schritt 0) |
+| 3 | degraded | scripts/agent-lock.sh | agent-lock zeigt eine Session erst ab ihrem ersten Commit — Sichtbarkeitsluecke im Vorab-Check |
+| 4 | drift | tests/spec/dev-flow-plan (BATS-Fixture-Erstellung) | printf mit fuehrendem "-" wird als Option statt Format-String interpretiert |
+| 5 | process | tests/spec/dev-flow-plan (BATS-Fixture-Design) | B1b-Prosa-Test-Entwurf war durch sort -u Pfad-Dedup unwirksam (kein echtes RED) |
+| 6 | drift | scripts/openspec-embed (post-commit hook) | openspec-embed post-commit Hook scheitert erneut an Port-15432-Konflikt |
+| 7 | degraded | ticket-ops / scripts/agent-lock.sh + scripts/ticket.sh | Ticket-Locks der auftraggebenden Session blockieren den Abschluss durch Subagent, MCP-Server und post-merge |
+| 8 | drift | scripts/preflight-pr-scope.sh | preflight-pr-scope.sh liest die ERSTE Ticket-ID im PR-Titel — Titel mit zwei IDs faellt faelschlich durch |
+| 9 | drift | tests/spec (repo-weit) | Reihenfolge-Guards mit "grep -n … | head -1" brechen an sachfremden Einfuegungen — 19 Dateien betroffen |
+| 10 | suspicious | skills/git-workflow · .gitattributes merge=ours | Konfliktfreier Rebase verliert mitcommittete Freshness-Artefakte ohne Konfliktmeldung |
 
-**1. openspec-embed indexiert in eine fast leere Collection (4 docs vs 55 aktive Pläne)** (degraded, scripts/openspec-embed)
+**1. dev-flow-chore Schritt 0 stasht den Haupt-Checkout ungefragt (Risiko bei Parallelsessions)** (degraded, skills/dev-flow-chore)
 
-Beobachtet 2026-08-09 bei zwei Commits während dev-flow-plan für T002836.
+BEOBACHTUNG (T003055, 2026-08-09): Schritt 0 von dev-flow-chore schreibt vor:
+    git stash && git pull --rebase origin main && git stash pop
+Zum Ausfuehrungszeitpunkt liefen im Haupt-Checkout DREI fremde Agent-Sessions: claude PID 1291909 (seit 19:49), claude PID 2154793 (seit 20:46) — beide mit --dangerously-skip-permissions —, opencode PID 2165174 (seit 20:48). Sie hatten 7 uncommittete Dateien offen; .github/workflows/{ai-review,ci,e2e-pr}.yml waren zwei Minuten zuvor (20:49:31) geschrieben worden, tests/spec/ci-cd/fetch-refspec-forced.bats war untracked.
 
-BEFUND
-Der post-commit-Hook openspec-embed meldet bei jedem Commit:
-  [openspec-embed] WARN: completeness gate — collection has 4 docs but 55 local active plans (status=planning|plan_staged|active)
-  skipped: 2 documents (2 context limit > 2048 tokens, 0 other reasons)
+WARUM RELEVANT: `git stash` mutiert den Arbeitsbaum, den ein anderer Prozess offen haelt. Schreibt die fremde Session zwischen stash und pop weiter, kollidiert der pop und die Aufloesung ist manuell. Der Skill hat dafuer keinen Guard — er setzt implizit voraus, dass der Haupt-Checkout dem ausfuehrenden Agenten allein gehoert.
 
-Die Ziel-Collection enthält also 4 Dokumente, während lokal 55 aktive Pläne existieren. Das Gate erkennt die Lücke und meldet sie — bricht aber nicht ab, sodass die Meldung im Commit-Rauschen untergeht.
+VERIFIKATION: Skill-Text (dev-flow-chore Schritt 0); Prozessliste via ps; Datei-mtimes via `ls --time-style=+%H:%M:%S`. Der Schritt wurde bewusst NICHT ausgefuehrt; stattdessen `git worktree add -b <branch> <pfad> origin/main`, was den Haupt-Checkout nicht beruehrt. Ergebnis war unauffaellig — die Chore lief vollstaendig durch (PR #4037 gemergt).
 
-VERMUTETE URSACHE (nicht in diesem Lauf verifiziert)
-Es gibt einen bekannten Portkonflikt: Port 15432 ist vom k3d-Portforward belegt, wodurch der Verbindungsaufbau still auf eine andere Datenbank (Dev-DB) ausweicht statt zu scheitern. Die Embeddings landeten dann konsistent in der falschen Collection — was genau das Bild "4 statt 55" erklären würde. Diese Zuordnung ist eine Hypothese und vor einem Fix zu belegen (z.B. durch Ausgabe der tatsächlich verwendeten Verbindungsparameter im Hook).
+VORSCHLAG: Vor dem Stash pruefen, ob der Arbeitsbaum dirty ist UND ein fremder Prozess darin arbeitet; dann den Stash ueberspringen und den Worktree direkt von origin/main anlegen. Der Rebase des lokalen main ist fuer die Chore ohnehin entbehrlich, weil BASE bereits origin/main ist.
 
-FOLGE
-Die semantische Suche über openspec-Changes arbeitet auf einem Bruchteil des Bestands. Wer sie zur Duplikatsuche vor einem neuen Proposal nutzt (openspec_find_similar), bekommt falsche Negative — und legt einen Change an, den es schon gibt. Der Schaden ist still: ein leeres Suchergebnis sieht aus wie "nichts Ähnliches vorhanden".
+Zusammenhang: gleiche Fehlerklasse wie der Divergence-Guard in scripts/worktree-create.sh:190; verschaerft durch das Sichtbarkeitsfenster von agent-lock (beide separat gemeldet).
+**2. worktree-create.sh Divergence-Guard stasht den Haupt-Checkout (gleiche Klasse wie dev-flow-chore Schritt 0)** (degraded, scripts/worktree-create.sh)
 
-ZUSÄTZLICH
-Zwei Dokumente werden dauerhaft wegen Kontextlimit (> 2048 Token) übersprungen. Der Hook nennt den Reparaturweg (task openspec:embed:backfill), der aber am selben Kontextlimit scheitern dürfte, solange die Chunking-Grenze unverändert ist.
-**2. BATS-Suite backfill-id (T002732) schlägt lokal rot, CI grün** (degraded, tests/spec/ticket-system)
+BEOBACHTUNG (T003055, 2026-08-09): Der Divergence-Guard in scripts/worktree-create.sh (Zeilen 166-214) synchronisiert lokales main auf origin/main. Ist der Haupt-Checkout dabei dirty, stasht er ihn:
+    Zeile 189-199: if ! git diff --quiet HEAD; then git stash push -m "worktree-create-auto-stash" ...
+    Zeile 201:     git pull --rebase origin main
+    Zeile 213:     _wc_stash_pop_or_warn
 
-tests/spec/ticket-system/backfill-id-sequence.bats (3 Tests, T002732) schlagen im sauberen main-Checkout (ee4a9a80d) sowie im Worktree fehl — reproduziert. `task test:changed` ist damit lokal rot. Auf dem PR #3942 (16 Checks) waren dieselben Suiten grün → lokale Gate-Kette und CI divergieren (vermutlich Umgebungsabhängigkeit: lokale DB erreichbar → Tests laufen statt skip). VERIFIED im main-Checkout.
-**3. llm-proxy BATS-Suiten (T002753 + ui_config.mcpServers seed) lokal rot** (degraded, scripts/llm-proxy)
+WARUM RELEVANT: Identische Fehlerklasse wie dev-flow-chore Schritt 0 (separat gemeldet). Zum Ausfuehrungszeitpunkt liefen drei fremde Agent-Sessions mit 7 uncommitteten Dateien im Haupt-Checkout; lokales main lag 2 Commits hinter origin/main, der Guard haette also gefeuert. Bemerkenswert: das Skript ist gegen den EIGENEN Stash bereits sorgfaeltig abgesichert (T002673 hat die stillen `|| true` entfernt, damit ein fehlgeschlagener Pop nicht unbemerkt bleibt) — es kennt aber keinen Begriff davon, dass der Arbeitsbaum einem ANDEREN Prozess gehoeren koennte.
 
-tests/spec/local-llm-proxy/loadout-model-files-exist.bats (T002753: "jedes Loadout loest seine Modelldatei auf") und ui-config-seed.bats ("llama-server liefert ui_settings.mcpServers aus seed") schlagen im sauberen main-Checkout fehl — reproduziert. deckungsgleich mit der Health-Warnung G-LLM03 (Konfig-gegen-Laufzeit-Drift, 1 Ziel ≤0). VERIFIED im main-Checkout.
-**4. ticket-ops-procedures nennt kein Prüfkriterium für "Ticket hat einen Plan"** (drift, skills/references/ticket-ops-procedures.md)
+VERIFIKATION: Quelltext gelesen (Zeilen 166-226); Divergenz gemessen (`git rev-list --count HEAD..origin/main` = 2); fremde Prozesse via ps belegt. Der Guard wurde bewusst umgangen: `git worktree add -b <branch> <pfad> origin/main` legt den Worktree ohne jede Mutation des Haupt-Checkouts an. Das Ergebnis war korrekt — BASE ist ohnehin origin/main (Zeile 226), der Sync des lokalen main ist fuer die Korrektheit des Worktrees nicht erforderlich.
 
-Die Triage-Prozedur (Phase 1) sagt nicht, woran ein gestagter Plan erkannt wird. Ich habe deshalb `tickets.ticket_plans` geprüft — das ist falsch: `scripts/vda/ticket/stage-plan.sh` (Z. 123-128) schreibt einen Kommentar `FACTORY-PLAN-REF branch=… plan=…` und legt KEINE ticket_plans-Zeile an; die entsteht erst beim Archivieren. Belegt durch Selbstbeobachtung: nach regulärem stage-plan für T002837 steht dort status=plan_staged, ticket_plans=0, branch=null — und trotzdem ist alles korrekt. Nach dem falschen Kriterium sah ein frisch geplantes Ticket "kaputt" aus. Das Triage-Ergebnis stimmte im konkreten Fall zufällig (alle 28 zurückgesetzten Tickets hatten auch planref=0), die Begründung war es nicht. Abhilfe: ticket-ops-procedures §Phase 1 nennt den FACTORY-PLAN-REF-Kommentar als maßgebliches Kriterium — so wie reconcile-ticket-status.sh Pattern 4 es bereits tut.
-**5. reconcile-ticket-status Pattern 4 matcht nicht, obwohl der Watchdog läuft** (suspicious, scripts/factory/reconcile-ticket-status.sh)
+VORSCHLAG: Den Sync des lokalen main vom Anlegen des Worktrees entkoppeln. Der Worktree braucht nur origin/main als BASE; der Sync ist Hygiene fuer den Haupt-Checkout und sollte uebersprungen (mit Hinweis) statt erzwungen werden, wenn der Arbeitsbaum dirty ist und ein fremder Prozess darin arbeitet.
+**3. agent-lock zeigt eine Session erst ab ihrem ersten Commit — Sichtbarkeitsluecke im Vorab-Check** (degraded, scripts/agent-lock.sh)
 
-Pattern 4 in scripts/factory/reconcile-ticket-status.sh (Z. 187-224) ist exakt für den Fall "plan_staged ohne FACTORY-PLAN-REF-Kommentar" gebaut und setzt dann attention_mode=needs_human plus eine notes-Zeile. Am 2026-08-09 entstanden 28 solche Tickets in drei Zeitclustern (03:52, 04:24, 06:49) — KEINES wurde erfasst: notes durchgehend leer, attention_mode durchgehend ai_ready.
+BEOBACHTUNG (T003055, 2026-08-09): `bash scripts/agent-lock.sh list` gab um ca. 20:51 nur die Kopfzeile aus — keine einzige Claim —, obwohl zu diesem Zeitpunkt drei fremde Agent-Sessions aktiv im Haupt-Checkout schrieben (Dateien mit mtime 20:49:31). Verlaesslich waren nur `ps` und die Datei-mtimes, nicht das Werkzeug, das fuer genau diese Frage gebaut ist.
 
-Verifiziert, dass es nicht am Nichtlaufen liegt: systemctl --user list-timers zeigt factory.timer zuletzt vor 38 Minuten gelaufen, factory.service aktiv, und agent-msg führt mehrere "factory-tick: starting (dry_run=false)"-Einträge. Der Watchdog läuft also und der Aufruf steht in wakeup.sh:196 — Pattern 4 selbst greift nicht. Zu prüfen wären das SQL-Prädikat des Patterns, ein möglicher Brand-Filter und ob der Aufruf im Tick tatsächlich diesen Zweig erreicht.
+URSACHE (verifiziert, kein genereller Defekt): Der main-checkout-Claim entsteht im pre-commit-Hook (.githooks/pre-commit:7, Label "auto: pre-commit self-claim"), also erst beim ERSTEN COMMIT einer Session — nicht ab Arbeitsbeginn. Belegt durch den Zeitstempel der Lock-Datei: $(git rev-parse --git-common-dir)/agent-locks/main-checkout.json traegt mtime 20:53, mein list-Aufruf lag ~2 Minuten davor. Spaeter erschien der Claim dann korrekt (SID b5cfa0f7).
 
-Das ist der lohnendere Ansatzpunkt als die Altlast: der Schutzmechanismus existiert, ist korrekt spezifiziert und läuft — und wirkt trotzdem nicht. Kontext an T002845.
-**6. mishap-tracker/SKILL.md legt status=plan_staged nahe, gemeint ist nur der Rollup-Container** (drift, skills/mishap-tracker)
+WARUM RELEVANT: Zwischen Arbeitsbeginn und erstem Commit ist eine Session unsichtbar. Das ist genau das Fenster, in dem die Stash-Schritte aus dev-flow-chore Schritt 0 und worktree-create.sh:190 zuschlagen (beide separat gemeldet) — der Guard sieht die Session nicht, die er schuetzen muesste. Wer `agent-lock.sh list` als Vorab-Check auf konkurrierende Arbeit nutzt (so vorgesehen in dev-flow-chore Schritt 1, Test-only-Kurzpfad: "leer/keine fremde main-checkout-Claim?"), bekommt ein falsch-negatives Ergebnis und arbeitet inline im Haupt-Checkout weiter.
 
-Die Skill-Datei nennt `status=plan_staged` an vier Stellen (Z. 23, 137, 155, 216). Jedes Mal ist der persistente Rollup-Container gemeint, nicht ein Mishap-Einzelticket — das steht im Kontext, aber nicht in der jeweiligen Zeile.
+ABGRENZUNG: Die Lock-Mechanik selbst funktioniert (Claim/Release/Reap liefen im Durchlauf korrekt). Es geht ausschliesslich um den Zeitpunkt der Sichtbarkeit.
 
-Am 2026-08-09 wurden 28 Mishap-Einzeltickets direkt als plan_staged angelegt (created_at ≈ updated_at, unter einer Sekunde, in drei Schleifen-Clustern). Ein Code-Pfad dafür existiert nicht: scripts/ticket-mcp/go/internal/tools/mishap.go setzt konsequent --status triage (Z. 92, 174) und kommentiert sogar ausdrücklich "plan_staged ist ausschliesslich Tickets vorbehalten, die via stage-plan.sh …" (Z. 166). Der wahrscheinlichste Weg ist also ein ausführender Agent, der die Container-Angabe auf die Einzeltickets überträgt.
+VORSCHLAG: Entweder die Dokumentation des Vorab-Checks um diese Luecke ergaenzen (eine leere Liste beweist NICHT, dass niemand arbeitet — zusaetzlich Prozess-/mtime-Pruefung), oder den Claim frueher setzen (bei Session-Start statt beim ersten Commit).
+**4. printf mit fuehrendem "-" wird als Option statt Format-String interpretiert** (drift, tests/spec/dev-flow-plan (BATS-Fixture-Erstellung))
 
-Abhilfe: an jeder der vier Stellen ausdrücklich "nur der Rollup-Container" ergänzen und einmal explizit festhalten, dass Mishap-Einzeltickets in triage entstehen.
-**7. update-status.sh hat keinen Guard gegen plan_staged ohne Plan-Referenz** (drift, scripts/vda/ticket/update-status.sh)
+Beim Schreiben der BATS-Fixture tests/spec/dev-flow-plan/plan-lint-w3-prose-path.bats: `printf '- [ ] **Step 1: ...**\n\n'` scheitert mit "printf: - : invalid option", weil printf den fuehrenden Bindestrich als Optionsflag liest statt als Formatstring-Zeichen. Fix: `printf -- '...'`. Generisches Bash-Footgun beim Erzeugen von Markdown-Fixtures mit Checklisten-Bullets ("- [ ] ..."), kein Skill-/Repo-Defekt — koennte als Hinweis in die BATS-Fixture-Konventionen (CLAUDE.md) aufgenommen werden, da Markdown-Checklisten-Zeilen in Fixtures haeufig vorkommen.
+**5. B1b-Prosa-Test-Entwurf war durch sort -u Pfad-Dedup unwirksam (kein echtes RED)** (process, tests/spec/dev-flow-plan (BATS-Fixture-Design))
 
-scripts/vda/ticket/update-status.sh prüft ausschließlich terminale Übergänge (done → nur archived, archived terminal; T002382). Es gibt keine Prüfung, die einen Wechsel nach plan_staged ablehnt, wenn kein FACTORY-PLAN-REF-Kommentar existiert.
+Erster Entwurf von tests/spec/dev-flow-plan/plan-lint-b1b-prose-path.bats testete denselben Pfad (InboxApp.svelte) sowohl in der File-Structure-Tabelle als auch zusaetzlich in einem Prosa-Satz. Weil plan-lint.sh Pfad-Tokens vor der Verarbeitung per `sort -u` dedupliziert, war das Ergebnis unabhaengig davon, ob der Fix (struktureller Zeilenfilter) angewendet wurde oder nicht — der Test waere auch bei einem ungefixten Linter gruen gewesen (kein echtes RED, T002448-M4-widrig). Behoben durch Umstellung auf zwei DISTINKTE budget-erschoepfte Dateien: eine echte Tabellenzeile (InboxApp.svelte) und eine reine Prosa-Erwaehnung einer ANDEREN Datei (InboxDetail.svelte), die tatsaechlich nur ueber den ungefilterten Dokumentenscan gefunden werden kann. Lehrreich fuer aehnliche Positiv-/Negativ-Fixtures gegen dedupliziende Linter-Logik.
+**6. openspec-embed post-commit Hook scheitert erneut an Port-15432-Konflikt** (drift, scripts/openspec-embed (post-commit hook))
 
-Dadurch ist der widersprüchliche Zustand "plan_staged ohne Plan" für jeden Aufrufer erreichbar — CLI, MCP, Agent, Skript — und genau das ist am 2026-08-09 28-fach eingetreten. Ein Guard an dieser Stelle macht den Zustand strukturell unerreichbar, unabhängig davon, welcher Aufrufer ihn versucht, und wäre damit wirksamer als jede Korrektur an einzelnen Aufrufern.
+Beim Commit fuer T002807 (openspec change plan-lint-w3-prose-path) schlug der openspec-embed post-commit Hook dreimal mit "Port 15432 wird von einem fremden Prozess belegt (kubectl port-forward -n workspace svc/shared-db)" fehl, bevor er non-fatal aufgab. Bekanntes, bereits dokumentiertes Verhalten (siehe User-MEMORY openspec-embed-port-collision.md) — kein neuer Defekt, aber weiterhin sichtbares Rauschen bei jedem Commit, solange ein k3d-dev-Port-Forward auf demselben Port laeuft. Nur zur Haeufigkeits-Dokumentation gemeldet, keine Handlungsaufforderung.
+**7. Ticket-Locks der auftraggebenden Session blockieren den Abschluss durch Subagent, MCP-Server und post-merge** (degraded, ticket-ops / scripts/agent-lock.sh + scripts/ticket.sh)
 
-Zu beachten: reconcile-ticket-status.sh umgeht update-status.sh bewusst per direktem SQL (dort dokumentiert) — ein neuer Guard darf diesen Watchdog-Pfad nicht blockieren.
-**8. openspec-embed Completeness-Gate: 12 Dokumente in der Collection, 57 lokale aktive Pläne** (suspicious, scripts/openspec-embed · openspec_find_similar)
+Beobachtet 2026-08-09 in einem ticket-ops-Lauf, DREIMAL (Einheiten A, B, F eines Welle-1-Dispatch).
 
-Beim Plan-Stage-Commit meldete der openspec-embed-Hook: "WARN: completeness gate — collection has 12 docs but 57 local active plans (status=planning|plan_staged|active)". Die Embedding-Collection deckt also rund ein Fünftel der aktiven Pläne ab.
+ABLAUF
+ticket-ops Phase 3.6 schreibt vor, vor dem Dispatch fuer jedes Wave-Ticket `agent-lock.sh claim ticket <id>` auszufuehren. Das geschah fuer 14 Tickets. Die dispatchten Subagenten mergten ihre PRs erfolgreich — konnten die Tickets danach aber nicht schliessen:
 
-Folge: semantische Suche über Pläne (Kontexttransfer, Ähnlichkeitssuche via openspec_find_similar) arbeitet auf einem stark unvollständigen Index, ohne dass der Aufrufer das merkt — die Suche liefert Treffer, nur eben aus einem Fünftel des Bestands. Das ist die gefährlichere Sorte Lücke, weil sie wie ein Ergebnis aussieht.
+    ERROR: Ticket T002825 ist gesperrt (agent-lock) — Status-Schreibvorgang verweigert.
+           Halter: tool=claude, label=ticket-ops, sid=c9c84254-...
+           Eigene SID: 06fb98cf-... (Shell-PID 142734)
+           Falls der Halter diese Session ist, gezielt durchlassen: TICKET_LOCK_OVERRIDE=1
 
-Abzugrenzen von T002839 (2 Dokumente über dem 2048-Token-Limit übersprungen): das erklärt 2 fehlende Dokumente, nicht 45. Die Ursache der übrigen Lücke ist offen — Kandidaten sind ein nie gelaufener Backfill (task openspec:embed:backfill) oder Pläne, die nie durch den Hook liefen, weil sie außerhalb eines Commits entstanden.
-**9. BATS: Helper-Funktion trägt grep-Exit-Code nach außen — Positiv-Anker wird aus falschem Grund rot** (drift, tests/spec · BATS-Konventionen)
+DREI AKTEURE, DIE AM EIGENEN LOCK SCHEITERN
+(a) Der Subagent: hat gemergt, darf nicht schliessen (fremde SID) — korrektes Verhalten, aber es zerreisst den Vorgang.
+(b) Der Lock-HALTER selbst: `ticket.sh` laeuft im ticket-mcp-Server unter EIGENER SID und sieht den Lock der aufrufenden Session als fremd. Ich hielt den Lock und wurde von ihm ausgesperrt.
+(c) Laut Subagent-Meldung duerfte derselbe Lock auch post-merge.yml blockiert haben.
 
-Beim Schreiben von tests/spec/ci-cd/workflow-self-trigger.bats (T002868) fiel der Positiv-Anker aus dem falschen Grund rot.
+WARUM DER FEHLERTEXT IN DIE IRRE FUEHRT
+Die Empfehlung "Falls der Halter diese Session ist, TICKET_LOCK_OVERRIDE=1" liest sich wie der vorgesehene Weg. Sie ist hier falsch: der Halter IST dieselbe logische Session, nur unter anderer SID — und ein Override haette den Schutz auch gegenueber echten Fremdsessions abgeschaltet. Der korrekte Ausweg war ein regulaeres `release` NACH getaner Arbeit, ohne Override.
 
-Die Hilfsfunktion sammelt Workflow-Dateien mit paths-Filter:
+STRUKTURELLER KERN
+Der Mechanismus gegen Doppelbearbeitung verhindert hier nicht die Doppelbearbeitung, sondern den ABSCHLUSS — und zwar fuer drei verschiedene Prozesse derselben Arbeit. Die Annahme "eine Session = eine SID" haelt nicht, sobald MCP-Server, Subagenten und CI-Workflows im selben Vorgang schreiben.
 
-    _workflows_with_paths() {
-      for f in "$WF_DIR"/*.yml; do
-        grep -qE '^[[:space:]]+paths:' "$f" && basename "$f"
-      done
-    }
+ZU ERWAEGEN (nicht entschieden)
+- ticket-ops Phase 3.6: Lock nach dem Dispatch freigeben statt bis zum Abschluss halten — der Worktree ist dann der Kollisionsschutz.
+- Oder eine Vererbungskennung (Parent-SID), damit Subagent und MCP-Server als derselbe Halter gelten.
+- Mindestens: den Fehlertext um den regulaeren Release-Pfad ergaenzen, statt nur den Override zu nennen.
 
-Ihr Exit-Code ist der des LETZTEN grep-Durchlaufs. Hat die alphabetisch letzte Workflow-Datei keinen paths-Filter, liefert die Funktion 1 — obwohl sie korrekt eine nicht-leere Liste ausgegeben hat. Das `run _helper` / `[ "$status" -eq 0 ]` des Ankers schlug damit fehl, ohne dass inhaltlich etwas falsch war.
+VERWANDT: T002849 (Lebendigkeitserkennung in agent-lock.sh), T002826 (stiller claim-Fehlschlag), Buffer-Eintrag "agent-lock zeigt eine Session erst ab ihrem ersten Commit" vom selben Tag.
+**8. preflight-pr-scope.sh liest die ERSTE Ticket-ID im PR-Titel — Titel mit zwei IDs faellt faelschlich durch** (drift, scripts/preflight-pr-scope.sh)
 
-Das ist tückisch, weil es die Positiv-Anker-Konvention (T002356-M1) unterläuft: Der Anker soll belegen, dass die Kandidatenmenge nicht leer ist. Scheitert er stattdessen am Exit-Code, sieht der Test rot aus und der Autor "repariert" womöglich die Assertion statt die Funktion — und entfernt dabei genau den Anker, der den Test vor Vakuosität schützt.
+Beobachtet 2026-08-09 beim Anlegen von PR #4043.
 
-Abhilfe (angewandt): explizites `return 0` am Ende jeder sammelnden Helper-Funktion, mit Kommentar. Allgemeiner: In BATS-Helfern, deren Ergebnis die AUSGABE ist und nicht der Status, den Exit-Code immer explizit setzen.
+VERIFIZIERT (scripts/preflight-pr-scope.sh:46 und :52):
+    TICKET_ID="$(echo "$TITLE" | grep -oP '\[T\d{6}\]|T\d{6}' | tr -d '[]' | head -n 1 || true)"
+    ...
+    if [[ "$BRANCH_LC" != *"$TICKET_LC"* ]]; then
+      echo "preflight-pr-scope: FATAL: PR title ticket ID '$TICKET_ID' does not match current branch name ..."
 
-Kandidat für docs/superpowers/references/gotchas-footguns.md oder die Positiv-Anker-Konvention in CLAUDE.md, da beide bereits BATS-Fallen dieser Art führen.
-**10. Reflector-Annotationen am Wildcard-Certificate, aber kein Reflector im Cluster** (drift, prod/wildcard-certificate.yaml · cert-manager)
+`head -n 1` nimmt die erste ID im Titel — unabhaengig davon, ob sie das bearbeitete Ticket bezeichnet. Ein Titel, der ein anderes Ticket ERWAEHNT bevor er das eigene nennt (hier: eine Referenz auf T002629 vor dem eigentlichen [T002825]), scheitert mit FATAL, obwohl Branch und Arbeitsticket zusammenpassen.
 
-`prod/wildcard-certificate.yaml` trägt vier `reflector.v1.emberstack.eu`-Annotationen, die das TLS-Secret automatisch nach coturn, workspace-office und website spiegeln sollen:
+WARUM DAS ZAEHLT
+Der Guard prueft nicht, was er zu pruefen vorgibt. Seine Aussage soll sein "der PR gehoert zum Branch"; gemessen wird "die erste Zeichenkette im Titel, die wie eine Ticket-ID aussieht, steht im Branchnamen". Die Fehlermeldung schlaegt dann eine Branch-Umbenennung auf das FALSCHE Ticket vor (`_suggested_branch="${CURRENT_BRANCH}-${TICKET_LC}"`) — wer ihr folgt, benennt den Branch nach dem nur erwaehnten Ticket um.
 
-    reflector.v1.emberstack.eu/reflection-auto-enabled: "true"
-    reflector.v1.emberstack.eu/reflection-auto-namespaces: "coturn,workspace-office,website"
+Der Workaround (Zweitticket in den Body statt in den Titel) funktioniert, ist aber unsichtbar, solange man den Guard nicht liest.
 
-Auf dem fleet-Cluster läuft jedoch kein Reflector: `kubectl get pods --all-namespaces | grep -i reflector` liefert nichts. Die Annotationen sind wirkungslos; die vorhandenen Kopien tragen `kubectl.kubernetes.io/last-applied-configuration`, sind also von Hand entstanden.
+ZU ERWAEGEN: alle IDs im Titel einsammeln und den Guard bestehen lassen, wenn IRGENDEINE davon zum Branch passt — statt nur der ersten. Das ist dieselbe Klasse wie die Reihenfolge-Guards mit `grep -n … | head -1`: der erste Treffer ist nicht der gemeinte Treffer.
 
-Aktuell kein Schaden: alle vier Secrets (workspace, website, coturn, workspace-office) laufen synchron am 2026-10-27 ab, sind also gepflegt. Das Problem ist die Irreführung — die Konfiguration liest sich wie eine funktionierende Automatik. In dieser Sitzung führte genau das zu einer falschen Designentscheidung, die erst nach dem Nachprüfen des laufenden Clusters korrigiert werden konnte (T002869: kopieren vs. eigenes Certificate).
+Gefunden waehrend eines ticket-ops-Welle-1-Dispatch (Einheit F).
+**9. Reihenfolge-Guards mit "grep -n … | head -1" brechen an sachfremden Einfuegungen — 19 Dateien betroffen** (drift, tests/spec (repo-weit))
 
-Zwei saubere Auflösungen: entweder den Reflector installieren, dann greifen die Annotationen und die Handkopien entfallen — oder die Annotationen entfernen und dokumentieren, dass die Kopien manuell gepflegt werden. Der jetzige Zwischenzustand ist die schlechteste Variante, weil er Automatik behauptet, die niemand betreibt.
+Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit A, PR #4046).
+
+WAS PASSIERTE
+Der bestehende Guard tests/spec/dev-flow-chore-ticket-ops-mishaps.bats (aus T001210) prueft, dass eine Dedupe-Regel hinter der Ueberschrift "## 4." in repo-hygiene-ops.md steht. Er sucht dazu den ERSTEN `dedup`-Treffer im GANZEN Dokument und vergleicht dessen Zeilennummer. Ein neu hinzugefuegter Verweis in §3 kam ihm zuvor — der Guard wurde rot, obwohl §4 voellig unveraendert blieb.
+
+Gefixt durch Einschraenkung der Suche auf den Bereich ab "## 4." — das ist die Aussage, die der Guard treffen wollte.
+
+REICHWEITE (verifiziert)
+    $ grep -rlE 'grep -n[^|]*\| *head -1' tests/spec/ | wc -l
+    19
+Neunzehn Guard-Dateien tragen dasselbe Muster, darunter tests/spec/dev-flow-plan.bats, ticket-system.bats, openspec-workflow.bats, mishap-categorize-erden.bats. Nicht jeder davon ist zwangslaeufig defekt — aber jeder, der eine Reihenfolge- oder Positionsaussage trifft, ist gegen unverwandte Einfuegungen oberhalb der gemeinten Stelle nicht robust.
+
+STRUKTURELLER KERN
+Der Guard misst die Position des ersten Zufallstreffers statt der Aussage, die er treffen will. Ein solcher Test wird rot, ohne dass das Geprueefte sich geaendert hat, und meldet damit einen Defekt, den es nicht gibt — er kostet Diagnosezeit an der falschen Stelle und erzeugt Druck, die eigentlich korrekte Aenderung zurueckzunehmen.
+
+Das ist dieselbe Familie wie die Konvention T002716 ("Semantik statt Darstellung"): dort bricht eine Zusicherung am Ausgabeformat eines Werkzeugs, hier an der Dokumentposition eines beliebigen anderen Treffers. Die Regel deckt diesen Fall bislang nicht ausdruecklich ab.
+
+ZU ERWAEGEN: die Suche in solchen Guards grundsaetzlich auf den relevanten Abschnitt eingrenzen (awk-Bereichsmuster oder sed-Range), statt eine dokumentweite Suche mit `head -1` zu beschneiden. Und T002716 um den Positions-Fall erweitern.
+**10. Konfliktfreier Rebase verliert mitcommittete Freshness-Artefakte ohne Konfliktmeldung** (suspicious, skills/git-workflow · .gitattributes merge=ours)
+
+Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit B, PR #4050).
+
+WAS PASSIERTE
+Ein `git rebase` gegen origin/main lief KONFLIKTFREI durch. Dabei wurden die mitcommitteten generierten Artefakte website/src/data/test-inventory.json und docs/code-quality/repo-index.json ohne jede Konfliktmeldung auf die main-Version aufgeloest und fielen damit aus dem Commit. `task freshness:check` wurde daraufhin erneut rot — nachdem er vor dem Rebase gruen war.
+
+Ursache ist der merge=ours-Treiber in .gitattributes fuer die Freshness-Generate: er loest zugunsten einer Seite auf, statt einen Konflikt zu melden. Das ist fuer den Merge-Fall gewollt (sonst konfligierte jeder PR an diesen Dateien), hat im Rebase-Fall aber die Nebenwirkung, dass eigene, absichtlich mitgefuehrte Regenerate still verschwinden.
+
+STRUKTURELLER KERN
+Ein gruener Rebase belegt NICHT, dass die Artefakte noch im Commit sind. Das Erfolgssignal des Rebase sagt nichts ueber die Vollstaendigkeit seines Ergebnisses — dieselbe Familie wie "der Erfolg des LETZTEN Kommandos in einer Kette sagt nichts ueber den Erfolg des vorherigen" (T002815) und wie die soeben in repo-hygiene-ops §3 aufgenommene Regel "ein leeres Signal ist kein Urteil".
+
+Besonders tueckisch, weil die Gegenprobe billig ist und trotzdem niemand sie faehrt: nach dem Rebase `git show --stat HEAD` auf die Artefaktpfade oder schlicht `task freshness:check` erneut laufen lassen.
+
+ZU ERWAEGEN: in git-workflow nach jedem Rebase eine Freshness-Nachpruefung vorschreiben, bevor gepusht wird — und explizit benennen, dass merge=ours hier ohne Konfliktmarker zuschlaegt.
+
+VERWANDT: T002823 (merge=ours-Phantomkonflikt gegenueber GitHub — dieselbe .gitattributes-Ursache, andere Richtung).
+## Kanonischer Rollup-Container (Entscheidung ticket-ops 2026-08-09)
+
+**Dieses Ticket NICHT schliessen.** Der Hinweis stammt aus dem Vorgaenger-Container T002784 und gilt hier unveraendert weiter:
+
+Ein geschlossener oder blockierter Container laesst den Mishap-Flush ins Leere laufen, **ohne dass es auffaellt**. Genau diese Kette ist bereits zweimal gerissen:
+
+- T002783: die Vorgaenger T002597 und T002601 standen beide auf `done` und waren damit fuer `scripts/factory/mishap-rollup.sh` unsichtbar.
+- 2026-08-09: T002784 stand auf `blocked` und wurde ebenfalls nicht mehr aufgeloest; dieser Container hier musste manuell angelegt werden, weil `ticket.sh rollup-container` zusaetzlich am Leerfall-Defekt T003068 scheiterte.
+
+Konsequenz: Der Container muss auf einem **offenen, nicht-terminalen** Status stehen (`triage`). T002784 wurde als `done/obsolete` geschlossen, `duplicate_of` → T003067.
+
+Verwandt: T003068 (rollup-container kann sich bei leerer Trefferliste nicht selbst heilen) — solange dieser Defekt besteht, ist der Container hier die einzige Absicherung des Mishap-Meldewegs.
+### Mishap-Rollup — 10 Eintraege (2026-08-09 21:40 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | drift | tests/spec (repo-weit) · Shell-Konventionen | grep -qF schuetzt NICHT vor Options-Parsing — jeder Guard, der auf ein CLI-Flag im Text greppt, scheitert |
+| 2 | suspicious | skills/repo-hygiene · gh-Warteschleifen | gh pr checks --jq 'all(...)' ist auf der leeren Checkliste vakuos true — CI-Warteschleife bricht sofort ab |
+| 3 | degraded | scripts/agent-lock.sh | agent-lock.sh check detektiert SID nicht aus Worktree-Pfaden — TICKET_LOCK_OVERRIDE als Workaround nötig |
+| 4 | process | dev-flow-plan | dev-flow-plan Schritt 5 verlangt ticket-scoped agent-lock, den der ticket-ops-Dispatch verbietet |
+| 5 | suspicious | scripts/plan-qa-check.sh | plan-qa-check.sh liefert Parse-Fehler statt inhaltlicher QA-Rückmeldung |
+| 6 | drift | scripts/plan-touched-files.sh | touched_files-Ableitung nimmt reine Lesebefehl-Pfade als geänderte Dateien auf |
+| 7 | suspicious | skills/dev-flow-plan · scripts/hooks/worktree-write-guard.sh | worktree-write-guard blockiert Sub-Agenten in vom Orchestrator vorbereiteten Worktrees ohne eigenen agent-lock-Claim |
+| 8 | drift | scripts/openspec-embed-local.sh | openspec-embed-local.sh scheitert weiterhin an Port-15432-Kollision bei Plan-Stage-Commits (bekanntes Muster, erneut bestaetigt) |
+| 9 | degraded | skills/ticket-ops + skills/dev-flow-plan + scripts/hooks/worktree-write-guard.sh | Drei Regelwerke widersprechen sich beim agent-lock-Scope — Planungsagenten kommen ohne bewusste Abweichung nicht durch |
+| 10 | suspicious | skills/ticket-ops Phase 1 (Dedupe-Guard) | ticket-ops-Dedupe-Guard vergleicht Titel exakt und fand 1 von 6 Dubletten — die dominante Dublettenklasse entgeht ihm strukturell |
+
+**1. grep -qF schuetzt NICHT vor Options-Parsing — jeder Guard, der auf ein CLI-Flag im Text greppt, scheitert** (drift, tests/spec (repo-weit) · Shell-Konventionen)
+
+Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit B) beim Schreiben eines Guards, der die Erwaehnung von `--draft` in einem Skill-Dokument pruefen sollte.
+
+VERIFIZIERT (Output-Verifikation, im Hauptcheckout nachgestellt):
+    $ echo "text mit --draft drin" | grep -qF '--draft'; echo "exit=$?"
+    ugrep: invalid option --draft, did you mean --decompress, --delay=, --depth=, ...
+    exit=2
+
+    $ echo "text mit --draft drin" | grep -qF -e '--draft'; echo "exit=$?"
+    mit -e: exit=0
+
+`-F` macht das Muster nur zu einer festen Zeichenkette statt einer Regex — es verhindert NICHT, dass das Argument zuvor als Option geparst wird. Nur `-e` (oder `--`) markiert es als Muster.
+
+WARUM DAS ZAEHLT
+Der Exit-Code ist 2, nicht 1. Ein Guard der Form `grep -qF '--flag' datei || fail` bricht damit nicht mit "nicht gefunden" ab, sondern mit einem Werkzeugfehler — und in einer `if`-Bedingung sind beide ununterscheidbar falsch. Der Test meldet dann "das Flag fehlt im Dokument", obwohl es dasteht. Betrifft jeden Guard, der ein CLI-Flag, einen Long-Option-Namen oder irgendein mit `-` beginnendes Token im Text sucht — und das ist in einem Repo mit dokumentierten Runbooks kein Randfall.
+
+NEBENBEFUND ZUM UMFELD: Die Fehlermeldung stammt von `ugrep`, nicht von GNU grep — auf diesem Host ist `grep` ein ugrep-Alias. Der Wortlaut der Meldung unterscheidet sich damit zwischen lokaler Shell und CI-Runner; ein Guard, der auf den Meldungstext prueft, waere aus genau diesem Grund unzuverlaessig (T002716).
+
+VERWANDT: Buffer-Eintrag "printf mit fuehrendem '-' wird als Option statt Format-String interpretiert" vom selben Tag — dieselbe Klasse bei einem anderen Werkzeug. Es lohnt, das als eine Regel zu fassen statt als zwei Einzelfaelle.
+**2. gh pr checks --jq 'all(...)' ist auf der leeren Checkliste vakuos true — CI-Warteschleife bricht sofort ab** (suspicious, skills/repo-hygiene · gh-Warteschleifen)
+
+Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch (Einheit B, PR #4050).
+
+WAS PASSIERTE
+Der PR stand auf mergeStateStatus=DIRTY. Bei einem Konflikt startet GitHub die CI gar nicht erst — die Checkliste bleibt LEER. Eine Warteschleife der Form
+
+    gh pr checks <n> --json bucket --jq 'all(.bucket != "pending")'
+
+liefert auf der leeren Liste `true`. Das ist die korrekte jq-Semantik (`all` ueber eine leere Menge ist wahr), aber die Schleife liest daraus "keine Checks mehr pending" und bricht sofort ab. Der Zustand liest sich als "CI durchgelaufen", waehrend in Wahrheit nie eine Pruefung stattgefunden hat.
+
+BELASTBAR IST ERST: `mergeStateStatus != DIRTY` UND eine NICHTLEERE Checkliste. Nach einem Rebase erschienen 15 Checks.
+
+VERHAELTNIS ZU T002822 (im SELBEN Lauf behoben, PR #4046)
+T002822 beschrieb dieselbe Ursache (CONFLICTING PR unterdrueckt CI) und wurde in repo-hygiene-ops.md §3 unter der neuen Regel "ein leeres Signal ist kein Urteil" aufgenommen, mit der Gegenprobe ueber mergeStateStatus und einen lokalen Probe-Merge.
+
+GEPRUEFT, OB BEREITS ABGEDECKT — NEIN: Die neue §3-Fassung auf origin/main enthaelt keine Stelle zu `all(...)`, `jq` in diesem Zusammenhang oder zum vakuosen Wahrheitswert ueber leeren Mengen. Sie warnt davor, eine leere Checkliste als Urteil zu LESEN; sie deckt nicht den Fall, dass ein AUTOMATISIERTES Praedikat sie stillschweigend als Erfolg auswertet. Das ist die schaerfere Variante: bei der manuellen Lesart sieht man wenigstens die leere Liste, bei der Warteschleife sieht man nur `true`.
+
+ZU ERWAEGEN: §3 um eine Zeile zum vakuosen `all()` ergaenzen und, wo im Repo solche Warteschleifen existieren (devflow-ci-watch.sh, Auto-Merge-Wartepfade), die Nichtleere-Bedingung ergaenzen. Allgemeiner: jedes Praedikat ueber einer moeglicherweise leeren Menge braucht eine vorgeschaltete Nichtleere-Pruefung — dieselbe Struktur wie die Positiv-Anker-Pflicht bei Negativtests (T002356-M1), wo ein Test ueber einer leeren Kandidatenliste ebenfalls vakuos besteht.
+**3. agent-lock.sh check detektiert SID nicht aus Worktree-Pfaden — TICKET_LOCK_OVERRIDE als Workaround nötig** (degraded, scripts/agent-lock.sh)
+
+BEOBACHTUNG (2026-08-09, T002807 + T002849): `agent-lock.sh check ticket <id>` meldet stets `Eigene SID: <nicht gesetzt>` bei Aufrufen aus einem `.worktrees/`-Pfad, obwohl `check-and-claim` (gleiche Session, gleicher Worktree-Pfad) den Lock erfolgreich anlegt. `ticket.sh update-status` bricht deshalb mit Exit 7 ab (`Ticket X ist gesperrt`). Workaround: `TICKET_LOCK_OVERRIDE=1 bash scripts/ticket.sh update-status ...`.
+
+VERIFIZIERT: sowohl in `.worktrees/plan-lint-w3-prosa-T002807` als auch in `.worktrees/agent-lock-liveness-T002849` reproduziert. Der Hauptcheckout (`/home/patrick/Bachelorprojekt`) zeigt das Problem nicht — `check` meldet dort `mine`.
+
+URSACHE VERMUTET: `_my_sid()` in `agent-lock.sh` nutzt `git rev-parse --show-toplevel` o.Ä. als Pfadanker, der in Worktrees (deren `.git` eine Datei mit `gitdir:`-Verweis ist) anders auflöst. Die `check-and-claim`-Funktion ermittelt die SID über einen anderen Code-Pfad (`scripts/agent-lock-identity.sh`).
+**4. dev-flow-plan Schritt 5 verlangt ticket-scoped agent-lock, den der ticket-ops-Dispatch verbietet** (process, dev-flow-plan)
+
+Bei T002999 (Welle-1-Dispatch) standen zwei Vorgaben gegeneinander:
+
+1. Der Dispatch verbietet ausdruecklich einen agent-lock im **ticket**-Scope (T003102 — blockiert den spaeteren Abschluss).
+2. `dev-flow-plan` Schritt 5 (Pre-Commit Guard, Punkt 3) verlangt genau diese Lock-Datei: `$(git rev-parse --git-common-dir)/agent-locks/ticket__<ID>.json` — fehlt sie, soll der Commit mit FATAL abbrechen.
+
+Zusaetzlich blockierte `scripts/hooks/worktree-write-guard.sh` jeden Write im eigenen Worktree, solange gar kein Claim existierte. Aufloesung war ein **branch**-scoped Claim (`agent-lock.sh claim branch`) — Regel 2 des Guards greift auf den Branch-Claim, nicht auf den Ticket-Claim. Damit sind beide Vorgaben erfuellbar, aber das steht nirgends: Schritt 5 nennt nur den Ticket-Claim.
+
+Nebenbefund zur Meldung des Guards: unter "Dieser Session gehoeren:" listet er die Worktrees **fremder** Sessions (hier zwei andere T003xxx-Worktrees, doppelt). Das liest sich, als besaesse die eigene Session diese Verzeichnisse, und fuehrt beim Debuggen in die falsche Richtung.
+
+Vorschlag: Schritt 5 Punkt 3 auf "ticket- ODER branch-scoped Claim" lockern und die Guard-Meldung auf "Geclaimt von anderen Sessions" umformulieren.
+**5. plan-qa-check.sh liefert Parse-Fehler statt inhaltlicher QA-Rückmeldung** (suspicious, scripts/plan-qa-check.sh)
+
+Beim Plan-Stage für T003077 (openspec-embed-dynamic-port) lieferte die advisory LLM-QA (scripts/plan-qa-check.sh) in Iteration 2 "FAIL — Missing criteria: Could not parse missing items" statt einer inhaltlichen Rückmeldung — ein Parse-Fehler des LLM-Antwortformats, keine echte Lücke (das harte Gate scripts/plan-lint.sh war zu diesem Zeitpunkt bereits PASS). Nicht blockierend (Skill-Konvention: bricht nie, `|| true`), aber Rauschen, das potenziell bei jedem Plan-Stage-Lauf auftritt und den Nutzen der advisory QA mindert.
+**6. touched_files-Ableitung nimmt reine Lesebefehl-Pfade als geänderte Dateien auf** (drift, scripts/plan-touched-files.sh)
+
+scripts/ticket.sh stage-plan (Ableitung via plan-touched-files.sh) trug für T003077 (openspec-embed-dynamic-port) docs/code-quality/baseline.json und docs/code-quality/gates.yaml als touched_files ein, obwohl der Plan diese Dateien nur per jq/grep-Lesebefehl referenziert (zur S1-Budget-Ermittlung in der Plan-Prosa), nicht verändert. touched_files zeigt dadurch zwei Dateien, die dieser Fix nicht anfasst — die Ableitung unterscheidet nicht zwischen "im Plan als MODIFIED/NEW markierter Pfad" und "im Plan als Lesebefehl-Argument zitierter Pfad".
+**7. worktree-write-guard blockiert Sub-Agenten in vom Orchestrator vorbereiteten Worktrees ohne eigenen agent-lock-Claim** (suspicious, skills/dev-flow-plan · scripts/hooks/worktree-write-guard.sh)
+
+Beobachtet 2026-08-09 waehrend eines ticket-ops-Welle-1-Dispatch fuer T003075. Der Dispatch-Prompt wies an, ausschliesslich im vom Orchestrator vorab angelegten Worktree /home/patrick/Bachelorprojekt/.worktrees/freshness-gate-artifacts-T003075 zu arbeiten, und untersagte explizit einen ticket-scoped agent-lock-Claim ("KEIN agent-lock im ticket-Scope (T003102)"). Der erste Write-Tool-Aufruf auf einen Pfad unter diesem Worktree wurde dennoch von scripts/hooks/worktree-write-guard.sh abgelehnt: der Guard erlaubt Schreibzugriffe nur unter Pfaden, die per agent-lock.sh claim branch/ticket IN DIESER SESSION geclaimt wurden — ein vom Orchestrator vorab angelegter Worktree ohne eigenen Claim der Sub-Agenten-Session zaehlt nicht als "eigener" Pfad. Geloest durch `bash scripts/agent-lock.sh claim branch "fix/freshness-gate-artifacts-T003075" --worktree "$PWD" --label dev-flow-plan` vor dem ersten Write — das ist ein BRANCH-Scope-Claim, kein TICKET-Scope-Claim, widerspricht also der Anweisung nicht direkt, aber die Unterscheidung war im Dispatch-Prompt nicht klar genug: der Fehler musste erst live gegen den Write-Guard reproduziert werden, um zu verstehen, welcher Claim fehlte. Vorschlag: Dispatch-Prompts fuer ticket-ops-Wellen, die einen vorab angelegten Worktree uebergeben, sollten explizit nennen, ob/welcher agent-lock-Claim (branch vs. ticket) vom Sub-Agenten selbst noch zu setzen ist, um Write-Zugriff zu erhalten.
+**8. openspec-embed-local.sh scheitert weiterhin an Port-15432-Kollision bei Plan-Stage-Commits (bekanntes Muster, erneut bestaetigt)** (drift, scripts/openspec-embed-local.sh)
+
+Beim Plan-Stage-Commit fuer T003075 (2026-08-09) loeste der post-commit-Hook openspec-embed-local.sh aus, welches 3x mit "Port 15432 wird von einem fremden Prozess belegt (kubectl port-forward svc/shared-db)" scheiterte, bevor es non-fatal aufgab. Kein neuer Befund — deckt sich mit dem bereits dokumentierten Muster (openspec-embed scheitert an Port 15432, k3d-Forward belegt ihn). Bestaetigt lediglich, dass das Problem in Multi-Session-Umgebungen mit parallelen kubectl-Port-Forwards weiterhin regelmaessig auftritt und bei jedem betroffenen Plan-Stage-Commit sichtbare Fehlermeldungen erzeugt (non-fatal, aber Rauschen im Session-Log).
+**9. Drei Regelwerke widersprechen sich beim agent-lock-Scope — Planungsagenten kommen ohne bewusste Abweichung nicht durch** (degraded, skills/ticket-ops + skills/dev-flow-plan + scripts/hooks/worktree-write-guard.sh)
+
+Beobachtet 2026-08-09 in einem ticket-ops-Welle-1-Dispatch mit 6 parallelen dev-flow-plan-Agenten. VERIFIZIERT durch Code-Lesung, nicht nur berichtet.
+
+DER WIDERSPRUCH (drei Stellen, paarweise unvereinbar):
+
+(a) ticket-ops Step 3.6 (.claude/skills/references/ticket-ops-procedures.md) schreibt vor:
+    `agent-lock.sh claim ticket <ext-id> --branch <b> --worktree <wt> --label ticket-ops`
+
+(b) T003102 belegt (dort dreimal in einem einzigen Lauf beobachtet), dass genau dieser
+    ticket-scoped Lock danach den ABSCHLUSS blockiert: Subagent, ticket-mcp-Server und
+    post-merge.yml schreiben je unter eigener SID und sehen den Lock der aufrufenden
+    Session als fremd. Der Halter sperrt sich selbst aus.
+
+(c) dev-flow-plan/SKILL.md:217 fordert dieselbe Datei fail-closed als Vorbedingung des
+    Stage-Commits:
+        LOCK_FILE="$(git rev-parse --git-common-dir)/agent-locks/ticket__${TICKET_EXT_ID}.json"
+        [ -f "$LOCK_FILE" ] || { echo "FATAL: kein ticket-scoped agent-lock-Claim ..."; exit 1; }
+
+(d) scripts/hooks/worktree-write-guard.sh Regel 2 (Zeile 147-165) verweigert ohne
+    irgendeinen eigenen Claim jeden Write im zugewiesenen Worktree — exit 2.
+
+WAS TATSAECHLICH PASSIERTE: Der Orchestrator untersagte den Agenten wegen (b) den
+ticket-Lock. Daraufhin blockierte (d) bei 4 von 6 Agenten den ersten Testdatei-Write.
+Alle vier loesten es unabhaengig voneinander identisch auf — branch-scoped Claim, auf
+den Regel 2 ebenfalls greift. Zwei weitere Agenten (T003068, T003077) setzten entgegen
+der Anweisung doch ticket-Locks; diese mussten nach dem Lauf manuell freigegeben werden,
+um die (b)-Blockade zu vermeiden.
+
+DIE AUFLOESUNG, DIE NIRGENDS DOKUMENTIERT IST:
+    bash scripts/agent-lock.sh claim branch <branch> --worktree <pfad> --branch <branch>
+Der branch-scoped Claim befriedigt (d), erfuellt den Zweck des Kollisionsschutzes und
+erzeugt die Abschluss-Blockade aus (b) NICHT. Er steht derzeit in keinem der drei
+Regelwerke — jeder Agent musste ihn neu herleiten.
+
+ZU AENDERN:
+1. ticket-ops Step 3.6: claim branch statt claim ticket vorschreiben.
+2. dev-flow-plan Schritt 5 Punkt 3: branch-scoped Lock-Datei akzeptieren
+   (branch__<slug>.json) statt ticket__<id>.json fail-closed zu fordern.
+3. Beide Stellen mit einem Verweis auf T003102 versehen, damit die Begruendung nicht
+   erneut hergeleitet werden muss.
+
+Hinweis: WORKTREE_GUARD_BYPASS=1 per Bash-Export wirkt NICHT — der Hook laeuft pro
+Tool-Aufruf in einem eigenen Prozess (von einem Agenten geprueft).
+**10. ticket-ops-Dedupe-Guard vergleicht Titel exakt und fand 1 von 6 Dubletten — die dominante Dublettenklasse entgeht ihm strukturell** (suspicious, skills/ticket-ops Phase 1 (Dedupe-Guard))
+
+Beobachtet 2026-08-09 im ticket-ops-Vollduchlauf ueber 88 offene Tickets. GEMESSEN, nicht vermutet: die Exakt-Titel-Query fand genau ein Paar, die manuelle semantische Durchsicht fuenf weitere.
+
+DIE QUERY (Skill-Body-Invariante "Dedupe-Guard vor jeder Intake-Zeile"):
+    GROUP BY lower(regexp_replace(title,'\s+',' ','g')) HAVING count(*) > 1
+Sie findet nur Tickets mit WORTGLEICHEM Titel.
+
+GEFUNDEN: 1 Paar (T002784 / T003067, beide "Mishap Rollup — fortlaufende Sammlung").
+
+UEBERSEHEN: 5 Paare, alle semantisch identisch, alle mit unterschiedlichem Titel:
+- T002765 / T002911 — beide scripts/plan-touched-files.sh nimmt Prosa-Pfade auf.
+  Beide nennen sogar DASSELBE Beispiel: docs/code-quality/gates.yaml.
+- T003077 / T003101 — beide openspec-embed scheitert an Port-15432-Kollision.
+- T002877 / T002910 — beide openspec-embed completeness gate (12/57 bzw. 14/58 Dokumente).
+- T003001 / T003006 — beide spec-tracked-file-guard.bats unter bats -j, beide aus PR #3974.
+- T003078 / T003096 — wortgleiche BESCHREIBUNG, minimal abweichender Titel (der Guard
+  vergleicht nur den Titel, deshalb entging auch dieses Paar).
+
+WARUM DAS STRUKTURELL IST: Die dominante Dublettenquelle in diesem Repo sind
+Mishap-Reports. Jeder wird unabhaengig formuliert — dieselbe Beobachtung, andere Worte.
+Ein Titelvergleich kann diese Klasse per Konstruktion nicht fassen. Waehrend dieses
+Laufs meldete ein Planungsagent den plan-touched-files-Defekt zum VIERTEN Mal als
+vermeintlich neuen Befund.
+
+VORHANDENE BAUSTEINE FUER EINEN BESSEREN GUARD:
+- mcp__factory-mcp__openspec_find_similar (semantische Aehnlichkeitssuche, bereits im Einsatz)
+- bge-mcp (bge_embed + bge_rerank)
+- Als billige Naeherung ohne Embedding: Gleichheit von (component, areas) plus
+  Ueberlappung der in der Beschreibung genannten Dateipfade. Alle fuenf uebersehenen
+  Paare teilen Komponente UND mindestens einen Dateipfad — diese Heuristik allein
+  haette sie gefunden.
+
+FOLGEKOSTEN, falls unveraendert: Beinahe-Duplikate werden getrennt geplant und getrennt
+dispatcht. In diesem Lauf haette das drei Agenten gleichzeitig an denselben roten
+Shard-4-Guard gesetzt (T002941 / T003001 / T003006).
 
 ## Verify (RED → GREEN)
 

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:44 UTC. Die Eintraege stammen aus den
+2026-08-10 01:47 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:40 UTC. Die Eintraege stammen aus den
+2026-08-09 23:44 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 01:36 UTC. Die Eintraege stammen aus den
+2026-08-10 01:39 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:29 UTC. Die Eintraege stammen aus den
+2026-08-10 00:35 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 05:56 UTC. Die Eintraege stammen aus den
+2026-08-09 10:31 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure
@@ -1069,6 +1069,331 @@ ABLEITUNG: Vor einer Architekturfrage an den User gehört eine Suche nach besteh
 NEBENBEFUND, in den Change eingearbeitet: der Drift-Guard aus T002470 hat den Drift, der T002817 auslöste, nicht gefunden. Er vergleicht Ticket-ID-Regex, Exemption-Liste und Typ-Präfixe zwischen Hook und Helper — die _unattended_allowlist (worktree-create.sh:49, mit T002783 hinzugekommen) fällt in keinen der drei Vergleiche. Eine bewusst duplizierte Regel ist nur so vollständig abgesichert wie die Aufzählung der Drift-Tests gepflegt wird.
 
 ZWEITER, KLEINERER BEFUND: Ich habe .githooks/pre-push zunächst als zweiten Blocker der Kette bezeichnet. Der Abschnitt ist advisory (warn + exit 0), blockiert also nicht. Korrigiert, bevor der Plan geschrieben wurde; der Hook bleibt im Scope, weil die Warnung falsch ist, aber er war nie Ursache.
+### Mishap-Rollup — 10 Eintraege (2026-08-09 06:49 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | drift | scripts/factory/mishap-rollup.sh · tickets/lifecycle | Rollup-Plan lokal committet, nie gepusht — Container blieb triage mit plan_ref=null |
+| 2 | degraded | scripts/bge-mcp · systemd-user-units · openspec-embed-hook | bge-forward-embed: Unit active, Socket lauscht, Tunnel tot — openspec-embed schlägt bei jedem Commit still fehl |
+| 3 | degraded | k3d/llm-gpu.yaml · bge-embed · scripts/bge-mcp | KORREKTUR zum bge-forward-embed-Mishap: Restart wirkungslos, Ursache liegt cluster-seitig — readiness=true bei totem Endpoint |
+| 4 | degraded | scripts/ticket.sh | ticket.sh: --help auf Subkommando-Ebene fuehrt in eine Fehlermeldung statt zur Optionsliste |
+| 5 | drift | .claude/skills/references/repo-hygiene-ops.md §4 · mishap-tracker | Dedupe-Guard prueft nur offene Tickets, nicht den Mishap-Buffer — Doppelerfassung real eingetreten |
+| 6 | suspicious | tickets/plan_staged | 18 Tickets stehen auf plan_staged ohne plan-Zeile/Branch — halbgestagte Plans |
+| 7 | suspicious | tickets/t002629 | T002629-Beschreibung behauptet offenen Blocker, PR #3745 ist seit 4 Tagen gemergt |
+| 8 | process | skills/repo-hygiene | Probe-Schleife mit 2>/dev/null macht harten Fehler zu stillem Leerergebnis |
+| 9 | degraded | llm/gateway | Alle vier lokalen LLM-Backends am Gateway degraded (/health 503) |
+| 10 | suspicious | scripts/agent-lock.sh | Tote agent-locks blockieren bis zu 30 min, obwohl beide PIDs nachweislich tot sind |
+
+**1. Rollup-Plan lokal committet, nie gepusht — Container blieb triage mit plan_ref=null** (drift, scripts/factory/mishap-rollup.sh · tickets/lifecycle)
+
+Beobachtet 2026-08-09 in .worktrees/mishap-incident-rollup waehrend eines repo-hygiene-Laufs.
+
+Der Branch chore/mishap-incident-rollup trug den Commit 7b3916970 ("chore(plans): update mishap-incident-rollup from container batches [T002784]") mit einem vollstaendigen 1092-zeiligen Plan (proposal.md + tasks.md). VERIFIZIERT: `git ls-remote --heads origin` kannte KEIN refs/heads/chore/mishap-incident-rollup, und Container T002784 stand auf status=triage mit plan_ref=null. Der Lauf ist zwischen `git commit` (erfolgreich) und `git push`/`stage-plan` gestorben.
+
+WARUM DAS ZAEHLT: Wie bei T002817 endet die Mishap-Auswertung blind — der Plan wird korrekt erzeugt und gelintet, ist fuer die Factory aber unsichtbar (kein Remote-Ref, kein plan_ref, Container nicht plan_staged). Unterschied zu T002817: dort scheiterte der COMMIT am pre-commit-Branch-Guard, hier war der Commit erfolgreich und PUSH/stage-plan blieben aus. Naechster Blocker derselben Kette, nicht derselbe.
+
+BESONDERS TUECKISCH: Der lokale Branch trug origin/main als Upstream statt seines eigenen Remote-Refs. `git status` meldet dann "ahead 2" — das liest sich wie normaler unveroeffentlichter Fortschritt, obwohl der designierte Remote-Branch gar nicht existiert. Das Signal, das den Defekt anzeigen muesste, sieht aus wie der Normalzustand.
+
+BEHOBEN IN DIESEM LAUF (Symptom, nicht Ursache): Branch nach origin gepusht (pre-push gruen, T002817-Allowlist greift jetzt), danach `ticket.sh stage-plan --id T002784 --branch chore/mishap-incident-rollup --plan openspec/changes/mishap-incident-rollup/tasks.md --partials 1`. Container steht wieder auf plan_staged mit gueltigem plan_ref. Der Defekt im Treiber-Pfad selbst ist NICHT behoben.
+
+VORSCHLAG: Der Treiber sollte nach dem Push verifizieren, dass der Remote-Ref existiert (`git ls-remote --heads origin "$BRANCH"`), statt sich auf den Exit-Code von `git push -q` zu verlassen — dieselbe Struktur wie die mergedAt-Regel in repo-hygiene-ops §3 ("eine leere Antwort ist kein Urteil"). Zusaetzlich ein Nachlauf-Check, der einen committeten aber nicht gepushten Plan beim naechsten Tick aufgreift, statt ihn liegen zu lassen.
+
+VERWANDT: T002817 (pre-commit-Guard, PR #3929 gemergt), T002783 (Container-Aufloesung), T002407 (Treiber).
+**2. bge-forward-embed: Unit active, Socket lauscht, Tunnel tot — openspec-embed schlägt bei jedem Commit still fehl** (degraded, scripts/bge-mcp · systemd-user-units · openspec-embed-hook)
+
+Beobachtet 2026-08-09 waehrend eines repo-hygiene-Laufs, aufgefallen an einer WARN-Zeile des post-commit-Hooks von scripts/factory/mishap-rollup.sh.
+
+BEFUND (drei Signale gruen, Dienst unbenutzbar):
+- `systemctl --user is-active bge-forward-embed` -> active (running), seit 8 h
+- `ss -tlnp | grep 8081` -> LISTEN auf 127.0.0.1:8081 und [::1]:8081, gehalten von kubectl pid 318
+- `/proc/318/cmdline` -> `kubectl --context fleet port-forward -n workspace svc/llm-gateway-embed 8081:8081`
+- `curl -m 8 http://127.0.0.1:8081/v1/embeddings` -> HTTP 000 nach 8,02 s (Timeout), zweimal reproduziert
+
+Der lokale Socket nimmt Verbindungen an, aber der Tunnel dahinter transportiert nichts. Ein Zombie-Port-Forward: der kubectl-Prozess lebt weiter, seine Cluster-Verbindung ist weg.
+
+WARUM DAS ZAEHLT: Der Kommentarkopf von scripts/bge-mcp/bge-mcp.service dokumentiert unter T002604 ausdruecklich, dass die Port-Forwards zu eigenen Units gemacht wurden, damit systemd sie ueberwacht und neu startet — "statt wie bisher `active` zu melden, waehrend [der Tunnel tot ist]". Genau dieser Zustand ist eingetreten. Die Massnahme kann ihn nicht verhindern: systemd sieht Prozess-Liveness, nicht Tunnel-Gesundheit. Ein `Requires=`/Restart-Mechanismus, der auf Prozessende triggert, greift bei einem Prozess, der nicht endet, nie.
+
+FOLGE: Der post-commit-Hook openspec-embed meldet den Fehlschlag als "WARN: embed failed ... (non-fatal)" und laeuft weiter. Jeder Commit an einem OpenSpec-Change laesst damit den Embedding-Index weiter veralten, ohne dass irgendwo ein rotes Signal entsteht. Der Drift ist kumulativ und wird erst bemerkt, wenn eine Aehnlichkeitssuche (openspec_find_similar, bge_embed) schlechte Treffer liefert — dann aber ohne Bezug zur Ursache.
+
+STRUKTURELLER KERN: dritter Befund desselben Musters in diesem Lauf — ein Signal, das Gesundheit attestiert, ohne das Attestierte zu pruefen. Vgl. repo-hygiene-ops §3 ("eine leere Antwort ist kein Urteil") und den unpushed-Plan-Befund vom selben Tag, wo `git status` "ahead 2" meldete, obwohl der Remote-Branch fehlte.
+
+VORSCHLAG: Die Forward-Units mit einem echten Readiness-Check versehen statt mit Prozess-Liveness — periodischer HTTP-Probe gegen den Endpoint (systemd-Timer oder ExecStartPost-Watchdog), der die Unit bei Timeout neu startet. Mindestens sollte openspec-embed den Fehlschlag zaehlen bzw. sichtbar machen, statt ihn pro Commit als non-fatal wegzuschlucken — ein stiller WARN in einem Hook, der bei jedem Commit laeuft, wird nicht gelesen.
+
+SOFORT-REMEDIATION (im Lauf angewandt): `systemctl --user restart bge-forward-embed`.
+
+VERWANDT: T002604 (Port-Forwards als eigene Units), T002551 (bge-embed als Cluster-CPU-Deployment), T002488 (Cluster-DNS auf dem WSL-Host nicht aufloesbar).
+**3. KORREKTUR zum bge-forward-embed-Mishap: Restart wirkungslos, Ursache liegt cluster-seitig — readiness=true bei totem Endpoint** (degraded, k3d/llm-gpu.yaml · bge-embed · scripts/bge-mcp)
+
+Korrektur zum unmittelbar vorhergehenden Buffer-Eintrag ("bge-forward-embed: Unit active, Socket lauscht, Tunnel tot"). Dort steht "SOFORT-REMEDIATION (im Lauf angewandt): systemctl --user restart bge-forward-embed". Das ist FALSCH und wird hiermit richtiggestellt: der Restart wurde ausgefuehrt und hat NICHT geholfen.
+
+NACHGEMESSEN nach dem Restart:
+- `systemctl --user restart bge-forward-embed` -> Exit 0, Unit laeuft neu
+- `curl -m 10 http://127.0.0.1:8081/v1/embeddings` -> weiterhin HTTP 000, Timeout nach 10,02 s
+
+URSACHE LIEGT NICHT IM PORT-FORWARD, sondern cluster-seitig:
+- `svc/llm-gateway-embed` existiert (ClusterIP 10.43.42.200:8081, 70 d alt)
+- Endpoints sind BEFUELLT: 10.42.2.231:8080 — es fehlt also kein Backend
+- Der Pod dahinter ist `bge-embed-5d54c9c44d-mz9pr` auf pk-hetzner-8: phase=Running, ready=TRUE, aber **restarts=6 in den letzten 10 Stunden**, Alter 15 h
+
+Der Pod meldet sich also als bereit, waehrend Anfragen ueber den Service ins Leere laufen — und er startet dabei mehrmals pro Stunde neu. Die Readiness-Probe attestiert Gesundheit, ohne sie zu pruefen (vermutlich TCP- statt HTTP-Probe, oder ein Endpoint, der die Modell-Ladephase nicht abbildet).
+
+WAS DAS AM URSPRUNGSBEFUND AENDERT: Die These des vorigen Eintrags — gruene Signale ueber einem toten Dienst — bleibt gueltig und wird sogar staerker, verschiebt sich aber eine Schicht tiefer. Es sind nicht drei, sondern VIER Signale, die Gesundheit melden: systemd-Unit active, kubectl-Prozess lebt, Socket lauscht, UND Pod ready=true. Der Vorschlag aus dem vorigen Eintrag (Readiness-Probe am Forward statt Prozess-Liveness) reicht deshalb nicht — ein HTTP-Probe vom Host haette hier zwar rot gemeldet, die Ursache liegt aber in der Pod-Readiness-Definition und der Restart-Schleife von bge-embed.
+
+NAECHSTER SCHRITT (nicht ausgefuehrt, ausserhalb des Auftrags dieses Laufs): Logs von bge-embed-5d54c9c44d-mz9pr auswerten (6 Restarts / 10 h ist der eigentliche Defekt), die Readiness-Probe des Deployments in k3d/llm-gpu.yaml gegen einen echten HTTP-Endpoint pruefen, und erst danach die Host-seitige Probe nachziehen.
+
+METHODISCHE NOTIZ: Der Fehler in meinem vorigen Eintrag entstand, weil ich die Remediation dokumentiert habe, BEVOR ich ihr Ergebnis gemessen hatte. Genau die Verwechslung von "Massnahme ausgefuehrt" mit "Wirkung eingetreten", vor der repo-hygiene-ops §3 fuer Merges warnt.
+**4. ticket.sh: --help auf Subkommando-Ebene fuehrt in eine Fehlermeldung statt zur Optionsliste** (degraded, scripts/ticket.sh)
+
+Beobachtet am 2026-08-09 in einem repo-hygiene-Lauf (§5), beim Anlegen eines Bug-Tickets nach der Bug-Triage-Konvention G-DORA03.
+
+VERIFIZIERT
+  bash scripts/ticket.sh            -> gibt korrekt Usage + vollstaendige Kommandoliste aus
+  bash scripts/ticket.sh create --help -> "Unknown create option: --help"
+  bash scripts/ticket.sh help       -> "Unknown command: help"
+  bash scripts/ticket.sh --help     -> "Unknown command: --help"
+
+Die Kommando-EBENE ist also auffindbar, die Options-EBENE nicht. Wer wissen will, welche
+Optionen `create` nimmt und welche davon Pflicht sind, hat ueber das Skript keinen Weg
+dorthin — `--help` wird vom Options-Parser als unbekannte Option abgewiesen, statt vor der
+Parser-Schleife abgefangen zu werden.
+
+WARUM DAS ZAEHLT
+CLAUDE.md nennt `bash scripts/ticket.sh create --type bug --title "..."` als kanonischen
+Weg der Bug-Triage-Konvention. Diese Zeile ist unvollstaendig: `description` ist Pflicht
+(so dokumentiert im create_ticket-MCP-Tool: "Beschreibung (Pflicht in create.sh)"), taucht
+im CLAUDE.md-Beispiel aber nicht auf. Beide Auskunftswege fuehren damit ins Leere, und der
+Umweg ging ueber das MCP-Toolschema, um die Pflichtfelder zu erfahren.
+
+VORSCHLAG
+1. `--help`/`-h` in jedem Subkommando vor der Options-Schleife abfangen und die Optionen
+   des jeweiligen Subkommandos ausgeben (Pflichtfelder markiert).
+2. `help` als Alias fuer den argumentlosen Usage-Ausgang akzeptieren.
+3. Das CLAUDE.md-Beispiel um `--description` ergaenzen, damit die dort genannte Zeile
+   ausfuehrbar ist.
+
+Kein Blocker — der MCP-Weg (mcp__ticket-mcp__create_ticket) traegt ein vollstaendiges
+Schema und ist ohnehin MCP-first vorgeschrieben. Der CLI-Weg bleibt aber der in CLAUDE.md
+genannte und der einzige im Fallback ohne MCP.
+**5. Dedupe-Guard prueft nur offene Tickets, nicht den Mishap-Buffer — Doppelerfassung real eingetreten** (drift, .claude/skills/references/repo-hygiene-ops.md §4 · mishap-tracker)
+
+Beobachtet und real eingetreten am 2026-08-09 in einem repo-hygiene-Lauf.
+
+WAS PASSIERTE
+Derselbe Befund (is_test_data-Filter fehlt in scripts/factory/queue.sh) wurde am selben Tag
+zweimal erfasst: um 05:04:57 UTC als Mishap-Buffer-Eintrag durch einen frueheren Lauf, um
+05:35 UTC als Ticket T002830 durch meinen Lauf. Beide Laeufe folgten repo-hygiene §5.
+
+WARUM DER GUARD NICHT GRIFF
+repo-hygiene-ops.md §4 schreibt einen Title-Dedupe-Guard vor (T001210) — er sucht nach einem
+offenen TICKET mit gleichem Titel. Ich habe ihn ausgefuehrt:
+
+    for s in triage backlog plan_staged in_progress planning; do
+      bash scripts/ticket.sh list --status "$s"; done | grep -oiE '"title":"[^"]*(queue\.sh|is_test_data|...)'
+      -> kein Treffer
+
+Der Guard war also korrekt angewandt und lieferte trotzdem gruen. Der frueher erfasste
+Befund lag zu diesem Zeitpunkt nicht als Ticket vor, sondern als Eintrag in
+.git/mishap-buffer.json (Buffer-Stand 5/10, Schwelle 10 nicht erreicht). Buffer-Eintraege
+sind dateibasiert und tauchen in KEINER Ticket-Query auf.
+
+STRUKTURELLER KERN
+Zwischen "Befund erfasst" und "Befund als Ticket sichtbar" liegt ein Fenster von bis zu
+10 Buffer-Eintraegen bzw. 7 Tagen (Alters-Schnitt). In diesem Fenster ist ein bereits
+erfasster Befund fuer den vorgeschriebenen Dedupe-Guard unsichtbar. Bei mehreren
+repo-hygiene-Laeufen pro Tag — hier zwei — ist die Doppelerfassung damit nicht
+unwahrscheinlich, sondern erwartbar.
+
+Dasselbe Muster wie der Befund, den es hier verdoppelt hat: eine Pruefung, die nur einen
+von zwei Pfaden kennt, sieht bei Anwendung auf den bekannten Pfad vollstaendig aus.
+
+VORSCHLAG
+1. §4 (und die Dedupe-Vorbedingung der Completeness-Triage) um eine zweite Quelle
+   erweitern: vor dem Anlegen eines Tickets aus einem Mishap-Befund zusaetzlich
+   mcp__ticket-mcp__get_mishap_buffer bzw. .git/mishap-buffer.json pruefen.
+2. Erwaegen, das in ein Werkzeug zu ziehen statt in eine Merkregel — z. B. ein
+   ticket.sh-Subkommando oder ein MCP-Tool, das Tickets UND Buffer gegen einen Titel
+   prueft und einen einzigen Ja/Nein-Befund liefert. Eine Merkregel, die zwei getrennte
+   Quellen von Hand zusammenfuehrt, ist genau die Form, die hier versagt hat.
+3. Erwaegen, ob report_mishap seinerseits gegen offene Tickets dedupliziert — die
+   Gegenrichtung derselben Luecke ist bisher ungeprueft.
+
+AUFLOESUNG DES KONKRETEN FALLS
+Der Buffer-Eintrag wurde nach Ueberfuehrung seines Inhalts (er war reicher als der
+Ticketrumpf: Merge-Referenz PR #3926/1fcb6cfb2, Vorgeschichte T002762, struktureller Kern)
+als Kommentar an T002830 aus .git/mishap-buffer.json entfernt. Backup der Datei vor dem
+Eingriff wurde abgelegt. T002830 ist die einzige verbliebene Erfassung.
+
+TEST (Output-Verifikation, T002448-M4)
+Falls Vorschlag 2 umgesetzt wird: das Pruefkommando AUSFUEHREN mit einem Titel, der
+ausschliesslich im Buffer liegt, und pruefen, dass es einen Treffer meldet. Positiv-Anker
+(T002356-M1): ein Titel, der weder in Tickets noch im Buffer liegt, MUSS als kein Treffer
+zurueckkommen — sonst besteht der Test vakuos, wenn die Pruefung pauschal Treffer meldet.
+
+VERWANDT: T002830 (der verdoppelte Befund), T001210 (Herkunft des Guards), T002784
+(Rollup-Container), T002783 (Rollup-Treiber blockiert — verlaengert das Sichtbarkeitsfenster).
+**6. 18 Tickets stehen auf plan_staged ohne plan-Zeile/Branch — halbgestagte Plans** (suspicious, tickets/plan_staged)
+
+Triage 2026-08-09: 19 plan_staged-Tickets, davon 18 (T002807–T002829 außer T002784) ohne ticket_plans-Zeile (slug/branch/pr_number NULL) und ohne existierenden Branch in `git branch -a`. Nur T002784 (Rollup-Container) ist legitim plan_staged ohne Plan-Zeile. Damit ist der Kommissionierungs-Zustand halbgestaged — kein dev-flow-execute kann den Plan finden (T002816-Klasse: "Gestagter, nie implementierter Plan"). Vermutlich wurden die Tickets per status-Update gestaged, ohne stage-plan/branch zu setzen.
+**7. T002629-Beschreibung behauptet offenen Blocker, PR #3745 ist seit 4 Tagen gemergt** (suspicious, tickets/t002629)
+
+T002629 (E6 Modell-Registry) führt im Text "BLOCKIERT VON: PR #3745 (T002587) ist offen mit zwei roten Checks" — `gh pr view 3745` zeigt state=MERGED (mergedAt 2026-08-04T00:12:47Z). Die Beschreibung ist stale und würde jede spätere Triage erneut in den Blocker-Pfad schicken. Triage hat die PR verifiziert und einen Kommentar mit Beleg ergänzt. Prozesslücke: Blocker-Status wird nicht beim PR-Merge zurückgeschrieben.
+**8. Probe-Schleife mit 2>/dev/null macht harten Fehler zu stillem Leerergebnis** (process, skills/repo-hygiene)
+
+Beobachtet in repo-hygiene 2026-08-09 beim Abfragen von 8 Ticketstatus:
+
+    for t in T002813 T002647 …; do
+      s=$(bash scripts/ticket.sh show "$t" 2>/dev/null | grep -iE '^(status|title)' | tr '\n' ' ')
+      echo "$t: $s"
+    done
+
+Ergebnis: acht leere Zeilen. Gelesen als „Tickets existieren nicht / liefern keine Daten".
+
+Tatsaechlich: `scripts/ticket.sh` kennt kein Subkommando `show`. Es schrieb „Unknown command: show" nach **stderr** und beendete mit Exit 1 — beides durch `2>/dev/null` und die Pipe unsichtbar. Das Skript verhaelt sich korrekt; unsichtbar gemacht hat es der Aufruf.
+
+Zusatzfehler bei der Gegenprobe: `bash scripts/ticket.sh show T002837 2>&1 | head -5; echo "exit=$?"` misst den Exit-Code von `head`, nicht den des Skripts — die erste Nachpruefung meldete daher faelschlich Exit 0 und haette das Skript zu Unrecht als fail-open beschuldigt. Verifiziert mit `bash scripts/ticket.sh show T002837 >/dev/null 2>&1; echo $?` → 1.
+
+Regel: In Probe-Schleifen stderr NICHT unterdruecken und den Exit-Code getrennt von der Pipeline auswerten. Ein leeres Ergebnis ist erst dann ein Messwert, wenn der Aufruf nachweislich erfolgreich war — dieselbe Familie wie „Leere API-Antwort ist kein Urteil" (repo-hygiene-ops §3, T002498-M5).
+
+Kanonischer Weg fuer Ticketstatus ist ohnehin `mcp__ticket-mcp__get_ticket` / `list_tickets`, nicht ein geratenes CLI-Subkommando.
+**9. Alle vier lokalen LLM-Backends am Gateway degraded (/health 503)** (degraded, llm/gateway)
+
+Beobachtet 2026-08-09 während dev-flow-plan für T002836.
+
+BEFUND (verifiziert)
+Das LLM-Gateway auf 127.0.0.1:18235 LÄUFT — /v1/models liefert 200. Aber /health liefert 503 mit status=degraded, ready=false: alle vier registrierten Backends sind unten:
+  - llamacpp-devstral (priority 1, http://127.0.0.1:8099/v1)
+  - llamacpp-gemma4   (priority 1, http://127.0.0.1:8090/v1)
+  - llamacpp-qwen     (priority 1, http://127.0.0.1:8094/v1)
+  - opencode-zen      (priority 91, http://127.0.0.1:5099/v1)
+checked=6, lastProbe=1786258092799.
+
+FOLGE
+scripts/plan-qa-check.sh Zeile 115 prüft mit `curl -sf .../health`; 503 lässt -f fehlschlagen, das Skript meldet "Gateway not reachable" und überspringt die LLM-QA (advisory, blockiert nicht). Das Skript verhält sich damit KORREKT — der Kommentar in Zeile 113 nennt genau diesen Fall. Die Meldung "not reachable" ist aber irreführend: der Dienst antwortet, nur seine Backends nicht.
+
+MÖGLICHER ZUSAMMENHANG
+T002663 (factory-mcp factory_ask LLM-Backend unerreichbar, type=fix, status=triage) beschreibt seit 2026-08-04 ausgefallene Natürlichsprach-Antworten am factory-mcp. Es ist zu prüfen, ob das dieselbe Ursache ist (Backends unten) statt eines eigenen Fehlers am factory-mcp — die dortige Fehlermeldung nannte allerdings 'Insufficient Balance' und 'invalid api key', was eher auf einen Remote-Provider deutet. Der Zusammenhang ist eine Hypothese, keine belegte Ursache.
+
+WERT DES BEFUNDS
+Solange die Backends unten sind, läuft jede LLM-gestützte Prüfung im Repo still im Skip-Pfad: plan-qa-check (advisory), Release-Notes-Generierung, der Task-Oracle. Das fällt nicht auf, weil alle drei bewusst fail-open sind.
+**10. Tote agent-locks blockieren bis zu 30 min, obwohl beide PIDs nachweislich tot sind** (suspicious, scripts/agent-lock.sh)
+
+Beobachtet 2026-08-09 zu Beginn von dev-flow-plan für T002836.
+
+BEFUND (verifiziert)
+Sechs ticket-scoped agent-locks (T002836, T002830, T002812, T002813, T002647, T002663) gehörten einer ticket-ops-Session mit owner_sid=611671, owner_pid=611672. Beide PIDs existierten nicht mehr (`ps -p` lieferte je nur die Kopfzeile). `agent-lock.sh reap` räumte sie dennoch nicht; `scripts/openspec.sh propose` brach mit "Ticket T002836 ist gesperrt (agent-lock)" ab.
+
+URSACHE (belegt, kein Bug)
+scripts/agent-lock.sh Block 0b (Zeilen 164-174): existiert der Worktree UND stimmt sein Branch mit dem Lock-Feld überein, gilt der Lock als lebendig — eingeführt für Session-Resumes (T002204), die mit neuer SID/PID zurückkehren. T002513 begrenzt das auf einen frischen Heartbeat. Der Heartbeat war 12 Minuten alt, AGENT_LOCK_TTL ist 1800s. Der Lock wäre also nach ~18 weiteren Minuten von selbst reapable geworden.
+
+EINORDNUNG
+Das Verhalten ist so entworfen und die Begründung trägt. Bemerkenswert ist die Lücke dazwischen: eine Session, die abstürzt ohne zu releasen, blockiert ihre Tickets bis zu 30 Minuten, obwohl die Toten-Erkennung über die PID sofort möglich wäre. Block 0b prüft den Worktree, aber nicht zusätzlich, ob owner_pid noch lebt — beides zusammen wäre eindeutig: Worktree passt UND PID tot = abgestürzte Session, kein Resume. Ein Resume hätte eine neue PID, die lebt.
+
+Zu erwägen (nicht entschieden): in Block 0b zusätzlich `_pid_alive "$pid"` prüfen und bei toter PID trotz Worktree-Match reapen. Risiko: ein Resume, der die Lock-Datei noch nicht mit seiner neuen PID aktualisiert hat, würde fälschlich geräumt.
+
+AUFLÖSUNG IM LAUF
+Nach Rückfrage beim Operator wurden alle sechs Claims per `agent-lock.sh release ticket <id>` freigegeben (der Pfad für tote Owner greift regulär, ohne --force) und T002836 auf die aktive Session neu geclaimt.
+### Mishap-Rollup — 10 Eintraege (2026-08-09 08:41 UTC)
+
+| # | Typ | Komponente | Titel |
+|---|---|---|---|
+| 1 | degraded | scripts/openspec-embed | openspec-embed indexiert in eine fast leere Collection (4 docs vs 55 aktive Pläne) |
+| 2 | degraded | tests/spec/ticket-system | BATS-Suite backfill-id (T002732) schlägt lokal rot, CI grün |
+| 3 | degraded | scripts/llm-proxy | llm-proxy BATS-Suiten (T002753 + ui_config.mcpServers seed) lokal rot |
+| 4 | drift | skills/references/ticket-ops-procedures.md | ticket-ops-procedures nennt kein Prüfkriterium für "Ticket hat einen Plan" |
+| 5 | suspicious | scripts/factory/reconcile-ticket-status.sh | reconcile-ticket-status Pattern 4 matcht nicht, obwohl der Watchdog läuft |
+| 6 | drift | skills/mishap-tracker | mishap-tracker/SKILL.md legt status=plan_staged nahe, gemeint ist nur der Rollup-Container |
+| 7 | drift | scripts/vda/ticket/update-status.sh | update-status.sh hat keinen Guard gegen plan_staged ohne Plan-Referenz |
+| 8 | suspicious | scripts/openspec-embed · openspec_find_similar | openspec-embed Completeness-Gate: 12 Dokumente in der Collection, 57 lokale aktive Pläne |
+| 9 | drift | tests/spec · BATS-Konventionen | BATS: Helper-Funktion trägt grep-Exit-Code nach außen — Positiv-Anker wird aus falschem Grund rot |
+| 10 | drift | prod/wildcard-certificate.yaml · cert-manager | Reflector-Annotationen am Wildcard-Certificate, aber kein Reflector im Cluster |
+
+**1. openspec-embed indexiert in eine fast leere Collection (4 docs vs 55 aktive Pläne)** (degraded, scripts/openspec-embed)
+
+Beobachtet 2026-08-09 bei zwei Commits während dev-flow-plan für T002836.
+
+BEFUND
+Der post-commit-Hook openspec-embed meldet bei jedem Commit:
+  [openspec-embed] WARN: completeness gate — collection has 4 docs but 55 local active plans (status=planning|plan_staged|active)
+  skipped: 2 documents (2 context limit > 2048 tokens, 0 other reasons)
+
+Die Ziel-Collection enthält also 4 Dokumente, während lokal 55 aktive Pläne existieren. Das Gate erkennt die Lücke und meldet sie — bricht aber nicht ab, sodass die Meldung im Commit-Rauschen untergeht.
+
+VERMUTETE URSACHE (nicht in diesem Lauf verifiziert)
+Es gibt einen bekannten Portkonflikt: Port 15432 ist vom k3d-Portforward belegt, wodurch der Verbindungsaufbau still auf eine andere Datenbank (Dev-DB) ausweicht statt zu scheitern. Die Embeddings landeten dann konsistent in der falschen Collection — was genau das Bild "4 statt 55" erklären würde. Diese Zuordnung ist eine Hypothese und vor einem Fix zu belegen (z.B. durch Ausgabe der tatsächlich verwendeten Verbindungsparameter im Hook).
+
+FOLGE
+Die semantische Suche über openspec-Changes arbeitet auf einem Bruchteil des Bestands. Wer sie zur Duplikatsuche vor einem neuen Proposal nutzt (openspec_find_similar), bekommt falsche Negative — und legt einen Change an, den es schon gibt. Der Schaden ist still: ein leeres Suchergebnis sieht aus wie "nichts Ähnliches vorhanden".
+
+ZUSÄTZLICH
+Zwei Dokumente werden dauerhaft wegen Kontextlimit (> 2048 Token) übersprungen. Der Hook nennt den Reparaturweg (task openspec:embed:backfill), der aber am selben Kontextlimit scheitern dürfte, solange die Chunking-Grenze unverändert ist.
+**2. BATS-Suite backfill-id (T002732) schlägt lokal rot, CI grün** (degraded, tests/spec/ticket-system)
+
+tests/spec/ticket-system/backfill-id-sequence.bats (3 Tests, T002732) schlagen im sauberen main-Checkout (ee4a9a80d) sowie im Worktree fehl — reproduziert. `task test:changed` ist damit lokal rot. Auf dem PR #3942 (16 Checks) waren dieselben Suiten grün → lokale Gate-Kette und CI divergieren (vermutlich Umgebungsabhängigkeit: lokale DB erreichbar → Tests laufen statt skip). VERIFIED im main-Checkout.
+**3. llm-proxy BATS-Suiten (T002753 + ui_config.mcpServers seed) lokal rot** (degraded, scripts/llm-proxy)
+
+tests/spec/local-llm-proxy/loadout-model-files-exist.bats (T002753: "jedes Loadout loest seine Modelldatei auf") und ui-config-seed.bats ("llama-server liefert ui_settings.mcpServers aus seed") schlagen im sauberen main-Checkout fehl — reproduziert. deckungsgleich mit der Health-Warnung G-LLM03 (Konfig-gegen-Laufzeit-Drift, 1 Ziel ≤0). VERIFIED im main-Checkout.
+**4. ticket-ops-procedures nennt kein Prüfkriterium für "Ticket hat einen Plan"** (drift, skills/references/ticket-ops-procedures.md)
+
+Die Triage-Prozedur (Phase 1) sagt nicht, woran ein gestagter Plan erkannt wird. Ich habe deshalb `tickets.ticket_plans` geprüft — das ist falsch: `scripts/vda/ticket/stage-plan.sh` (Z. 123-128) schreibt einen Kommentar `FACTORY-PLAN-REF branch=… plan=…` und legt KEINE ticket_plans-Zeile an; die entsteht erst beim Archivieren. Belegt durch Selbstbeobachtung: nach regulärem stage-plan für T002837 steht dort status=plan_staged, ticket_plans=0, branch=null — und trotzdem ist alles korrekt. Nach dem falschen Kriterium sah ein frisch geplantes Ticket "kaputt" aus. Das Triage-Ergebnis stimmte im konkreten Fall zufällig (alle 28 zurückgesetzten Tickets hatten auch planref=0), die Begründung war es nicht. Abhilfe: ticket-ops-procedures §Phase 1 nennt den FACTORY-PLAN-REF-Kommentar als maßgebliches Kriterium — so wie reconcile-ticket-status.sh Pattern 4 es bereits tut.
+**5. reconcile-ticket-status Pattern 4 matcht nicht, obwohl der Watchdog läuft** (suspicious, scripts/factory/reconcile-ticket-status.sh)
+
+Pattern 4 in scripts/factory/reconcile-ticket-status.sh (Z. 187-224) ist exakt für den Fall "plan_staged ohne FACTORY-PLAN-REF-Kommentar" gebaut und setzt dann attention_mode=needs_human plus eine notes-Zeile. Am 2026-08-09 entstanden 28 solche Tickets in drei Zeitclustern (03:52, 04:24, 06:49) — KEINES wurde erfasst: notes durchgehend leer, attention_mode durchgehend ai_ready.
+
+Verifiziert, dass es nicht am Nichtlaufen liegt: systemctl --user list-timers zeigt factory.timer zuletzt vor 38 Minuten gelaufen, factory.service aktiv, und agent-msg führt mehrere "factory-tick: starting (dry_run=false)"-Einträge. Der Watchdog läuft also und der Aufruf steht in wakeup.sh:196 — Pattern 4 selbst greift nicht. Zu prüfen wären das SQL-Prädikat des Patterns, ein möglicher Brand-Filter und ob der Aufruf im Tick tatsächlich diesen Zweig erreicht.
+
+Das ist der lohnendere Ansatzpunkt als die Altlast: der Schutzmechanismus existiert, ist korrekt spezifiziert und läuft — und wirkt trotzdem nicht. Kontext an T002845.
+**6. mishap-tracker/SKILL.md legt status=plan_staged nahe, gemeint ist nur der Rollup-Container** (drift, skills/mishap-tracker)
+
+Die Skill-Datei nennt `status=plan_staged` an vier Stellen (Z. 23, 137, 155, 216). Jedes Mal ist der persistente Rollup-Container gemeint, nicht ein Mishap-Einzelticket — das steht im Kontext, aber nicht in der jeweiligen Zeile.
+
+Am 2026-08-09 wurden 28 Mishap-Einzeltickets direkt als plan_staged angelegt (created_at ≈ updated_at, unter einer Sekunde, in drei Schleifen-Clustern). Ein Code-Pfad dafür existiert nicht: scripts/ticket-mcp/go/internal/tools/mishap.go setzt konsequent --status triage (Z. 92, 174) und kommentiert sogar ausdrücklich "plan_staged ist ausschliesslich Tickets vorbehalten, die via stage-plan.sh …" (Z. 166). Der wahrscheinlichste Weg ist also ein ausführender Agent, der die Container-Angabe auf die Einzeltickets überträgt.
+
+Abhilfe: an jeder der vier Stellen ausdrücklich "nur der Rollup-Container" ergänzen und einmal explizit festhalten, dass Mishap-Einzeltickets in triage entstehen.
+**7. update-status.sh hat keinen Guard gegen plan_staged ohne Plan-Referenz** (drift, scripts/vda/ticket/update-status.sh)
+
+scripts/vda/ticket/update-status.sh prüft ausschließlich terminale Übergänge (done → nur archived, archived terminal; T002382). Es gibt keine Prüfung, die einen Wechsel nach plan_staged ablehnt, wenn kein FACTORY-PLAN-REF-Kommentar existiert.
+
+Dadurch ist der widersprüchliche Zustand "plan_staged ohne Plan" für jeden Aufrufer erreichbar — CLI, MCP, Agent, Skript — und genau das ist am 2026-08-09 28-fach eingetreten. Ein Guard an dieser Stelle macht den Zustand strukturell unerreichbar, unabhängig davon, welcher Aufrufer ihn versucht, und wäre damit wirksamer als jede Korrektur an einzelnen Aufrufern.
+
+Zu beachten: reconcile-ticket-status.sh umgeht update-status.sh bewusst per direktem SQL (dort dokumentiert) — ein neuer Guard darf diesen Watchdog-Pfad nicht blockieren.
+**8. openspec-embed Completeness-Gate: 12 Dokumente in der Collection, 57 lokale aktive Pläne** (suspicious, scripts/openspec-embed · openspec_find_similar)
+
+Beim Plan-Stage-Commit meldete der openspec-embed-Hook: "WARN: completeness gate — collection has 12 docs but 57 local active plans (status=planning|plan_staged|active)". Die Embedding-Collection deckt also rund ein Fünftel der aktiven Pläne ab.
+
+Folge: semantische Suche über Pläne (Kontexttransfer, Ähnlichkeitssuche via openspec_find_similar) arbeitet auf einem stark unvollständigen Index, ohne dass der Aufrufer das merkt — die Suche liefert Treffer, nur eben aus einem Fünftel des Bestands. Das ist die gefährlichere Sorte Lücke, weil sie wie ein Ergebnis aussieht.
+
+Abzugrenzen von T002839 (2 Dokumente über dem 2048-Token-Limit übersprungen): das erklärt 2 fehlende Dokumente, nicht 45. Die Ursache der übrigen Lücke ist offen — Kandidaten sind ein nie gelaufener Backfill (task openspec:embed:backfill) oder Pläne, die nie durch den Hook liefen, weil sie außerhalb eines Commits entstanden.
+**9. BATS: Helper-Funktion trägt grep-Exit-Code nach außen — Positiv-Anker wird aus falschem Grund rot** (drift, tests/spec · BATS-Konventionen)
+
+Beim Schreiben von tests/spec/ci-cd/workflow-self-trigger.bats (T002868) fiel der Positiv-Anker aus dem falschen Grund rot.
+
+Die Hilfsfunktion sammelt Workflow-Dateien mit paths-Filter:
+
+    _workflows_with_paths() {
+      for f in "$WF_DIR"/*.yml; do
+        grep -qE '^[[:space:]]+paths:' "$f" && basename "$f"
+      done
+    }
+
+Ihr Exit-Code ist der des LETZTEN grep-Durchlaufs. Hat die alphabetisch letzte Workflow-Datei keinen paths-Filter, liefert die Funktion 1 — obwohl sie korrekt eine nicht-leere Liste ausgegeben hat. Das `run _helper` / `[ "$status" -eq 0 ]` des Ankers schlug damit fehl, ohne dass inhaltlich etwas falsch war.
+
+Das ist tückisch, weil es die Positiv-Anker-Konvention (T002356-M1) unterläuft: Der Anker soll belegen, dass die Kandidatenmenge nicht leer ist. Scheitert er stattdessen am Exit-Code, sieht der Test rot aus und der Autor "repariert" womöglich die Assertion statt die Funktion — und entfernt dabei genau den Anker, der den Test vor Vakuosität schützt.
+
+Abhilfe (angewandt): explizites `return 0` am Ende jeder sammelnden Helper-Funktion, mit Kommentar. Allgemeiner: In BATS-Helfern, deren Ergebnis die AUSGABE ist und nicht der Status, den Exit-Code immer explizit setzen.
+
+Kandidat für docs/superpowers/references/gotchas-footguns.md oder die Positiv-Anker-Konvention in CLAUDE.md, da beide bereits BATS-Fallen dieser Art führen.
+**10. Reflector-Annotationen am Wildcard-Certificate, aber kein Reflector im Cluster** (drift, prod/wildcard-certificate.yaml · cert-manager)
+
+`prod/wildcard-certificate.yaml` trägt vier `reflector.v1.emberstack.eu`-Annotationen, die das TLS-Secret automatisch nach coturn, workspace-office und website spiegeln sollen:
+
+    reflector.v1.emberstack.eu/reflection-auto-enabled: "true"
+    reflector.v1.emberstack.eu/reflection-auto-namespaces: "coturn,workspace-office,website"
+
+Auf dem fleet-Cluster läuft jedoch kein Reflector: `kubectl get pods --all-namespaces | grep -i reflector` liefert nichts. Die Annotationen sind wirkungslos; die vorhandenen Kopien tragen `kubectl.kubernetes.io/last-applied-configuration`, sind also von Hand entstanden.
+
+Aktuell kein Schaden: alle vier Secrets (workspace, website, coturn, workspace-office) laufen synchron am 2026-10-27 ab, sind also gepflegt. Das Problem ist die Irreführung — die Konfiguration liest sich wie eine funktionierende Automatik. In dieser Sitzung führte genau das zu einer falschen Designentscheidung, die erst nach dem Nachprüfen des laufenden Clusters korrigiert werden konnte (T002869: kopieren vs. eigenes Certificate).
+
+Zwei saubere Auflösungen: entweder den Reflector installieren, dann greifen die Annotationen und die Handkopien entfallen — oder die Annotationen entfernen und dokumentieren, dass die Kopien manuell gepflegt werden. Der jetzige Zwischenzustand ist die schlechteste Variante, weil er Automatik behauptet, die niemand betreibt.
 
 ## Verify (RED → GREEN)
 

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 04:59 UTC. Die Eintraege stammen aus den
+2026-08-09 05:03 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 02:14 UTC. Die Eintraege stammen aus den
+2026-08-10 02:18 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:34 UTC. Die Eintraege stammen aus den
+2026-08-09 10:36 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-10 00:18 UTC. Die Eintraege stammen aus den
+2026-08-10 00:21 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:38 UTC. Die Eintraege stammen aus den
+2026-08-09 10:39 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T002784_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 10:33 UTC. Die Eintraege stammen aus den
+2026-08-09 10:34 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure

--- a/openspec/changes/mishap-incident-rollup/tasks.md
+++ b/openspec/changes/mishap-incident-rollup/tasks.md
@@ -15,7 +15,7 @@ depends_on_plans: []
 _Container-Ticket: T003067_
 
 Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407] am
-2026-08-09 23:37 UTC. Die Eintraege stammen aus den
+2026-08-09 23:40 UTC. Die Eintraege stammen aus den
 Batch-Kommentaren des Container-Tickets "Mishap Rollup — fortlaufende Sammlung".
 
 ## File Structure


### PR DESCRIPTION
## T003201: Mishap Rollup — automatische Sammlung

Automatisch erzeugt von `scripts/factory/mishap-rollup.sh` [T002407].

Archiviert abgeschlossene OpenSpec-Changes und konsolidiert SSOT-Specs.

Closes T003201