### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 922,
+      "file_count": 923,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -393,6 +393,7 @@
         "tests/spec/ci-cd/automerge-run-scope.bats",
         "tests/spec/ci-cd/bats-no-live-branch-assertion.bats",
         "tests/spec/ci-cd/branch-allowlist-ssot.bats",
+        "tests/spec/ci-cd/branch-reaper-sweep.bats",
         "tests/spec/ci-cd/branch-reaper.bats",
         "tests/spec/ci-cd/changed-tests-collection-parity.bats",
         "tests/spec/ci-cd/changed-tests-env-hermetic.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31424947619).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
