### PR TITLE
fix(factory): Modell-ID-Drift beenden und den Routing-Guard endlich aufrufen [T003538]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 926,
+      "file_count": 927,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -707,6 +707,7 @@
         "tests/spec/software-factory/dashboard.bats",
         "tests/spec/software-factory/db-pod-phase-guard.bats",
         "tests/spec/software-factory/dispatcher.bats",
+        "tests/spec/software-factory/factory-model-id-default.bats",
         "tests/spec/software-factory/factory-prep-stdout-json.bats",
         "tests/spec/software-factory/opencode-exec-result-check.bats",
         "tests/spec/software-factory/orphan-slot-reap.bats",

--- a/scripts/factory/provider-register-local.sh
+++ b/scripts/factory/provider-register-local.sh
@@ -24,7 +24,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-MODEL_ID="${FACTORY_MODEL_ID:-gemma26-factory}"
+MODEL_ID="${FACTORY_MODEL_ID:-gemma26-throughput}"
 # Immer das vereinheitlichte Gateway, nie ein Backend-Port. Welches Backend
 # dahinter haengt, entscheidet die Registry tickets.llm_proxy_backends.
 # [T003492] OHNE '/v1' — die Konsumenten haengen '/v1/chat/completions' selbst an

--- a/scripts/factory/route-provider.sh
+++ b/scripts/factory/route-provider.sh
@@ -50,7 +50,18 @@ fi
 # Gateway nicht mehr aufloest (routing-check.sh meldete ihn als FEHLT). Der
 # Default ist per FACTORY_MODEL_ID ueberschreibbar, damit ein Modellwechsel
 # nicht wieder an drei Stellen nachgezogen werden muss.
-OPUS_FALLBACK=$'llamacpp\t'"${FACTORY_MODEL_ID:-gemma26-factory}"$'\thttp://127.0.0.1:18235'
+# [T003538] ZWEITER Fall derselben Klasse: der Nachfolger 'gemma26-factory' war ab
+# spaetestens 2026-08-10 ebenfalls tot — das Loadout ist in loadouts.json zwar
+# aktiviert, sein Backend (Port 8091) aber nicht geladen. "Aktiviert" und "geladen"
+# sind verschiedene Dinge; nur Letzteres entscheidet, und es ist offline nicht
+# pruefbar. Weil resolveModel() im llm-proxy eine unbekannte ID STILL auf das erste
+# gesunde Backend umleitet, entsteht dabei nirgends ein Fehler: die Anfrage wird
+# beantwortet, nur von einem anderen Modell — oder vom Cloud-Backend, das dann
+# HTTP 402 ("Insufficient Balance") liefert und wie ein sporadischer Modellfehler
+# aussieht. Der Default zeigt jetzt auf 'gemma26-throughput' (Port 8092, geladen).
+# Dass es zweimal passierte, lag nicht am Wert, sondern daran, dass niemand
+# routing-check.sh aufrief — wakeup.sh tut das seither pro Tick (fail-soft).
+OPUS_FALLBACK=$'llamacpp\t'"${FACTORY_MODEL_ID:-gemma26-throughput}"$'\thttp://127.0.0.1:18235'
 if [[ "$TIER" == "opus" ]]; then
   OPUS_ROW=$(factory_psql -v src="$SOURCE" 2>/dev/null <<'SQL' || true
 SELECT provider||E'\t'||model_id||E'\t'||COALESCE(base_url,'')
@@ -160,4 +171,4 @@ done <<< "$CANDS"
 # regulaere Weg; damit gibt es nur noch eine Stelle, die ein Modell benennen kann.
 echo "route-provider: ALLE Kandidaten fuer source=$SOURCE tier=$TIER belegt oder auf Cooldown." >&2
 echo "  Emergency-Fallback aktiv — pruefe 'bash scripts/factory/reap-provider-slots.sh --dry-run'." >&2
-printf '{"provider":"llamacpp","modelId":"%s","baseUrl":"http://127.0.0.1:18235","slotId":null,"ctx":0,"apiKeyEnv":null,"emergency":true}\n' "${FACTORY_MODEL_ID:-gemma26-factory}"
+printf '{"provider":"llamacpp","modelId":"%s","baseUrl":"http://127.0.0.1:18235","slotId":null,"ctx":0,"apiKeyEnv":null,"emergency":true}\n' "${FACTORY_MODEL_ID:-gemma26-throughput}"

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -244,6 +244,21 @@ while true; do
     BRAND="$_ae_brand" bash "${REPO}/scripts/factory/auto-enqueue.sh" 2>&1 \
       | sed "s/^/[auto-enqueue:${_ae_brand}] /" >&2 || true
   done
+  # [T003538] Routing-Guard VOR den LLM-Schritten dieses Ticks. scripts/llm/routing-check.sh
+  # existierte, wurde aber von nirgendwo aufgerufen — weder hier noch in einem Workflow.
+  # Genau deshalb blieb eine driftende Modell-ID unsichtbar: resolveModel() im llm-proxy
+  # leitet eine unbekannte ID STILL auf das erste gesunde Backend um, es entsteht also
+  # nirgends ein Fehler. Landet die Umleitung beim Cloud-Backend, kommt dessen HTTP 402
+  # ("Insufficient Balance") zurück — und sieht aus wie ein sporadischer Modellfehler.
+  # Zweiter Fall dieser Art (T002582: 'gemma-4-12b'), deshalb jetzt ein Aufrufer.
+  #
+  # FAIL-SOFT mit Absicht: eine rote Prüfung ist ein Befund, kein Grund den Tick
+  # anzuhalten — sonst legt ein nicht geladenes Loadout die gesamte Factory still.
+  # Das Skript ist ohnehin fail-soft ohne erreichbares Backend (es meldet "übersprungen"
+  # und endet mit 0), sagt also nichts, wo es nichts sagen kann.
+  bash "${REPO}/scripts/llm/routing-check.sh" 2>&1 \
+    | sed "s/^/[routing-check] /" >&2 || true
+
   # T000933: KI-Ticket-Auto-Triage — DeepSeek klassifiziert untriagierte Tickets
   # und schreibt Vorschläge nach grilling_meta.triage. Best-effort, nicht fatal.
   for _t_brand in mentolder korczewski; do

--- a/scripts/plan-qa-check.sh
+++ b/scripts/plan-qa-check.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # === Config ===
 MAX_ITERATIONS=2
-MODEL="${PLAN_QA_MODEL:-gemma26-factory}"
+MODEL="${PLAN_QA_MODEL:-gemma26-throughput}"
 GATEWAY_BASE_URL="${GATEWAY_BASE_URL:-http://127.0.0.1:18235}"
 
 # === Helpers ===

--- a/tests/spec/dev-flow-plan/plan-qa-payload.bats
+++ b/tests/spec/dev-flow-plan/plan-qa-payload.bats
@@ -105,13 +105,28 @@ PLANEOF
 }
 
 @test "T002595: Payload nennt das Gateway-Modell und deaktiviert Thinking" {
-  # gemma26-factory liefert ohne enable_thinking:false ein leeres content-Feld
+  # Die Gemma-Loadouts liefern ohne enable_thinking:false ein leeres content-Feld
   # (finish_reason=length, Budget im reasoning verbraucht) — gemessen 2026-08-03.
   # Das Flag ist damit Funktionsbedingung, nicht Optimierung.
+  #
+  # [T003538] Der Modellname wird NICHT mehr als Literal gepinnt. Hier stand
+  # '.model == "gemma26-factory"'; die ID war zu dem Zeitpunkt bereits tot (Loadout
+  # aktiviert, Backend nicht geladen), und der Test schrieb sie als Sollzustand fest.
+  # Ein Modellwechsel soll moeglich bleiben — geprueft wird die Semantik: das Payload
+  # traegt UEBERHAUPT ein Modell, und dieses kommt aus PLAN_QA_MODEL. Damit belegt der
+  # Test die Verdrahtung statt den Tageswert (Konvention "Semantik statt Darstellung",
+  # T002716).
   mkplan "$BATS_TEST_TMPDIR/plan.md"
+
   run bash "$QA" --emit-payload "$BATS_TEST_TMPDIR/plan.md"
   [ "$status" -eq 0 ]
-  echo "$output" | jq -e '.model == "gemma26-factory"' >/dev/null
+  echo "$output" | jq -e '.model | type == "string" and length > 0' >/dev/null
   echo "$output" | jq -e '.enable_thinking == false' >/dev/null
   echo "$output" | jq -e '.chat_template_kwargs.enable_thinking == false' >/dev/null
+
+  # Gegenprobe: der Wert stammt tatsaechlich aus PLAN_QA_MODEL und ist nicht
+  # irgendwo im Skript festverdrahtet.
+  run env PLAN_QA_MODEL=pruefmodell-xyz bash "$QA" --emit-payload "$BATS_TEST_TMPDIR/plan.md"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.model == "pruefmodell-xyz"' >/dev/null
 }

--- a/tests/spec/software-factory/factory-model-id-default.bats
+++ b/tests/spec/software-factory/factory-model-id-default.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/factory-model-id-default.bats — T003538
+#
+# PRUEFMODUS: gemischt, mit Begruendung je Test.
+#   - Die Default-Konsistenz wird an den Zuweisungen gelesen (Quelle), weil sich
+#     ihr Ergebnis sonst nur als DB-Zeile auf einem Cluster zeigt, den CI nicht hat.
+#   - Der Aufruf des Runtime-Guards in wakeup.sh wird ebenfalls an der Quelle
+#     geprueft: ihn auszufuehren verlangt ein laufendes GPU-Backend, das CI nicht
+#     stellt. Dokumentierter Ausnahmefall der Test-Resultats-Konvention (T002448-M4).
+#
+# WAS HIER BEWUSST NICHT GEPRUEFT WIRD — und warum das der Kern ist:
+# Der ausloesende Defekt war 'gemma26-factory' als Default, waehrend der llm-proxy
+# dieses Modell nicht servierte (Loadout aktiviert, aber nicht GELADEN; Port 8091
+# lauschte nicht). resolveModel() leitet unbekannte IDs STILL auf das erste gesunde
+# Backend um — mal ein anderes lokales Modell (HTTP 200), mal DeepSeek mit HTTP 402
+# "Insufficient Balance". Nirgends entsteht ein Fehler.
+#
+# Ein erster Entwurf dieses Guards pruefte "der Default muss ein in loadouts.json
+# aktiviertes Loadout sein". Der war VOR dem Fix gruen: 'gemma26-factory' IST dort
+# aktiviert. "Aktiviert" und "geladen" sind verschiedene Dinge, und der Defekt sitzt
+# im zweiten — offline nicht entscheidbar. Ein Test, der vor dem Fix gruen ist,
+# schuetzt nicht, er beruhigt nur.
+#
+# Die wirksame Absicherung ist deshalb, `scripts/llm/routing-check.sh` ueberhaupt
+# AUSZUFUEHREN. Das Werkzeug hat den Defekt korrekt gemeldet ("FEHLT — 'gemma26-factory'
+# wird von keinem lokalen Backend serviert"); es wurde nur von nirgendwo aufgerufen.
+# Genau das pruefen die Tests unten.
+#
+# WIEDERHOLUNGSFALL: derselbe Defekt lag schon einmal vor (T002582, damals
+# 'gemma-4-12b' — siehe Kommentar in route-provider.sh). Ohne einen Aufrufer des
+# Guards ist die dritte Runde nur eine Frage der Zeit.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  WAKEUP="${REPO_ROOT}/scripts/factory/wakeup.sh"
+  CHECK="${REPO_ROOT}/scripts/llm/routing-check.sh"
+  ROUTE="${REPO_ROOT}/scripts/factory/route-provider.sh"
+  REG_LOCAL="${REPO_ROOT}/scripts/factory/provider-register-local.sh"
+}
+
+@test "routing-check.sh existiert und ist syntaktisch valide" {
+  # Positiv-Anker: ohne das Skript sind die folgenden Aussagen gegenstandslos.
+  [ -f "$CHECK" ]
+  run bash -n "$CHECK"
+  [ "$status" -eq 0 ]
+}
+
+@test "wakeup.sh ruft den Routing-Guard pro Tick auf" {
+  # Der eigentliche Regressionsfall: der Guard existierte, wurde aber nirgends
+  # ausgefuehrt — weder in wakeup.sh noch in einem Workflow.
+  run bash -c "grep -c 'routing-check\|routing:check' \"\$1\"" _ "$WAKEUP"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "der Routing-Guard bricht den Tick nicht ab (fail-soft)" {
+  # Eine rote Routing-Pruefung ist ein Befund, kein Grund die Factory anzuhalten —
+  # sonst legt ein nicht geladenes Loadout den gesamten Tick stumm still.
+  # Geprueft wird die LOGISCHE Zeile des Aufrufs: Backslash-Fortsetzungen werden
+  # zuvor zusammengefuegt. Ohne das schlaegt der Test bei einem ueber mehrere
+  # Zeilen umbrochenen Aufruf falsch-negativ fehl — dieselbe Ueberlegung wie beim
+  # Pod-Phase-Guard, der ebenfalls per logischer Zeile auswertet.
+  line="$(sed -e ':a' -e '/\\$/{N;s/\\\n//;ta' -e '}' "$WAKEUP" \
+          | grep 'routing-check' | grep -v '^[[:space:]]*#' | head -1)"
+  [ -n "$line" ]                                     # Positiv-Anker
+  [[ "$line" == *"||"* ]]
+}
+
+@test "alle FACTORY_MODEL_ID-Defaults nennen denselben Slug" {
+  # Vier Stellen tragen denselben Wert. Laufen sie auseinander, routet ein Teil
+  # der Factory woanders hin als der Rest — eine zweite Drift-Klasse, die offline
+  # sehr wohl entscheidbar ist.
+  mapfile -t vals < <(grep -rhoE '\$\{FACTORY_MODEL_ID:-[^}]*\}' \
+      "$ROUTE" "$REG_LOCAL" | sed 's/.*:-//; s/}//' | sort -u)
+  [ "${#vals[@]}" -ge 1 ]                            # Positiv-Anker
+  [ "${#vals[@]}" -eq 1 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -4110,6 +4110,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/factory-model-id-default",
+    "file": "tests/spec/software-factory/factory-model-id-default.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/factory-prep-stdout-json",
     "file": "tests/spec/software-factory/factory-prep-stdout-json.bats",
     "category": "software-factory",


### PR DESCRIPTION
## Symptom

Sporadisch fehlschlagende LLM-Schritte der Factory — `curl to llamacpp failed`, `no content in <provider> response` — die bei Wiederholung durchliefen. Sah nach Ueberlastung aus, war aber eine Fehlleitung.

## Ursache: stille Umleitung auf eine ID, die niemand serviert

`provider_config` routete auf `gemma26-factory`. Der llm-proxy fuehrt diese ID nicht — das Loadout ist in `loadouts.json` **aktiviert**, sein Backend auf Port 8091 aber nicht **geladen**. Auf einer GPU laeuft jeweils nur ein grosses Modell.

`resolveModel()` leitet unbekannte IDs still auf das erste gesunde Backend um. Nachgewiesen:

```
curl -d '{"model":"gptoss-context",...}' http://127.0.0.1:18235/v1/chat/completions | jq -r .model
# angefragt: gptoss-context   ->   geantwortet: gemma26-throughput
```

| | |
|---|---|
| `provider_config` (enabled) | `gemma26-factory`, deepseek-v4-flash, deepseek-v4-pro |
| Proxy serviert | `gemma26-throughput`, deepseek-v4-flash, deepseek-v4-pro |

Landet die Umleitung beim Cloud-Backend, kommt dessen **HTTP 402 „Insufficient Balance"** zurueck — und sieht aus wie ein Modellfehler. Ein Fehler entsteht dabei nirgends, weshalb so eine Drift monatelang leben kann.

## Der eigentliche Befund

`scripts/llm/routing-check.sh` meldet genau das korrekt:

```
routing-check: FEHLT — 'gemma26-factory' wird von keinem lokalen Backend serviert.
```

**Es wurde nur von nirgendwo aufgerufen** — weder in `wakeup.sh` noch in einem Workflow. Deshalb ist das der *zweite* Fall derselben Klasse: `route-provider.sh:49` dokumentiert den ersten (T002582, damals `gemma-4-12b`, ebenfalls von routing-check gemeldet).

Behoben wird daher nicht nur der Wert, sondern die fehlende Ausfuehrung. `wakeup.sh` ruft den Guard jetzt pro Tick auf, **fail-soft**: eine rote Pruefung ist ein Befund, kein Grund den Tick anzuhalten — sonst legt ein nicht geladenes Loadout die ganze Factory still. Das Skript ist ohnehin fail-soft ohne erreichbares Backend, sagt also nichts, wo es nichts sagen kann.

Zusaetzlich: Defaults auf `gemma26-throughput` (Port 8092, geladen) an allen vier Stellen — `route-provider.sh` (OPUS_FALLBACK + Notfall-Zweig), `provider-register-local.sh`, `plan-qa-check.sh`. Die Datenzeilen sind in dev und fleet bereits umgestellt.

## Zum Test — warum er nicht prueft, was man erwarten wuerde

Ein erster Entwurf verlangte „der Default muss ein aktiviertes Loadout benennen". **Der war vor dem Fix gruen**, denn `gemma26-factory` *ist* in `loadouts.json` aktiviert. „Aktiviert" und „geladen" sind verschiedene Dinge, und der Defekt sitzt im zweiten — offline nicht entscheidbar. Ein Test, der vor dem Fix gruen ist, schuetzt nicht, er beruhigt nur; ich habe ihn deshalb verworfen und das im Dateikopf begruendet.

Geprueft wird stattdessen, was offline entscheidbar UND wirksam ist: dass der Runtime-Guard aufgerufen wird, dass er den Tick nicht abbricht, und dass die vier Defaults nicht auseinanderlaufen. Die Betriebszustands-Frage beantwortet weiterhin nur `routing-check` zur Laufzeit — jetzt aber jeden Tick.

## Verifikation

```
4/4 neue BATS grün                       (vorher 2 rot)
Gegenprobe: Aufruf aus wakeup.sh entfernt -> 2 Tests rot   (der Guard greift wirklich)
task llm:routing:check -> "alle lokalen Modell-IDs haben ein Backend"   (vorher exit 1)
angefragt == geantwortet == gemma26-throughput             (keine stille Umleitung mehr)
```

## Hinweise fuer den Review

- **Die Modellwahl ist eine Nutzungsentscheidung, keine technische.** `gemma26-throughput` ist das derzeit geladene Loadout; die Alternative waere gewesen, 8091 hochzufahren. Explizit so entschieden. Laeuft kuenftig ein anderes Loadout, meldet der Tick-Guard das jetzt, statt still umzuleiten.
- Unabhaengig von T003492 (base_url mit doppeltem `/v1`, gemergt). Jener Fix wirkt; **dieser** erklaert die danach verbliebenen sporadischen Fehlschlaege.
- Abgespalten aus T003495 — dort lag kein Defekt vor (die `/anthropic`-Zeile wird vom Anthropic-SDK konsumiert, das `/v1/messages` selbst anhaengt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrbYQhyiMNMzycF6YYzS7m