### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -3179,8 +3179,8 @@
   ],
   "T003276": [
     {
-      "slug": "quickwins-script-fixes",
-      "status": "plan_staged"
+      "slug": "2026-08-10-quickwins-script-fixes",
+      "status": "archived"
     }
   ],
   "T003417": [


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31432722489).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
