### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -3141,12 +3141,6 @@
       "status": "plan_staged"
     }
   ],
-  "T003202": [
-    {
-      "slug": "llm-proxy-group-readiness",
-      "status": "plan_staged"
-    }
-  ],
   "T003203": [
     {
       "slug": "2026-08-10-fix-brain-ingest-port-T003203",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31434287952).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
