### PR TITLE
fix(scripts): openspec-embed-Probe nennt den konkreten Fehlerzustand [T003177]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 927,
+      "file_count": 928,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -596,6 +596,7 @@
         "tests/spec/openspec-embedding.bats",
         "tests/spec/openspec-embedding/dynamic-port-T003077.bats",
         "tests/spec/openspec-embedding/port-forward-identity-T002870.bats",
+        "tests/spec/openspec-embedding/probe-diagnosis.bats",
         "tests/spec/openspec-pgvector.bats",
         "tests/spec/openspec-ticket-links-evaluation.bats",
         "tests/spec/openspec-upstream-cli.bats",

--- a/scripts/openspec-embed-local.sh
+++ b/scripts/openspec-embed-local.sh
@@ -43,25 +43,63 @@ cleanup() { [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null || true; }
 trap cleanup EXIT
 
 # --- 1. Embedding-Backend proben (fail-fast, bevor wir die DB anfassen) -----
+# T003177: Der Probe-Code kollabierte bisher JEDEN Fehlschlag auf einen
+# HTTP-Code-String ("000" im curl-Fehlerfall) und die Meldung nannte daraufhin
+# pauschal "nicht erreichbar" — auch dann, wenn das Backend antwortete und nur
+# der Status ungleich 200 war. Eine Fehlermeldung mit falscher Ursache kostet
+# beim Debuggen mehr als gar keine. Deshalb werden curl-Exit-Code, HTTP-Status
+# und curl-stderr jetzt GETRENNT erfasst und der konkrete Zustand benannt.
+PROBE_HTTP=""
+PROBE_RC=0
+PROBE_ERR=""
 probe_embed() {
-  curl -s --max-time "${OPENSPEC_EMBED_PROBE_TIMEOUT:-20}" -o /dev/null -w '%{http_code}' \
+  local err_file
+  err_file="$(mktemp)"
+  PROBE_RC=0
+  # `|| PROBE_RC=$?` statt `; PROBE_RC=$?`: unter `set -e` bricht eine
+  # Zuweisung aus fehlgeschlagener Kommandosubstitution das Skript ab, bevor
+  # der Exit-Code ueberhaupt ausgewertet werden kann.
+  PROBE_HTTP="$(curl -s --max-time "${OPENSPEC_EMBED_PROBE_TIMEOUT:-20}" -o /dev/null -w '%{http_code}' \
     -X POST "$1/v1/embeddings" -H 'Content-Type: application/json' \
-    -d '{"input":["ping"],"model":"bge-m3"}' 2>/dev/null || echo 000
+    -d '{"input":["ping"],"model":"bge-m3"}' 2>"$err_file")" || PROBE_RC=$?
+  PROBE_ERR="$(tr -d '\r' < "$err_file" | head -3)"
+  rm -f "$err_file"
 }
+
+# Benennt den curl-Exit-Code, statt ihn zu "nicht erreichbar" zu verallgemeinern.
+probe_diagnosis() {
+  case "$PROBE_RC" in
+    0)  echo "Backend ANTWORTET (HTTP ${PROBE_HTTP}), aber nicht mit 200 — das ist KEIN Erreichbarkeitsproblem." ;;
+    6)  echo "DNS-Auflösung fehlgeschlagen (curl 6)." ;;
+    7)  echo "Verbindung abgelehnt / kein Lauscher am Port (curl 7)." ;;
+    28) echo "Zeitüberschreitung nach ${OPENSPEC_EMBED_PROBE_TIMEOUT:-20}s (curl 28) — Port belegt, aber keine Antwort." ;;
+    35|60) echo "TLS-Handshake fehlgeschlagen (curl ${PROBE_RC})." ;;
+    *)  echo "curl brach mit Exit ${PROBE_RC} ab." ;;
+  esac
+}
+
 EMBED_URL="${LLM_EMBED_URL:-http://127.0.0.1:18235}"
-if [[ "$(probe_embed "$EMBED_URL")" != "200" ]]; then
-  cat >&2 <<'EOF'
-[openspec-embed-local] FEHLER: kein Embedding-Backend erreichbar (:18235).
+probe_embed "$EMBED_URL"
+if [[ "$PROBE_RC" -ne 0 || "$PROBE_HTTP" != "200" ]]; then
+  {
+    # Die tatsächlich geprobte URL nennen, nicht den Default-Port: bei gesetztem
+    # LLM_EMBED_URL nannte die alte Meldung :18235, obwohl ein anderer Endpunkt
+    # geprüft wurde — der Widerspruch, mit dem T003177 gemeldet wurde.
+    echo "[openspec-embed-local] FEHLER: Embedding-Probe gegen ${EMBED_URL}/v1/embeddings fehlgeschlagen."
+    echo "  Befund: $(probe_diagnosis)"
+    [[ -n "$PROBE_ERR" ]] && echo "  curl:   ${PROBE_ERR}"
+    cat <<'EOF'
 Remediation (seit T003205 läuft bge über den llm-proxy, lokal zuerst):
   Der llm-proxy startet das lokale bge-embed-cpu-Loadout bei Bedarf und fällt
   auf den Cluster-Forward (bge-forward-embed.service, :8081) zurück:
     systemctl --user status llm-proxy.service
     systemctl --user restart llm-proxy.service
-  Prüfe dann: curl -s http://127.0.0.1:18235/v1/embeddings -H 'Content-Type: application/json' -d '{"model":"bge-m3","input":["test"]}'
   Überschreibbar per LLM_EMBED_URL, falls gezielt ein anderes Backend
   angesprochen werden soll.
 EOF
-    exit 1
+    echo "  Gegenprobe: curl -s ${EMBED_URL}/v1/embeddings -H 'Content-Type: application/json' -d '{\"model\":\"bge-m3\",\"input\":[\"test\"]}'"
+  } >&2
+  exit 1
 fi
 
 # --- 2. DB-URL beschaffen (nie ausgeben!) -----------------------------------

--- a/tests/spec/openspec-embedding/probe-diagnosis.bats
+++ b/tests/spec/openspec-embedding/probe-diagnosis.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# tests/spec/openspec-embedding/probe-diagnosis.bats
+# SSOT: openspec/specs/openspec-embedding.md
+#
+# Pruefmodus: command output verification (T002448-M4). Der Test RUFT
+# scripts/openspec-embed-local.sh auf und prueft dessen Ausgabe und Exit-Code —
+# er greppt nicht den Quelltext des Probe-Codes.
+#
+# Hintergrund (T003177): Die Probe kollabierte jeden Fehlschlag auf einen
+# HTTP-Code-String und meldete daraufhin pauschal "kein Embedding-Backend
+# erreichbar (:18235)" — auch dann, wenn das Backend antwortete (nur eben nicht
+# mit 200) und auch dann, wenn per LLM_EMBED_URL ein ganz anderer Endpunkt
+# geprueft wurde. Eine Fehlermeldung mit falscher Ursache kostet beim Debuggen
+# mehr als gar keine.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SCRIPT="$REPO/scripts/openspec-embed-local.sh"
+  # Kurze Probe-Zeit: der Test soll nicht 20s am Default haengen.
+  export OPENSPEC_EMBED_PROBE_TIMEOUT=3
+}
+
+# Startet einen Wegwerf-HTTP-Server, der auf POST mit dem gewuenschten Status
+# antwortet, und setzt SERVE_PORT auf den tatsaechlich gebundenen Port. Das ist
+# der Kern des Tests: nur ein ANTWORTENDES Backend kann belegen, dass "nicht
+# erreichbar" die falsche Diagnose war.
+#
+# Der Port wird vom Kernel vergeben (bind auf 0) und zurueckgemeldet, statt ihn
+# im Test festzuschreiben: unter WSL2 sind ganze Portbereiche von Hyper-V
+# reserviert und binden mit EADDRINUSE, ohne dass ein Lauscher existiert — ein
+# fester Port faellt dort sporadisch aus, und zwar nur lokal, nie in CI.
+_serve_status() {
+  local status="$1" port_file
+  port_file="$(mktemp)"
+  python3 - "$status" "$port_file" <<'PY' &
+import http.server, sys
+status = int(sys.argv[1]); port_file = sys.argv[2]
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.send_response(status); self.end_headers(); self.wfile.write(b'x')
+    def log_message(self, *a): pass
+srv = http.server.HTTPServer(('127.0.0.1', 0), H)
+with open(port_file, 'w') as fh:
+    fh.write(str(srv.server_address[1]))
+srv.serve_forever()
+PY
+  SERVER_PID=$!
+  # Auf den gebundenen Port warten, statt blind zu schlafen.
+  SERVE_PORT=""
+  for _ in $(seq 1 50); do
+    SERVE_PORT="$(cat "$port_file" 2>/dev/null)"
+    [ -n "$SERVE_PORT" ] && break
+    sleep 0.1
+  done
+  rm -f "$port_file"
+  [ -n "$SERVE_PORT" ]
+}
+
+teardown() {
+  [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null
+  return 0
+}
+
+@test "T003177: ein antwortendes Backend wird NICHT als unerreichbar gemeldet" {
+  _serve_status 500
+
+  run env LLM_EMBED_URL="http://127.0.0.1:$SERVE_PORT" bash "$SCRIPT" __probe_only__
+  [ "$status" -ne 0 ]
+
+  # Positiv-Anker (T002356-M1): erst belegen, dass die Probe ueberhaupt
+  # stattgefunden hat und den echten Status gesehen hat. Ohne ihn bestuende
+  # die Negativ-Aussage unten vakuos, sobald das Skript vorher abbricht.
+  echo "$output" | grep -qF '500'
+
+  # Der eigentliche Befund: die Ursache darf nicht "nicht erreichbar" lauten,
+  # wenn das Backend nachweislich geantwortet hat.
+  ! echo "$output" | grep -qiF 'kein Embedding-Backend erreichbar'
+}
+
+@test "T003177: die Meldung nennt die tatsaechlich geprobte URL, nicht den Default-Port" {
+  _serve_status 503
+
+  run env LLM_EMBED_URL="http://127.0.0.1:$SERVE_PORT" bash "$SCRIPT" __probe_only__
+  [ "$status" -ne 0 ]
+
+  # Positiv-Anker: die geprobte URL steht in der Meldung.
+  echo "$output" | grep -qF "127.0.0.1:$SERVE_PORT"
+  # Negativ: der hartcodierte Default-Port darf nicht als Fundort auftauchen,
+  # wenn gar nicht gegen ihn geprobt wurde.
+  ! echo "$output" | grep -qF 'erreichbar (:18235)'
+}
+
+@test "T003177: ein toter Port wird weiterhin als Verbindungsfehler benannt" {
+  # Gegenprobe: der echte Nicht-erreichbar-Fall muss weiterhin als solcher
+  # erkannt werden — sonst waere der Fix nur eine Umbenennung.
+  run env LLM_EMBED_URL='http://127.0.0.1:59973' bash "$SCRIPT" __probe_only__
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -qiE 'curl 7|abgelehnt'
+}

--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -3141,12 +3141,6 @@
       "status": "plan_staged"
     }
   ],
-  "T003202": [
-    {
-      "slug": "llm-proxy-group-readiness",
-      "status": "plan_staged"
-    }
-  ],
   "T003203": [
     {
       "slug": "2026-08-10-fix-brain-ingest-port-T003203",

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3492,6 +3492,12 @@
     "kind": "shell"
   },
   {
+    "id": "openspec-embedding/probe-diagnosis",
+    "file": "tests/spec/openspec-embedding/probe-diagnosis.bats",
+    "category": "openspec-embedding",
+    "kind": "shell"
+  },
+  {
     "id": "openspec-pgvector",
     "file": "tests/spec/openspec-pgvector.bats",
     "category": "openspec-pgvector",


### PR DESCRIPTION
## Probe nennt den konkreten Fehlerzustand [T003177]

### Befund
`probe_embed()` in `scripts/openspec-embed-local.sh` presste jeden Fehlschlag in einen HTTP-Code-String (`curl … || echo 000`). Timeout, Connection-Refused, DNS-Fehler und HTTP 500 waren danach ununterscheidbar — die Meldung verallgemeinerte alles zu *„kein Embedding-Backend erreichbar (:18235)"*.

Zwei Folgefehler in derselben Meldung:
1. Sie behauptete Nichterreichbarkeit auch dann, wenn das Backend **antwortete** (nur nicht mit 200).
2. Sie nannte hartcodiert `:18235`, obwohl `LLM_EMBED_URL` den Endpunkt überschreibt — daher der Widerspruch aus dem Ticket („meldet :8081 nicht erreichbar, curl liefert dort 200").

### Fix
curl-Exit-Code, HTTP-Status und curl-stderr werden getrennt erfasst; `probe_diagnosis()` benennt den Zustand (curl 6 DNS / 7 refused / 28 Timeout / 35,60 TLS / sonst Exit-Code), und die Meldung nennt die **tatsächlich geprobte URL**.

`|| PROBE_RC=$?` statt `; PROBE_RC=$?`: unter `set -e` bricht eine Zuweisung aus fehlgeschlagener Kommandosubstitution ab, bevor der Exit-Code ausgewertet werden kann.

### Verifikation (RED → GREEN)
```
# RED — gegen den unveränderten Stand:
tests/unit/lib/bats-core/bin/bats tests/spec/openspec-embedding/probe-diagnosis.bats
# not ok 1, not ok 2, not ok 3

# GREEN — mit dem Fix:
# ok 1, ok 2, ok 3
```
Der Test startet einen echten HTTP-Server, der mit 500/503 antwortet — nur ein *antwortendes* Backend kann belegen, dass „nicht erreichbar" die falsche Diagnose war. Der Port wird vom Kernel vergeben (bind auf 0), weil unter WSL2 feste Ports sporadisch mit EADDRINUSE binden, ohne dass ein Lauscher existiert.

Testablage nach Konvention T002416 (`tests/spec/<spec-slug>/<kurz-slug>.bats`), nicht als Sammeldatei.

### Abgrenzung
Das ist p3 des Batch-Plans `batch-openspec-embed-fixes` (T003491); die übrigen sieben Partials bleiben offen. Als eigener PR eingereicht, weil der Fix für sich abgeschlossen und verifizierbar ist.

Closes T003177
