### PR TITLE
chore(agents): Toolset-Registry um wiki-nachschlagen, web-audit, finetune-pipeline, werkzeug-discovery ergaenzen [T003552]

### DIFF
--- a/docs/agent-guide/maps/toolset-map.md
+++ b/docs/agent-guide/maps/toolset-map.md
@@ -295,6 +295,15 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
   - _Rollen:_ `orchestrator`
   - _Tiefe:_ `.claude/skills/brain-ingest/SKILL.md`
 
+## Fähigkeit: `wiki-nachschlagen`
+
+- **`mcp:brain-mcp`** — Status `canonical` · Tier `safe`
+  - _Wann:_ Im Brain-Wiki nachschlagen: BM25-Suche und Seiten lesen (brain_search, brain_read).
+  - _Nicht:_ Wiki kompilieren/veröffentlichen — dafür wissens-wiki/brain-ingest.
+  - _Fallback:_ `grep -r <begriff> ~/brain/wiki`
+  - _Rollen:_ `all`
+  - _Tiefe:_ `.claude/skills/references/mcp-tool-guide.md`
+
 ## Fähigkeit: `dokumentations-lookup`
 
 - **`plugin:context7@claude-plugins-official`** — Status `canonical` · Tier `safe`
@@ -336,6 +345,15 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
   - _Nicht:_ Ohne vorherige Zustimmung — der Skill hat ein Consent-Gate.
   - _Rollen:_ `orchestrator`
   - _Tiefe:_ `.claude/skills/lavish/SKILL.md`
+
+## Fähigkeit: `web-audit`
+
+- **`skill:web-audit`** — Status `canonical` · Tier `assisted`
+  - _Wann:_ Brand-Seiten semantisch prüfen: axe, Lighthouse und LLM-Triage manuell gegen die Live-Marken.
+  - _Nicht:_ PR-Entscheidungen — der Skill ist bewusst kein Merge-Gate.
+  - _Fallback:_ `task web:audit ENV=<brand> [WEB_AUDIT_ROUTES=...]`
+  - _Rollen:_ `bachelorprojekt-website`, `bachelorprojekt-test`
+  - _Tiefe:_ `.claude/skills/web-audit/SKILL.md`
 
 ## Fähigkeit: `browser-automation`
 
@@ -414,6 +432,17 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
   - _Rollen:_ `orchestrator`
   - _Tiefe:_ `.claude/skills/unsloth-buddy/SKILL.md`
 
+## Fähigkeit: `finetune-pipeline`
+
+- **`cli:scripts/finetune`** — Status `canonical` · Tier `assisted`
+  - _Wann:_ Repo-Trainingslauf durchfuehren: Messschritt (measure_corpus.py) vor jeder Modellwahl, Template-Guard vor jedem Training, dann finetune:train/export ueber Taskfile.finetune.yml.
+  - _Nicht:_ Reine Unsloth/TRL-API-Fragen ohne Bezug zu diesem Repo-Subsystem — dafuer modell-finetuning/skill:unsloth-buddy direkt.
+  - _Fallback:_ `unsloth-buddy-Referenzcode manuell adaptieren, wenn Taskfile.finetune.yml nicht verfuegbar ist.`
+  - _Rollen:_ `orchestrator`, `bachelorprojekt-ops`
+  - _Tiefe:_ `.claude/skills/finetune-run/SKILL.md`
+- **`skill:finetune-run`** — Status `suppressed`
+  - _Grund:_ cli:scripts/finetune ist die kanonische Instanz und verlinkt dieses SKILL.md bereits als deep_ref — das Skill wird nicht separat injiziert.
+
 ## Fähigkeit: `huggingface-hub-operationen`
 
 - **`plugin:huggingface-skills@claude-plugins-official`** — Status `canonical` · Tier `safe`
@@ -446,6 +475,15 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
   - _Fallback:_ `node scripts/toolset/collect.mjs --unreviewed`
   - _Rollen:_ `orchestrator`
   - _Tiefe:_ `.claude/skills/toolset-curate/SKILL.md`
+
+## Fähigkeit: `werkzeug-discovery`
+
+- **`skill:agentic-resource-lookup`** — Status `canonical` · Tier `safe`
+  - _Wann:_ Externe MCP-Server/Plugins suchen, Live-Schema inspizieren, Urteil festhalten — ohne Installation.
+  - _Nicht:_ Bereits vorhandene Instanzen kuratieren — dafür werkzeug-kuration/toolset-curate.
+  - _Fallback:_ `node scripts/agentic-lookup.mjs find <query>`
+  - _Rollen:_ `orchestrator`
+  - _Tiefe:_ `.claude/skills/agentic-resource-lookup/SKILL.md`
 
 ## Fähigkeit: `gedaechtnis`
 

--- a/docs/agent-guide/registry/capabilities.yaml
+++ b/docs/agent-guide/registry/capabilities.yaml
@@ -367,6 +367,16 @@ capabilities:
       tier: caution
       deep_ref: ".claude/skills/brain-ingest/SKILL.md"
 
+  wiki-nachschlagen:
+    mcp:brain-mcp:
+      state: canonical
+      use_when: "Im Brain-Wiki nachschlagen: BM25-Suche und Seiten lesen (brain_search, brain_read)."
+      avoid_when: "Wiki kompilieren/veröffentlichen — dafür wissens-wiki/brain-ingest."
+      fallback: "grep -r <begriff> ~/brain/wiki"
+      roles: [all]
+      tier: safe
+      deep_ref: ".claude/skills/references/mcp-tool-guide.md"
+
   dokumentations-lookup:
     plugin:context7@claude-plugins-official:
       state: canonical
@@ -417,6 +427,16 @@ capabilities:
       roles: [orchestrator]
       tier: safe
       deep_ref: ".claude/skills/lavish/SKILL.md"
+
+  web-audit:
+    skill:web-audit:
+      state: canonical
+      use_when: "Brand-Seiten semantisch prüfen: axe, Lighthouse und LLM-Triage manuell gegen die Live-Marken."
+      avoid_when: "PR-Entscheidungen — der Skill ist bewusst kein Merge-Gate."
+      fallback: "task web:audit ENV=<brand> [WEB_AUDIT_ROUTES=...]"
+      roles: [bachelorprojekt-website, bachelorprojekt-test]
+      tier: assisted
+      deep_ref: ".claude/skills/web-audit/SKILL.md"
 
   # ─── Browser & Debugging ────────────────────────────────────────────────────────────
   browser-automation:
@@ -533,6 +553,9 @@ capabilities:
       roles: [orchestrator, bachelorprojekt-ops]
       tier: assisted
       deep_ref: ".claude/skills/finetune-run/SKILL.md"
+    skill:finetune-run:
+      state: suppressed
+      reason: "cli:scripts/finetune ist die kanonische Instanz und verlinkt dieses SKILL.md bereits als deep_ref — das Skill wird nicht separat injiziert."
 
   # huggingface-skills lag bis T002596 unter `modell-finetuning` und war dort suppressed,
   # weil unsloth-buddy die kanonische Trainings-Instanz ist. Der Schnitt war falsch: das
@@ -578,6 +601,16 @@ capabilities:
       roles: [orchestrator]
       tier: caution
       deep_ref: ".claude/skills/toolset-curate/SKILL.md"
+
+  werkzeug-discovery:
+    skill:agentic-resource-lookup:
+      state: canonical
+      use_when: "Externe MCP-Server/Plugins suchen, Live-Schema inspizieren, Urteil festhalten — ohne Installation."
+      avoid_when: "Bereits vorhandene Instanzen kuratieren — dafür werkzeug-kuration/toolset-curate."
+      fallback: "node scripts/agentic-lookup.mjs find <query>"
+      roles: [orchestrator]
+      tier: safe
+      deep_ref: ".claude/skills/agentic-resource-lookup/SKILL.md"
 
   gedaechtnis:
     plugin:remember@claude-plugins-official:

--- a/docs/agent-guide/registry/toolset.lock.yaml
+++ b/docs/agent-guide/registry/toolset.lock.yaml
@@ -1,4 +1,2 @@
-# docs/agent-guide/registry/toolset.lock.yaml
-# Probe snapshot lockfile for live MCP servers
 lock_version: 1
 servers: {}


### PR DESCRIPTION
## Summary
Überführt den repo-hygiene-§0-Befund (Stash `stash@{0}` vom 2026-08-11) in die Toolset-Registry (T003552). Die Kuration war bereits erstellt, lag aber uncommitted im main-checkout und wurde während des T003277-Postmerge gesichert.

Neue Capabilities in `docs/agent-guide/registry/capabilities.yaml` + `docs/agent-guide/maps/toolset-map.md`:
- `wiki-nachschlagen` — `mcp:brain-mcp` (canonical, safe)
- `web-audit` — `skill:web-audit` (canonical, assisted)
- `finetune-pipeline` — `cli:scripts/finetune` (canonical) + `skill:finetune-run` (suppressed, da cli kanonisch)
- `werkzeug-discovery` — `skill:agentic-resource-lookup` (canonical, safe)

Map via `scripts/toolset/emit-map.mjs` regeneriert (identisch zum Stash-Inhalt), Lockfile-Version bereinigt.

## Test Plan
- `task agents:toolset:check` → "Toolset registry check passed."
- `node scripts/toolset/emit-map.mjs` → regenerierte Map identisch zur committeten
- `scripts/toolset/check.test.mjs`-Failure ist vorbestehend auf main (verifiziert am Base-Commit), nicht durch diese Änderung verursacht