### PR TITLE
fix(scripts): remove type=feat override from enqueue operations [T003286]

### DIFF
--- a/scripts/ticket-mcp/go/internal/tools/workflow.go
+++ b/scripts/ticket-mcp/go/internal/tools/workflow.go
@@ -162,7 +162,7 @@ func RegisterWorkflowTools(s *server.MCPServer) {
 	// enqueue_ticket → ticket.sh enqueue --id [--branch --plan]
 	s.AddTool(
 		mcp.NewTool("enqueue_ticket",
-			mcp.WithDescription("Reiht ein Ticket in den Software-Factory-Backlog ein (type=feature, status=backlog)."),
+			mcp.WithDescription("Reiht ein Ticket in den Software-Factory-Backlog ein (status=backlog)."),
 			mcp.WithString("id", mcp.Description("external_id z.B. T000123"), mcp.Required()),
 			mcp.WithString("branch", mcp.Description("Optionaler Branch")),
 			mcp.WithString("plan", mcp.Description("Optionaler Plan-Pfad")),

--- a/scripts/vda/ticket/enqueue.sh
+++ b/scripts/vda/ticket/enqueue.sh
@@ -14,7 +14,7 @@ main() {
   if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
   local pod; pod=$(_pgpod)
   _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
-UPDATE tickets.tickets SET type='feat', status='backlog' WHERE external_id = :'ext_id';
+UPDATE tickets.tickets SET status='backlog' WHERE external_id = :'ext_id';
 EOF
   if [[ -n "$branch" || -n "$plan" ]]; then
     _exec_sql "$pod" -v ext_id="$id" -v ref="FACTORY-PLAN-REF branch=${branch} plan=${plan}" <<'EOF' >/dev/null
@@ -28,7 +28,7 @@ SELECT t.id, 'factory', :'ref', 'internal'
    );
 EOF
   fi
-  echo "Ticket $id enqueued for the Software Factory (type=feat, status=backlog)"
+  echo "Ticket $id enqueued for the Software Factory (status=backlog)"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then


### PR DESCRIPTION
The enqueue_ticket MCP tool and the vda/ticket/enqueue.sh script unconditionally set `type='feat'` when enqueuing tickets. This demotes plan_staged fix-Tickets to feat/backlog.

**Changes:**
- `scripts/ticket-mcp/go/internal/tools/workflow.go`: Remove `type=feat` from enqueue_ticket description and SQL
- `scripts/vda/ticket/enqueue.sh`: Remove `SET type='feat'` from the enqueue SQL

Fixes T003286.