### PR TITLE
fix(scripts): enqueue demoted gestagte Tickets nicht mehr nach backlog [T003575]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 930,
+      "file_count": 931,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -710,6 +710,7 @@
         "tests/spec/software-factory/dashboard.bats",
         "tests/spec/software-factory/db-pod-phase-guard.bats",
         "tests/spec/software-factory/dispatcher.bats",
+        "tests/spec/software-factory/enqueue-preserves-plan-staged.bats",
         "tests/spec/software-factory/factory-model-id-default.bats",
         "tests/spec/software-factory/factory-prep-stdout-json.bats",
         "tests/spec/software-factory/opencode-exec-result-check.bats",

--- a/scripts/ticket-mcp/go/internal/tools/workflow.go
+++ b/scripts/ticket-mcp/go/internal/tools/workflow.go
@@ -162,7 +162,7 @@ func RegisterWorkflowTools(s *server.MCPServer) {
 	// enqueue_ticket → ticket.sh enqueue --id [--branch --plan]
 	s.AddTool(
 		mcp.NewTool("enqueue_ticket",
-			mcp.WithDescription("Reiht ein Ticket in den Software-Factory-Backlog ein (status=backlog)."),
+			mcp.WithDescription("Reiht ein Ticket in den Software-Factory-Backlog ein (status=backlog). Ein bereits plan_staged Ticket bleibt unveraendert — es ist ueber die Staged-Lane schon dispatchbar [T003575]."),
 			mcp.WithString("id", mcp.Description("external_id z.B. T000123"), mcp.Required()),
 			mcp.WithString("branch", mcp.Description("Optionaler Branch")),
 			mcp.WithString("plan", mcp.Description("Optionaler Plan-Pfad")),

--- a/scripts/vda/ticket/enqueue.sh
+++ b/scripts/vda/ticket/enqueue.sh
@@ -13,9 +13,31 @@ main() {
     esac; done
   if [[ -z "$id" ]]; then echo "ERROR: --id is required." >&2; exit 2; fi
   local pod; pod=$(_pgpod)
-  _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
+
+  # [T003575] Ein bereits gestagtes Ticket NICHT nach backlog demoten.
+  #
+  # queue.sh hat zwei Dispatch-Zweige mit unterschiedlichen Zusatzgates:
+  #   Zweig A: type IN (feature,feat) AND status='backlog'     AND lastenheft_locked=true
+  #   Zweig B: type NOT IN (project,incident) AND status='plan_staged' AND execution_released!=false
+  # Ein gestagtes Ticket erfuellt Zweig B und ist damit bereits dispatchbar. Die
+  # Demotion nach backlog wirft es in Zweig A, der zusaetzlich lastenheft_locked
+  # verlangt — eine Flag, die aus dev-flow-plan stammende Tickets nicht tragen
+  # (COALESCE-Default false). Das Ticket faellt dann aus BEIDEN Zweigen und ist
+  # fuer den Dispatcher unsichtbar. Der Statuswechsel tauscht also die
+  # Torwaechter mit aus; enqueue stammt aus der Zeit, als es nur Zweig A gab.
+  local current_status
+  current_status=$(_exec_sql "$pod" -v ext_id="$id" <<'EOF' | head -1 | tr -d '[:space:]'
+SELECT status FROM tickets.tickets WHERE external_id = :'ext_id';
+EOF
+  )
+  local staged=false
+  if [[ "$current_status" == "plan_staged" ]]; then
+    staged=true
+  else
+    _exec_sql "$pod" -v ext_id="$id" <<'EOF' >/dev/null
 UPDATE tickets.tickets SET status='backlog' WHERE external_id = :'ext_id';
 EOF
+  fi
   if [[ -n "$branch" || -n "$plan" ]]; then
     _exec_sql "$pod" -v ext_id="$id" -v ref="FACTORY-PLAN-REF branch=${branch} plan=${plan}" <<'EOF' >/dev/null
 INSERT INTO tickets.ticket_comments (ticket_id, author_label, body, visibility)
@@ -28,7 +50,11 @@ SELECT t.id, 'factory', :'ref', 'internal'
    );
 EOF
   fi
-  echo "Ticket $id enqueued for the Software Factory (status=backlog)"
+  if [[ "$staged" == true ]]; then
+    echo "Ticket $id ist bereits plan_staged — Status unveraendert gelassen (queue.sh dispatcht gestagte Tickets direkt; eine Demotion nach backlog haette es unsichtbar gemacht)."
+  else
+    echo "Ticket $id enqueued for the Software Factory (status=backlog)"
+  fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/tests/spec/software-factory/enqueue-preserves-plan-staged.bats
+++ b/tests/spec/software-factory/enqueue-preserves-plan-staged.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# Prüfmodus: COMMAND OUTPUT VERIFICATION (CLAUDE.md → Test-Resultats-Konvention).
+# Die Tests führen `ticket.sh enqueue` AUS und prüfen das SQL, das dabei tatsächlich
+# an die Datenbank ginge (protokolliert durch einen kubectl-Stub im PATH). Sie
+# greppen NICHT den Quelltext von enqueue.sh.
+#
+# SSOT: openspec/specs/software-factory.md
+# Hintergrund [T003575]: queue.sh hat zwei Dispatch-Zweige mit unterschiedlichen
+# Zusatzgates. Ein gestagtes Ticket erfüllt Zweig B (status='plan_staged'). Wird es
+# nach 'backlog' demoted, landet es in Zweig A, der zusätzlich lastenheft_locked=true
+# verlangt — eine Flag, die dev-flow-plan-Tickets nicht tragen. Das Ticket fällt damit
+# aus BEIDEN Zweigen und ist für den Dispatcher unsichtbar.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  STUBDIR="$BATS_TEST_TMPDIR/stub"
+  SQLLOG="$BATS_TEST_TMPDIR/sql.log"
+  mkdir -p "$STUBDIR"
+  : > "$SQLLOG"
+}
+
+# make_kubectl_stub <status-den-die-db-meldet>
+#
+# Der Stub beantwortet beide Aufrufformen von _ticket-core.sh:
+#   `kubectl get pod …`  → ein Pod-Name, damit _pgpod nicht abbricht
+#   `kubectl exec … psql` → protokolliert das SQL von stdin und liefert den
+#                           übergebenen Status zurück (für Status-Vorabfragen)
+make_kubectl_stub() {
+  local reported_status="$1"
+  cat > "$STUBDIR/kubectl" <<STUB
+#!/usr/bin/env bash
+for a in "\$@"; do
+  if [[ "\$a" == "get" ]]; then echo "pod/shared-db-stub"; exit 0; fi
+done
+# exec-Pfad: SQL von stdin mitschreiben
+sql="\$(cat)"
+printf '%s\n---\n' "\$sql" >> "$SQLLOG"
+# Status-Vorabfragen beantworten; alles andere liefert leer
+if [[ "\$sql" == *"SELECT"* && "\$sql" == *"status"* ]]; then
+  printf '%s\n' "$reported_status"
+fi
+exit 0
+STUB
+  chmod +x "$STUBDIR/kubectl"
+}
+
+# Zählt UPDATEs, die den Status auf 'backlog' setzen.
+count_backlog_updates() {
+  grep -c "status='backlog'" "$SQLLOG" 2>/dev/null || true
+}
+
+@test "T003575: enqueue demoted ein plan_staged-Ticket NICHT nach backlog" {
+  make_kubectl_stub "plan_staged"
+
+  run env PATH="$STUBDIR:$PATH" bash "$REPO_ROOT/scripts/ticket.sh" enqueue --id T009999
+
+  # POSITIV-ANKER (CLAUDE.md → Positiv-Anker-Pflicht bei Negativtests):
+  # Erst belegen, dass der Befehl überhaupt gelaufen ist und die DB berührt hat.
+  # Ohne diesen Anker wäre "0 backlog-UPDATEs" auch bei einem Frühabbruch erfüllt.
+  [ "$status" -eq 0 ]
+  [ -s "$SQLLOG" ]
+
+  # Die eigentliche Zusicherung.
+  local n; n="$(count_backlog_updates)"
+  [ "${n:-0}" -eq 0 ] || {
+    echo "erwartet: kein status='backlog'-UPDATE bei plan_staged, gefunden: $n"
+    echo "--- SQL-Log ---"; cat "$SQLLOG"
+    false
+  }
+}
+
+@test "T003575: enqueue meldet sichtbar, dass ein gestagtes Ticket unveraendert bleibt" {
+  make_kubectl_stub "plan_staged"
+
+  run env PATH="$STUBDIR:$PATH" bash "$REPO_ROOT/scripts/ticket.sh" enqueue --id T009999
+
+  [ "$status" -eq 0 ]
+  # Semantik, nicht Wortlaut (CLAUDE.md → Semantik statt Darstellung): geprüft wird,
+  # dass der Ausgabetext den Vorzustand benennt, nicht seine exakte Formulierung.
+  [[ "$output" == *"plan_staged"* ]] || {
+    echo "Ausgabe muss den unveraenderten Zustand benennen; erhalten:"; echo "$output"
+    false
+  }
+}
+
+@test "T003575: enqueue setzt ein triage-Ticket weiterhin auf backlog (Regression)" {
+  make_kubectl_stub "triage"
+
+  run env PATH="$STUBDIR:$PATH" bash "$REPO_ROOT/scripts/ticket.sh" enqueue --id T009999
+
+  [ "$status" -eq 0 ]
+  local n; n="$(count_backlog_updates)"
+  [ "${n:-0}" -ge 1 ] || {
+    echo "erwartet: genau der bisherige backlog-UPDATE fuer nicht-gestagte Tickets, gefunden: ${n:-0}"
+    echo "--- SQL-Log ---"; cat "$SQLLOG"
+    false
+  }
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -4128,6 +4128,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/enqueue-preserves-plan-staged",
+    "file": "tests/spec/software-factory/enqueue-preserves-plan-staged.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/factory-model-id-default",
     "file": "tests/spec/software-factory/factory-model-id-default.bats",
     "category": "software-factory",


### PR DESCRIPTION
## Problem

`scripts/vda/ticket/enqueue.sh` setzte `status='backlog'` bedingungslos — ohne `WHERE` auf den Vorzustand. Für ein bereits gestagtes Ticket ist das kein Fortschritt, sondern macht es **unsichtbar**.

`scripts/factory/queue.sh` hat zwei Dispatch-Zweige mit **unterschiedlichen Zusatzgates**:

| Zweig | Bedingungen |
|---|---|
| **A** (Zeile 30) | `type IN (feature,feat)` **UND** `status='backlog'` **UND** `lastenheft_locked=true` |
| **B** (Zeile 48) | `type NOT IN (project,incident)` **UND** `status='plan_staged'` **UND** `execution_released ≠ false` |

Ein gestagtes Ticket erfüllt Zweig B und ist damit bereits dispatchbar. Die Demotion wirft es in Zweig A — der zusätzlich `lastenheft_locked=true` verlangt, eine Flag, die aus `dev-flow-plan` stammende Tickets nicht tragen (COALESCE-Default `false`). Das Ticket erfüllt danach **keinen** der beiden Zweige.

Der Kern ist also nicht „backlog ist schlechter als plan_staged" — beide sind gültige Dispatch-Zustände. Der Statuswechsel **tauscht die Torwächter mit aus**. `enqueue` stammt aus der Zeit, als es nur Zweig A gab, und kennt Zweig B nicht.

## Änderung

`enqueue` fragt den Status vorab ab und lässt `plan_staged` unverändert — sichtbar gemeldet statt still. Alle anderen Ausgangszustände verhalten sich unverändert. Der `FACTORY-PLAN-REF`-Insert läuft in beiden Fällen weiter (idempotent per `NOT EXISTS`).

Der MCP-Pfad (`enqueue_ticket` in `workflow.go`) delegiert an `ticket.sh` und erbt das Verhalten; nur seine Werkzeugbeschreibung wird nachgezogen.

## Verifikation

Neuer Test `tests/spec/software-factory/enqueue-preserves-plan-staged.bats` — Command-Output-Verifikation über einen `kubectl`-Stub, der das tatsächlich abgesetzte SQL protokolliert (kein Source-Grep).

Rot-Grün belegt. Vor dem Fix:

```
not ok 1 enqueue demoted ein plan_staged-Ticket NICHT nach backlog
# erwartet: kein status='backlog'-UPDATE bei plan_staged, gefunden: 1
# --- SQL-Log ---
# UPDATE tickets.tickets SET status='backlog' WHERE external_id = :'ext_id';
ok 3 enqueue setzt ein triage-Ticket weiterhin auf backlog (Regression)
```

Nach dem Fix alle drei grün; `bats -r tests/spec/software-factory/` **592 ok, 0 Fehlschläge**; `go build`/`go test` grün; `task freshness:check` rc=0.

Der Regressionstest (Fall 3) war schon vor dem Fix grün und ist der Positiv-Anker: er belegt, dass die Negativ-Zusicherung nicht durch einen Frühabbruch vakuos erfüllt wird.

## Abgrenzung

Die Typ-Hälfte desselben UPDATE (`type='feat'`) wurde in PR #4219 (T003286) bereits entfernt. Dieser PR betrifft nur die verbliebene Status-Demotion.

Closes T003575

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kgHrJkuzhg1AyVA9iDRdQ