### PR TITLE
chore(skills): Batch-Grouping, Hygiene-Empfehlungen und branch -D aus Stash einpflegen [T003550]

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -222,11 +222,20 @@ Nur wenn in einem `.worktrees/*`-Worktree gearbeitet wurde:
 
 ```bash
 WORKTREE_PATH="$(git rev-parse --show-toplevel)"
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 
 cd "$MAIN_REPO"
 git worktree remove "$WORKTREE_PATH"
 git worktree prune
+
+# Der Remote-Branch wurde durch `gh pr merge --squash --delete-branch` bereits
+# gelöscht — der lokale Ref bleibt aber übrig, weil der Squash-Commit auf main
+# ein neuer Commit ist und Git den Branch nicht als "merged" erkennen kann.
+# `git branch -d` würde daher fehlschlagen; `-D` ist nötig.
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
+  git branch -D "$BRANCH_NAME"
+fi
 ```
 
 Agent-Lock freigeben (`release ticket` + `release branch`, VOR dem Worktree-Remove) —

--- a/.claude/skills/references/repo-hygiene-ops.md
+++ b/.claude/skills/references/repo-hygiene-ops.md
@@ -464,3 +464,145 @@ Issues leben in Postgres, nicht auf GitHub. Falls `gh issue list --state open` e
 
 MCP-first via `factory-mcp` (Health-Guard, Tools, Fallbacks): siehe
 [`mcp-tool-guide.md`](mcp-tool-guide.md) §factory-mcp.
+
+## 6. Proactive Hygiene Recommendations
+
+Nach jedem Durchlauf der Abschnitte 0–5 wird ein **Recommendation-Report** ausgegeben.
+Ziel: nicht nur aufräumen, sondern dem Operator sagen, welche 3 Aktionen den größten
+Hygiene-Gewinn bringen — priorisiert nach Impact.
+
+### 6.1 Hygiene-Metriken erheben
+
+```bash
+# Stale Worktrees (ohne main, ohne aktuell geclaimte)
+git worktree list | grep -v '\[main\]' | wc -l
+
+# Stale Branches (lokal, remote-tracking gone)
+git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads \
+  | awk '$2 == "[gone]" {print $1}' | wc -l
+
+# Offene PRs nach Status
+gh pr list --state open --json number,title,statusCheckRollup,isDraft,createdAt \
+  --jq 'group_by(if .isDraft then "draft" elif (.statusCheckRollup | length) == 0 then "no-ci" else "ci-ok" end) | map({key: .[0].statusCheckRollup, count: length})'
+
+# Factory-Queue
+mcp__factory-mcp__factory_status({})   # liefert queue_depth + is_running
+```
+
+### 6.2 Aging-Report
+
+Tickets, Worktrees und Branches nach Alter bucketen:
+
+| Alter | Worktrees | Branches | PRs | Bedeutung |
+|-------|-----------|----------|-----|-----------|
+| <1d | N | N | N | Aktiv — nicht anfassen |
+| 1–7d | N | N | N | Normal — prüfen ob gemergt/abandoned |
+| 7–30d | N | N | N | **Aufräumkandidat** — wahrscheinlich vergessen |
+| >30d | N | N | N | **Kritisch** — definitiv vergessen, belegt Resourcen |
+
+```bash
+# Worktree-Alter ermitteln (via letztem Commit-Datum im Worktree):
+for wt in $(git worktree list --porcelain | grep '^worktree ' | grep -v '/main$' | cut -d' ' -f2); do
+  last_commit=$(git -C "$wt" log -1 --format='%ct' 2>/dev/null || echo 0)
+  age_days=$(( ($(date +%s) - last_commit) / 86400 ))
+  echo "$wt: ${age_days}d"
+done
+```
+
+### 6.3 Top-3-Empfehlungen
+
+Aus den Metriken werden die drei wirkungsvollsten Aktionen abgeleitet:
+
+| Rang | Bedingung | Empfehlung |
+|------|-----------|------------|
+| 1 | `>5 stale Worktrees` ODER `>10 [gone]-Branches` | **Massen-Cleanup**: `repo-hygiene` §1+§2 vollständig ausführen. Vorher `bash scripts/agent-lock.sh reap`. Geschätzte Zeit: 2–5 min. |
+| 2 | `≥1 PR mit CI=green, kein Draft, reviewDecision=APPROVED` | **PR mergen**: `gh pr merge --squash --delete-branch`. Ticket schließen nicht vergessen (§3). |
+| 3 | `Factory queue_depth > 3` | **Factory-Health check**: `mcp__factory-mcp__factory_ask({ question: "Sind alle Worker gesund? Gibt es blockierte Jobs?" })`. Ggf. `mcp__factory-mcp__factory_trigger({})`. |
+| 4 | `≥1 Worktree >30d ohne Commit` | **Worktree entsorgen**: `git worktree remove --force` nach Allowlist-Check (§1). |
+| 5 | `≥3 PRs offen vom selben Author` | **PR-Stau**: Author pingen oder PRs bündeln (wenn thematisch verwandt). |
+| 6 | `≥5 Tickets mit attention_mode=needs_human` | **Klärungsrunde fällig**: `ticket-ops` Phase 2 ausführen. |
+
+Die Top 3 werden am Ende jedes `repo-hygiene`-Laufs ausgegeben:
+
+```
+🧹 HYGIENE-EMPFEHLUNGEN (Top 3):
+  1. ⚠ 7 stale Worktrees, 12 [gone]-Branches — Massen-Cleanup empfohlen
+  2. ✅ PR #3921 (CI grün, approved) — mergebereit seit 2d
+  3. 📊 Factory-Queue: 5 wartend, 0 aktiv — Worker-Health prüfen
+
+📊 HYGIENE-METRIKEN:
+  Worktrees: 9 total, 2 aktiv (<1d), 7 stale (>7d)
+  Branches:  14 [gone], 3 gemergt (per --merged)
+  PRs:       4 offen (1 mergeable, 1 draft, 2 CI-failing)
+  Tickets:   23 offen, 6 needs_human
+  Factory:   5 queue, last tick: vor 3h
+```
+
+### 6.4 Aging Alerts (automatische Warnungen)
+
+Diese Warnungen erscheinen im Report, wenn Schwellen überschritten werden:
+
+| Alert | Schwelle | Aktion |
+|-------|----------|--------|
+| 🕐 **Ticket-Aging** | >5 Tickets >30d ohne Status-Update | Review-Empfehlung: sind diese Tickets noch relevant? → `obsolete`? |
+| 🧹 **Worktree-Leak** | >3 Worktrees mit letztem Commit >7d | Wahrscheinlich nach Factory-Run liegen geblieben — Cleanup §1 |
+| 📋 **PR-Stagnation** | PR >5d offen ohne Review | Reviewer pingen oder PR schließen wenn abandoned |
+| ⏱️ **Factory-Stall** | Queue >0, last tick >6h | Factory-Trigger oder Worker-Health-Check |
+
+---
+
+## 7. Scheduling & Trigger Guidance
+
+Wann und wie oft sollte `repo-hygiene` ausgeführt werden?
+
+### 7.1 Empfohlene Trigger
+
+| Trigger | Kadenz | Priorität |
+|---------|--------|-----------|
+| **Post-`ticket-ops` Lauf** | Nach jedem Phase-3-Dispatch | hoch — direkte Folge: Worktrees und Branches entstehen |
+| **Post-`dev-flow-execute` Abschluss** | Nach jedem Merge | mittel — ein toter Branch/Worktree mehr |
+| **Daily Hygiene Sweep** | 1×/Tag (idealerweise morgens) | mittel — verhindert Akkumulation |
+| **Pre-Batch-Dispatch** | Vor Dispatch von >3 Tickets | hoch — stellt sicher, dass genug saubere Worktree-Slots frei sind |
+| **Weekly Deep Clean** | 1×/Woche (z.B. Montag) | niedrig — voller Durchlauf inkl. Aging-Report und verwaiste Remote-Branches |
+
+### 7.2 Ausführungstiefe (Light vs. Full)
+
+Nicht jeder Lauf muss alle 8 Abschnitte abdecken:
+
+| Modus | Abschnitte | Dauer | Wann? |
+|-------|-----------|-------|-------|
+| **Quick** | §0, §5 (Arbeitsbaum + Factory-Queue) | <30s | Nach jedem `ticket-ops`-Dispatch |
+| **Standard** | §0–§3 (Arbeitsbaum, Worktrees, Branches, PRs) | 2–5 min | Daily Sweep, Pre-Batch-Dispatch |
+| **Full** | §0–§7 (alles + Aging-Report + Empfehlungen) | 5–10 min | Weekly Deep Clean |
+
+### 7.3 Automatisierung (Cron)
+
+Für den Daily Sweep kann ein Cron-Job eingerichtet werden:
+
+```bash
+# In crontab -e (läuft als User patrick):
+0 8 * * * bash /home/patrick/Bachelorprojekt/scripts/repo-hygiene-cron.sh standard >> /tmp/repo-hygiene-cron.log 2>&1
+```
+
+Das Cron-Skript (`scripts/repo-hygiene-cron.sh`, seit T003486) ist ein schlanker Wrapper, der:
+1. `git fetch origin main --prune` ausführt
+2. `bash scripts/agent-lock.sh reap` (stale Locks)
+3. Die Hygiene-Metriken (Worktree/Branch/PR-Counts) als JSON nach stdout schreibt
+4. Oberhalb von `STALE_THRESHOLD` stale Artifacts eine Warnung per `ticket.sh add-comment`
+   an das Hygiene-Tracking-Ticket anhängt
+
+> **Es kennt zwei Modi — `standard` (default) und `deep`**, nicht die drei Tiefen aus §7.2.
+> `deep` ergänzt `branch-reaper.sh --dry-run` und zählt dessen Kandidaten mit. Die Zuordnung
+> lautet also: §7.2 *Quick*/*Standard* → `standard`, §7.2 *Full* → `deep`.
+
+### 7.4 Hygiene-Gesundheitsampel
+
+Einfache Status-Übersicht für den Operator:
+
+```
+🟢 GRÜN  — <3 stale Worktrees, <5 [gone]-Branches, kein PR >3d
+🟡 GELB  — 3–5 stale Worktrees ODER 5–10 [gone]-Branches ODER 1 PR >3d
+🔴 ROT   — >5 stale Worktrees ODER >10 [gone]-Branches ODER Factory-Stall >6h
+```
+
+Die Ampel wird am Anfang jedes Quick-Laufs berechnet und bei GELB/ROT im Report ausgegeben.

--- a/.claude/skills/references/ticket-ops-procedures.md
+++ b/.claude/skills/references/ticket-ops-procedures.md
@@ -161,6 +161,86 @@ T000738 | Unbekanntes Feature  | backlog     | niedrig | —       | description
 
 ---
 
+## Phase 1.5 — Backlog Grouping Scan
+
+Nach Phase 1 sind alle Tickets klassifiziert. Bei vielen Tickets im Backlog (>10) lohnt es sich,
+zusammengehörige Tickets zu **Batch-Gruppen** zu bündeln: ein Parent-Ticket, dessen Branch alle
+enthaltenen Änderungen in einem Durchlauf abdeckt — statt N getrennter Planungs- und Merge-Zyklen.
+
+### Step 1.5.1: Grouping-Heuristiken
+
+Für jedes ready/incomplete-Ticket prüfen, ob es einer Gruppe zugeordnet werden kann:
+
+| Heuristik | Bedingung | Gewicht |
+|-----------|-----------|---------|
+| **Same-area** | Mindestens ein `areas`-Eintrag gemeinsam, **und** die `impact_files` (aus `intel.json` oder Ticket-Beschreibung) disjunkt — kein Dateikonflikt | stark (auto-group wenn ≥2 Treffer) |
+| **Explicit link** | `ticket_links` enthält `kind='relates_to'` zwischen beiden Tickets | stark (auto-group) |
+| **Bulk pattern** | Titel-Muster erkennbar: gleiches Verb + Objekt über mehrere Tickets, z.B. "Add X to dashboard", "Fix Y in all handlers", "Update Z across components" | mittel (Candidate-Flag) |
+| **Same component** | Gleicher `component`-Wert **und** `effort IN (klein, mittel)` | schwach (nur wenn ≥3) |
+| **Common dependency** | Beide Tickets hängen von demselben Dritt-Ticket ab (in `depends_on`) | mittel (Sub-Group) |
+
+**Ausschlusskriterien — diese Tickets NIEMALS gruppieren:**
+- `severity = 'critical'` → braucht eigenen Fokus
+- `status IN ('in_progress', 'plan_staged')` → wird bereits bearbeitet
+- Bereits in einer anderen Gruppe als Kind verlinkt
+- `attention_mode = 'needs_human'` → erst Phase 2 abwarten
+
+### Step 1.5.2: Batch Parent erstellen
+
+Für jede gefundene Gruppe (≥2 Tickets):
+
+1. **Parent-Ticket anlegen:**
+   ```bash
+   # Via ticket-mcp:
+   mcp__ticket-mcp__create_ticket({
+     type: "feat",
+     brand: "mentolder",
+     title: "Batch: <kurzer-gruppen-titel>",
+     description: "Batch-Gruppe aus N Tickets:\n- T000AAA: <titel>\n- T000BBB: <titel>\n...",
+     priority: "<höchste Prio der Kinder>",
+     severity: "<höchste Severity der Kinder>",
+     areas: "<Union aller Kinder-Areas>"
+   })
+   ```
+   Die Rückgabe liefert `BATCH_PARENT_ID`.
+
+2. **`child_of`-Links setzen** (für jedes Kind-Ticket):
+   ```
+   mcp__ticket-mcp__link_tickets({ from: "<child_ext_id>", to: "<BATCH_PARENT_ID>", kind: "child_of" })
+   ```
+
+3. **Kind-Tickets markieren:**
+   ```
+   mcp__ticket-mcp__add_comment({
+     id: "<child_ext_id>",
+     body: "🔗 Batch-Gruppe: Parent <BATCH_PARENT_ID>. Wird gemeinsam mit N anderen Tickets geplant."
+   })
+   ```
+
+### Step 1.5.3: Batch-Map ausgeben
+
+```json
+{
+  "groups": [
+    {
+      "parent_id": "T000XXX",
+      "title": "Batch: Dashboard-Verbesserungen",
+      "children": ["T000AAA", "T000BBB", "T000CCC"],
+      "areas": ["website", "dashboard"],
+      "total_effort": "mittel",
+      "rationale": "3 Tickets teilen area=website+dashboard, keine Dateikonflikte"
+    }
+  ],
+  "ungrouped_ready": ["T000DDD", "T000EEE"],
+  "deferred_to_phase2": ["T000FFF"]
+}
+```
+
+Diese Map fließt in Phase 3 ein — Batch-Gruppen werden als **eine Einheit** in die Wellen-Sortierung
+aufgenommen (alle Kinder einer Gruppe sitzen in derselben Welle).
+
+---
+
 ## Phase 2 — Human Escalation Round
 
 Escalate to the user **only for significant decisions** that AI cannot resolve autonomously: ambiguous business impact, unclear scope boundaries, multi-area conflicts without clear owner. All other tickets proceed with AI-decided values. Use subagent dispatch when validation/clarification requires domain expertise.
@@ -257,9 +337,52 @@ Edges come from two sources — merge both:
 **Soft conflict edges:** two ready tickets that share any `areas` entry have a file-collision risk → they may not sit in the **same** wave (serialise them). This is conservative by design (the approved heuristic); flag it rather than hide it.
 
 ### Step 3.2: Topologically sort into waves
-- **Wave N** = every ready ticket whose hard dependencies are all satisfied by waves `< N` **and** which has no `areas` conflict with another ticket already placed in wave N.
+
+- **Input:** Ready-Tickets + Batch-Gruppen (aus Phase 1.5).
+- **Batch-Gruppen** werden als **atomare Einheiten** behandelt — alle Kinder einer Gruppe landen in derselben Welle (der Parent-Branch deckt sie ab).
+- **Wave N** = every ready ticket/group whose hard dependencies are all satisfied by waves `< N` **and** which has no `areas` conflict with another ticket/group already placed in wave N.
 - **Maximise wave width** (the goal is "as much in parallel as possible") subject to those two constraints.
-- Order ties by `priority` (hoch > mittel > niedrig), then smaller `effort` first (quick wins).
+
+**Impact-gewichtete Reihenfolge innerhalb einer Welle:**
+
+Tickets/Groupen innerhalb einer Welle werden nach **Impact-Score** sortiert (höchster zuerst):
+
+```
+impact_score = blocked_count * 10 + age_days * 0.5 + priority_bonus
+```
+
+| Faktor | Berechnung |
+|--------|-----------|
+| `blocked_count` | Wie viele andere Tickets hängen via `depends_on` oder `ticket_links(kind='blocked_by')` von diesem Ticket ab? (Query: siehe Step 3.2a) |
+| `age_days` | `now() - created_at` in Tagen. Ältere Tickets bekommen Boost, damit sie nicht ewig liegen. |
+| `priority_bonus` | `hoch=30`, `mittel=15`, `niedrig=0` |
+
+**Tie-Breaking:** Bei gleichem Score: kleinere `effort` zuerst (Quick Wins), dann `planning_rank` (niedriger = höhere Priorität).
+
+#### Step 3.2a: Blocked-Count pro Ticket ermitteln
+
+```sql
+-- Tickets, die von diesem Ticket geblockt werden (hard deps + ticket_links):
+SELECT t.external_id AS blocker,
+       COUNT(DISTINCT blocked.id) AS blocked_count
+FROM tickets.tickets t
+LEFT JOIN tickets.tickets blocked ON t.external_id = ANY(blocked.depends_on)
+LEFT JOIN tickets.ticket_links l ON l.to_id = t.id AND l.kind = 'blocked_by'
+LEFT JOIN tickets.tickets blocked2 ON l.from_id = blocked2.id
+WHERE t.external_id = ANY($ready_ticket_ids)
+GROUP BY t.external_id;
+```
+
+#### Step 3.2b: Quick-Win Detection
+
+Tickets, die alle drei Bedingungen erfüllen, werden im Masterplan mit `⚡ QUICK WIN` markiert:
+1. `effort = 'klein'`
+2. `depends_on IS NULL` (keine harten Abhängigkeiten)
+3. Nur ein `areas`-Eintrag (kein Cross-Cutting → geringeres Kollisionsrisiko)
+
+Quick Wins sind ideale Kandidaten für eine **Quick-Win-Batch**: bis zu 5 Quick Wins ohne
+Dateikonflikte können in eine Ad-hoc-Gruppe (ohne Parent-Ticket) zusammengefasst werden.
+Der Gruppe wird im Masterplan eine eigene Zeile mit `[QUICK-WIN BATCH: N]` gegeben.
 ### Step 3.3: Pre-Check — Lock-Status der Wave-1-Tickets prüfen
 
 > **Pre-Check-Invariante [T002422]:** Vor dem ersten `claim`-Aufruf wird für jedes Wave-1-Ticket
@@ -300,6 +423,7 @@ Edges come from two sources — merge both:
 The dev-flow contract splits the parallel unit, orchestrated by all available subagents:
 - `status = 'plan_staged'` → **execution wave**: dispatch `dev-flow-execute` via relevant subagent (`website-specialist`, `bachelorprojekt-test`, etc.)
 - `attention_mode = 'ai_ready'` / DoR-complete → **planning wave**: dispatch `dev-flow-plan` via domain-specific subagent for plan creation and staging
+- **Batch parent** (`type='feat'`, hat `child_of`-Kinder) → **batch planning wave**: EIN `dev-flow-plan`-Lauf für den Parent, dessen `tasks.md` die Änderungen aller Kind-Tickets als Partials enthält. Der Parent-Branch `feature/batch-<slug>` deckt alle Kinder ab.
 - **Any other ready ticket** → **parallel planning wave**: all available subagents work in parallel to create plans, set readiness flags, stage branches. No ready ticket is left without a route or owner.
 
 Any subagent that lands a `type='feat'` ticket in `status='backlog'` must, in the same pass, populate `requirements_list` and > **Wichtig [T002471-M3]:** Vor `lastenheft lock` muss `requirements_list` gefüllt sein:
@@ -310,17 +434,53 @@ Any subagent that lands a `type='feat'` ticket in `status='backlog'` must, in th
 All subagents report back with: ticket_id, decisions made, branch created, plan staged, **lastenheft locked (y/n)**. Consolidate for Phase 3 masterplan completion.
 
 ### Step 3.5: Present the masterplan
+
 ```
-WELLE 1  (parallel · keine offenen Abh.)
-  T000953  Cockpit Fullscreen   hoch   area:website  plan_staged → execute (wt-A)
-  T000801  DB-Index Backfill    hoch   area:db       plan_staged → execute (wt-B)
-WELLE 2  (nach T000953)
-  T000959  Status-Badge         mittel area:website  ai_ready    → plan    (wt-C)  ⊳ depends T000953
-⚠ KONFLIKT: T000953 & T000961 beide area:website/admin → seriell (T000961 → Welle 2)
-LOCK-KONFLIKTE: [T002424]  (erscheint nur bei Konflikten)
+┌─ BACKLOG SUMMARY ─────────────────────────────────────────────────────┐
+│ Total offen: 23  │  Ready (Triage done): 14  │  Blocked (deps): 5    │
+│ Batch-Gruppen: 2 (deckt 6 Tickets ab)  │  Quick Wins: 4             │
+│ Offene PRs: 3 (1 mergeable, 1 CI-failing, 1 in review)              │
+│ Factory-Queue: 2 wartend, 1 aktiv                                    │
+└──────────────────────────────────────────────────────────────────────┘
+
+WELLE 1  (parallel · keine offenen Abh. · 3 Einheiten)
+  [BATCH:3] T000987  Batch: Dashboard-Fixes          hoch   area:website  plan      (wt-batch-dash)
+            ├─ T000953 Cockpit Fullscreen                                            (child)
+            ├─ T000959 Status-Badge                                                  (child)
+            └─ T000961 Admin-Table                                                    (child)
+  T000801  DB-Index Backfill                         hoch   area:db       plan_staged → execute (wt-db)
+  [QUICK-WIN BATCH:4]                                ⚡     areas:mixed   plan      (wt-quickwins)
+            ├─ T001002 README-Link fix               ⚡klein area:docs
+            ├─ T001003 Typo in footer                 ⚡klein area:website
+            ├─ T001004 Dead import cleanup            ⚡klein area:scripts
+            └─ T001005 CI badge URL update            ⚡klein area:ci
+
+WELLE 2  (nach T000801 · 1 Einheit)
+  T000977  Auth-Token Refresh                        mittel area:auth     ai_ready → plan (wt-auth) ⊳ depends T000801
+  Age: 14d | Impact: blockiert 3 Tickets
+
+WELLE 3  (nach Welle 2 · 2 Einheiten)
+  T000965  Brett-Mobile-Layout                       mittel area:brett    ai_ready → plan  ⊳ depends T000977
+  T000972  Chat-Notification-Throttle                mittel area:chat     ai_ready → plan  ⊳ depends T000977
+
+⚠ SOFT-KONFLIKT: T000965 & T000972 beide area:brett → seriell
+⚠ LOCK-KONFLIKTE:
   T002XXX bereits gehalten von claude (sid …, label …, seit …)  → deferred
-DEFERRED (needs_human, ungeklärt): T000738
+
+DEFERRED (needs_human, ungeklärt): T000738, T000740
+DEFERRED (severity=critical, eigener Fokus): T001001
+
+AGE-ALERT: 3 Tickets >30 Tage ohne Aktivität — Review empfohlen
+HYGIENE-EMPFEHLUNG: 5 stale Worktrees, 8 [gone]-Branches — `repo-hygiene` ausführen
 ```
+
+**Format-Regeln:**
+- Batch-Gruppen: `[BATCH:N]` mit Parent-Ticket, eingerückte Kinder mit `├─`/`└─`
+- Quick-Win-Batch: `[QUICK-WIN BATCH:N]` mit `⚡`-Marker
+- Impact: Nur anzeigen wenn `blocked_count > 0` — als `blockiert N Tickets`
+- Age: Nur anzeigen wenn `age_days > 7`
+- Age-Alert: Automatisch wenn Tickets >30 Tage ohne Update
+- Hygiene-Empfehlung: Wenn `repo-hygiene` seit >5 Tagen oder >10 stale Artifacts
 
 ### Step 3.6: Dispatch wave 1 (after the user approves)
 
@@ -349,30 +509,33 @@ Merge = Abschluss: each ticket closes on its own green auto-merge; the masterpla
 │                    Open Tickets (N=17)                       │
 └─────────────────────┬───────────────────────────────────────┘
                       │
-          ┌───────────┴───────────────────────────────────────┐
-          │                                                   │
-    Autonomous AI Decisions                          Significant Human Decisions
-    (severity/component/areas/readiness)                    ↑
-          │                                                  │
-    Dispatch subagents for validation &             └────────┘
-    enrichment                                        Escalation gate
-          │
-    Set attention_mode = 'ai_ready' or              (ambiguous impact, unclear scope)
-    add to missing[] list                          → needs_human flag
-          │
-          ▼
-    Parallel execution across all subagents:
-    - bachelorprojekt-test
-    - bachelorprojekt-infra  
-    - bachelorprojekt-website
-    - database-specialist
-    - security-specialist
-          │
-          ▼
-    Consolidate decisions & set readiness flags
-          │
-          ▼
-    Phase 3: Masterplan with ALL tickets → Plan staging
+           ┌──────────┴───────────────────────────────────────┐
+           │                                                   │
+     Autonomous AI Decisions                          Significant Human Decisions
+     (severity/component/areas/readiness)                    ↑
+           │                                                  │
+           ├──► Phase 1.5: Grouping Scan             └────────┘
+           │     (Batch-Gruppen bilden)                Escalation gate
+           │                                                   │
+     Dispatch subagents for validation &              (ambiguous impact, unclear scope)
+     enrichment                                      → needs_human flag
+           │
+     Set attention_mode = 'ai_ready' or
+     add to missing[] list
+           │
+           ▼
+     Parallel execution across all subagents:
+     - bachelorprojekt-test
+     - bachelorprojekt-infra
+     - bachelorprojekt-website
+     - database-specialist
+     - security-specialist
+           │
+           ▼
+     Consolidate decisions & set readiness flags
+           │
+           ▼
+     Phase 3: Masterplan with ALL tickets & Batch-Gruppen → Plan staging
 ```
 
 ### Key Changes
@@ -381,6 +544,9 @@ Merge = Abschluss: each ticket closes on its own green auto-merge; the masterpla
 2. **Human gate only for significant ambiguity** — unclear business impact or scope boundaries
 3. **Full subagent fan-out** — all available subagents work in parallel to complete planning/staging
 4. **All tickets to plan_staged** — no backlog waiting, every ticket gets a domain expert assigned
+5. **Batch grouping (Phase 1.5)** — zusammengehörige Tickets zu Gruppen bündeln, um Planungs-Overhead zu senken
+6. **Impact-weighted ordering** — Tickets, die viele andere blockieren, werden priorisiert
+7. **Quick-Win detection** — `effort=klein`-Tickets ohne Abhängigkeiten automatisch erkennen und batchen
 
 ### Subagent Responsibilities Matrix
 

--- a/.claude/skills/repo-hygiene/SKILL.md
+++ b/.claude/skills/repo-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-hygiene
-description: 'Use for the state of the repository itself — stale branches and worktrees, open PRs to merge and close, GitHub issue intake, software factory queue status. Triggers on "clean branches", "merge PRs", "prune worktrees", "stale worktrees", "factory queue status", "close resolved tickets", git worktree remove, gh pr merge. Not for the content of tickets — triage, missing information and parallel-work planning belong to ticket-ops.'
+description: 'Use for the state of the repository itself — stale branches and worktrees, open PRs to merge and close, GitHub issue intake, software factory queue status, proactive hygiene recommendations, and scheduling guidance. Triggers on "clean branches", "merge PRs", "prune worktrees", "stale worktrees", "factory queue status", "close resolved tickets", git worktree remove, gh pr merge, "repo health check", "hygiene recommendations", "what should I clean up". Not for the content of tickets — triage, missing information and parallel-work planning belong to ticket-ops.'
 ---
 
 > **Mishap Tracking:** Führe während dieses Skills ein `MISHAP_LOG` und rufe am Ende
@@ -19,7 +19,7 @@ Der interne Postgres-Tracker `tickets.tickets` ist die SSOT für Issues. DB-Zugr
 
 Die gesamte Housekeeping-Mechanik ist **SSOT** in
 [`repo-hygiene-ops`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/repo-hygiene-ops.md) —
-die sechs Abschnitte der Reihe nach ausführen:
+die acht Abschnitte der Reihe nach ausführen:
 
 0. **Arbeitsbaum & Stashes** — §0
 1. **Stale Git Worktrees** — §1
@@ -27,8 +27,10 @@ die sechs Abschnitte der Reihe nach ausführen:
 3. **PR-Triage → verknüpftes Ticket schließen** — §3
 4. **GitHub-Issue-Intake** (Dedupe-Guard [T001210]) — §4
 5. **Software-Factory-Queue** (MCP-first via `factory-mcp`) — §5
+6. **Proactive Hygiene Recommendations** — §6 (nach jedem Lauf: Top-3-Empfehlungen, Aging-Report)
+7. **Scheduling & Trigger Guidance** — §7 (wann und wie oft Hygiene laufen sollte)
 
-Für Completeness-Triage, Klärungsrunden und Parallelisierungs-Masterplan (Phasen 1–3) →
+Für Completeness-Triage, Klärungsrunden und Parallelisierungs-Masterplan (Phasen 1–4) →
 `ticket-ops`.
 
 ---

--- a/.claude/skills/ticket-ops/SKILL.md
+++ b/.claude/skills/ticket-ops/SKILL.md
@@ -19,16 +19,23 @@ und werden gelesen, wenn die jeweilige Phase dran ist.
 
 ## Workflow at a glance
 
-Ein vollständiger Durchlauf hat drei Phasen. Für eine enge Anfrage direkt in die passende Phase
-springen; für „triagiere alles / was kann ich parallel machen" 1 → 2 → 3 der Reihe nach.
+Ein vollständiger Durchlauf hat vier Phasen. Für eine enge Anfrage direkt in die passende Phase
+springen; für „triagiere alles / was kann ich parallel machen" 1 → 2 → 3 → 4 der Reihe nach.
 
 1. **Completeness triage** — alle offenen Tickets holen, pro Ticket berechnen *was fehlt*,
    klassifizieren. Der Agent entscheidet Severity, Component, Areas und Readiness-Flags
    autonom nach Rubrik; nur echte Ermessensfragen werden eskaliert.
-2. **Human clarification** — für die gefilterte Teilmenge die fehlenden Angaben beim Menschen
+2. **Backlog grouping scan** — nach der Triage: zusammengehörige Tickets zu **Batch-Gruppen**
+   bündeln, um den Planungs- und Merge-Overhead bei vielen kleinen Tickets zu senken.
+   Heuristiken: gleiche `areas` + kein Dateikonflikt, explizite `relates_to`-Links,
+   Bulk-Operationen mit gleichförmigem Titel. Jede Gruppe bekommt ein Parent-Ticket
+   (`type='feat'`, `child_of`-Links), dessen Branch alle enthaltenen Tickets abdeckt.
+3. **Human clarification** — für die gefilterte Teilmenge die fehlenden Angaben beim Menschen
    erfragen (gebündelt), Antworten in die DB zurückschreiben.
-3. **Parallelization masterplan** — Abhängigkeitsgraph über die nun fertigen Tickets bauen, in
-   Wellen sortieren, Konflikte sichtbar machen und nach Freigabe Welle 1 dispatchen.
+4. **Parallelization masterplan** — Abhängigkeitsgraph über die nun fertigen Tickets bauen, in
+   Wellen sortieren (Impact-gewichtete Reihenfolge, Batch-Gruppen als Einheiten), Konflikte
+   sichtbar machen und nach Freigabe Welle 1 dispatchen. Enthält **Quick-Win-Detection**
+   für `effort=klein`-Tickets ohne Abhängigkeiten.
 
 Repo-Housekeeping (stale Worktrees/Branches, PR-Triage, Issue-Intake, Factory-Queue) ist **nicht
 mehr Teil dieses Skills** — es liegt vollständig bei [`repo-hygiene`](../repo-hygiene/SKILL.md),
@@ -93,12 +100,31 @@ alles Mehrdeutige bleibt unangetastet und wird zur Phase-2-Frage.
 `ticket-mcp`-Wrapper oder den `psql()`-Helper — SSOT:
 [`MCP-Tool-Guide`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/mcp-tool-guide.md) §mcp-postgres.
 
+**Batch-Grouping-Regel [T003550]:** Bei >10 offenen Tickets im Backlog lohnt sich Batch-Gruppierung.
+Tickets, die in denselben `areas` liegen, keine disjunkten Dateimengen berühren und keinen
+harten Blockierer (`depends_on`) untereinander haben, KÖNNEN in eine Batch-Gruppe. Eine Gruppe
+erhält ein neu angelegtes Parent-Ticket (`type='feat'`, `child_of`-Links von den Kind-Tickets);
+der Parent-Branch `feature/batch-<slug>` deckt alle Kinder in einem Durchlauf ab. Kind-Tickets
+behalten ihre eigene `external_id` und schließen einzeln — der Parent dient nur als
+Planungsanker. **Nicht** gruppieren: Tickets mit `severity=critical`, Tickets in `in_progress`,
+oder Tickets, die bereits einen gestagten Plan haben.
+
 ## Phase 1 — Completeness Triage
 
 Entscheidungsrubrik (severity/component/areas/readiness mit Eskalationsschwellen), die
 Enriched-Fetch-Query, die Tier-A/Tier-B-Berechnung der `missing[]`-Liste, das Laden des
 OpenSpec-Status und die Klassifikation (resolved · obsolete · ready · incomplete):
 [`ticket-ops-procedures`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/ticket-ops-procedures.md) §Phase 1.
+
+## Phase 1.5 — Backlog Grouping Scan
+
+Nachdem alle Tickets klassifiziert sind: zusammengehörige Tickets zu Batch-Gruppen bündeln.
+Die Heuristiken, Parent-Ticket-Erstellung und die Ausgabe als `batch-map.json`:
+[`ticket-ops-procedures`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/ticket-ops-procedures.md) §Phase 1.5.
+
+> **Wann lohnt sich das?** Ab ~10 offenen Tickets im Backlog. Darunter ist der Overhead
+> (Parent-Ticket anlegen, `child_of`-Links setzen) größer als der Gewinn durch gebündelte
+> Planung und einen Merge statt N.
 
 ## Phase 2 — Human Escalation Round
 
@@ -112,7 +138,8 @@ Harness und das Zurückschreiben per JSONB-Merge:
 
 ## Phase 3 — Parallelization Masterplan
 
-Aufbau des Abhängigkeitsgraphen aus beiden Quellen, topologische Sortierung in Wellen, das
+Aufbau des Abhängigkeitsgraphen aus beiden Quellen, topologische Sortierung in Wellen
+(Impact-gewichtet, Batch-Gruppen als Einheiten), Quick-Win-Detection, das
 Routing (plan vs. execute), das Masterplan-Format und der Wave-1-Dispatch:
 [`ticket-ops-procedures`](file:///home/patrick/Bachelorprojekt/.claude/skills/references/ticket-ops-procedures.md) §Phase 3.
 


### PR DESCRIPTION
## Warum

`stash@{0}` (fremde WIP der Session zu T003215) enthielt funktionale Arbeit, die **nirgends sonst existiert** — nicht in `main`, in keinem Remote-Branch und in keinem lebenden Worktree. Nachweis im repo-hygiene-Lauf 2026-08-11, dokumentiert in T003550.

```bash
for m in 'Proactive Hygiene Recommendations' 'Backlog Grouping Scan'; do
  git grep -lF "$m" $(git for-each-ref --format='%(refname:short)' refs/remotes/origin | head -40)
done   # → 0 Treffer
```

## Was drin ist

- **`ticket-ops`** — Phase 1.5 „Backlog Grouping Scan": Heuristiken (gleiche `areas` ohne Dateikonflikt, `relates_to`-Links, gleichförmige Bulk-Titel), Parent-Ticket via `child_of`, Ausgabe als `batch-map.json`. Phasenzählung 3 → 4, Quick-Win-Detection für `effort=klein`.
- **`repo-hygiene-ops`** — §6 (Hygiene-Metriken, Aging-Report, Top-3-Empfehlungen, Aging Alerts) und §7 (Trigger-Kadenz, Ausführungstiefe, Cron, Gesundheitsampel).
- **`git-workflow`** — nach squash-merge den lokalen Branch mit `git branch -D` entfernen; `-d` verweigert, weil git den Squash-Commit nicht als merged erkennt.

## Abweichungen vom eingefrorenen Stash-Stand

| Stelle | Stash sagte | Realität |
|---|---|---|
| §7.3 | „Das Cron-Skript existiert noch nicht — dies ist die Spezifikation dafür" | `scripts/repo-hygiene-cron.sh` liegt seit T003486 (#4202) in `main`. Text auf die Implementierung gezogen: Modi `standard\|deep`, `STALE_THRESHOLD`, `ticket.sh add-comment`. |
| ticket-ops SKILL | Platzhalter `[T003XXX]` | `[T003550]` |

Ein sauber anwendbarer Patch ist nicht automatisch ein inhaltlich gültiger — `git apply` prüft Zeilen, nicht Aussagen.

## Nicht übernommen

Bleibt bewusst im Stash, Entscheidung offen in **T003550**:
- **gemma4-Removal** (`loadouts.json`, `agent-models.jsonc`, `gemma-kv-quant.bats`) — der nicht gemergte Zwilling zu T003460 (qwen3-coder-30b abdrehen), aber eine fachliche Entscheidung über ein laufendes Loadout.
- **auto-triage-Vokabular** — in `main` inzwischen anders gelöst (T003492, Werte aus `triage-enums.json`).

Der Stash bleibt liegen, bis diese beiden entschieden sind.

## Verifikation

- `task test:changed` — 52/52 grün
- `bats -r tests/spec/agent-skills` — 30/30 grün (u. a. Pfadverweis-Guard und die Guard-Reihenfolge in `repo-hygiene-ops.md` §1)
- `task freshness:regenerate` + `task freshness:check` — grün, keine Generat-Drift

## Kollisionshinweis

**T003490** (`Batch: repo-hygiene-ops §1-§3 Fixes`, backlog) ändert dieselbe Datei, aber andere Abschnitte (§1–§3 vs. §6/§7 hier). Kein inhaltlicher Konflikt, aber beim Rebase kollidiert es am Dateiende.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TcuJLhNzmiZTEGVKui1Nf
