### PR TITLE
fix(skills): add read-after-write verification for plan agent readiness flags [T002929]

### DIFF
--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -231,6 +231,31 @@ FOR each partial pX (p1, p2, ...):
   │     ticket-mcp: set_readiness_flag({ id: "$TICKET_EXT_ID", flag: "offene_fragen_geklaert", value: true })
   │     ticket-mcp: set_readiness_flag({ id: "$TICKET_EXT_ID", flag: "aufwand_geschaetzt", value: true })
   │
+  ├─► Schritt C.2e5: Read-After-Write-Verifikation [T002929]
+  │     Die gesetzten Flags muessen per DB-Abfrage BESTAETIGT werden — nicht einfach die
+  │     beabsichtigten Werte behaupten.
+  │
+  │     # Alle 4 DoR-Flags + lastenheft_locked aus der DB lesen:
+  │     DB_READINESS=$(mcp__mcp-postgres__query({
+  │       sql: "SELECT readiness FROM tickets.tickets WHERE external_id = '$TICKET_EXT_ID'"
+  │     }))
+  │     # Erwartete Werte pruefen:
+  │     for flag in spec_skizziert abhaengigkeiten_klar offene_fragen_geklaert aufwand_geschaetzt; do
+  │       val=$(echo "$DB_READINESS" | jq -r ".[0].result | fromjson | .readiness.$flag // false")
+  │       [ "$val" != "true" ] && echo "FEHLER: Readiness-Flag $flag wurde NICHT in die DB geschrieben (Wert: $val)" >&2 && exit 1
+  │     done
+  │     # Status verifizieren:
+  │     DB_STATUS=$(mcp__mcp-postgres__query({
+  │       sql: "SELECT status FROM tickets.tickets WHERE external_id = '$TICKET_EXT_ID'"
+  │     }))
+  │     ACTUAL_STATUS=$(echo "$DB_STATUS" | jq -r ".[0].result | fromjson | .status")
+  │     [ "$ACTUAL_STATUS" != "plan_staged" ] && echo "FEHLER: Ticket-Status wurde NICHT auf plan_staged gesetzt (IST: $ACTUAL_STATUS)" >&2 && exit 1
+  │
+  │     Bei Diskrepanz: process.exit(1) — die Rückmeldung DARF NICHT einfach
+  │     die beabsichtigten Werte durchreichen, sie muss die DB-Wahrheit abbilden.
+  │     [T002929] Fix: Plan-Agenten melden Readiness-Flags falsch (behaupten
+  │     Werte, die sie zu setzen GEDACHT haben, statt die tatsaechlichen DB-Werte).
+  │
   ├─► Schritt C.2f: In Factory enqueuen ⚡
   │     ticket-mcp: enqueue_ticket({ id: "$TICKET_EXT_ID" })
   │     # Factory dispatcher startet jetzt WORK an diesem Partial!

--- a/openspec/changes/fix-plan-agent-readiness/specs/dev-flow-plan.md
+++ b/openspec/changes/fix-plan-agent-readiness/specs/dev-flow-plan.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Readiness-Flag-Verifikation (Read-After-Write)
+
+Der Plan-Agent SHALL nach dem Setzen von Readiness-Flags die tatsaechlichen DB-Werte verifizieren,
+bevor er Erfolg meldet. Die Rueckmeldung MUSS die DB-Wahrheit abbilden, nicht die beabsichtigten Werte.
+
+#### Scenario: Readiness-Flags werden gesetzt und verifiziert
+
+- **GIVEN** der Plan-Agent hat `set_readiness_flag` fuer alle vier DoR-Flags aufgerufen
+  (`spec_skizziert`, `abhaengigkeiten_klar`, `offene_fragen_geklaert`, `aufwand_geschaetzt`)
+- **WHEN** er eine Read-After-Write-Abfrage ausfuehrt (`SELECT readiness FROM tickets.tickets WHERE external_id = $TICKET_ID`)
+- **THEN** alle vier DoR-Flags muessen den Wert `true` in der DB haben
+- **AND** der Ticket-Status MUSS `plan_staged` sein
+
+#### Scenario: Diskrepanz wird als Fehler gemeldet
+
+- **GIVEN** ein Readiness-Flag wurde per `set_readiness_flag` gesetzt
+- **WHEN** die Read-After-Write-Abfrage zeigt einen abweichenden Wert (z.B. `false` statt `true`)
+- **THEN** der Plan-Agent MUSS mit Exit-Code 1 abbrechen
+- **AND** die Fehlermeldung MUSS das betroffene Flag und den IST-Wert nennen
+- **AND** die Rueckmeldung DARF NICHT die beabsichtigten Werte als DB-Wahrheit durchreichen
+
+#### Scenario: Status wird verifiziert
+
+- **GIVEN** der Plan-Agent hat `stage-plan` aufgerufen
+- **WHEN** er eine Status-Abfrage ausfuehrt (`SELECT status FROM tickets.tickets WHERE external_id = $TICKET_ID`)
+- **THEN** der Ticket-Status MUSS `plan_staged` sein
+- **AND** bei Abweichung MUSS der Agent mit Exit-Code 1 abbrechen und den IST-Status melden

--- a/openspec/changes/fix-plan-agent-readiness/tasks.md
+++ b/openspec/changes/fix-plan-agent-readiness/tasks.md
@@ -1,0 +1,18 @@
+# T002929: Plan-Agenten melden falsche Readiness-Flags
+
+## Ziel
+Plan-Agenten melden Readiness-Flags und Status korrekt an die DB zurück, sodass die gemeldeten Werte mit dem DB-Stand übereinstimmen.
+
+## Tasks
+
+### 1. Diskrepanz analysieren
+- [ ] `scripts/vda/ticket/stage-plan.sh` — schreibt es alle Readiness-Flags korrekt?
+- [ ] `scripts/ticket.sh plan-meta` — werden die Flags via JSONB-Merge gesetzt?
+
+### 2. Fix
+- [ ] Readiness-Flags nach stage-plan verifizieren (Read-After-Write-Check)
+- [ ] Diskrepanz als Fehler melden, nicht stillschweigend übergehen
+
+### Verify
+- [ ] Nach `stage-plan`: `readiness.spec_skizziert = true` in der DB
+- [ ] Plan-Agent-Rückmeldung stimmt mit DB überein


### PR DESCRIPTION
## Summary

Fixes T002929: Plan agenten melden Readiness-Flags, die die DB nicht bestätigt.

### Problem
Zweimal im selben ticket-ops-Lauf wich die Selbstauskunft eines dev-flow-plan-Subagenten vom DB-Zustand ab:
- Agent meldete "Lastenheft locked: y", aber die DB hatte `lastenheft_locked` nicht gesetzt
- Agent meldete "Status = plan_staged", aber der DB-Status war `in_progress`

### Fix
Adds Schritt C.2e5 (Read-After-Write-Verifikation) to `opencode-flow-plan` SKILL.md. After setting readiness flags, the plan agent MUST query the DB to confirm the actual values match the expected values, and MUST report the DB-truth (not the intended values).

### Verification
- Readiness flags are queried from DB after setting
- Each flag is compared with expected `true` value
- Ticket status is verified as `plan_staged`
- On discrepancy: exit 1 with FEHLER message