### PR TITLE
fix(skills): enforce synchronous foreground verification in dev-flow-execute [T003003]

### DIFF
--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -182,16 +182,56 @@ Läuft **vor** der Verifikation und lokal **vor** dem Push, reduziert die Last a
 
 ## Schritt 3: Lokale Verifikation
 
+> **[T003003] WICHTIG: Verifikation MUSS synchron im VORDERGRUND laufen.** Kein
+> Hintergrund-`task`-Aufruf mit anschliessendem Polling — die Benachrichtigung
+> ueberlebt einen Sessionwechsel nicht (DREI Agents blockierten darauf am
+> 2026-08-09: Arbeit fertig, aber Push/PR/Merge unterblieben).
+
 Phase-Telemetrie (PFLICHT — das Phase-Chain-Gate erzwingt sie):
 ```
 ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "done", driver: "devflow", detail: "Implementierung fertig" })
-ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "entered", driver: "devflow", detail: "task test:changed + freshness" })
+ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "verify", state: "entered", driver: "devflow", detail: "Verifikation (tests + freshness)" })
 ```
 
+### Schritt 3.1: Zielgerichtete Tests (im Vordergrund)
+
+Statt `task test:changed` (das bei breitem Plan-Minuten dauert und zum
+Hintergrund-Muster verleitet) fokussierte Suiten direkt aufrufen:
+
 ```bash
-task workspace:validate
-task test:changed && task freshness:regenerate && task freshness:check
+# Variante A: Gerichtete BATS-Suite (schnell, empfohelen)
+# Leite die Testdomaene aus den vom Branch beruehrten Pfaden ab:
+#   scripts/ → tests/spec/scripts*, tests/spec/ticket-system*
+#   skills/  → tests/spec/skills*
+#   .opencode/ → tests/spec/opencode-*
+PLAN_FILES=$(git diff --name-only origin/main...HEAD)
+if echo "$PLAN_FILES" | grep -q '^scripts/'; then
+  bats -r tests/spec/scripts* tests/spec/ticket-system* || exit 1
+elif echo "$PLAN_FILES" | grep -q '^\.opencode/'; then
+  bats -r tests/spec/opencode-* || exit 1
+else
+  task test:changed || exit 1
+fi
+
+# Variante B: task test:changed (vollstaendig, als Fallback)
+# task test:changed || exit 1
 ```
+
+### Schritt 3.2: Freshness (im Vordergrund)
+
+```bash
+task freshness:regenerate && task freshness:check || exit 1
+```
+
+### Schritt 3.3: Workspace-Validierung
+
+```bash
+task workspace:validate || exit 1
+```
+
+> **Kein || true, kein &, kein Hintergrund.** Jeder Befehl blockiert synchron.
+> Der Agent meldet sich ERST nach vollstaendigem Durchlauf zurueck — kein
+> "waiting for background task to complete"-Pattern. [T003003]
 
 Nach grünen Tests:
 ```

--- a/openspec/changes/fix-devflow-background-block/specs/dev-flow-plan.md
+++ b/openspec/changes/fix-devflow-background-block/specs/dev-flow-plan.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Synchrone Verifikation (Vordergrund)
+
+Die lokale Verifikation in `opencode-flow-execute` (Schritt 3) SHALL synchron im Vordergrund
+laufen. Kein Hintergrund-Task-Muster, kein Polling auf Benachrichtigungen, die einen
+Sessionwechsel nicht ueberleben.
+
+#### Scenario: Verifikation laeuft synchron
+
+- **GIVEN** ein dev-flow-execute-Agent hat die Implementierung abgeschlossen
+- **WHEN** er `task test:changed` oder `bats -r tests/spec/<domain>` aufruft
+- **THEN** der Aufruf MUSS im Vordergrund blockieren bis zur vollstaendigen Ausfuehrung
+- **AND** der Agent DARF NICHT parallel zur Verifikation weitere Schritte ausfuehren
+- **AND** Exit-Code != 0 MUSS zum Abbruch fuehren (`|| exit 1`, kein `|| true`)
+
+#### Scenario: Kein Hintergrund-Warte-Muster
+
+- **GIVEN** ein dev-flow-execute-Agent hat die Verifikation gestartet
+- **WHEN** die Verifikation laeuft
+- **THEN** der Agent DARF NICHT "waiting for background task to complete" melden
+- **AND** der Agent DARF NICHT vor Abschluss der Verifikation mit Commit/Push/PR fortfahren
+- **AND** die Rueckmeldung ERST nach vollstaendigem Durchlauf erfolgen
+
+### Requirement: Zielgerichtete Testauswahl
+
+Statt `task test:changed` (das bei breitem Plan Minuten dauert) SHALL der Agent die vom Plan
+beruehrten Test-Suiten direkt aufrufen.
+
+#### Scenario: Testdomaene aus Branch-Diff ableiten
+
+- **GIVEN** der Branch aendert Dateien unter `scripts/`
+- **WHEN** der Agent die Verifikation startet
+- **THEN** er SHALL `bats -r tests/spec/scripts* tests/spec/ticket-system*` aufrufen
+- **AND** nur bei nicht zuordenbaren Aenderungen auf `task test:changed` als Fallback zurueckfallen
+
+#### Scenario: Fallback bei breiten Aenderungen
+
+- **GIVEN** der Branch aendert Dateien in mehreren nicht-zugeordneten Domaenen
+- **WHEN** die heuristische Zuordnung scheitert
+- **THEN** `task test:changed` SHALL als Fallback synchron ausgefuehrt werden

--- a/openspec/changes/fix-devflow-background-block/tasks.md
+++ b/openspec/changes/fix-devflow-background-block/tasks.md
@@ -1,0 +1,23 @@
+# T003003: dev-flow-execute blockiert auf Hintergrund-Verifikation
+
+## Ziel
+dev-flow-execute-Subagents blockieren nicht mehr auf Hintergrund-Verifikation, die einen Sessionwechsel nicht überlebt.
+
+## Tasks
+
+### 1. Verifikation in den Vordergrund holen
+- [ ] `task test:changed` / `task freshness:check` NICHT als Hintergrund-Task starten
+- [ ] Synchron auf Abschluss warten (blockierend, aber zuverlässig)
+- [ ] Timeout (5 min) mit klarer Fehlermeldung bei Überschreitung
+
+### 2. Zielgerichtete Verifikation
+- [ ] Statt `test:changed` die vom Plan berührten Test-Suiten direkt aufrufen
+- [ ] `bats -r tests/spec/<domain>` als Default-Fallback
+
+### 3. Commit + Push + PR erst nach bestandener Verifikation
+- [ ] Kein "waiting for background task"-Pattern mehr
+- [ ] Agent meldet sich erst nach vollständigem Durchlauf zurück
+
+### Verify
+- [ ] `task test:changed` besteht lokal
+- [ ] Kein Hintergrund-Warte-Pattern im dev-flow-execute Skill


### PR DESCRIPTION
## Summary

Fixes T003003: DREI dev-flow-execute-Agents blockierten auf Hintergrund-Verifikation und schlossen nie ab (Arbeit fertig, aber Push/PR/Merge unterblieben).

### Problem
Agenten starteten `task test:changed` als Hintergrund-Task und pollten auf Benachrichtigung, die einen Sessionwechsel nicht ueberlebt. Der Agent meldete sich als "fertig", ohne fertig zu sein.

### Fix
- **Schritt 3 umgeschrieben**: Verifikation MUSS synchron im Vordergrund laufen
- **Zielgerichtete Tests**: `bats -r tests/spec/<domain>` statt breitem `task test:changed`
- **Anti-Pattern-Guard**: Kein `|| true`, kein `&`, kein Hintergrund
- **Agent-Rueckmeldung erst nach vollstaendigem Durchlauf**

### Changes
- `.opencode/skills/opencode-flow-execute/SKILL.md`: Schritt 3 neu (43 Zeilen geaendert/neu)
- `openspec/changes/fix-devflow-background-block/specs/dev-flow-plan.md`: Delta (41 Zeilen)