### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 936,
+      "file_count": 937,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -337,6 +337,7 @@
         "tests/spec/active-sessions-hub/opencode-session-id-stable.bats",
         "tests/spec/active-sessions-hub/release-foreign-lock-guard.bats",
         "tests/spec/active-sessions-hub/session-activity-visibility-T003098.bats",
+        "tests/spec/active-sessions-hub/ticket-lock-closure-T003102.bats",
         "tests/spec/admin-cockpit.bats",
         "tests/spec/admin-token-consolidation.bats",
         "tests/spec/admin-ui-modal-drawer.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31457076312).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
