### PR TITLE
fix(factory): Ticket-Locks blockieren Abschluss nicht mehr — closure-Modus + branch-scoped Claims [T003102]

### DIFF
--- a/openspec/changes/fix-ticket-lock-subagent/tasks.md
+++ b/openspec/changes/fix-ticket-lock-subagent/tasks.md
@@ -3,16 +3,24 @@
 ## Ziel
 Ticket-Scoped-Locks der auftraggebenden Session blockieren nicht mehr den Abschluss durch Subagenten, ticket-mcp und post-merge.yml.
 
+## Status
+
+Erledigt — T003102. Der Abschluss (update-status → done/archived) läuft im closure-Modus am
+ticket-scoped Lock vorbei; Subagent/`ticket-mcp`/post-merge (auto-close-merged.sh) schließen
+im selben Vorgang mit je eigener SID ab. Execute-Skills und ticket-ops claimen branch-scoped;
+`factory-prep.sh` erkennt branch-scoped Claims über die Ticket-ID im Branch-Namen und dispatcht
+nicht doppelt.
+
 ## Tasks
 
 ### 1. Lock-Scope-Analyse
-- [ ] `scripts/agent-lock.sh` — ticket-scoped vs. branch-scoped Verhalten dokumentieren
-- [ ] Welche Komponenten prüfen den ticket-scoped Lock? (Subagent, ticket-mcp, post-merge.yml)
+- [x] `scripts/agent-lock.sh` — ticket-scoped vs. branch-scoped Verhalten dokumentieren
+- [x] Welche Komponenten prüfen den ticket-scoped Lock? (Subagent, ticket-mcp, post-merge.yml)
 
 ### 2. Fix
-- [ ] ticket-ops: NUR branch-scoped Locks claimen (keine ticket-scoped)
-- [ ] Subagent: ticket-scoped Lock beim Abschluss ignorieren oder eigenen Lock verwenden
+- [x] ticket-ops: NUR branch-scoped Locks claimen (keine ticket-scoped)
+- [x] Subagent: ticket-scoped Lock beim Abschluss ignorieren oder eigenen Lock verwenden
 
 ### Verify
-- [ ] ticket-ops claimt branch-Lock, Subagent kann trotzdem abschließen
-- [ ] post-merge.yml kann Ticket schließen trotz ticket-Lock
+- [x] ticket-ops claimt branch-Lock, Subagent kann trotzdem abschließen
+- [x] post-merge.yml kann Ticket schließen trotz ticket-Lock


### PR DESCRIPTION
## Kontext

T003102 (Mishap-Fix): Ticket-scoped Locks der auftraggebenden Session blockierten den
Abschluss durch Subagent, `ticket-mcp` und den post-merge-Poller — drei Prozesse desselben
Vorgangs, jeder mit eigener SID. Die Annahme "eine Session = eine SID" hält nicht, sobald
MCP-Server, Subagenten und CI-Workflows im selben Vorgang schreiben.

## Änderungen

**Kern-Fix (Abschluss entblockt):**
- `scripts/vda/ticket/_ticket-core.sh` — `_ticket_lock_guard` erhält einen `closure`-Modus:
  Bei Terminal-Übergängen (`update-status → done|archived`) blockt ein fremder ticket-scoped
  Lock nicht mehr; der Guard warnt (Halter tool/label/sid) und nennt den regulären
  Release-Pfad. Der Schutz gegen Doppelbearbeitung (T002282) bleibt für alle
  nicht-terminalen Übergänge vollständig erhalten.
- `scripts/vda/ticket/update-status.sh` — reicht `closure` genau für `done`/`archived` durch.

**Branch-scoped Claims (keine ticket-Locks im Dispatch/Execute):**
- `scripts/agent-lock.sh` — dokumentiert die Scope-Semantik (ticket vs. branch) samt
  Komponenten-Analyse (wer prüft den ticket-Scope: `_ticket_lock_guard`, factory-prep,
  watchdog) und der T003102-Falle.
- `.opencode/skills/opencode-flow-execute/SKILL.md`, `.claude/skills/dev-flow-execute/SKILL.md`,
  `.claude/skills/references/dev-flow-execute-phases.md`,
  `.claude/skills/references/ticket-preflight-lock.md` — Pre-Flight claimt `branch` statt
  `ticket`; Claim-Verifikation und Release ebenfalls branch-scoped (konsistent mit
  ticket-ops Step 3.6).

**Race-Schließung:**
- `scripts/vda/factory-prep.sh` — das Dispatch-Gate sieht zusätzlich zum ticket-Scope
  branch-scoped Claims (Ticket-ID im Branch-Namen `*-<ext-id>`), damit die Factory das
  Ticket nicht doppelt dispatcht, während der Subagent es bearbeitet.

**Tests:**
- `tests/spec/active-sessions-hub/ticket-lock-closure-T003102.bats` (neu, 10 Tests):
  closure-Verhalten des Guards, Schutz bleibt bei Nicht-Abschluss, eigene SID, Skill-Regelwerk
  (branch-scoped), agent-lock.sh-Doku, factory-prep-Gate.
- `tests/spec/ticket-system.bats` — T002282-M3 auf nicht-terminalen Übergang umgestellt;
  neuer T003102-Test: Abschluss (`done`) kommt trotz fremdem ticket-Lock durch.

OpenSpec-Delta: `openspec/changes/fix-ticket-lock-subagent/specs/active-sessions-hub.md`.

## Verifikation

- `task test:changed` grün (Exit 0)
- `task freshness:check` grün
- `task workspace:validate` grün
- Phase-Chain: plan:done / implement:done / verify:done

Closes T003102