### PR TITLE
fix(infra): sdlc:refresh Digest-Vergleich + SDLC-Nachweisdoku [T003874]

### DIFF
--- a/docs/sdlc-stack/README.md
+++ b/docs/sdlc-stack/README.md
@@ -57,6 +57,26 @@ Platzhalter mit lokalen Werten:
 
 DB-Passwörter stammen aus `k3d/secrets.yaml` (dev-Plaintext).
 
+## Nach einem main-Merge nachziehen (T003740)
+
+Der lokale Stack läuft nicht automatisch hinter main her: `sdlc-console`
+referenziert `ghcr.io/paddione/website-sdlc:latest` mit `imagePullPolicy: Always`
+(k3d/sdlc-stack/sdlc-console.yaml, T003740) — der Kubelet zieht die frische
+`:latest` also bei **jedem** Pod-Neustart. Ein laufender Pod startet aber nicht
+von selbst neu. Nach einem main-Merge mit SDLC-Änderungen deshalb:
+
+```bash
+task sdlc:sdlc:refresh
+```
+
+Der Task vergleicht den Digest der laufenden imageID mit dem Registry-Digest von
+`:latest`, startet das Deployment bei Abweichung per `kubectl rollout restart`
+neu (mit `imagePullPolicy: Always` zieht der Neustart die frische `:latest`) und
+prüft abschließend `BUILD_TARGET=sdlc` im Container.
+
+Nachweis (DoD T003740): laufende imageID == Registry-Digest von `:latest`, und
+`BUILD_TARGET` ist im Container gesetzt.
+
 ## Pocket ID Admin-Bootstrap
 
 Der Stack seeded die 16 OIDC-Clients automatisch (`pocket-id-client-seed`).
@@ -67,12 +87,12 @@ zeigt den Setup-Code.
 
 ```bash
 # Console erreichbar
-curl -sS -o /dev/null -w '%{http_code}' http://sdlc.localhost
-# → 200
+curl -sS -L -o /dev/null -w '%{http_code}' http://sdlc.localhost
+# → 200 (302-Redirect auf /sdlc/cockpit wird gefolgt, T003036)
 
 # Health-Check zeigt BUILD_TARGET=sdlc
-curl -s http://sdlc.localhost/api/health | jq .buildTarget
-# → "sdlc"
+kubectl --context k3d-mentolder-dev exec -n workspace deploy/sdlc-console -- sh -c 'echo BUILD_TARGET=$BUILD_TARGET'
+# → BUILD_TARGET=sdlc
 
 # bge antwortet
 kubectl --context k3d-mentolder-dev port-forward -n workspace svc/llm-gateway-embed 8081:8081 &

--- a/taskfiles/Taskfile.sdlc.yml
+++ b/taskfiles/Taskfile.sdlc.yml
@@ -109,12 +109,6 @@ tasks:
         kubectl --context k3d-mentolder-dev rollout status deployment/bge-embed -n workspace --timeout=300s
         kubectl --context k3d-mentolder-dev rollout status deployment/bge-rerank -n workspace --timeout=300s
 
-  sdlc:refresh:
-    desc: "SDLC-Console neu starten, damit :latest-Pull greift (imagePullPolicy: Always)"
-    cmds:
-      - kubectl --context k3d-mentolder-dev rollout restart deploy/sdlc-console -n workspace
-      - kubectl --context k3d-mentolder-dev rollout status deploy/sdlc-console -n workspace --timeout=300s
-
   sdlc:status:
     desc: "SDLC-Stack Health-Übersicht"
     cmds:
@@ -258,3 +252,35 @@ tasks:
         if [ -f ../.env ]; then set -a; . ../.env; set +a; fi
         export BUILD_TARGET=sdlc
         pnpm dev -- --force
+
+  sdlc:refresh:
+    desc: "SDLC-Console nach einem main-Merge auf die aktuelle :latest nachziehen (T003740)"
+    # T003740: imagePullPolicy Always in k3d/sdlc-stack/sdlc-console.yaml sorgt dafuer,
+    # dass der Kubelet beim Neustart die frische :latest zieht. Mit IfNotPresent bliebe
+    # der alte Layer lokal liegen und ein rollout restart waere wirkungslos. Dieser
+    # Task ist der dokumentierte Handgriff nach einem main-Merge.
+    cmds:
+      - |
+        set -e
+        CTX="${K3D_CTX:-k3d-mentolder-dev}"
+        NS="${WORKSPACE_NAMESPACE:-workspace}"
+        IMAGE="ghcr.io/paddione/website-sdlc:latest"
+        REG_DIGEST="$(docker manifest inspect "${IMAGE}" | grep -m1 digest | awk -F'"' '{print $4}')"
+        POD="$(kubectl --context "$CTX" -n "$NS" get pod -l app=sdlc-console -o jsonpath='{.items[0].metadata.name}')"
+        RUN_IMAGE_ID="$(kubectl --context "$CTX" -n "$NS" get pod "$POD" -o jsonpath='{.status.containerStatuses[0].imageID}')"
+        RUN_DIGEST="$(printf '%s' "$RUN_IMAGE_ID" | sed 's|^[^@]*@||')"
+        echo "Registry :latest Digest: ${REG_DIGEST}"
+        echo "Laufende imageID:        ${RUN_IMAGE_ID}"
+        if [ "${RUN_DIGEST}" = "${REG_DIGEST}" ]; then
+          echo "sdlc-console laeuft bereits auf der aktuellen :latest — kein Neustart noetig."
+        else
+          echo "Abweichung erkannt — rollout restart zieht die frische :latest ..."
+          kubectl --context "$CTX" -n "$NS" rollout restart deploy/sdlc-console
+          kubectl --context "$CTX" -n "$NS" rollout status deploy/sdlc-console --timeout=300s
+        fi
+        BUILD_TARGET="$(kubectl --context "$CTX" -n "$NS" exec deploy/sdlc-console -- sh -c 'echo BUILD_TARGET=$BUILD_TARGET')"
+        echo "${BUILD_TARGET}"
+        case "${BUILD_TARGET}" in
+          *BUILD_TARGET=sdlc*) echo "OK: BUILD_TARGET=sdlc im Container gesetzt." ;;
+          *) echo "FEHLER: BUILD_TARGET nicht gesetzt — Image aelter als T003036." >&2; exit 1 ;;
+        esac

--- a/tests/spec/sdlc-isolation/e2-local-stack.bats
+++ b/tests/spec/sdlc-isolation/e2-local-stack.bats
@@ -44,6 +44,12 @@ cluster_running() {
   grep -q 'POCKET_ID_FALLBACK_FRONTEND_URL' "${SDLC_STACK}/sdlc-console.yaml"
 }
 
+@test "E2: Console zieht :latest bei jedem Neustart — imagePullPolicy Always (T003740)" {
+  [ -f "${SDLC_STACK}/sdlc-console.yaml" ]
+  grep -q 'imagePullPolicy: Always' "${SDLC_STACK}/sdlc-console.yaml"
+  grep -q 'sdlc:refresh' "${REPO_ROOT}/taskfiles/Taskfile.sdlc.yml"
+}
+
 @test "E2: Auth provider file and test exist" {
   [ -f "${AUTH_DIR}/provider.ts" ]
   [ -f "${AUTH_DIR}/provider.test.ts" ]
@@ -71,14 +77,19 @@ cluster_running() {
 
 @test "E2 DoD: Console responds 200 on sdlc.localhost" {
   if ! cluster_running; then skip "cluster k3d-mentolder-dev not running"; fi
-  run curl -sS -o /dev/null -w '%{http_code}' http://sdlc.localhost
+  # T003036: im sdlc-Build leitet / per 302 auf /sdlc/cockpit um (sdlcRootRedirect).
+  # -L folgt dem Redirect; das Cockpit rendert mit 200.
+  run curl -sS -L -o /dev/null -w '%{http_code}' http://sdlc.localhost
   [ "$output" = "200" ]
 }
 
-@test "E2 DoD: /api/health returns sdlc build target" {
+@test "E2 DoD: BUILD_TARGET=sdlc im Container gesetzt (T003740)" {
   if ! cluster_running; then skip "cluster k3d-mentolder-dev not running"; fi
-  run curl -sS http://sdlc.localhost/api/health
-  echo "$output" | grep -q '"BUILD_TARGET"'
+  # T003740-FOLGEFUND: dieselbe Messung wie im Ticket — /api/health liefert
+  # bewusst kein BUILD_TARGET-Feld (nur ok/commit/builtAt, T002202).
+  run kubectl --context k3d-mentolder-dev exec -n workspace deploy/sdlc-console -- \
+    sh -c 'echo BUILD_TARGET=$BUILD_TARGET'
+  echo "$output" | grep -q 'BUILD_TARGET=sdlc'
 }
 
 @test "E2 DoD: local tickets schema bootstrapped" {


### PR DESCRIPTION
## Kontext
T003874 (Hygiene-Befund): Branch `fix/sdlc-console-imagepull-always-T003740` trug ungemergte Zusatzarbeit über den gemergten Kern von T003740 (#4293) hinaus. Diese Zusatzarbeit wird hier als sauberer Follow-up-Branch (von main, ohne den bereits gemergten imagePullPolicy-Kern) eingespielt.

## Änderungen
- **`taskfiles/Taskfile.sdlc.yml`**: `sdlc:refresh` vergleicht Registry-Digest von `:latest` mit laufender imageID und restartet NUR bei Abweichung (statt blindem `rollout restart`) + prüft `BUILD_TARGET=sdlc` im Container.
- **`docs/sdlc-stack/README.md`**: Abschnitt „Nach einem main-Merge nachziehen (T003740)" mit korrigiertem Nachweis (kubectl statt /api/health, `curl -L` für T003036-Redirect).
- **`tests/spec/sdlc-isolation/e2-local-stack.bats`**: Guard-Test imagePullPolicy Always + BUILD_TARGET=sdlc-Test + `-L`-Redirect.

## Verifikation
- Blob-Vergleich: diese 3 Dateien waren in main NICHT enthalten.
- Konfliktmarker-frei, diff nur auf die erwarteten Hunks begrenzt.