### PR TITLE
feat(brain-mcp): Index-Rebuild bei Wiki-Change nach Serverstart (self-heal) [T003873]

### DIFF
--- a/scripts/brain-mcp-server.py
+++ b/scripts/brain-mcp-server.py
@@ -45,6 +45,8 @@ class BrainIndex:
     def __init__(self, wiki_dir: Path):
         self.wiki_dir = wiki_dir
         self.pages: dict[str, dict] = {}  # slug -> {frontmatter, body, path, title, tags}
+        self._built = False  # True after a successful build (see _ensure_fresh)
+        self._mtimes: dict[str, int] = {}  # page path -> mtime_ns snapshot (staleness check)
         self._build_index()
 
     def _parse_frontmatter(self, content: str) -> tuple[dict, str]:
@@ -74,6 +76,7 @@ class BrainIndex:
             sys.stderr.flush()
             return
 
+        self._mtimes = {}
         for fpath in sorted(wiki.rglob("*.md")):
             slug = fpath.stem
             try:
@@ -93,12 +96,40 @@ class BrainIndex:
                 "title": title,
                 "tags": tags,
             }
+            try:
+                self._mtimes[str(fpath)] = fpath.stat().st_mtime_ns
+            except OSError:
+                pass
 
+        self._built = True
         sys.stderr.write(f"[brain-mcp] indexed {len(self.pages)} pages from {wiki}\n")
         sys.stderr.flush()
 
+    def _wiki_changed(self) -> bool:
+        """True if the wiki content changed since the last build (mtime snapshot)."""
+        wiki = Path(self.wiki_dir).expanduser()
+        if not wiki.is_dir():
+            return False
+        current = {str(p): p.stat().st_mtime_ns for p in wiki.rglob("*.md")}
+        return current != self._mtimes
+
+    def _ensure_fresh(self) -> None:
+        """Rebuild the index if the wiki appeared or changed after startup.
+
+        The index is built once in __init__; a server started before the wiki
+        clone (or before an auto-ingest run) would otherwise serve an empty or
+        stale index until restart. Rebuild lazily on the next request instead.
+        """
+        wiki = Path(self.wiki_dir).expanduser()
+        if not wiki.is_dir():
+            return
+        if self._built and not self._wiki_changed():
+            return
+        self._build_index()
+
     def search(self, query: str, top_k: int = 5) -> list[dict]:
         """BM25-ranked search over indexed pages."""
+        self._ensure_fresh()
         if not self.pages:
             return []
 
@@ -196,6 +227,7 @@ class BrainIndex:
 
     def read_page(self, slug: str) -> dict | None:
         """Return full page data for a slug."""
+        self._ensure_fresh()
         if slug not in self.pages:
             return None
         page = self.pages[slug]

--- a/tests/spec/brain-k4-brain-wiki/brain-mcp-server.bats
+++ b/tests/spec/brain-k4-brain-wiki/brain-mcp-server.bats
@@ -300,3 +300,79 @@ for line in sys.stdin:
     false
   }
 }
+
+@test "brain_search rebuilds the index when the wiki appears after startup" {
+  # Regression: a server started before the wiki clone (or before an
+  # auto-ingest update) served an empty/stale index forever. It must
+  # self-heal on the next request without a restart.
+  local wiki_dir="$BATS_TEST_TMPDIR/late-wiki"
+  local fifo="$BATS_TEST_TMPDIR/server-in.fifo"
+  local out_file="$BATS_TEST_TMPDIR/server.out"
+  rm -rf "$wiki_dir"
+  rm -f "$fifo" "$out_file"
+  mkfifo "$fifo"
+
+  # Start the server against a wiki dir that does not exist yet
+  BRAIN_WIKI_DIR="$wiki_dir" python3 "$SERVER" < "$fifo" > "$out_file" 2>/dev/null &
+  local server_pid=$!
+  exec 9>"$fifo"  # keep the FIFO open so the server stays alive
+
+  local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+  printf '%s\n' "$init" >&9
+
+  # Wiki clone arrives after startup, with a searchable page
+  mkdir -p "$wiki_dir"
+  cat > "$wiki_dir/late-page.md" << 'LATEEOF'
+---
+type: note
+tags: [late]
+status: active
+---
+# Late Page
+
+This page mentions SEARCHTERM only after the server started.
+LATEEOF
+
+  local search='{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"brain_search","arguments":{"query":"SEARCHTERM","top_k":5}}}'
+  printf '%s\n' "$search" >&9
+
+  # Auto-ingest adds another page later
+  cat > "$wiki_dir/second-late-page.md" << 'SECONDEOF'
+---
+type: note
+tags: [late]
+status: active
+---
+# Second Late Page
+
+This page also mentions SEARCHTERM and arrives with a later ingest.
+SECONDEOF
+  local search2='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"brain_search","arguments":{"query":"SEARCHTERM","top_k":5}}}'
+  printf '%s\n' "$search2" >&9
+
+  # Wait for both responses (bounded)
+  local i
+  for i in $(seq 1 50); do
+    if grep -q '"id": *2' "$out_file" 2>/dev/null && grep -q '"id": *3' "$out_file" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  exec 9>&-
+  wait "$server_pid" 2>/dev/null || true
+
+  # First request after the wiki appeared must trigger a rebuild
+  if ! grep '"id": *2' "$out_file" | grep -q 'late-page'; then
+    echo "id=2 did not return late-page:" >&2
+    grep '"id": *2' "$out_file" >&2
+    false
+  fi
+
+  # Request after a later ingest must also see the new page
+  if ! grep '"id": *3' "$out_file" | grep -q 'second-late-page'; then
+    echo "id=3 did not return second-late-page:" >&2
+    grep '"id": *3' "$out_file" >&2
+    false
+  fi
+}


### PR DESCRIPTION
## Kontext
T003873: Ungemergte Stash-Arbeit aus `stash@{0}` gesichert. Dieser PR trägt die brain-mcp-Freshness-Komponente.

## Änderungen
- **`scripts/brain-mcp-server.py`**: `_ensure_fresh()` — Index wird lazy neu gebaut, wenn die Wiki nach Serverstart erscheint oder sich ändert (mtime-Snapshot). Behebt: Server vor Wiki-Clone/Auto-Ingest gestartet liefert leeren/veralteten Index bis zum Neustart.
- **`tests/spec/brain-k4-brain-wiki/brain-mcp-server.bats`**: Regressionstest — Wiki erscheint nach Serverstart, Suche muss die neue Seite ohne Neustart finden.

## Verifikation
- Blobs identisch mit `stash@{0}` (geprüft per `git rev-parse`).
- BATS-Test liegt im Spez-Ordner des betroffenen Moduls.