### PR TITLE
feat(billing): paid_amount/paid_at aus v_billing_invoices_with_state statt entfernter Spalten [T003873]

### DIFF
--- a/website/src/lib/invoice-dunning.test.ts
+++ b/website/src/lib/invoice-dunning.test.ts
@@ -209,7 +209,7 @@ describe('invoice-dunning.runDunningDetection (no-op end-to-end)', () => {
 
     const updateCall = query.mock.calls.find((c) => /UPDATE billing_invoices/.test(c[0] as string));
     expect(updateCall).toBeDefined();
-    expect(updateCall![1]).toEqual(['inv-1', 'dunning_1', 1]);
+    expect(updateCall![1]).toEqual(['inv-1', 'dunning_1']);
 
     expect(logBillingEvent).toHaveBeenCalledWith(expect.objectContaining({
       invoiceId: 'inv-1', action: 'dunning_generated', toStatus: 'dunning_1',

--- a/website/src/lib/invoice-dunning.ts
+++ b/website/src/lib/invoice-dunning.ts
@@ -112,8 +112,12 @@ export async function runDunningDetection(brand: string): Promise<{ generated: n
     paid_amount: number | null;
     customer_id: string;
   }>(
+    // T000375 (View-Migration): paid_amount/dunning_level/last_dunning_at sind
+    // keine Spalten von billing_invoices mehr, sondern werden von
+    // v_billing_invoices_with_state aus billing_invoice_payments bzw.
+    // billing_invoice_dunnings berechnet.
     `SELECT id, number, status, dunning_level, due_date, last_dunning_at, gross_amount, paid_amount, customer_id
-       FROM billing_invoices
+       FROM v_billing_invoices_with_state
       WHERE brand=$1
         AND status IN ('open','partially_paid','overdue','dunning_1','dunning_2')
         AND locked=true`,
@@ -169,11 +173,14 @@ export async function runDunningDetection(brand: string): Promise<{ generated: n
       continue;
     }
 
+    // T000375: dunning_level/last_dunning_at liegen seit der View-Migration in
+    // billing_invoice_dunnings (Zeile oben), nicht mehr auf billing_invoices —
+    // hier wird nur noch der Status fortgeschrieben.
     await pool.query(
       `UPDATE billing_invoices
-          SET status=$2, dunning_level=$3, last_dunning_at=now(), updated_at=now()
+          SET status=$2, updated_at=now()
         WHERE id=$1`,
-      [invoice.id, `dunning_${nextLevel}`, nextLevel]
+      [invoice.id, `dunning_${nextLevel}`]
     );
     await logBillingEvent({
       invoiceId: invoice.id,

--- a/website/src/lib/invoice-payments.test.ts
+++ b/website/src/lib/invoice-payments.test.ts
@@ -97,6 +97,7 @@ describe('invoice-payments.recordPayment — transactional error paths', () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ ...baseInvoiceRow, paid_amount: '80' }] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '80' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [] });
     await expect(
       recordPayment({ invoiceId: 'inv-1', paidAt: '2026-02-01', amount: 30, method: 'bank', recordedBy: 'admin' }),
@@ -107,6 +108,7 @@ describe('invoice-payments.recordPayment — transactional error paths', () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ ...baseInvoiceRow, paid_amount: '10' }] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '10' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [] });
     await expect(
       recordPayment({
@@ -120,6 +122,7 @@ describe('invoice-payments.recordPayment — transactional error paths', () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ ...baseInvoiceRow }] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
       .mockRejectedValueOnce(new Error('insert failed')) // INSERT payment fails
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK (in catch)
     await expect(
@@ -133,6 +136,7 @@ function mockHappyPath(payRow: Record<string, unknown>) {
   clientQ
     .mockResolvedValueOnce({ rows: [] }) // BEGIN
     .mockResolvedValueOnce({ rows: [{ ...baseInvoiceRow }] }) // SELECT FOR UPDATE
+    .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
     .mockResolvedValueOnce({ rows: [payRow] }) // INSERT ... RETURNING *
     .mockResolvedValueOnce({ rows: [] }) // UPDATE billing_invoices
     .mockResolvedValueOnce({ rows: [] }); // COMMIT
@@ -155,7 +159,7 @@ describe('invoice-payments.recordPayment — happy paths', () => {
     expect(pay.notes).toBeUndefined();
 
     const updateCall = clientQ.mock.calls.find((c) => String(c[0]).includes('UPDATE billing_invoices'));
-    expect(updateCall![1]).toEqual(['inv-1', 40, 'partially_paid', null]);
+    expect(updateCall![1]).toEqual(['inv-1', 'partially_paid']);
 
     expect(addBooking).toHaveBeenCalledTimes(1);
     expect(addBooking).toHaveBeenCalledWith(expect.objectContaining({
@@ -174,14 +178,14 @@ describe('invoice-payments.recordPayment — happy paths', () => {
     await recordPayment({ invoiceId: 'inv-1', paidAt: '2026-02-10', amount: 100, method: 'bank', recordedBy: 'admin' });
 
     const updateCall = clientQ.mock.calls.find((c) => String(c[0]).includes('UPDATE billing_invoices'));
-    expect(updateCall![1][2]).toBe('paid');
-    expect(updateCall![1][3]).toEqual(new Date('2026-02-10'));
+    expect(updateCall![1][1]).toBe('paid');
   });
 
   it('a negative correction uses category zahlungseingang_korrektur', async () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [{ ...baseInvoiceRow, paid_amount: '30' }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '30' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 3, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-02-05T00:00:00Z'), amount: '-30',
@@ -202,6 +206,7 @@ describe('invoice-payments.recordPayment — happy paths', () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
       .mockResolvedValueOnce({ rows: [{ ...baseInvoiceRow, paid_amount: '40' }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '40' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 4, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-02-05T00:00:00Z'), amount: '-40',
@@ -215,7 +220,7 @@ describe('invoice-payments.recordPayment — happy paths', () => {
       method: 'bank', recordedBy: 'admin', notes: 'Storno',
     });
     const updateCall = clientQ.mock.calls.find((c) => String(c[0]).includes('UPDATE billing_invoices'));
-    expect(updateCall![1]).toEqual(['inv-1', 0, 'open', null]);
+    expect(updateCall![1]).toEqual(['inv-1', 'open']);
   });
 
   it('does not swallow the transaction when EÜR booking fails (best-effort, logs error)', async () => {
@@ -246,6 +251,7 @@ describe('invoice-payments.recordPayment — Kursdifferenz (foreign currency)', 
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [usdInvoiceRow] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 6, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-05-15T00:00:00Z'), amount: '1000',
@@ -270,6 +276,7 @@ describe('invoice-payments.recordPayment — Kursdifferenz (foreign currency)', 
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [usdInvoiceRow] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 7, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-05-15T00:00:00Z'), amount: '1000',
@@ -293,6 +300,7 @@ describe('invoice-payments.recordPayment — Kursdifferenz (foreign currency)', 
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [usdInvoiceRow] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 8, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-05-15T00:00:00Z'), amount: '1000',
@@ -313,6 +321,7 @@ describe('invoice-payments.recordPayment — Kursdifferenz (foreign currency)', 
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [usdInvoiceRow] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 9, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-05-15T00:00:00Z'), amount: '1000',
@@ -331,6 +340,7 @@ describe('invoice-payments.recordPayment — Kursdifferenz (foreign currency)', 
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [usdInvoiceRow] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] }) // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{
         id: 10, invoice_id: 'inv-1', brand: 'mentolder',
         paid_at: new Date('2026-05-15T00:00:00Z'), amount: '1000',

--- a/website/src/lib/invoice-payments.ts
+++ b/website/src/lib/invoice-payments.ts
@@ -48,7 +48,17 @@ export async function recordPayment(p: RecordPaymentInput): Promise<InvoicePayme
       throw new Error(`cannot record payment on status=${inv.status}`);
     }
     const gross = Number(inv.gross_amount);
-    const prevPaid = Number(inv.paid_amount ?? 0);
+    // T000375 (View-Migration): `paid_amount`/`paid_at` sind keine Spalten von
+    // billing_invoices mehr, sondern werden in v_billing_invoices_with_state aus
+    // billing_invoice_payments berechnet. prevPaid kommt deshalb aus der
+    // Payments-Summe statt aus einer (entfernten) Spalte.
+    const paidR = await client.query(
+      `SELECT COALESCE(SUM(amount), 0) AS paid_amount
+         FROM billing_invoice_payments
+        WHERE invoice_id = $1`,
+      [p.invoiceId],
+    );
+    const prevPaid = Number(paidR.rows[0].paid_amount);
     const newPaid  = round2(prevPaid + p.amount);
     if (p.amount > 0 && newPaid > gross + 0.001) {
       await client.query('ROLLBACK');
@@ -69,19 +79,18 @@ export async function recordPayment(p: RecordPaymentInput): Promise<InvoicePayme
     const payRow = ins.rows[0];
 
     let nextStatus: string;
-    let paidAtCol: Date | null;
     if (newPaid >= gross - 0.001 && newPaid > 0) {
-      nextStatus = 'paid'; paidAtCol = new Date(p.paidAt);
+      nextStatus = 'paid';
     } else if (newPaid > 0) {
-      nextStatus = 'partially_paid'; paidAtCol = null;
+      nextStatus = 'partially_paid';
     } else {
-      nextStatus = 'open'; paidAtCol = null;
+      nextStatus = 'open';
     }
     await client.query(
       `UPDATE billing_invoices
-         SET paid_amount=$2, status=$3, paid_at=$4, updated_at=now()
+         SET status=$2, updated_at=now()
        WHERE id=$1`,
-      [p.invoiceId, newPaid, nextStatus, paidAtCol],
+      [p.invoiceId, nextStatus],
     );
 
     const net = Number(inv.net_amount);

--- a/website/src/lib/invoice-storno.test.ts
+++ b/website/src/lib/invoice-storno.test.ts
@@ -103,6 +103,7 @@ describe('invoice-storno.createCreditNote', () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] })                                              // BEGIN
       .mockResolvedValueOnce({ rows: [{ ...baseOrigRow, status: 'paid', paid_amount: '119.00' }] })  // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '119.00' }] })                      // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{ id: 'gs-1', brand: 'mentolder', number: 'GS-2026-0001', status: 'open', customer_id: 'cust-1', issue_date: new Date(), due_date: new Date(), tax_mode: 'regelbesteuerung', net_amount: '-100.00', tax_rate: '19', tax_amount: '-19.00', gross_amount: '-119.00', paid_amount: '0', locked: true, cancels_invoice_id: 'inv-1', kind: 'gutschrift', parent_invoice_id: null, currency: 'EUR', currency_rate: '1', net_amount_eur: '-100.00', gross_amount_ur: '-119.00', supply_type: null, payment_reference: 'GS-2026-0001', notes: null }] }) // INSERT
       .mockResolvedValueOnce({ rows: [] })                                              // SELECT lines
       .mockResolvedValueOnce({ rows: [] })                                              // INSERT line
@@ -126,6 +127,7 @@ describe('invoice-storno.createCreditNote', () => {
     clientQ
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ ...baseOrigRow, status: 'open', paid_amount: '0' }] })
+      .mockResolvedValueOnce({ rows: [{ paid_amount: '0' }] })                          // payments SUM (T000375)
       .mockResolvedValueOnce({ rows: [{ id: 'gs-2', brand: 'mentolder', number: 'GS-2026-0002', status: 'open', customer_id: 'cust-1', issue_date: new Date(), due_date: new Date(), tax_mode: 'regelbesteuerung', net_amount: '-100', tax_rate: '19', tax_amount: '-19', gross_amount: '-119', paid_amount: '0', locked: true, cancels_invoice_id: 'inv-1', kind: 'gutschrift', parent_invoice_id: null, currency: 'EUR', currency_rate: '1', net_amount_eur: '-100', gross_amount_eur: '-119', supply_type: null, payment_reference: 'GS-2026-0002', notes: null }] })
       .mockResolvedValueOnce({ rows: [] })  // SELECT lines
       .mockResolvedValueOnce({ rows: [] })  // INSERT line

--- a/website/src/lib/invoice-storno.ts
+++ b/website/src/lib/invoice-storno.ts
@@ -23,6 +23,15 @@ export async function createCreditNote(invoiceId: string, reason: string, actor?
     if (!orig) { await client.query('ROLLBACK'); return null; }
     if (orig.status === 'draft' || orig.status === 'cancelled') throw new Error('invoice cannot be cancelled');
     if (orig.kind === 'gutschrift') throw new Error('credit note cannot be cancelled again');
+    // T000375 (View-Migration): paid_amount ist keine Spalte von billing_invoices
+    // mehr, sondern ergibt sich aus der Summe der billing_invoice_payments.
+    const paidR = await client.query(
+      `SELECT COALESCE(SUM(amount), 0) AS paid_amount
+         FROM billing_invoice_payments
+        WHERE invoice_id = $1`,
+      [invoiceId]
+    );
+    const origPaid = Number(paidR.rows[0].paid_amount);
 
     const number = await getNextInvoiceNumber(orig.brand, 'gutschrift');
     const issueDate = iso(new Date());
@@ -31,10 +40,10 @@ export async function createCreditNote(invoiceId: string, reason: string, actor?
       `INSERT INTO billing_invoices
          (brand, number, status, customer_id, issue_date, due_date, tax_mode,
           net_amount, tax_rate, tax_amount, gross_amount, notes, payment_reference,
-          paid_amount, locked, cancels_invoice_id, kind, parent_invoice_id,
+          locked, cancels_invoice_id, kind, parent_invoice_id,
           currency, currency_rate, net_amount_eur, gross_amount_eur, supply_type)
        VALUES
-         ($1,$2,'open',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,0,true,$13,'gutschrift',$14,$15,$16,$17,$18,$19)
+         ($1,$2,'open',$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,true,$13,'gutschrift',$14,$15,$16,$17,$18,$19)
        RETURNING *`,
       [
         orig.brand,
@@ -77,15 +86,15 @@ export async function createCreditNote(invoiceId: string, reason: string, actor?
     await client.query(`UPDATE billing_invoices SET status='cancelled', updated_at=now() WHERE id=$1`, [orig.id]);
     await client.query('COMMIT');
 
-    if (Number(orig.paid_amount ?? 0) > 0 && Number(orig.gross_amount) !== 0) {
+    if (origPaid > 0 && Number(orig.gross_amount) !== 0) {
       await addBooking({
         brand: orig.brand,
         bookingDate: issueDate,
         type: 'income',
         category: 'storno',
         description: `Storno ${orig.number}`,
-        netAmount: -round2(Number(orig.paid_amount) * Number(orig.net_amount) / Number(orig.gross_amount)),
-        vatAmount: -round2(Number(orig.paid_amount) * Number(orig.tax_amount) / Number(orig.gross_amount)),
+        netAmount: -round2(origPaid * Number(orig.net_amount) / Number(orig.gross_amount)),
+        vatAmount: -round2(origPaid * Number(orig.tax_amount) / Number(orig.gross_amount)),
         invoiceId: credit.id,
         belegnummer: number,
         taxMode: orig.tax_mode,
@@ -134,7 +143,8 @@ export async function createCreditNote(invoiceId: string, reason: string, actor?
 }
 
 export async function generateCreditNotePdf(invoiceId: string): Promise<Buffer | null> {
-  const invR = await pool.query(`SELECT * FROM billing_invoices WHERE id=$1`, [invoiceId]);
+  // T000375: paid_amount/paid_at sind nur noch ueber die View verfuegbar.
+  const invR = await pool.query(`SELECT * FROM v_billing_invoices_with_state WHERE id=$1`, [invoiceId]);
   const inv = invR.rows[0];
   if (!inv) return null;
   const customer = await getCustomerById(inv.brand, inv.customer_id);

--- a/website/src/lib/native-billing.ts
+++ b/website/src/lib/native-billing.ts
@@ -159,7 +159,8 @@ export async function createInvoice(params: {
 
 export async function getInvoice(id: string): Promise<Invoice | null> {
   await initBillingTables();
-  const r = await pool.query(`SELECT * FROM billing_invoices WHERE id=$1`, [id]);
+  // T000375: paid_amount/paid_at existieren nur noch in v_billing_invoices_with_state.
+  const r = await pool.query(`SELECT * FROM v_billing_invoices_with_state WHERE id=$1`, [id]);
   return r.rows[0] ? mapInvoice(r.rows[0]) : null;
 }
 

--- a/website/src/lib/stripe-billing.ts
+++ b/website/src/lib/stripe-billing.ts
@@ -137,7 +137,7 @@ export async function getAllBillingInvoices(params?: {
   const statusFilter = params?.status ? `AND i.status = '${params.status.replace(/'/g,"''")}'` : '';
   const r = await pool.query(
     `SELECT i.*, c.name AS customer_name, c.email AS customer_email
-     FROM billing_invoices i
+     FROM v_billing_invoices_with_state i
      JOIN billing_customers c ON c.id = i.customer_id AND c.brand = $1
      WHERE i.brand = $1 ${statusFilter}
      ORDER BY i.created_at DESC LIMIT $2`,
@@ -151,7 +151,7 @@ export async function getDraftInvoices(): Promise<AdminBillingInvoice[]> {
   const brand = process.env.BRAND || 'mentolder';
   const r = await pool.query(
     `SELECT i.*, c.name AS customer_name, c.email AS customer_email
-     FROM billing_invoices i
+     FROM v_billing_invoices_with_state i
      JOIN billing_customers c ON c.id = i.customer_id AND c.brand = $1
      WHERE i.brand = $1 AND i.status = 'draft'
      ORDER BY i.created_at DESC LIMIT 100`,
@@ -164,7 +164,7 @@ export async function getCustomerInvoices(customerEmail: string): Promise<Billin
   await initBillingTables();
   const brand = process.env.BRAND || 'mentolder';
   const r = await pool.query(
-    `SELECT i.* FROM billing_invoices i
+    `SELECT i.* FROM v_billing_invoices_with_state i
      JOIN billing_customers c ON c.id = i.customer_id AND c.brand = $1
      WHERE i.brand = $1 AND c.email = $2
      ORDER BY i.created_at DESC LIMIT 50`,
@@ -178,7 +178,7 @@ export async function getDraftInvoiceDetail(invoiceId: string): Promise<DraftInv
   const brand = process.env.BRAND || 'mentolder';
   const r = await pool.query(
     `SELECT i.*, c.name AS customer_name, c.email AS customer_email
-     FROM billing_invoices i
+     FROM v_billing_invoices_with_state i
      JOIN billing_customers c ON c.id = i.customer_id AND c.brand = $1
      WHERE i.id = $2 AND i.brand = $1`,
     [brand, invoiceId]


### PR DESCRIPTION
## Kontext
T003873: Ungemergte Stash-Arbeit aus `stash@{0}` gesichert. Dieser PR trägt die Invoice-View-Migration (T000375).

## Änderungen
- **`website/src/lib/invoice-dunning.ts` / `invoice-payments.ts` / `invoice-storno.ts`**: `paid_amount`/`paid_at` sind keine Spalten von `billing_invoices` mehr, sondern werden aus `billing_invoice_payments` (bzw. `v_billing_invoices_with_state`) berechnet.
- **`native-billing.ts` / `stripe-billing.ts`**: SELECTs auf `v_billing_invoices_with_state` umgestellt.
- **`.test.ts`-Dateien**: angepasste Mock-Sequenzen (Payments-SUM) und UPDATE-Assertions.

## Verifikation
- Blobs identisch mit `stash@{0}` (geprüft per `git rev-parse`).
- Vitest-Tests im Commit enthalten.