### PR TITLE
test(e2e): Admin-/Platform-Routen auf /sdlc/api/* nach T002624-Split [T003873]

### DIFF
--- a/tests/e2e/specs/fa-44-platform-health-integrity.spec.ts
+++ b/tests/e2e/specs/fa-44-platform-health-integrity.spec.ts
@@ -8,13 +8,15 @@ const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
 // unified `fleet` cluster) reports 'korczewski'. The single-cluster assertion
 // in T3 holds for both — there is deliberately no cross-cluster fan-out.
 test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', { tag: ['@admin', '@smoke'] }, () => {
-  test('T1: /api/admin/platform/software requires authentication', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/platform/software`);
+  // Routen seit dem SDLC-Build-Target-Split (T002624) unter /sdlc/api/*:
+  // die alten /api/admin/platform/* und /api/admin/ops/* existieren nicht mehr.
+  test('T1: /sdlc/api/platform/software requires authentication', async ({ request }) => {
+    const res = await request.get(`${BASE}/sdlc/api/platform/software`);
     expect([401, 403]).toContain(res.status());
   });
 
-  test('T2: /api/admin/ops/health requires authentication', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/ops/health`);
+  test('T2: /sdlc/api/ops/health requires authentication', async ({ request }) => {
+    const res = await request.get(`${BASE}/sdlc/api/ops/health`);
     expect([401, 403]).toContain(res.status());
   });
 
@@ -23,7 +25,7 @@ test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', { 
     if (!cronSecret) { test.fixme(true, 'CRON_SECRET not set'); return; }
 
     await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent('paddione')}&token=${encodeURIComponent(cronSecret)}&returnTo=%2Fadmin`);
-    const res = await page.request.get(`${BASE}/api/admin/ops/health`);
+    const res = await page.request.get(`${BASE}/sdlc/api/ops/health`);
     if (res.status() === 401) test.fixme(true, 'Not authenticated');
     if (res.status() !== 200) return;
 
@@ -50,7 +52,7 @@ test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', { 
     if (!cronSecret) { test.fixme(true, 'CRON_SECRET not set'); return; }
 
     await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent('paddione')}&token=${encodeURIComponent(cronSecret)}&returnTo=%2Fadmin`);
-    const res = await page.request.get(`${BASE}/api/admin/platform/software`);
+    const res = await page.request.get(`${BASE}/sdlc/api/platform/software`);
     if (res.status() === 401) test.fixme(true, 'Not authenticated');
     if (res.status() !== 200) return;
 
@@ -66,7 +68,7 @@ test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', { 
     if (!cronSecret) { test.fixme(true, 'CRON_SECRET not set'); return; }
 
     await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent('paddione')}&token=${encodeURIComponent(cronSecret)}&returnTo=%2Fadmin`);
-    const res = await page.request.get(`${BASE}/api/admin/ops/health`);
+    const res = await page.request.get(`${BASE}/sdlc/api/ops/health`);
     if (res.status() === 401) test.fixme(true, 'Not authenticated');
     if (res.status() !== 200) return;
 
@@ -74,6 +76,15 @@ test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', { 
     const clusterKey = Object.keys(body.results)[0];
     const collabora = (body.results[clusterKey] as any[]).find((s: any) => s.name === 'Collabora');
     expect(collabora).toBeDefined();
+    // Lokaler Dev-Server (Host) kann den Cluster-internen Service-DNS
+    // (collabora.workspace-office.svc.cluster.local) nicht auflösen — der
+    // Probe meldet dann zu Recht 'error'. Auf prod/in-cluster ist Collabora
+    // ok/slow. Kein App-Defekt, sondern Laufzeit-Umgebung (T002624-Split:
+    // die SDLC-Console läuft im Cluster, nicht auf dem Host).
+    if (collabora.status === 'error' && /localhost|127\.0\.0\.1/.test(BASE)) {
+      test.fixme(true, `Collabora-Status 'error' auf lokalem Host (Cluster-DNS nicht auflösbar): ${collabora.url}`);
+      return;
+    }
     expect(['ok', 'slow']).toContain(collabora.status);
   });
 
@@ -82,7 +93,7 @@ test.describe('FA-44: Platform Hub — Software Assets & System-Integrität', { 
     if (!cronSecret) { test.fixme(true, 'CRON_SECRET not set'); return; }
 
     await page.goto(`${BASE}/api/auth/e2e-login?username=${encodeURIComponent('paddione')}&token=${encodeURIComponent(cronSecret)}&returnTo=%2Fadmin`);
-    const res = await page.request.get(`${BASE}/api/admin/ops/health`);
+    const res = await page.request.get(`${BASE}/sdlc/api/ops/health`);
     if (res.status() === 401) test.fixme(true, 'Not authenticated');
     if (res.status() !== 200) return;
 

--- a/tests/e2e/specs/fa-admin-monitoring.spec.ts
+++ b/tests/e2e/specs/fa-admin-monitoring.spec.ts
@@ -8,8 +8,9 @@ test.describe('FA: Admin Monitoring page', { tag: ['@admin'] }, () => {
     await expect(page).not.toHaveURL(`${BASE}/admin/monitoring`);
   });
 
-  test('T2: GET /api/admin/monitoring returns 401 or 403 without auth', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/monitoring`);
+  test('T2: GET /sdlc/api/monitoring returns 401 or 403 without auth', async ({ request }) => {
+    // Route seit dem SDLC-Build-Target-Split (T002624) unter /sdlc/api/monitoring.
+    const res = await request.get(`${BASE}/sdlc/api/monitoring`);
     expect([401, 403]).toContain(res.status());
   });
 });

--- a/tests/e2e/specs/fa-admin-settings.spec.ts
+++ b/tests/e2e/specs/fa-admin-settings.spec.ts
@@ -67,18 +67,20 @@ test.describe('FA: Admin settings pages', { tag: ['@admin'] }, () => {
   });
 
   // ── Deployment control API ────────────────────────────────────
-  test('GET /api/admin/deployments returns 401/403 without auth', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/deployments`);
+  // Routen seit dem SDLC-Build-Target-Split (T002624) unter /sdlc/api/*:
+  // GET /sdlc/api/deployments, POST /sdlc/api/ops/deployments/[ns]/[name]/{restart,scale}.
+  test('GET /sdlc/api/deployments returns 401/403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/sdlc/api/deployments`);
     expect([401, 403]).toContain(res.status());
   });
 
-  test('POST /api/admin/deployments/:name/restart returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/deployments/website/restart`, { data: {} });
+  test('POST /sdlc/api/ops/deployments/:ns/:name/restart returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/sdlc/api/ops/deployments/workspace/website/restart`, { data: {} });
     expect([401, 403]).toContain(res.status());
   });
 
-  test('POST /api/admin/deployments/:name/scale returns 401/403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/deployments/website/scale`, { data: { replicas: 1 } });
+  test('POST /sdlc/api/ops/deployments/:ns/:name/scale returns 401/403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/sdlc/api/ops/deployments/workspace/website/scale`, { data: { replicas: 1 } });
     expect([401, 403]).toContain(res.status());
   });
 });

--- a/tests/e2e/specs/fa-admin-tickets.spec.ts
+++ b/tests/e2e/specs/fa-admin-tickets.spec.ts
@@ -3,7 +3,7 @@
 // PR4/5 — admin /admin/tickets coverage:
 //   1. Filter the index page (status=open + type=bug)
 //   2. Open a freshly minted bug ticket via /admin/tickets/:id
-//   3. Add an internal comment (POST /api/admin/tickets/:id/comments)
+//   3. Add an internal comment (POST /sdlc/api/tickets/:id/comments)
 //   4. Add a public comment → reporter receives an email (Mailpit)
 //   5. Transition the ticket to done with resolution=fixed →
 //      close-mail to reporter (Mailpit subject contains T-ID)
@@ -94,14 +94,14 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
 
       // ── 4. Internal comment ──
       const internalRes = await page.request.post(
-        `${BASE}/api/admin/tickets/${ticketUuid}/comments`,
+        `${BASE}/sdlc/api/tickets/${ticketUuid}/comments`,
         { headers: { 'Content-Type': 'application/json', ...e2eHeaders },
           data: JSON.stringify({ body: 'PR4 internal comment', visibility: 'internal' }) });
       expect(internalRes.ok()).toBeTruthy();
 
       // ── 5. Public comment → reporter mail ──
       const publicRes = await page.request.post(
-        `${BASE}/api/admin/tickets/${ticketUuid}/comments`,
+        `${BASE}/sdlc/api/tickets/${ticketUuid}/comments`,
         { headers: { 'Content-Type': 'application/json', ...e2eHeaders },
           data: JSON.stringify({ body: 'PR4 public reply for the reporter', visibility: 'public' }) });
       expect(publicRes.ok()).toBeTruthy();
@@ -118,7 +118,7 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
 
       // ── 6. Transition to done → close-mail ──
       const transRes = await page.request.post(
-        `${BASE}/api/admin/tickets/${ticketUuid}/transition`,
+        `${BASE}/sdlc/api/tickets/${ticketUuid}/transition`,
         { headers: { 'Content-Type': 'application/json', ...e2eHeaders },
           data: JSON.stringify({ status: 'done', resolution: 'fixed', note: 'PR4 done', noteVisibility: 'internal' }) });
       expect(transRes.ok()).toBeTruthy();
@@ -152,13 +152,13 @@ test.describe('FA-admin-tickets', { tag: ['@admin'] }, () => {
     }
   });
 
-  test('GET /api/admin/tickets returns 403 without auth', async ({ request }) => {
-    const res = await request.get(`${BASE}/api/admin/tickets`);
+  test('GET /sdlc/api/tickets returns 403 without auth', async ({ request }) => {
+    const res = await request.get(`${BASE}/sdlc/api/tickets`);
     expect([401, 403]).toContain(res.status());
   });
 
-  test('POST /api/admin/tickets/:id/transition returns 403 without auth', async ({ request }) => {
-    const res = await request.post(`${BASE}/api/admin/tickets/00000000-0000-0000-0000-000000000000/transition`,
+  test('POST /sdlc/api/tickets/:id/transition returns 403 without auth', async ({ request }) => {
+    const res = await request.post(`${BASE}/sdlc/api/tickets/00000000-0000-0000-0000-000000000000/transition`,
       { headers: { 'Content-Type': 'application/json' },
         data: JSON.stringify({ status: 'done', resolution: 'fixed' }) });
     expect([401, 403]).toContain(res.status());


### PR DESCRIPTION
## Kontext
T003873: Ungemergte Stash-Arbeit aus `stash@{0}` gesichert. Dieser PR trägt die e2e-Routen-Komponente.

## Änderungen
- **`tests/e2e/specs/fa-44-platform-health-integrity.spec.ts`**: `/api/admin/platform/software` + `/api/admin/ops/health` → `/sdlc/api/*`; Collabora-Fixme für lokalen Host.
- **`fa-admin-monitoring.spec.ts`**: `/api/admin/monitoring` → `/sdlc/api/monitoring`.
- **`fa-admin-settings.spec.ts`**: Deployments-Routen → `/sdlc/api/deployments`, `/sdlc/api/ops/deployments/*`.
- **`fa-admin-tickets.spec.ts`**: Ticket-Admin-Routen → `/sdlc/api/tickets`.

Routen existieren seit dem SDLC-Build-Target-Split (T002624) unter `/sdlc/api/*` — die alten Pfade nicht mehr.

## Verifikation
- Blobs identisch mit `stash@{0}`.