### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -4425,10 +4425,9 @@
       "id": "openclaw",
       "name": "OpenClaw WSL gateway config",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 2,
+      "file_count": 1,
       "files": [
-        "openclaw/.env.example",
-        "openclaw/README.md"
+        "openclaw/.env.example"
       ]
     },
     {


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31537569635).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
