### PR TITLE
chore(ci): Shard-1-Tail rotieren — deterministischer --seed aus HEAD-SHA [T004024]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -806,7 +806,11 @@ tasks:
         # schlimmer waere als ein roter Test.
         FILES=$(find tests/spec -name '*.bats' -type f | LC_ALL=C sort)
         if [ "${SPEC_SHARDS:-1}" -gt 1 ]; then
-          FILES=$(printf '%s\n' "$FILES" | bash scripts/spec-shard.sh --shard "${SPEC_SHARD:?SPEC_SHARD fehlt}" --of "$SPEC_SHARDS")
+          # [T004024] Seed aus HEAD-SHA: alle Matrix-Legs desselben Commits
+          # partitionieren identisch, aber die schwerste Datei rotiert je nach
+          # Commit ueber die Shards (statt immer auf Shard 1 zu landen).
+          SPEC_SHARD_SEED="$(git rev-parse HEAD 2>/dev/null | cut -c1-12 || true)"
+          FILES=$(printf '%s\n' "$FILES" | bash scripts/spec-shard.sh --shard "${SPEC_SHARD:?SPEC_SHARD fehlt}" --of "$SPEC_SHARDS" --seed "${SPEC_SHARD_SEED:-}")
           echo "→ Shard ${SPEC_SHARD}/${SPEC_SHARDS}: $(printf '%s' "$FILES" | grep -c .) Dateien"
         fi
         # Leere Auswahl ist ein Fehler, kein No-op. Ein still gruener Leerlauf saehe
@@ -908,7 +912,10 @@ tasks:
         # aendert ein PR ci.yml/Taskfile.yml oder ein geteiltes Harness, faellt
         # find-changed-tests.sh fail-closed auf die volle Suite zurueck (~400s).
         if [ "${SPEC_SHARDS:-1}" -gt 1 ]; then
-          CHANGED_FILES=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/spec-shard.sh --shard "${SPEC_SHARD:?SPEC_SHARD fehlt}" --of "$SPEC_SHARDS")
+          # [T004024] Seed wie in test:spec — gleicher Commit, gleiche Partition;
+          # die schwerste geaenderte Datei rotiert ueber die Shards.
+          SPEC_SHARD_SEED="$(git rev-parse HEAD 2>/dev/null | cut -c1-12 || true)"
+          CHANGED_FILES=$(printf '%s\n' "$CHANGED_FILES" | bash scripts/spec-shard.sh --shard "${SPEC_SHARD:?SPEC_SHARD fehlt}" --of "$SPEC_SHARDS" --seed "${SPEC_SHARD_SEED:-}")
           # Anders als bei test:spec ist ein leerer Shard hier legitim: eine
           # diff-gescopte Auswahl kann weniger Dateien haben als es Shards gibt.
           if [ "$(printf '%s' "$CHANGED_FILES" | grep -c .)" -eq 0 ]; then

--- a/scripts/spec-shard.sh
+++ b/scripts/spec-shard.sh
@@ -23,9 +23,21 @@
 # waeren die Ergebnisse nicht bitgleich, liefen Dateien doppelt oder — schlimmer —
 # gar nicht, und der Lauf saehe trotzdem gruen aus.
 #
+# --seed rotiert die Startbucket-Wahl [T004024]. Ohne Seed landet die eine
+# schwerste Datei per LPT immer in Bucket 1 — bei diff-gescopten Laeufen (PR /
+# Merge-Delta) ist Shard 1 damit strukturell der Tail (gemessen PR #4332: 4m50s
+# vs 1m26s, dominiert von einer einzigen Datei). Mit Seed starten alle Buckets
+# mit winzigen, deterministisch aus dem Seed gehashten Offsets (< 1e-9), sodass
+# die schwerste Datei je nach Commit auf einem anderen Shard landet. Die Offsets
+# sind so klein, dass die Balance unveraendert bleibt; die Rotation ist rein
+# kosmetisch — sie verkuerzt keine Wanduhr, verteilt aber den Tail ueber die
+# Zeit auf alle Shards. CI reicht die HEAD-SHA als Seed durch (Taskfile.yml),
+# damit alle Matrix-Legs desselben Commits identisch partitionieren.
+#
 # Usage:
 #   find tests/spec -name '*.bats' | bash scripts/spec-shard.sh --shard 2 --of 4
 #   find tests/spec -name '*.bats' | bash scripts/spec-shard.sh --verify --of 4
+#   find tests/spec -name '*.bats' | bash scripts/spec-shard.sh --shard 1 --of 4 --seed "$(git rev-parse HEAD | cut -c1-12)"
 
 set -euo pipefail
 
@@ -33,12 +45,14 @@ SHARD=""
 TOTAL=""
 VERIFY=false
 WEIGHTS_FILE=""
+SEED=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --shard) SHARD="${2:-}"; shift 2 ;;
     --of)    TOTAL="${2:-}"; shift 2 ;;
     --weights) WEIGHTS_FILE="${2:-}"; shift 2 ;;
+    --seed)  SEED="${2:-}"; shift 2 ;;
     --verify) VERIFY=true; shift ;;
     -h|--help)
       grep '^# ' "$0" | sed 's/^# \{0,1\}//'
@@ -106,11 +120,30 @@ RESOLVED=$(
 # bei Bucket-Gleichstand der niedrigste Index — beides rein deterministisch.
 # Zeilenformat: <bucket>\t<gewicht>\t<pfad> (Gewicht bleibt fuer --verify
 # erhalten und wird nicht nur fuer die Sortierung benutzt).
+#
+# [T004024] Seed-Offsets: mit --seed starten die Buckets mit winzigen, aus dem
+# Seed-String gehashten Startlasten ((s+i) % total / 1e9). Fuer i = 1..total
+# ist genau ein Rest 0 — die erste (schwerste) Datei landet damit deterministisch
+# in einem vom Seed abhaengigen Bucket statt immer in Bucket 1. Leerer Seed
+# ergibt Offsets von 0 und damit exakt das alte Verhalten. Der Hash ist bewusst
+# POSIX-awk (tolower/substr/index auf Hex-Ziffern), kein strtonum (gawk-only).
 PARTITION=$(
   printf '%s\n' "$RESOLVED" \
     | LC_ALL=C sort -k1,1nr -k2,2 \
-    | awk -v total="$TOTAL" '
-        BEGIN { FS = "\t"; for (i = 1; i <= total; i++) load[i] = 0 }
+    | awk -v total="$TOTAL" -v seed="$SEED" '
+        BEGIN {
+          FS = "\t"
+          for (i = 1; i <= total; i++) load[i] = 0
+          if (length(seed) > 0) {
+            s = 0
+            for (j = 1; j <= length(seed); j++) {
+              c = index("0123456789abcdef", tolower(substr(seed, j, 1)))
+              if (c == 0) c = 1
+              s = (s * 31 + c) % 1000003
+            }
+            for (i = 1; i <= total; i++) load[i] = ((s + i) % total) / 1000000000
+          }
+        }
         {
           best = 1
           for (i = 2; i <= total; i++) if (load[i] < load[best]) best = i
@@ -146,6 +179,7 @@ if $VERIFY; then
 
   echo "spec-shard: OK — $in_count Dateien restlos und ueberschneidungsfrei auf $TOTAL Shards verteilt"
   echo "spec-shard: Gewichtsquelle: ${WEIGHTS_FILE:-@test-Anzahl (kein Manifest)}"
+  echo "spec-shard: Seed: ${SEED:-<keiner>}"
   max_load=0
   min_load=""
   for i in $(seq 1 "$TOTAL"); do

--- a/tests/spec/ci-cd/spec-shard-partition.bats
+++ b/tests/spec/ci-cd/spec-shard-partition.bats
@@ -207,3 +207,73 @@ print('OK')
   [ "$status" -eq 0 ]
   echo "$output" | grep -qx 'OK'
 }
+
+# ── [T004024] Seed-Rotation der LPT-Startpartition ──────────────────────────
+#
+# Ohne Seed landet die schwerste Datei per LPT immer in Bucket 1 — bei
+# diff-gescopten Laeufen (PR/Merge-Delta) ist Shard 1 damit strukturell der
+# Tail. Der Seed (CI: HEAD-SHA) rotiert die Startbucket-Wahl, ohne die Balance
+# zu veraendern. Die Erwartungswerte der Seeds sind gegen die Hash-Funktion
+# verifiziert — bricht die Rotation, fallen beide Seeds auf Bucket 1 zurueck
+# und der letzte Test wird rot.
+
+@test "T004024: --seed ist deterministisch (zwei Laeufe, identisches Ergebnis)" {
+  input="$(_all_spec_files)"
+  a=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 2 --of 4 --seed 3f2a9c1d8e0b)
+  b=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 2 --of 4 --seed 3f2a9c1d8e0b)
+  [ -n "$a" ]
+  [ "$a" = "$b" ]
+}
+
+@test "T004024: ohne --seed partitioniert exakt wie bisher (Seed '' = kein Seed)" {
+  # Abwaertskompatibilitaet: leere Seeds muessen Offsets von 0 ergeben und damit
+  # das Verhalten von vor T004024 bitgleich reproduzieren.
+  input="$(_all_spec_files)"
+  a=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 1 --of 4)
+  b=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 1 --of 4 --seed "")
+  [ -n "$a" ]
+  [ "$a" = "$b" ]
+}
+
+@test "T004024: der Seed rotiert die schwerste Datei ueber die Buckets" {
+  # Kontrollierte Eingabe mit einer dominanten Datei (Gewicht 100 vs. 1).
+  # Positiv-Anker zuerst: OHNE Seed liegt heavy.bats allein auf Shard 1 —
+  # genau der Zustand, den T004024 rotiert. Verifizierte Erwartungen:
+  #   Seed 000000000000 → heavy.bats auf Shard 4
+  #   Seed 3f2a9c1d8e0b → heavy.bats auf Shard 3
+  input=$'heavy.bats\nsmall-a.bats\nsmall-b.bats\nsmall-c.bats'
+  wf="$(mktemp)"
+  printf '100\theavy.bats\n1\tsmall-a.bats\n1\tsmall-b.bats\n1\tsmall-c.bats\n' > "$wf"
+
+  no_seed=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 1 --of 4 --weights "$wf")
+  [ "$no_seed" = "heavy.bats" ] \
+    || { echo "ohne Seed: erwartet heavy.bats allein auf Shard 1, bekam: [$no_seed]"; false; }
+
+  s1=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 4 --of 4 --weights "$wf" --seed 000000000000)
+  [ "$s1" = "heavy.bats" ] \
+    || { echo "Seed 000000000000: erwartet heavy.bats auf Shard 4, bekam: [$s1]"; false; }
+
+  s2=$(printf '%s\n' "$input" | bash "$SHARD_SH" --shard 3 --of 4 --weights "$wf" --seed 3f2a9c1d8e0b)
+  [ "$s2" = "heavy.bats" ] \
+    || { echo "Seed 3f2a9c1d8e0b: erwartet heavy.bats auf Shard 3, bekam: [$s2]"; false; }
+
+  rm -f "$wf"
+}
+
+@test "T004024: --verify funktioniert mit --seed und meldet ihn" {
+  run bash -c "cd '$REPO_ROOT' && find tests/spec -name '*.bats' -type f | bash '$SHARD_SH' --verify --of 4 --seed 3f2a9c1d8e0b"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '^spec-shard: OK'
+  echo "$output" | grep -q 'Seed: 3f2a9c1d8e0b'
+}
+
+@test "T004024: Taskfile reicht einen Seed aus der HEAD-SHA an spec-shard.sh durch" {
+  # Statischer Guard wie die ci.yml-Struktur-Tests oben: die Aussage "CI nutzt
+  # die Rotation" manifestiert sich ausschliesslich im Taskfile-Text.
+  run bash -c "
+    grep -q 'SPEC_SHARD_SEED=.*git rev-parse HEAD' '$REPO_ROOT/Taskfile.yml' \
+      && grep -q -- '--seed \"\${SPEC_SHARD_SEED:-}\"' '$REPO_ROOT/Taskfile.yml'
+  "
+  [ "$status" -eq 0 ] \
+    || { echo "Taskfile reicht keinen HEAD-SHA-Seed an spec-shard.sh durch"; false; }
+}


### PR DESCRIPTION
## Summary

Folge zu T004013: die LPT-Regel in `scripts/spec-shard.sh` legt die eine schwerste (geaenderte) Datei deterministisch in Bucket 1 — bei diff-gescopten Laeufen (PR/Merge-Delta) ist Shard 1 damit strukturell der Tail (gemessen PR #4332: 4m50s vs 1m26s, dominiert von einer Datei).

Aenderung:
- `spec-shard.sh` bekommt `--seed`: ein leerer Seed partitioniert bitgleich wie bisher (Abwaertskompatibilitaet, alle T002500-Tests gruen). Ein nicht-leerer Seed hasht (POSIX-awk: tolower/substr/index, kein gawk-only `strtonum`) winzige Start-Offsets (< 1e-9) in die Buckets — die erste, schwerste Datei landet damit deterministisch in einem vom Seed abhaengigen Bucket statt immer in Bucket 1. Balance bleibt unveraendert (verifiziert: 100% mit Seed).
- `Taskfile.yml` (test:spec + test:spec:changed) reicht `--seed "$(git rev-parse HEAD | cut -c1-12)"` durch — alle Matrix-Legs desselben Commits partitionieren identisch, aber die schwerste Datei rotiert je Commit ueber die Shards (gemessen: active-sessions-hub.bats auf Shard 3/2/2/4 bei vier Seeds statt immer 1).
- 5 neue Guards in `tests/spec/ci-cd/spec-shard-partition.bats`: Seed-Determinismus, Abwaertskompatibilitaet (Seed '' == kein Seed), Rotation der schwersten Datei bei zwei verifizierten Seeds, `--verify` mit Seed, Taskfile-Wiring.

Hinweis: Taskfile-Aenderung triggert `find-changed-tests.sh` fail-closed auf die volle Suite — der PR-CI-Lauf ist also ein Full-Run.

## Test Plan

- [x] `bats tests/spec/ci-cd/spec-shard-partition.bats` → 17/17 ok (12 bestehende + 5 neue)
- [x] `spec-shard.sh --verify --of 4 --seed <HEAD-SHA>` → OK, Balance 100%
- [x] Rotation manuell verifiziert (4 Seeds → heaviest auf Shards 3/2/2/4)
- [x] shellcheck spec-shard.sh sauber, `bash -n` ok, `task -l` parst