### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 966,
+      "file_count": 967,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -749,6 +749,7 @@
         "tests/spec/software-factory/queue-test-data-filter.bats",
         "tests/spec/software-factory/readiness-gate-before-launch.bats",
         "tests/spec/software-factory/retry-and-build-loop.bats",
+        "tests/spec/software-factory/retry-limit.bats",
         "tests/spec/software-factory/sandbox-egress.bats",
         "tests/spec/software-factory/scheduling.bats",
         "tests/spec/software-factory/scout-and-routing.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31749310222).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
