### PR TITLE
chore(docs): rename NEXTCLOUD_OIDC_SECRET to POCKET_ID_NEXTCLOUD_SECRET [T003876]

### DIFF
--- a/docs/legacy-html/nextcloud.html
+++ b/docs/legacy-html/nextcloud.html
@@ -134,7 +134,7 @@
 </tr>
 <tr>
 <td>Client-Secret</td>
-<td>aus Secret <code>workspace-secrets</code> (Key: <code>NEXTCLOUD_OIDC_SECRET</code>)</td>
+<td>aus Secret <code>workspace-secrets</code> (Key: <code>POCKET_ID_NEXTCLOUD_SECRET</code>)</td>
 </tr>
 <tr>
 <td>Auto-Redirect</td>
@@ -364,7 +364,7 @@ kubectl exec -n workspace deploy/nextcloud -c nextcloud -- \
 <h3>OIDC-Login schlägt fehl</h3>
 <ul>
 <li><code>user_oidc</code>-App in Nextcloud aktiviert? <code>task workspace:post-setup</code> erneut ausführen</li>
-<li>Keycloak-Client <code>nextcloud</code> vorhanden und Secret korrekt? Secret unter <code>workspace-secrets</code> Key <code>NEXTCLOUD_OIDC_SECRET</code> prüfen</li>
+<li>Keycloak-Client <code>nextcloud</code> vorhanden und Secret korrekt? Secret unter <code>workspace-secrets</code> Key <code>POCKET_ID_NEXTCLOUD_SECRET</code> prüfen</li>
 <li>Keycloak-Pod läuft: <code>kubectl get pods -n workspace | grep keycloak</code></li>
 <li>Provider-URL erreichbar: <code>http://keycloak:8080/realms/workspace/.well-known/openid-configuration</code></li>
 </ul>

--- a/k3d/docs-content-built/nextcloud.html
+++ b/k3d/docs-content-built/nextcloud.html
@@ -148,7 +148,7 @@
 </tr>
 <tr>
 <td>Client-Secret</td>
-<td>aus Secret <code>workspace-secrets</code> (Key: <code>NEXTCLOUD_OIDC_SECRET</code>)</td>
+<td>aus Secret <code>workspace-secrets</code> (Key: <code>POCKET_ID_NEXTCLOUD_SECRET</code>)</td>
 </tr>
 <tr>
 <td>Auto-Redirect</td>
@@ -378,7 +378,7 @@ kubectl exec -n workspace deploy/nextcloud -c nextcloud -- \
 <h3>OIDC-Login schlägt fehl</h3>
 <ul>
 <li><code>user_oidc</code>-App in Nextcloud aktiviert? <code>task workspace:post-setup</code> erneut ausführen</li>
-<li>Keycloak-Client <code>nextcloud</code> vorhanden und Secret korrekt? Secret unter <code>workspace-secrets</code> Key <code>NEXTCLOUD_OIDC_SECRET</code> prüfen</li>
+<li>Keycloak-Client <code>nextcloud</code> vorhanden und Secret korrekt? Secret unter <code>workspace-secrets</code> Key <code>POCKET_ID_NEXTCLOUD_SECRET</code> prüfen</li>
 <li>Keycloak-Pod läuft: <code>kubectl get pods -n workspace | grep keycloak</code></li>
 <li>Provider-URL erreichbar: <code>http://keycloak:8080/realms/workspace/.well-known/openid-configuration</code></li>
 </ul>


### PR DESCRIPTION
## Summary

T003876: Die generierte Doku `k3d/docs-content-built/nextcloud.html` nannte den Legacy-Keycloak-Altnamen `NEXTCLOUD_OIDC_SECRET` (seit 2026-06-22 zurückgezogen). Ersetzt durch `POCKET_ID_NEXTCLOUD_SECRET` — im Quelltext `docs/legacy-html/nextcloud.html` und im daraus gebauten Artefakt.

## Test Plan

- `node scripts/build-docs.mjs` (exit 0) — Build regeneriert, nur `nextcloud.html` übernommen (Rest des Rebuilds ist maschinenabhängiger Plugin-Cache-Drift, nicht Teil dieser Chore)
- `tests/unit/lib/bats-core/bin/bats tests/spec/ci-cd/docs-content-guards.bats` — 6/6 ok
- `task freshness:check` — exit 0
- Legacy-Name: 0 Treffer in Quelle und Build-Output; neuer Name an beiden Stellen vorhanden

🤖 Generated with [Claude Code](https://claude.com/claude-code)