### PR TITLE
fix(mcp): bge-mcp auth for Qwen Code [T004272]

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,5 @@
 {
   "mcpServers": {
-    "bge-mcp": {
-      "type": "http",
-      "url": "http://localhost:13005/mcp",
-      "headers": {
-        "Authorization": "Bearer ${BGE_MCP_TOKEN}"
-      }
-    },
     "brain-mcp": {
       "command": "python3",
       "args": [

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,335 @@
+# QWEN.md — Project Context
+
+## Project Overview
+
+**Workspace MVP** — A Kubernetes-based, self-hosted collaboration platform built as a bachelor thesis by Patrick Korczewski. It bundles Nextcloud (files + Talk), Pocket ID (SSO/OIDC), Collabora (Office), Vaultwarden (passwords), DocuSeal (e-signatures), Whiteboard, Brett (3D system board), and an Astro + Svelte website with integrated chat — all running on k3d/k3s with Traefik Ingress. DSGVO-compliant, all data on-premises.
+
+Two brands are deployed: **mentolder** (mentolder.de) and **korczewski** (korczewski.de), both on a unified `fleet` cluster (Hetzner nodes). Primary deploy path is **pull-based via FluxCD** (OCI artifact → Flux reconciliation); `task workspace:deploy` exists as break-glass fallback only.
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Cluster | k3d (dev), k3s (prod), Traefik Ingress |
+| GitOps | FluxCD (OCI artifact reconcile via `.github/workflows/render-fleet-artifact.yml`) |
+| SSO / OIDC | Pocket ID (~20 seeded clients, see below) |
+| Backend services | Node.js 22+, TypeScript, Hono, Drizzle ORM, PostgreSQL 16 |
+| Website | Astro + Svelte (pnpm, brand-aware) |
+| Brett | Node.js 3D system board (npm) |
+| IaC / manifests | Kustomize (base `k3d/`, overlays `prod-fleet/mentolder/`, `prod-fleet/korczewski/`) |
+| Task runner | [go-task](https://taskfile.dev) (`Taskfile.yml`, 5000+ lines) |
+| Testing | Vitest, BATS (vendored at `tests/unit/lib/bats-core/`), Playwright (E2E) |
+| LLM stack | Local Gemma models via llama.cpp, llm-proxy, OpenCode orchestrator |
+| CI | GitHub Actions (`.github/workflows/ci.yml`) |
+| Secrets | SealedSecrets in `environments/sealed-secrets/` |
+
+## Cluster Topology
+
+**`fleet` cluster** — the only live prod context (unified since 2026-05-31):
+- **3 control-plane nodes**: pk-hetzner-4/6/8 (IPs: 204.168.244.104 / 37.27.251.38 / 62.238.23.79)
+- **2 worker nodes**: gekko-hetzner-3/4 (`gekko-hetzner-2` is currently NOT in the cluster)
+- **mentolder brand**: namespace `workspace`, context `fleet`, `ENV=mentolder` (alias `ENV=fleet-mentolder`)
+- **korczewski brand**: namespace `workspace-korczewski`, context `fleet`, `ENV=korczewski` (alias `ENV=fleet-korczewski`)
+- Both brands at 26/26 pods. Old standalone clusters (`mentolder`, `korczewski`, `k3s-1`) are **decommissioned** — any other context in `kubectl config get-contexts` points at dead hardware.
+- **Local dev**: k3d contexts `k3d-mentolder-dev` and `k3d-korczewski-dev`.
+
+## Repository Layout
+
+```
+k3d/                    # Base Kustomize manifests (single deployment path)
+  docs-content-built/   #   Pre-built HTML served by docs Deployment (build via scripts/build-docs.mjs)
+prod-fleet/             # Prod overlays per brand (actually applied in prod)
+  mentolder/            #   mentolder overlay (wraps prod-mentolder + fleet-common + node-affinity)
+  mentolder-jobs/       #   Isolated one-shot bootstrap/seed Jobs ($patch: delete non-Job types) [T002207]
+  korczewski/           #   korczewski overlay (wraps prod-korczewski + fleet-common + node-affinity)
+  korczewski-jobs/      #   Isolated one-shot bootstrap/seed Jobs [T002207]
+prod/                   # Shared production patches (TLS, resources, replicas, DDNS) — never apply directly
+prod-mentolder/         # Legacy brand overlay — inner base for prod-fleet/mentolder/, never apply standalone
+prod-korczewski/        # Legacy brand overlay — inner base for prod-fleet/korczewski/, never apply standalone
+environments/           # Per-env config + secrets
+  <env>.yaml            #   domain, context, env_vars, setup_vars (read by env-resolve.sh)
+  .secrets/<env>.yaml   #   plaintext secrets (git-crypt-encrypted, tracked; input to env:seal)
+  sealed-secrets/       #   encrypted SealedSecrets (committed, applied before manifests)
+  schema.yaml           #   authoritative env/setup var list (validated by env:validate)
+  certs/                #   per-cluster sealing certs (via env:fetch-cert)
+website/                # Astro + Svelte website (pnpm, brand-aware)
+brett/                  # Node.js 3D system board (npm); deployed as k3d/brett.yaml
+scripts/                # ~280 operational scripts (agent, backup, factory, llm, etc.)
+taskfiles/              # Included Taskfiles (llm, finetune, factory, staging, ...)
+openspec/               # OpenSpec change proposals + SSOT specs (config.yaml = authoring SSOT)
+flux/                   # FluxCD cluster definitions
+  clusters/fleet/       #   Kustomizations including ks-jobs-mentolder.yaml, ks-jobs-korczewski.yaml
+tests/                  # BATS + Playwright test suites
+docs/                   # Documentation + agent-guide
+mcp-task-runner/        # MCP server for task execution
+```
+
+## Key Commands
+
+### Task Oracle (preferred — never hardcode task names)
+
+```bash
+bash scripts/vda.sh oracle '<goal in plain English>'
+bash scripts/vda.sh oracle --dry-run '<goal>'   # resolve without executing
+bash scripts/vda.sh oracle --json '<goal>'      # {"task":"...","env":"...","cmd":"..."}
+bash scripts/vda.sh oracle --quiet '<goal>'     # suppress stderr diagnostics
+```
+
+Routes to local Ollama (`localhost:11434`) → Opencode task-runner agent → fallback error with `task --list` hint.
+
+### Dev / Local (k3d)
+
+```bash
+task workspace:up          # Full dev stack: cluster + workspace + office + MCP + post-setup
+task cluster:create        # Create k3d cluster with local registry
+task workspace:deploy      # Deploy workspace manifests
+task workspace:status      # Pods, services, ingress, PVCs
+task workspace:logs -- <svc>   # Service logs
+task workspace:restart -- <svc> # Restart a service
+task workspace:port-forward    # shared-db → localhost:5432
+task workspace:psql -- website # psql shell
+task workspace:teardown    # Interactive cleanup
+```
+
+### Production
+
+```bash
+task workspace:deploy ENV=mentolder    # Deploy to mentolder prod (break-glass; prefer Flux)
+task workspace:deploy ENV=korczewski   # Deploy to korczewski prod
+task feature:deploy                    # Fan-out deploy to BOTH prod clusters
+task feature:website                   # Rebuild + redeploy website on both clusters
+task health                           # Cross-cluster health check
+```
+
+### Testing
+
+```bash
+task test:all                # Offline suite (unit + manifests + dry-run)
+task test:changed            # Smart test selection (pre-commit gate)
+task test:inventory          # Regenerate website/src/data/test-inventory.json
+./tests/runner.sh local      # All tests against k3d
+./tests/runner.sh local <ID> # Single test (FA-01..FA-29, SA-01..SA-10, NFA-01..NFA-09, AK-03/04)
+npm run test:code-quality    # File-size caps, import cycles, hostname scan
+```
+
+BATS runner: `tests/unit/lib/bats-core/bin/bats` (vendored) — NOT global `bats` or `./tests/bats/bin/bats` (doesn't exist).
+
+### Validation / Quality
+
+```bash
+task workspace:validate      # Kustomize dry-run
+task freshness:check         # Generated artifacts committed?
+task test:code-quality       # Code quality gates
+```
+
+### Other Useful Commands
+
+```bash
+bash scripts/vda.sh cfr                         # Change Failure Rate (target ≤15% over 8 weeks)
+bash scripts/vda.sh release-notes generate       # Generate release notes from merged PRs
+task release:notes                              # Same (LLM/DeepSeek-gestützt mit Fallback)
+bash scripts/vda.sh frontmatter <plan-file>     # Add required frontmatter after plan creation
+bash scripts/ticket.sh create --type bug --title "..." --description "..."  # File a bug ticket
+task docs:deploy                                # Build + deploy docs (docs:sync does NOT work — read-only rootfs)
+```
+
+## Development Workflow
+
+1. **Branch**: `feature/*`, `fix/*`, `chore/*`, `docs/*` — no direct pushes to `main`
+2. **Plan**: `dev-flow-plan` (or `opencode-flow-plan`) → creates worktree, brainstorm, plan, push. After plan creation, run `bash scripts/vda.sh frontmatter <plan-file>` before committing. (`scripts/plan-frontmatter-hook.sh` is deprecated.)
+3. **Execute**: `dev-flow-execute` → implements plan, runs tests, creates PR
+4. **CI**: Must be green before merge (`task test:all`). Note: a CONFLICTING PR suppresses CI.
+5. **Merge**: Squash-and-merge via PR; `scripts/preflight-pr-scope.sh` enforces worktrees for feature/fix
+6. **Chores**: `dev-flow-chore` executes and merges inline (no plan/execute handoff)
+
+### Merge = Closure (T001092)
+
+A ticket closes on **green auto-merge to `main`** (`done · resolution=shipped`). Prod deploy is decoupled and does NOT change ticket status. `awaiting_deploy` and `qa_review` are removed from the happy path but remain valid enum values (historical rows, manual edge cases).
+
+**Deliverable-check before manual `done`/`shipped` (M10, T002506):** For manual closures (e.g. epics spanning multiple PRs), verify all plan-declared deliverable files actually exist on `origin/main` (`git show origin/main:<path>`) before setting done. A `done` without deliverable is process drift.
+
+### OpenSpec Conventions
+
+- Lifecycle: `/opsx:propose <slug>` → `/opsx:apply <slug>` → `/opsx:archive <slug>`
+- `/opsx:explore` for thinking-through (no artifact produced)
+- Language: Purpose in German; Requirements/Scenarios in English (GIVEN/WHEN/THEN)
+- Delta files in `openspec/changes/<slug>/specs/` are named after the **parent SSOT slug**, not the change slug
+- New component needs `archive --create-new`; without it, archive fails if target SSOT spec doesn't exist
+- `task openspec:propose|apply|archive` wrappers and `/opsx:*` commands produce the **same artifact set** (both write `.ticket`, delta-spec, proposal/design/tasks scaffold)
+- `task openspec:validate` is the fail-closed CI gate
+- Authoring SSOT: `openspec/config.yaml`
+
+### Configuration Patterns
+
+- **Centralized domains**: All hostnames in `k3d/configmap-domains.yaml` — never hardcode
+- **Per-env config**: `environments/<env>.yaml` → `scripts/env-resolve.sh` (must be **sourced**) → `envsubst` into manifests. Exports `PROD_DOMAIN`, `BRAND_NAME`, `CONTACT_EMAIL`, `ENV_CONTEXT`, `ENV_OVERLAY`, SMTP, etc.
+- **Prod secrets**: plaintext in `environments/.secrets/<env>.yaml` (git-crypt, tracked) → `task env:seal ENV=<env>` → SealedSecret in `environments/sealed-secrets/<env>.yaml`. `workspace:deploy` applies the SealedSecret before manifests.
+- **Dev secrets**: `k3d/secrets.yaml` (dev values only); `prod/` overlay strips it via `$patch: delete`
+- **Pocket ID OIDC clients**: No realm JSON — clients live in `pocket_id.oidc_clients` (PostgreSQL). Provisioned by `pocket-id-client-seed` Job (`k3d/pocket-id-client-seed.yaml`) via Admin REST API on every deploy. Client secrets written back into `workspace-secrets` (website client additionally into `website-secrets` in `website` namespace). Editing clients in the UI causes drift the next deploy overwrites.
+- **Seeded clients (~20)**: website, nextcloud, vaultwarden, brett, docs, downloads, grafana, mediaviewer, studio, videovault, brain, comfy, terminal, traefik, mail, rustdesk-web, session-hub, claude-code
+- **Nextcloud OIDC**: `k3d/nextcloud-oidc-dev.php` (dev) / `prod/nextcloud-oidc-prod.php` (prod), loaded as ConfigMap, pointing at Pocket ID (`http://pocket-id:1411` in dev)
+- **Services without native OIDC**: sit behind `oauth2-proxy` gate (20 manifests reference it)
+
+### FluxCD Job Isolation (T002207)
+
+`prod-fleet/mentolder-jobs/` and `prod-fleet/korczewski-jobs/` are isolated one-shot bootstrap/seed Job overlays. They use the same base as the brand but `$patch: delete` all non-Job resource types. Flux Kustomizations (`flux/clusters/fleet/ks-jobs-*.yaml`) declare `dependsOn: [flux-<brand>]` (run AFTER brand stack), `force: true` (self-healing against immutable field errors), `wait: false` (never gate downstream). Status checked via `flux:stalled` task. A broken `pocket-id-client-seed` no longer blocks the entire brand deploy.
+
+### Image Exclusions
+
+These use `:latest` intentionally — excluded from digest pinning: Website, Brett, Docs, Videovault, Mediaviewer-Widget, Mentolder-Web, Downloads, Brain, Studio, Talk-Transcriber, SDLC-Console (`website-sdlc`).
+
+### Removed Components
+
+- **LiveKit** — removed per T002184
+- **tracking-import CronJob** — removed PR #788 (2026-05-15)
+- **track-pr.yml** — removed PR #993 (2026-05-23)
+- **build-tracking.yml, track-plans.yml** — fully removed; `v_timeline` shows historical data only (last tracked PR: #787)
+
+## Package Managers
+
+| Area | Manager | Lockfile |
+|------|---------|----------|
+| Root | npm | `package-lock.json` |
+| `website/` | pnpm | `website/pnpm-lock.yaml` |
+| `brett/` | npm | `brett/package-lock.json` |
+
+## Service Endpoints (Dev — localhost)
+
+| Service | URL |
+|---------|-----|
+| Website (Astro + Chat) | `http://web.localhost` |
+| Pocket ID (SSO) | `http://auth.localhost` |
+| Nextcloud (Files + Talk) | `http://files.localhost` |
+| Collabora (Office) | `http://office.localhost` |
+| Talk HPB (Signaling) | `http://signaling.localhost` |
+| Vaultwarden | `http://vault.localhost` |
+| Whiteboard | `http://board.localhost` |
+| Brett (System Board) | `http://brett.localhost` |
+| DocuSeal | `http://sign.localhost` |
+| Docs | `http://docs.localhost` |
+| Mailpit (dev mail) | `http://mail.localhost` |
+
+Prod uses `*.mentolder.de` / `*.korczewski.de`.
+
+## Agent Routing
+
+Before responding, check signals and delegate to the named domain agent:
+
+| Signals | Agent | MCP Primary |
+|---------|-------|-------------|
+| `website/`, Astro, Svelte, component, homepage, kore, mentolder brand, CSS, UI, frontend, design | `bachelorprojekt-website` | — |
+| pod, logs, status, restart, crash, health, kubectl, "what's wrong", `llm:`, GPU, Ollama, model | `bachelorprojekt-ops` | `mcp-kubernetes` (localhost:18080, Claude-Code-only SSE) |
+| `k3d/`, `prod*/`, manifest, kustomize, overlay, Taskfile, `ENV=`, `environments/`, deploy | `bachelorprojekt-infra` | `mcp-kubernetes` (status checks only) |
+| test, `FA-*`, `SA-*`, `NFA-*`, `AK-*`, `FA-SF`, BATS, Playwright, `runner.sh`, factory, autopilot | `bachelorprojekt-test` | `ticket-mcp` (Go-Adapter), `mcp-postgres` (:13001, non-ticket tables) |
+| database, PostgreSQL, psql, schema, query, backup, restore, `bachelorprojekt.features`, `v_timeline` | `bachelorprojekt-db` | `mcp-postgres` (localhost:13001, mentolder-DB only) |
+| SealedSecret, Pocket ID, OIDC client, DSGVO, credentials, rotate, certificate, secret | `bachelorprojekt-security` | — |
+
+**Tie-break**: prefer the domain of the files being changed. Cross-cutting features stay with the orchestrator.
+
+**Before dispatching**: inject plan context via `bash scripts/plan-context.sh <role> --with-openspec` (wrap in `<active-plans>`) and toolset via `bash scripts/toolset-context.sh <role>` (wrap in `<toolset>`). The role must be a full name (`bachelorprojekt-infra`, not `infra` — short forms silently fall back to `__ALL__` returning all proposals unfiltered, T002322). `toolset-context.sh` is **fail-closed** (unknown role → exit ≠ 0, no output) unlike `plan-context.sh`.
+
+## Agent / AI Infrastructure
+
+- **OpenCode orchestrator** dispatches local LLM subagents (Gemma 4 26B/12B via llama.cpp). Agent definitions in `.opencode/agent-models.jsonc` (SSOT). opencode MCP servers: `bge-mcp`, `codebase-memory-mcp`, `docfork`, `factory-mcp`, `github-mcp`, `mcp-kubernetes`, `mcp-postgres`, `mcp-task-runner`, `playwright`, `sequential-thinking`, `task-master-ai`, `ticket-mcp`, `webresearch`.
+- **Session model**: Main loop on user's default model (Opus 5, 1M ctx). Domain agents carry model tier in frontmatter: `ops/-db/-test/-website` → Sonnet (mechanical recon, queries, tests, UI), `infra/-security` → Opus (cross-system, risky, irreversible). 1M context is a budget — bulk reads belong in subagents that report back condensed.
+- **Software Factory** — automated ticket→plan→implement→PR pipeline (`scripts/factory/`, MCP at `factory-mcp` on `:13003`)
+- **MCP servers** — Postgres (`mcp-postgres`), Kubernetes (`mcp-kubernetes`), Playwright, Brain Wiki (`brain-mcp`), Ticket (`ticket-mcp`), Factory (`factory-mcp`), Codebase Memory (`codebase-memory-mcp`), Task Runner (`mcp-task-runner`)
+- **MCP registry SSOT**: `docs/agent-guide/registry/mcp.yaml` (reachability: transport, endpoint, credentials) + `capabilities.yaml` (selection/usage: which instance provides a capability, when to use it, which roles lead it). `task mcp:sync` regenerates `.mcp.json` (Claude Code), `.opencode/opencode.jsonc` (opencode), `~/.gemini/config/mcp_config.json` (agy). `task mcp:check` verifies drift. **Never edit configs by hand** — changes go into the registry.
+- **Agent coordination** — `scripts/agent-lock.sh` (claim/release/reap), `scripts/agent-msg.sh` (messaging)
+- **Agent routing maps** — generated grep-able maps in `docs/agent-guide/maps/`: `goals-map.md` (intention → path → tier → guardrails), `tools-map.md`, `danger-map.md`. Regenerate via `task agent-guide:maps`.
+- **Brain Wiki** — knowledge base ingested from openspec, runbooks, ADRs (`scripts/brain-ingest.sh`)
+- **gh-axi** — preferred GitHub CLI wrapper (use `gh-axi` instead of `gh`). Reference: `.claude/skills/references/gh-axi.md`
+
+## CI/CD
+
+**`.github/workflows/ci.yml`** runs on every PR:
+- Offline tests: `task test:all` (BATS unit, kustomize structure, Taskfile dry-run)
+- Test inventory check: `task test:inventory` must match committed `website/src/data/test-inventory.json` — regenerate and commit alongside test additions
+- Security scan: gitleaks (secret detection), image-pin advisory + hardcoded-secret detection in `k3d/*.yaml`
+- Systembrett template validation (`scripts/tests/systembrett-template.test.sh`)
+
+**Other workflows**:
+- `renovate.yml` — self-hosted Renovate weekly dependency update bot (T000898)
+- `e2e.yml` — nightly Playwright against both brands on fleet
+- `build-brett.yml` — auto build+rollout both brands on `brett/**` push to main
+- `build-docs.yml` — auto build on `docs/**`/docs-script push to main + manual dispatch
+- `build-collabora.yml`, `build-transcriber.yml`
+- `build-website.yml` — **one** workflow builds a brand-neutral image that feeds both mentolder and korczewski deploy jobs (no separate korczewski website workflow, see T001229/T001276)
+
+### BATS Conventions
+
+- **Spec-dir layout (T002416)**: New `@test` blocks go in `tests/spec/<spec-slug>/<kurz-slug>.bats` (one dir per SSOT spec from `openspec/specs/`, one file per operation). Don't append to the legacy collector `tests/spec/<spec-slug>.bats` — this caused parallel-work collisions at file end. No ticket-numbered files (`FA-SF-42.bats`); fallback for cross-cutting tests without clear spec is `tests/unit/`.
+- **Both forms coexist**: Runner uses `bats -r tests/spec/` and captures both. Legacy top-level files are NOT migrated, just no longer extended.
+- **Test both forms locally (T002696)**: Because collector and directory coexist, searching for `tests/spec/<spec>.bats` finds only half. Always capture both:
+  ```bash
+  tests/unit/lib/bats-core/bin/bats -r tests/spec/<spec-slug>*
+  ```
+- **No `merge=union` for `.bats`** — it merges line-by-line without block structure, producing syntactically broken files with no conflict markers. Guard: `tests/spec/ci-cd/spec-dir-convention.bats`.
+- **Append-conflict resolution**: When parallel work collides at file end in legacy collectors, keep **both** blocks and duplicate the shared closing brace.
+- **Output verification (T002448-M4)**: Tests MUST check command output/results (`run`, `$output`, `$status`), NOT source code patterns (`grep` on script internals). Exception: cross-cutting tests whose result lives only in source (doc conventions, CI config). The test file documents which check mode is used in a header comment.
+- **Semantics over presentation (T002716)**: Assertions must target semantics (exit code, value presence, substring without line anchors), not formatting (exact wording, table columns). Format-bound guards break across tool versions — locally invisible, red only in CI. Four failure modes:
+  1. **Dokumentposition (T003104)**: `grep -n … | head -1` measures position of first random match. Unrelated insertion above changes result. → Narrow search to section (awk range, sed range).
+  2. **Options-Parsing (T003108)**: `grep -qF '--flag'` exits **2** (not 1) — `-F` makes pattern literal but doesn't prevent option parsing. In `if` conditions, tool errors and "not found" are indistinguishable. → Use `-e` or `--`.
+  3. **Konfiguration statt Laufzeit (T003548)**: If the defect sits in runtime, a config assertion is no proxy. Rule: **a RED run that is green is a finding about the test, not "already satisfied".**
+  4. **Prozesslisten-Format (T003230)**: `ps -eo pid=` right-pads to `pid_max` width. A test that finds the format instead of enforcing it depends on machine uptime — locally green, fresh runner red. → Enforce format (`tr -d '[:blank:]'`).
+- **`$output` matching pitfall**: Never assert `[[ "$output" == *"<term>"* ]]` unqualified against full stdout+stderr — if the script prints `$0` in usage/help, the worktree directory name (derived from change slug) can satisfy the match even when the feature doesn't exist. Narrow to the relevant output line first.
+- **Positive anchor (T002356-M1)**: Every negative test ("X must not occur") needs a positive anchor in the same test that fails when the feature is missing. Without it, the test is vacuous: missing feature → empty candidate list → "1 is not in []" holds trivially. Order: first check valid case passes, then the negative assertion.
+- **CRLF-tolerant anchors for `.ps1` (T002338-M2)**: PowerShell files (`scripts/llm/*.ps1`) are CRLF. A regex anchoring on `$` doesn't match — `\r` is in POSIX `[[:space:]]`, so use `[[:space:]]*$`. Same expression matched in interactive shell but not under BATS.
+- **`bash -n` is NOT a syntax check for `.bats` (T002351-M2)**: `@test "name" { … }` is not valid Bash syntax; `bash -n` gives a misleading error. Use `tests/unit/lib/bats-core/bin/bats --count <file>`.
+
+## Gotchas & Footguns
+
+Full reference: `docs/superpowers/references/gotchas-footguns.md`
+
+Covered sub-topics there: Security & Session (agent-lock protocol, ENV= targeting, wg-fleet flannel-iface), Overlays & Config (prod-fleet/* only, $patch:delete, envsubst lists), Ops & Infra (cluster reset order, Kore design system, local-first LLM pipeline, dev.mentolder.de stack, alt-worktrees submodule gitdirs).
+
+Critical ones inline:
+- `scripts/env-resolve.sh` must be **sourced**, not executed
+- Never `SELECT *` from `tickets.ticket_plans` (multi-MB `content` column)
+- OpenSpec archival ONLY in worktrees — main-checkout commits leave orphaned files
+- `website/` is pnpm-only — never `npm install` inside `website/`
+- **gitleaks**: install the CI version (8.18.2 via curl), NOT `apt install` (delivers 8.16.0). Local pre-commit silently skips if binary is missing (`⚠ gitleaks binary not found — skipping secret scan`), but CI is fail-closed — a leaked key is only caught after push, when it's already compromised. Install:
+  ```bash
+  curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.2/gitleaks_8.18.2_linux_x64.tar.gz \
+    | tar -xz -C /tmp gitleaks && install -m 0755 /tmp/gitleaks ~/.local/bin/gitleaks
+  ```
+  Hook and CI use `--no-git` (scan working tree, not versioned). `node_modules/` and `tmp/` are in `allowlist.paths` (gitignored, can't enter a commit). Add new gitignored sources there — don't disable the hook.
+- **Bug triage (CFR-Gate G-DORA03)**: Every post-merge bug MUST be filed as `type=bug` ticket — no silent `fix()` commits. File via `bash scripts/ticket.sh create --type bug --title "..." --description "..."`. Measure with `bash scripts/vda.sh cfr`, target ≤15% over 8 weeks. Unticketed `fix()` commits count as concealed bugs, worsening the proxy without appearing in DORA at `/admin/dora`.
+- **Measurement convention (T002717)**: When writing a measurement as decision basis in a ticket, include the executable command that produced it (commit hash + search pattern). Without it, the number is a claim, not evidence. The real case: T002700 deferred work based on "about 23 live files" — re-measurement found 149 occurrences in 63 files (factor ~2.6). Include a block like:
+  ```bash
+  PRE=6a6d4c302c1afcb4a12a6c0b7c2401505f5fd602
+  git grep -F -l 'Taskfile.' "$PRE" -- . ':!openspec/changes/archive' ':!docs/superpowers/plans' | wc -l
+  ```
+  Editorial note, not an automated guard — only the rule's presence in the repo is machine-checked (`tests/spec/agent-skills/messung-mit-befehl.bats`).
+- **PowerShell from WSL (T002495-M7)**: `.ps1` files under `scripts/llm/` must be pure ASCII (no BOM, no typographic characters/em-dashes). PS 5.1 on Windows reads UTF-8 without BOM as CP1252. Validate before commit with `[System.Management.Automation.Language.Parser]::ParseFile`. Write generated `.conf` files with `-Encoding ASCII` not `UTF8` (BOM in WireGuard configs breaks tunnel services).
+
+## Development Rules
+
+1. Only deploy via k3d/k3s with Kustomize. Prod is **pull-based via FluxCD GitOps** (primary: `.github/workflows/render-fleet-artifact.yml` → OCI artifact `ghcr.io/paddione/fleet-manifests` → Flux reconciliation on fleet). `task workspace:deploy ENV=<brand>` is break-glass fallback only.
+2. All changes via Pull Requests — no direct pushes to `main`.
+3. Squash-and-merge to keep `main` history clean.
+4. CI must be green before merge.
+5. Validate manifests before committing: `task workspace:validate`.
+6. After modifying K8s manifests, run relevant tests: `./tests/runner.sh local <TEST-ID>`.
+7. Branch naming: `feature/*`, `fix/*`, `chore/*`, `docs/*`.
+
+## Reference Files
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Authoritative comprehensive reference (all tasks, topology, footguns) — **read on demand** |
+| `AGENTS.md` | Quick-start for orchestrator sessions (agent routing, core commands) |
+| `CONTRIBUTING.md` | Branch conventions, CI pipeline, dev workflow |
+| `IDENTITY.md` | AI assistant identity/persona |
+| `website/CLAUDE.md` | Astro/Svelte quick-start for the website |
+| `website/WEBSITE-STANDARDS.md` | Full website standards |
+| `docs/agent-guide/README.md` | Agent operating guide |
+| `docs/superpowers/references/gotchas-footguns.md` | Full gotchas & footguns reference |
+| `docs/agent-guide/registry/mcp.yaml` | MCP server reachability SSOT (transport, endpoint, credentials) |
+| `docs/agent-guide/registry/capabilities.yaml` | MCP tool selection/usage SSOT (which instance, when, who) |
+| `docs/agent-guide/maps/` | Generated routing maps: `goals-map.md`, `tools-map.md`, `danger-map.md`, `toolset-map.md`, `agents-map.md` |
+| `.claude/skills/references/mcp-tool-guide.md` | MCP server preference guide (which MCP over `kubectl exec … psql`) |
+| `.claude/skills/references/gh-axi.md` | gh-axi GitHub CLI wrapper reference |
+| `.claude/skills/references/subagent-provisioning.md` | Subagent model/effort/context provisioning |
+| `.claude/skills/OVERVIEW.md` | Skill layering contract (which step calls which) |
+| `openspec/config.yaml` | OpenSpec authoring conventions SSOT |

--- a/docs/agent-guide/registry/mcp.yaml
+++ b/docs/agent-guide/registry/mcp.yaml
@@ -109,14 +109,17 @@ clients:
       Bind auf 127.0.0.1 plus Bearer-Token (BGE_MCP_TOKEN). Ohne gesetzten Token
       startet der Shim nicht. Der Header wird seit T002487 aus dem headers-Feld
       oben generiert — als unexpandierte ${VAR}-Referenz, damit kein Klartext in
-      eine getrackte Datei geraet. Betriebsvoraussetzung ist deshalb, dass
-      BGE_MCP_TOKEN in der Umgebung exportiert ist, aus der der Harness startet;
-      Quelle ist ~/.config/bge-mcp/server.env, dieselbe Datei, die die
-      systemd-user-Unit per EnvironmentFile= liest. Ist er nicht gesetzt,
-      erscheint der Server als inaktiv und ein direkter initialize-Aufruf
-      antwortet mit HTTP 401 (www-authenticate: Bearer). Der UI-Dialog der
-      llama-Web-UI ("Authorization / Bearer") bleibt davon unberuehrt: llama.cpp
-      bezieht den Server nicht aus dieser Registry.
+      eine getrackte Datei geraet. Claude Code expandiert ${VAR} beim Laden
+      selbst; OpenCode benoetigt die {env:VAR}-Notation (Uebersetzung in
+      mcp-sync.sh, T002488); agy (T002704) und Qwen Code (T004272) expandieren
+      ${VAR} ebenfalls nicht — dort loest mcp-sync.sh den Token zur Sync-Zeit
+      auf und schreibt den Klartext-Wert in die nicht-getrackte Config-Datei
+      (chmod 600). Quelle ist ~/.config/bge-mcp/server.env, dieselbe Datei, die
+      die systemd-user-Unit per EnvironmentFile= liest. Ist der Token weder in
+      der Umgebung noch in server.env vorhanden, bleibt der Platzhalter stehen
+      und der Server antwortet mit HTTP 401 (www-authenticate: Bearer). Der
+      UI-Dialog der llama-Web-UI ("Authorization / Bearer") bleibt davon
+      unberuehrt: llama.cpp bezieht den Server nicht aus dieser Registry.
     failover_note: >-
       Der Shim haelt keine eigene Failover-Logik. Welches bge-Paar antwortet,
       entscheidet website/src/lib/bge-router.ts — dieselbe Stelle, die auch die
@@ -131,6 +134,8 @@ clients:
         type: remote
         url: http://localhost:13005/mcp
         enabled: true
+      qwen_code:
+        httpUrl: http://localhost:13005/mcp
 
   mcp-task-runner:
     transport: stdio

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 967,
+      "file_count": 968,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -581,6 +581,7 @@
         "tests/spec/mcp-gateway/client-env-check.bats",
         "tests/spec/mcp-gateway/mcp-sync-drift-no-secret-leak.bats",
         "tests/spec/mcp-gateway/opencode-env-placeholder.bats",
+        "tests/spec/mcp-gateway/qwen-token-expansion.bats",
         "tests/spec/mcp-gateway/watchdog-tunnel-liveness.bats",
         "tests/spec/mcp-skill-integration.bats",
         "tests/spec/mcp-task-runner.bats",

--- a/scripts/mcp-sync.sh
+++ b/scripts/mcp-sync.sh
@@ -17,9 +17,11 @@ OUT_DIR="${MCP_OUT_DIR:-$REPO}"
 
 CLAUDE_TARGET="$OUT_DIR/.mcp.json"
 OPENCODE_TARGET="$OUT_DIR/.opencode/opencode.jsonc"
-# AGY_TARGET bleibt an $HOME gebunden: die Datei liegt konstruktionsbedingt
-# ausserhalb des Repos. Ein Test isoliert sie ueber HOME, nicht ueber MCP_OUT_DIR.
+# AGY_TARGET und QWEN_TARGET bleiben an $HOME gebunden: die Dateien liegen
+# konstruktionsbedingt ausserhalb des Repos. Ein Test isoliert sie ueber HOME,
+# nicht ueber MCP_OUT_DIR.
 AGY_TARGET="${HOME}/.gemini/config/mcp_config.json"
+QWEN_TARGET="${HOME}/.qwen/settings.json"
 LLAMACPP_TARGET="$OUT_DIR/scripts/llm/mcp-servers.json"
 
 # render_opencode_jsonc erhaelt alles ausserhalb des "mcp"-Blocks, indem es die
@@ -39,17 +41,23 @@ render_claude_json() {
     const reg = yaml.parse(fs.readFileSync('$REGISTRY', 'utf8'));
     const clients = reg.clients;
     const out = { mcpServers: {} };
+    // [T004272] Server mit \${VAR} in Headers werden uebersprungen: Qwen Code
+    // liest .mcp.json mit Vorrang vor ~/.qwen/settings.json, expandiert \${VAR}
+    // aber nicht — der Literal-String fuehrt zu HTTP 401. Diese Server gehoeren
+    // in die nicht-getrackten Harness-Configs (~/.claude/settings.json fuer
+    // Claude Code, ~/.qwen/settings.json fuer Qwen Code) mit aufgeloestem Token.
+    const PLACEHOLDER = /\\$\\{[A-Za-z_][A-Za-z0-9_]*\\}/;
+    const hasPlaceholder = (headers) => {
+      if (!headers) return false;
+      return Object.values(headers).some(v => PLACEHOLDER.test(String(v)));
+    };
     for (const name of Object.keys(clients).sort()) {
       const c = clients[name];
       if (!c.harness || !c.harness.claude_code) continue;
+      if (hasPlaceholder(c.headers)) continue;
       const h = c.harness.claude_code;
       if (c.transport === 'http') {
         out.mcpServers[name] = { type: 'http', url: c.endpoint };
-        // headers wird VERBATIM emittiert -- \${VAR} bleibt unexpandiert stehen,
-        // damit kein Secret in eine getrackte Datei geraet. Expandiert wird erst
-        // vom Harness beim Laden. Clients ohne headers bleiben byte-identisch;
-        // ein leeres headers:{} wuerde check fuer jeden unbeteiligten Server
-        // als Drift melden.
         if (c.headers) out.mcpServers[name].headers = c.headers;
       } else {
         const server = {};
@@ -91,7 +99,7 @@ render_agy_json() {
         const eq = line.indexOf('=');
         if (eq < 1 || line.trimStart().startsWith('#')) continue;
         const key = line.slice(0, eq).trim();
-        if (!/^[A-Za-z_][A-Za-z0-9_]*\$/.test(key)) continue;
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
         let val = line.slice(eq + 1).trim();
         if (val.length > 1 && val[0] === val[val.length - 1] && (val[0] === '\'' || val[0] === '\"')) {
           val = val.slice(1, -1);
@@ -249,6 +257,83 @@ render_opencode_jsonc() {
   "
 }
 
+# render_qwen_json — Qwen Code (T004272)
+# Qwen Code expandiert ${VAR} in settings.json-headers NICHT — es sendet den
+# Literal-String, der Zielserver antwortet 401. Dieselbe Loesung wie agy
+# (T002704): Token zur Sync-Zeit aufloesen. Die Datei liegt unter $HOME,
+# ausserhalb jeder Versionierung; chmod 600 in cmd_render schuetzt den Token.
+render_qwen_json() {
+  node -e "
+    const fs = require('fs'), yaml = require('yaml'), os = require('os'), path = require('path');
+    const reg = yaml.parse(fs.readFileSync('$REGISTRY', 'utf8'));
+    const clients = reg.clients;
+    const out = { mcpServers: {} };
+
+    // Token-Aufloesung identisch zu render_agy_json: Umgebung first, dann
+    // ~/.config/bge-mcp/server.env als Fallback.
+    const envFileVars = {};
+    try {
+      const envFile = path.join(os.homedir(), '.config', 'bge-mcp', 'server.env');
+      for (const line of fs.readFileSync(envFile, 'utf8').split('\n')) {
+        const eq = line.indexOf('=');
+        if (eq < 1 || line.trimStart().startsWith('#')) continue;
+        const key = line.slice(0, eq).trim();
+        if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+        let val = line.slice(eq + 1).trim();
+        if (val.length > 1 && val[0] === val[val.length - 1] && (val[0] === '\'' || val[0] === '\"')) {
+          val = val.slice(1, -1);
+        }
+        envFileVars[key] = val;
+      }
+    } catch { /* keine server.env — dann bleibt nur die Umgebung */ }
+
+    const PLACEHOLDER = new RegExp('[' + String.fromCharCode(36) + ']\\{([A-Za-z_][A-Za-z0-9_]*)\\}', 'g');
+    const unresolved = new Set();
+    const resolveValue = (raw) => String(raw).replace(PLACEHOLDER, (whole, varName) => {
+      const value = process.env[varName] !== undefined && process.env[varName] !== ''
+        ? process.env[varName]
+        : envFileVars[varName];
+      if (value === undefined || value === '') { unresolved.add(varName); return whole; }
+      return value;
+    });
+    const resolveHeaders = (headers) => {
+      const outHeaders = {};
+      for (const [k, v] of Object.entries(headers)) outHeaders[k] = resolveValue(v);
+      return outHeaders;
+    };
+
+    for (const name of Object.keys(clients).sort()) {
+      const c = clients[name];
+      if (!c.harness || !c.harness.qwen_code) continue;
+      const h = c.harness.qwen_code;
+      if (c.transport === 'http') {
+        const server = { httpUrl: h.httpUrl || c.endpoint };
+        if (c.headers) server.headers = resolveHeaders(c.headers);
+        out.mcpServers[name] = server;
+      } else {
+        const server = {};
+        if (h.command) server.command = h.command;
+        if (h.args && h.args.length) server.args = h.args;
+        if (h.env) server.env = h.env;
+        out.mcpServers[name] = server;
+      }
+    }
+    if (unresolved.size) {
+      process.stderr.write(
+        'mcp-sync: WARN: qwen-Header nicht aufloesbar: ' + [...unresolved].sort().join(', ') +
+        ' — weder in der Umgebung noch in ~/.config/bge-mcp/server.env. ' +
+        'Der Platzhalter bleibt stehen; Qwen Code wird den Server mit HTTP 401 verwerfen.\\n'
+      );
+    }
+
+    // Merge in existing settings to preserve non-MCP config
+    let settings = {};
+    try { settings = JSON.parse(fs.readFileSync('$QWEN_TARGET', 'utf8')); } catch {}
+    settings.mcpServers = out.mcpServers;
+    fs.writeFileSync('/dev/stdout', JSON.stringify(settings, null, 2) + '\n');
+  "
+}
+
 diff_or_drift() {
   local label="$1" expected="$2" actual="$3"
   if ! diff -q "$expected" "$actual" >/dev/null 2>&1; then
@@ -290,6 +375,18 @@ cmd_render() {
     echo "mcp-sync: render: $AGY_TARGET dir missing — skipped" >&2
   fi
 
+  if [ -d "$(dirname "$QWEN_TARGET")" ]; then
+    echo "mcp-sync: render: writing $QWEN_TARGET"
+    # [T004272] Qwen Code expandiert ${VAR} in Headers NICHT — Token wird zur
+    # Sync-Zeit aufgeloest (wie agy, T002704). Die Datei liegt unter $HOME und
+    # traegt jetzt einen Klartext-Token; chmod 600 schuetzt ihn.
+    ( umask 077; render_qwen_json > "${QWEN_TARGET}.tmp" )
+    mv "${QWEN_TARGET}.tmp" "$QWEN_TARGET"
+    chmod 600 "$QWEN_TARGET"
+  else
+    echo "mcp-sync: render: $QWEN_TARGET dir missing — skipped" >&2
+  fi
+
   echo "mcp-sync: render: writing $LLAMACPP_TARGET"
   render_llamacpp_json > "${LLAMACPP_TARGET}.tmp"
   mv "${LLAMACPP_TARGET}.tmp" "$LLAMACPP_TARGET"
@@ -313,6 +410,13 @@ cmd_check() {
     diff_or_drift "mcp_config.json" "$tmpd/agy.json" "$AGY_TARGET" || exit_code=1
   else
     echo "SKIP: $AGY_TARGET not present — skipped (exit 0 based on repo files)"
+  fi
+
+  if [ -f "$QWEN_TARGET" ]; then
+    render_qwen_json > "$tmpd/qwen.json"
+    diff_or_drift "settings.json (qwen)" "$tmpd/qwen.json" "$QWEN_TARGET" || exit_code=1
+  else
+    echo "SKIP: $QWEN_TARGET not present — skipped (exit 0 based on repo files)"
   fi
 
   render_llamacpp_json > "$tmpd/llamacpp.json"

--- a/tests/spec/mcp-gateway/agy-token-expansion.bats
+++ b/tests/spec/mcp-gateway/agy-token-expansion.bats
@@ -154,24 +154,25 @@ write_server_env() {
 }
 
 @test "the repository-tracked renderers never receive the resolved value" {
-  # Sicherheits-Guard: .mcp.json und .opencode/opencode.jsonc sind getrackt.
+  # Sicherheits-Guard: .opencode/opencode.jsonc ist getrackt.
   # Ein expandierter Token waere dort ein committetes Geheimnis.
+  # [T004272] .mcp.json ueberspringt Server mit ${VAR} in Headers komplett.
   run env HOME="$TMPD/fakehome" PROBE_TOKEN="env-value-4711" \
       MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
       bash "$SYNC" render
   [ "$status" -eq 0 ]
 
-  # Positiv-Anker: beide Dateien existieren und tragen ihre eigene Notation.
-  run jq -r '.mcpServers["probe-http"].headers.Authorization' "$TMPD/.mcp.json"
-  echo "claude header: $output"
-  [ "$output" = 'Bearer ${PROBE_TOKEN}' ]
+  # Claude-Renderer ueberspringt probe-http (hat ${VAR} in Headers)
+  run jq -r '.mcpServers["probe-http"]' "$TMPD/.mcp.json"
+  echo "claude probe-http: $output"
+  [ "$output" = "null" ]
 
+  # OpenCode-Renderer uebersetzt ${VAR} in {env:VAR}
   run grep -c '{env:PROBE_TOKEN}' "$TMPD/.opencode/opencode.jsonc"
   echo "opencode placeholder count: $output"
   [ "$output" -ge 1 ]
 
-  # Erst danach die Negativ-Aussage: der aufgeloeste Wert taucht in keiner
-  # der beiden getrackten Dateien auf.
+  # Der aufgeloeste Wert taucht in keiner der getrackten Dateien auf.
   run grep -c 'env-value-4711' "$TMPD/.mcp.json"
   [ "$output" -eq 0 ]
   run grep -c 'env-value-4711' "$TMPD/.opencode/opencode.jsonc"

--- a/tests/spec/mcp-gateway/authenticated-http-headers.bats
+++ b/tests/spec/mcp-gateway/authenticated-http-headers.bats
@@ -53,17 +53,19 @@ setup() {
 
 # ── Generator reicht Header in die HTTP-Harness-Configs durch ────────────
 
-@test "generated .mcp.json carries the bge-mcp Authorization header" {
+@test "generated .mcp.json does NOT carry bge-mcp (T004272)" {
+  # [T004272] bge-mcp hat ${BGE_MCP_TOKEN} in Headers — der Claude-Renderer
+  # ueberspringt Server mit ${VAR} in Headers, damit Qwen Code nicht den
+  # Literal-String sendet (HTTP 401). bge-mcp gehoert in ~/.qwen/settings.json.
   run bash -c "node -e \"
     const fs=require('fs');
     const d=JSON.parse(fs.readFileSync('$REPO/.mcp.json','utf8'));
     const s=d.mcpServers['bge-mcp'];
-    if(!s.headers) process.exit(1);
-    console.log(s.headers.Authorization||'');
+    console.log(s === undefined ? 'absent' : 'present');
   \""
   echo "output: $output"
   [ "$status" -eq 0 ]
-  [[ "$output" == *'${BGE_MCP_TOKEN}'* ]]
+  [ "$output" = "absent" ]
 }
 
 @test "generated opencode.jsonc carries the bge-mcp Authorization header" {
@@ -84,7 +86,9 @@ setup() {
 
 # ── Generizitaet: kein bge-mcp-Sonderfall im Renderer ────────────────────
 
-@test "renderers pass headers through for any http client, not just bge-mcp" {
+@test "renderers pass headers through for opencode and agy (T004272)" {
+  # [T004272] Der Claude-Renderer ueberspringt Server mit ${VAR} in Headers.
+  # Dieser Test prueft, dass opencode und agy die Header korrekt durchreichen.
   local tmpd fixture
   tmpd="$(mktemp -d)"
   fixture="$tmpd/registry.yaml"
@@ -109,8 +113,6 @@ clients:
 cluster: {}
 YAML
 
-  # Der Generator laeuft vollstaendig gegen MCP_OUT_DIR, sodass die getrackten
-  # Repo-Zieldateien unberuehrt bleiben.
   run env HOME="$tmpd/fakehome" MCP_REGISTRY="$fixture" MCP_OUT_DIR="$tmpd" bash "$SYNC" render
   local render_status="$status"
   local render_output="$output"
@@ -118,16 +120,27 @@ YAML
   echo "render output: $render_output"
   [ "$render_status" -eq 0 ]
 
-  # Ergebnis messen: beide Header stehen in der gerenderten Claude-Config.
+  # Claude-Renderer ueberspringt probe-http (hat ${VAR} in Headers)
   run bash -c "node -e \"
     const fs=require('fs');
     const d=JSON.parse(fs.readFileSync('$tmpd/.mcp.json','utf8'));
-    const h=d.mcpServers['probe-http'].headers;
-    console.log(h.Authorization+'|'+h['X-Probe']);
+    console.log(d.mcpServers['probe-http'] === undefined ? 'absent' : 'present');
   \""
-  echo "output: $output"
+  echo "claude probe-http: $output"
   [ "$status" -eq 0 ]
-  [[ "$output" == 'Bearer ${PROBE_TOKEN}|static-value' ]]
+  [ "$output" = "absent" ]
+
+  # OpenCode-Renderer uebersetzt ${VAR} in {env:VAR}
+  # Hinweis: .opencode/opencode.jsonc ist JSONC (mit Kommentaren), also grep statt JSON.parse
+  run grep -o '"Authorization":"[^"]*"' "$tmpd/.opencode/opencode.jsonc"
+  echo "opencode auth header: $output"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'{env:PROBE_TOKEN}'* ]]
+
+  run grep -o '"X-Probe":"[^"]*"' "$tmpd/.opencode/opencode.jsonc"
+  echo "opencode X-Probe: $output"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'static-value'* ]]
 
   rm -rf "$tmpd"
 }
@@ -135,31 +148,29 @@ YAML
 # ── Kein Secret in getrackten Dateien ────────────────────────────────────
 
 @test "no expanded bearer token leaks into tracked harness configs" {
-  # Positiv-Anker: die Dateien existieren und tragen ueberhaupt einen Header.
+  # [T004272] .mcp.json hat jetzt KEINE Authorization-Header mehr, weil der
+  # Claude-Renderer Server mit ${VAR} in Headers ueberspringt. Der Test prueft,
+  # dass keine Klartext-Token in .mcp.json stehen.
   [ -f "$REPO/.mcp.json" ]
-  run grep -c 'Authorization' "$REPO/.mcp.json"
-  [ "$status" -eq 0 ]
-  [ "$output" -ge 1 ]
 
-  # Negativ-Aussage: jeder Authorization-Wert ist eine ${VAR}-Referenz.
-  # Extraktion bewusst per jq statt `node -e`: eine Regex auf `${...}` ueberlebt
-  # die drei Quoting-Ebenen (bats -> bash -c -> node -e) nicht — der Backslash
-  # vor dem Dollar geht unterwegs verloren und die Pruefung meldet falsch rot.
+  # Extraktion aller Authorization-Werte (sollte leer sein)
   run jq -r '.mcpServers | to_entries[] | select(.value.headers != null)
              | .key as $n | .value.headers | to_entries[]
              | select(.key | ascii_downcase == "authorization")
              | "\($n)=\(.value)"' "$REPO/.mcp.json"
   echo "authorization headers: $output"
   [ "$status" -eq 0 ]
-  [ -n "$output" ]
 
-  local leaked=""
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    case "$line" in
-      *'${'*'}'*) : ;;                   # Env-Referenz — in Ordnung
-      *) leaked="${leaked}${line} " ;;   # alles andere ist ein Klartext-Wert
-    esac
-  done <<< "$output"
-  [ -z "$leaked" ] || { echo "LEAK: $leaked"; false; }
+  # Wenn es Authorization-Header gibt, pruefe dass alle ${VAR}-Referenzen sind
+  if [ -n "$output" ]; then
+    local leaked=""
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      case "$line" in
+        *'${'*'}'*) : ;;                   # Env-Referenz — in Ordnung
+        *) leaked="${leaked}${line} " ;;   # alles andere ist ein Klartext-Wert
+      esac
+    done <<< "$output"
+    [ -z "$leaked" ] || { echo "LEAK: $leaked"; false; }
+  fi
 }

--- a/tests/spec/mcp-gateway/opencode-env-placeholder.bats
+++ b/tests/spec/mcp-gateway/opencode-env-placeholder.bats
@@ -65,7 +65,10 @@ YAML
   rm -rf "$tmpd"
 }
 
-@test "claude renderer keeps the canonical \${VAR} syntax" {
+@test "claude renderer skips servers with \${VAR} in headers (T004272)" {
+  # [T004272] Qwen Code liest .mcp.json mit Vorrang vor ~/.qwen/settings.json,
+  # expandiert ${VAR} aber nicht — der Literal-String fuehrt zu HTTP 401.
+  # Der Claude-Renderer ueberspringt deshalb Server mit ${VAR} in Headers.
   local tmpd
   tmpd="$(mktemp -d)"
   fixture_registry "$tmpd/registry.yaml"
@@ -74,19 +77,22 @@ YAML
       bash "$SYNC" render
   [ "$status" -eq 0 ]
 
-  run jq -r '.mcpServers["probe-http"].headers.Authorization' "$tmpd/.mcp.json"
-  echo "claude header: $output"
+  # probe-http hat ${PROBE_TOKEN} in Headers — darf NICHT in .mcp.json sein
+  run jq -r '.mcpServers["probe-http"]' "$tmpd/.mcp.json"
+  echo "claude probe-http: $output"
   [ "$status" -eq 0 ]
-  [ "$output" = 'Bearer ${PROBE_TOKEN}' ]
+  [ "$output" = "null" ]
 
   rm -rf "$tmpd"
 }
 
-@test "header values without a placeholder pass through untouched in both harnesses" {
+@test "header values without a placeholder pass through untouched in opencode" {
   # Positiv-Anker gegen eine zu gierige Ersetzung: ein Wert ohne ${...} darf
   # in KEINEM Renderer veraendert werden. Ohne diesen Test wuerde eine
   # Uebersetzung, die blind jede geschweifte Klammer umschreibt, unbemerkt
   # durchgehen.
+  # [T004272] Hinweis: Der Claude-Renderer ueberspringt Server mit ${VAR} in
+  # Headers komplett — deshalb wird hier nur opencode geprueft.
   local tmpd
   tmpd="$(mktemp -d)"
   fixture_registry "$tmpd/registry.yaml"
@@ -94,10 +100,6 @@ YAML
   run env HOME="$tmpd/fakehome" MCP_REGISTRY="$tmpd/registry.yaml" MCP_OUT_DIR="$tmpd" \
       bash "$SYNC" render
   [ "$status" -eq 0 ]
-
-  run jq -r '.mcpServers["probe-http"].headers["X-Static"]' "$tmpd/.mcp.json"
-  [ "$status" -eq 0 ]
-  [ "$output" = "no-placeholder-here" ]
 
   run grep -c 'no-placeholder-here' "$tmpd/.opencode/opencode.jsonc"
   [ "$status" -eq 0 ]

--- a/tests/spec/mcp-gateway/qwen-token-expansion.bats
+++ b/tests/spec/mcp-gateway/qwen-token-expansion.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# tests/spec/mcp-gateway/qwen-token-expansion.bats
+# Ticket: T004272
+#
+# Pruefmodus (Test-Resultats-Konvention T002448-M4): ERGEBNIS-orientiert.
+# Gemessen wird die tatsaechliche Generator-Ausgabe gegen eine Fixture-Registry
+# in einem tmpdir (MCP_REGISTRY/MCP_OUT_DIR/HOME aus T002487) — kein Muster im
+# Skriptquelltext. Die echte ~/.qwen-Config wird nie angefasst: QWEN_TARGET
+# haengt an HOME, und HOME zeigt in jedem Test in den tmpdir.
+#
+# Hintergrund: Qwen Code expandiert ${VAR} in den mcpServers.headers NICHT —
+# es sendet den Literal-String "Bearer ${BGE_MCP_TOKEN}", der Shim antwortet
+# 401. Gleicher Bug wie agy (T002704) und OpenCode (T002488). Die Loesung:
+# mcp-sync.sh loest den Token zur Sync-Zeit auf und schreibt den Klartext-
+# Wert in die nicht-getrackte ~/.qwen/settings.json (chmod 600).
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SYNC="$REPO/scripts/mcp-sync.sh"
+  TMPD="$(mktemp -d)"
+  mkdir -p "$TMPD/fakehome/.qwen"
+  QWEN_OUT="$TMPD/fakehome/.qwen/settings.json"
+  fixture_registry "$TMPD/registry.yaml"
+}
+
+teardown() {
+  rm -rf "$TMPD"
+}
+
+fixture_registry() {
+  cat > "$1" <<'YAML'
+clients:
+  probe-http:
+    transport: http
+    endpoint: http://localhost:19999/mcp
+    headers:
+      Authorization: "Bearer ${PROBE_TOKEN}"
+      X-Static: "no-placeholder-here"
+    harness:
+      claude_code:
+        type: http
+        url: http://localhost:19999/mcp
+      agy:
+        serverUrl: http://localhost:19999/mcp
+      opencode:
+        type: remote
+        url: http://localhost:19999/mcp
+        enabled: true
+      qwen_code:
+        httpUrl: http://localhost:19999/mcp
+cluster: {}
+YAML
+}
+
+write_server_env() {
+  mkdir -p "$TMPD/fakehome/.config/bge-mcp"
+  printf '%s\n' "$1" > "$TMPD/fakehome/.config/bge-mcp/server.env"
+}
+
+@test "qwen renderer resolves \${VAR} from the environment" {
+  run env HOME="$TMPD/fakehome" PROBE_TOKEN="env-value-5821" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  echo "render: $output"
+  [ "$status" -eq 0 ]
+
+  run jq -r '.mcpServers["probe-http"].headers.Authorization' "$QWEN_OUT"
+  echo "qwen header: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Bearer env-value-5821" ]
+}
+
+@test "qwen renderer falls back to server.env when the environment is empty" {
+  write_server_env 'PROBE_TOKEN=from-server-env-5822'
+
+  run env -u PROBE_TOKEN HOME="$TMPD/fakehome" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  echo "render: $output"
+  [ "$status" -eq 0 ]
+
+  run jq -r '.mcpServers["probe-http"].headers.Authorization' "$QWEN_OUT"
+  echo "qwen header: $output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Bearer from-server-env-5822" ]
+}
+
+@test "qwen: unresolvable placeholder is kept, warned about, and does not fail the render" {
+  run env -u PROBE_TOKEN HOME="$TMPD/fakehome" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  echo "render: $output"
+  [ "$status" -eq 0 ]
+
+  # Positiv-Anker zuerst (T002356-M1): der Renderer muss ueberhaupt gelaufen
+  # sein und die Datei geschrieben haben.
+  [ -f "$QWEN_OUT" ]
+  run jq -r '.mcpServers["probe-http"].httpUrl' "$QWEN_OUT"
+  [ "$output" = "http://localhost:19999/mcp" ]
+
+  run jq -r '.mcpServers["probe-http"].headers.Authorization' "$QWEN_OUT"
+  echo "qwen header: $output"
+  [ "$output" = 'Bearer ${PROBE_TOKEN}' ]
+
+  # Die Warnung nennt die Variable.
+  run env -u PROBE_TOKEN HOME="$TMPD/fakehome" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  echo "stderr+stdout: $output"
+  [[ "$output" == *"PROBE_TOKEN"* ]]
+}
+
+@test "qwen: header values without a placeholder pass through untouched" {
+  run env HOME="$TMPD/fakehome" PROBE_TOKEN="env-value-5821" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  [ "$status" -eq 0 ]
+
+  run jq -r '.mcpServers["probe-http"].headers["X-Static"]' "$QWEN_OUT"
+  echo "static header: $output"
+  [ "$output" = "no-placeholder-here" ]
+}
+
+@test "qwen: settings.json is written user-readable only, because it carries a resolved secret" {
+  run env HOME="$TMPD/fakehome" PROBE_TOKEN="env-value-5821" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  [ "$status" -eq 0 ]
+
+  run stat -c '%a' "$QWEN_OUT"
+  echo "mode (neu angelegt): $output"
+  [ "$output" = "600" ]
+
+  # Bestandsfall: chmod 600 wird auch fuer eine bereits existierende Datei gesetzt.
+  chmod 644 "$QWEN_OUT"
+  run env HOME="$TMPD/fakehome" PROBE_TOKEN="env-value-5821" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  [ "$status" -eq 0 ]
+
+  run stat -c '%a' "$QWEN_OUT"
+  echo "mode (bestehende Datei): $output"
+  [ "$output" = "600" ]
+}
+
+@test "qwen: settings.json preserves non-MCP config on merge" {
+  # Vor dem Render eine bestehende settings.json mit anderen Settings anlegen.
+  cat > "$QWEN_OUT" <<'JSON'
+{
+  "modelProviders": [{"name": "test-provider"}],
+  "theme": "dark"
+}
+JSON
+
+  run env HOME="$TMPD/fakehome" PROBE_TOKEN="env-value-5821" \
+      MCP_REGISTRY="$TMPD/registry.yaml" MCP_OUT_DIR="$TMPD" \
+      bash "$SYNC" render
+  [ "$status" -eq 0 ]
+
+  run jq -r '.modelProviders[0].name' "$QWEN_OUT"
+  [ "$output" = "test-provider" ]
+  run jq -r '.theme' "$QWEN_OUT"
+  [ "$output" = "dark" ]
+
+  # Und die MCP-Server sind auch da.
+  run jq -r '.mcpServers["probe-http"].headers.Authorization' "$QWEN_OUT"
+  [ "$output" = "Bearer env-value-5821" ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3420,6 +3420,12 @@
     "kind": "shell"
   },
   {
+    "id": "mcp-gateway/qwen-token-expansion",
+    "file": "tests/spec/mcp-gateway/qwen-token-expansion.bats",
+    "category": "mcp-gateway",
+    "kind": "shell"
+  },
+  {
     "id": "mcp-gateway/watchdog-tunnel-liveness",
     "file": "tests/spec/mcp-gateway/watchdog-tunnel-liveness.bats",
     "category": "mcp-gateway",


### PR DESCRIPTION
## Problem
Qwen Code liest `.mcp.json` mit Vorrang vor `~/.qwen/settings.json`, expandiert aber `${VAR}` in Headers nicht. Der Literal-String `Bearer ${BGE_MCP_TOKEN}` wurde an den bge-mcp Server gesendet → HTTP 401.

## Lösung
- `render_claude_json()` überspringt Server mit `${VAR}` in Headers → bge-mcp nicht mehr in `.mcp.json`
- Qwen Code fällt auf `~/.qwen/settings.json` zurück (aufgelöster Token aus `~/.config/bge-mcp/server.env`)
- `render_qwen_json()` und `QWEN_TARGET` für vollständige Qwen-Code-Unterstützung
- `docs/agent-guide/registry/mcp.yaml`: auth_note aktualisiert, `qwen_code` harness hinzugefügt
- 6 BATS-Tests für `render_qwen_json()` (Token-Auflösung, Fallback, chmod 600, Merge)

## Testing
- [x] bge-mcp verbindet sich erfolgreich nach Qwen Code Neustart
- [x] `task mcp:sync check` grün
- [x] BATS-Tests lokal bestanden

Closes T004272