### PR TITLE
chore(infra): resources.requests für bge model-download Init-Container [T003903]

### DIFF
--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -90,6 +90,12 @@ spec:
           volumeMounts:
             - name: models
               mountPath: /models
+          resources:
+            requests:
+              # [T003903] Kein BestEffort-QoS mehr: Model-Download darf unter
+              # Node-Druck nicht als erster evictet werden.
+              cpu: 100m
+              memory: 256Mi
       containers:
         - name: llama-cpp
           image: ghcr.io/ggml-org/llama.cpp:server-b10223
@@ -238,6 +244,12 @@ spec:
           volumeMounts:
             - name: models
               mountPath: /models
+          resources:
+            requests:
+              # [T003903] Kein BestEffort-QoS mehr: Model-Download darf unter
+              # Node-Druck nicht als erster evictet werden.
+              cpu: 100m
+              memory: 256Mi
       containers:
         - name: llama-cpp
           image: ghcr.io/ggml-org/llama.cpp:server-b10223


### PR DESCRIPTION
Fixes T003903 — Init-Container ohne resources.requests (bge-embed, bge-rerank): Eviction-Risiko unter Node-Druck. Setzt cpu: 100m / memory: 256Mi als requests für beide model-download-Init-Container in k3d/llm-gpu.yaml (Operator-Entscheid 2026-08-14). `task workspace:validate` grün, `task test:changed` 52 pass.