### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 975,
+      "file_count": 976,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -634,6 +634,7 @@
         "tests/spec/openspec-workflow/design-location-guard.bats",
         "tests/spec/openspec-workflow/half-archive-guard.bats",
         "tests/spec/openspec-workflow/half-archive-uncommitted.bats",
+        "tests/spec/openspec-workflow/main-staging-guard.bats",
         "tests/spec/openspec-workflow/plan-archive-git-add-coverage.bats",
         "tests/spec/openspec-workflow/propose-help.bats",
         "tests/spec/openspec-workflow/propose-tasks-testpath-guard.bats",
@@ -3369,7 +3370,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 723,
+      "file_count": 724,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3922,6 +3923,7 @@
         "scripts/openspec-embed.test.mjs",
         "scripts/openspec-half-archive-check.sh",
         "scripts/openspec-header-inject.sh",
+        "scripts/openspec-main-staging-guard.sh",
         "scripts/openspec-merge.mjs",
         "scripts/openspec-merge.test.ts",
         "scripts/openspec-status-map.sh",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31764093640).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
