### PR TITLE
fix(scripts): Modell-Registry Review-Fixes [T004445]

### DIFF
--- a/migrations/20260814-model-registry.sql
+++ b/migrations/20260814-model-registry.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS model_registry.adapters (
 CREATE TABLE IF NOT EXISTS model_registry.eval_scores (
   adapter_id    INT REFERENCES model_registry.adapters(id),
   role          TEXT NOT NULL,           -- "scout", "review-lens", "commit-msg", "triage"
-  score         FLOAT NOT NULL,          -- 0..1
+  score         FLOAT NOT NULL CHECK (score >= 0 AND score <= 1),  -- 0..1 (T004445)
   harness_version TEXT,
   evaluated_at   TIMESTAMPTZ DEFAULT now(),
   PRIMARY KEY (adapter_id, role)
@@ -51,8 +51,25 @@ CREATE TABLE IF NOT EXISTS model_registry.deployment_config (
 -- landet automatisch im Schema der Tabelle (model_registry).
 CREATE INDEX IF NOT EXISTS eval_scores_role_idx ON model_registry.eval_scores(role);
 
+-- CHECK 0..1 auf score: bei bereits existierender Tabelle greift CREATE TABLE
+-- IF NOT EXISTS nicht nach — der Constraint wird hier idempotent nachgezogen
+-- (T004445 Review-Fix). Benannte Constraints sind pro Tabelle eindeutig, daher
+-- ist ADD CONSTRAINT IF NOT EXISTS sicher.
+ALTER TABLE model_registry.eval_scores
+  DROP CONSTRAINT IF EXISTS eval_scores_score_range_check;
+ALTER TABLE model_registry.eval_scores
+  ADD CONSTRAINT eval_scores_score_range_check CHECK (score >= 0 AND score <= 1);
+
 -- Zugriff fuer den Website-User (Skripte verbinden als website):
 GRANT USAGE ON SCHEMA model_registry TO website;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA model_registry TO website;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA model_registry TO website;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA model_registry TO website;
+-- Zukuenftige Tabellen/Funktionen im Schema automatisch mitberechtigen
+-- (GRANT ON ALL TABLES wirkt nur auf bereits existierende Objekte; T004445):
+ALTER DEFAULT PRIVILEGES IN SCHEMA model_registry
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO website;
+ALTER DEFAULT PRIVILEGES IN SCHEMA model_registry
+  GRANT USAGE, SELECT ON SEQUENCES TO website;
+ALTER DEFAULT PRIVILEGES IN SCHEMA model_registry
+  GRANT EXECUTE ON FUNCTIONS TO website;

--- a/scripts/finetune/eval-runner.sh
+++ b/scripts/finetune/eval-runner.sh
@@ -7,8 +7,11 @@
 
 set -euo pipefail
 
+# --- Basis-Pfade (VOR der ersten Nutzung berechnen — CWD-unabhängig, T004445 Review-Fix) ---
+FINETUNE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # --- Defaults ---
-TESTSET="scripts/finetune/testsets/agent-actions.jsonl"
+TESTSET="$FINETUNE_DIR/testsets/agent-actions.jsonl"
 ENDPOINT="http://127.0.0.1:18235/v1"
 MODEL=""
 DB_URL=""
@@ -27,8 +30,15 @@ Options:
   --model <slug>     Modell-Slug am Endpunkt (Default: <adapter>-Name)
   --db-url <url>     MODEL_REGISTRY_DB_URL setzen
   --dry-run          Keine DB-Schreibzugriffe
+  --help             Zeige Hilfe
 EOF
-    exit 1
+    exit "${1:-1}"
+}
+
+# Rollen-Whitelist (T004445 Review-Fix: Tippfehler statt stiller Speicherung)
+VALID_ROLES=" scout review-lens commit-msg triage "
+validate_role() {
+    [[ "$VALID_ROLES" == *" $1 "* ]]
 }
 
 registry_psql() {
@@ -51,7 +61,7 @@ while [[ $# -gt 0 ]]; do
         --model) MODEL="$2"; shift 2 ;;
         --db-url) DB_URL="$2"; shift 2 ;;
         --dry-run) DRY_RUN=true; shift ;;
-        --help) usage ;;
+        --help) usage 0 ;;
         *) echo "Unknown option: $1" >&2; usage ;;
     esac
 done
@@ -59,18 +69,18 @@ done
 # Validierung Pflichtfelder
 [[ -z "${ADAPTER:-}" ]] && { echo "Error: --adapter is required" >&2; usage; }
 [[ -z "${ROLE:-}" ]] && { echo "Error: --role is required" >&2; usage; }
+validate_role "$ROLE" || { echo "Error: invalid role '$ROLE' — erlaubt: scout|review-lens|commit-msg|triage" >&2; usage; }
 [[ -z "${MODEL:-}" ]] && MODEL="$ADAPTER"
 export MODEL_REGISTRY_DB_URL="${DB_URL:-${MODEL_REGISTRY_DB_URL:-}}"
 
 # 1. Testset Validierung
-python3 scripts/finetune/eval_scoring.py validate-testset "$TESTSET" || {
+python3 "$FINETUNE_DIR/eval_scoring.py" validate-testset "$TESTSET" || {
     echo "Error: Testset validation failed" >&2
     exit 1
 }
 
 # 2. Generierungs-Schritt (Python Heredoc)
 # Erzeugt den Report als JSON auf stdout. Analog zu gen_fixtures.py.
-FINETUNE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PY_OUT="$(mktemp)"
 set +e
 python3 - "$TESTSET" "$ENDPOINT" "$MODEL" "$ADAPTER" "$ROLE" "$DRY_RUN" "$FINETUNE_DIR" >"$PY_OUT" <<'PYEOF'
@@ -195,9 +205,13 @@ fi
 
 # 3. DB-Update (wenn nicht --dry-run)
 if [[ "$DRY_RUN" == "false" ]]; then
-    # a. insert_adapter
-    # Wir nutzen 'unknown' als base_model, da p3 die Provenienz später setzt
-    ADAPTER_ID=$(registry_psql -t -A -c "SELECT model_registry.insert_adapter('$ADAPTER', 'unknown', NULL);") || {
+    # a. insert_adapter — get-or-create (existierende Metadaten bleiben erhalten).
+    # Werte als psql-Variablen (:'var'), SQL ueber stdin: psql ersetzt :'var'
+    # NUR bei stdin/-f, nicht bei -c (T004445 Review-Fix). Quoting macht psql.
+    ADAPTER_ID=$(registry_psql -t -A -v adapter="$ADAPTER" <<'SQL'
+SELECT model_registry.insert_adapter(:'adapter', 'unknown', NULL);
+SQL
+    ) || {
         echo "Error: DB update (insert_adapter) failed" >&2
         exit 1
     }
@@ -205,11 +219,14 @@ if [[ "$DRY_RUN" == "false" ]]; then
     # b. upsert_eval_score
     # Wir extrahieren den Score aus dem JSON Report
     SCORE=$(echo "$REPORT" | python3 -c "import sys, json; print(json.load(sys.stdin)['score'])")
-    
-    registry_psql -c "SELECT model_registry.upsert_eval_score('$ADAPTER_ID', '$ROLE', $SCORE, 'eval-harness-1');" || {
+
+    if ! registry_psql -v adapter_id="$ADAPTER_ID" -v role="$ROLE" -v score="$SCORE" <<'SQL'
+SELECT model_registry.upsert_eval_score(:'adapter_id'::int, :'role', :'score'::float, 'eval-harness-1');
+SQL
+    then
         echo "Error: DB update (upsert_eval_score) failed" >&2
         exit 1
-    }
+    fi
 fi
 
 echo "$REPORT"

--- a/scripts/finetune/model-registry.sh
+++ b/scripts/finetune/model-registry.sh
@@ -70,30 +70,33 @@ cmd_register() {
     # Handle DB URL
     export MODEL_REGISTRY_DB_URL="${db_url:-${MODEL_REGISTRY_DB_URL:-}}"
 
-    # 1. Insert Adapter
-    # Achtung: ${quant:+'$quant'} expandiert in bash NICHT rueckwärts — der
-    # Wortlaut waere wörtlich '$quant'. Deshalb explizit vorbereiten.
-    local sql_quant="NULL"
-    [[ -n "$quant" ]] && sql_quant="'$quant'"
+    # 1. Insert Adapter — Werte als psql-Variablen, SQL ueber stdin (psql
+    # ersetzt :'var' nur bei stdin/-f, nicht bei -c; T004445 Review-Fix).
+    # NULLIF(:'quant','') => NULL bei ungesetztem --quant.
     local adapter_id
-    adapter_id=$(registry_psql -t -A -c "SELECT model_registry.insert_adapter('$name', '$base_model', $sql_quant);" || { echo "DB error during adapter insertion" >&2; exit 1; })
+    adapter_id=$(registry_psql -t -A \
+      -v name="$name" -v base_model="$base_model" -v quant="${quant:-}" <<'SQL' || { echo "DB error during adapter insertion" >&2; exit 1; }
+SELECT model_registry.insert_adapter(:'name', :'base_model', NULLIF(:'quant',''));
+SQL
+    )
 
     if [[ -z "$adapter_id" ]]; then
         echo "Error: Failed to get adapter ID." >&2
         exit 1
     fi
 
-    # 2. Provenance (if any)
+    # 2. Provenance (if any) — ebenfalls über psql-Variablen
     if [[ -n "$corpus" || -n "$lora_rank" || -n "$lora_alpha" || -n "$git_commit" || -n "$training_config" ]]; then
-        # Prepare values: use NULL if not set
-        local sql_corpus="${corpus:+'$corpus'}"
-        local sql_rank="${lora_rank:-NULL}"
-        local sql_alpha="${lora_alpha:-NULL}"
-        local sql_git="${git_commit:+'$git_commit'}"
-        local sql_config="${training_config:+'$training_config'::jsonb}"
-        
-        # Fallback for empty string or NULL logic in SQL
-        registry_psql -c "SELECT model_registry.upsert_provenance($adapter_id, ${sql_corpus:-NULL}, $sql_rank, $sql_alpha, ${sql_git:-NULL}, ${sql_config:-NULL});" || { echo "DB error during provenance upsert" >&2; exit 1; }
+        if ! registry_psql \
+          -v adapter_id="$adapter_id" \
+          -v corpus="${corpus:-}" -v rank="${lora_rank:-}" -v alpha="${lora_alpha:-}" \
+          -v git_commit="${git_commit:-}" -v config="${training_config:-}" <<'SQL'
+SELECT model_registry.upsert_provenance(:'adapter_id'::int, NULLIF(:'corpus',''), NULLIF(:'rank','')::int, NULLIF(:'alpha','')::int, NULLIF(:'git_commit',''), NULLIF(:'config','')::jsonb);
+SQL
+        then
+            echo "DB error during provenance upsert" >&2
+            exit 1
+        fi
     fi
 
     echo "Registered adapter $name (id=$adapter_id, base_model=$base_model, quant=${quant:-NULL})"
@@ -162,10 +165,14 @@ cmd_list() {
 
     export MODEL_REGISTRY_DB_URL="${db_url:-${MODEL_REGISTRY_DB_URL:-}}"
 
-    local sql_role="${role:+'$role'}"
-    local sql_score="${min_score:-NULL}"
-
-    registry_psql -c "SELECT * FROM model_registry.list_adapters($sql_role, $sql_score);"
+    # Filter als psql-Variablen (injection-sicher; NULLIF => ungesetzte Filter = NULL)
+    if ! registry_psql -v role="${role:-}" -v min_score="${min_score:-}" <<'SQL'
+SELECT * FROM model_registry.list_adapters(NULLIF(:'role',''), NULLIF(:'min_score','')::float);
+SQL
+    then
+        echo "Error: DB query (list_adapters) failed" >&2
+        exit 1
+    fi
 }
 
 cmd_export_loadout() {
@@ -182,9 +189,12 @@ cmd_export_loadout() {
 
     export MODEL_REGISTRY_DB_URL="${db_url:-${MODEL_REGISTRY_DB_URL:-}}"
 
-    # Get data in clean format
+    # Get data in clean format — Adapter-Name als psql-Variable (injection-sicher)
     local data
-    data=$(registry_psql -t -A -F'|' -c "SELECT id, name, base_model, quantization, vram_mb, max_context, throughput_toks, load_time_ms, best_score, best_role FROM model_registry.get_adapter('$adapter');" || { echo "Error: Could not fetch adapter data" >&2; exit 1; })
+    data=$(registry_psql -t -A -F'|' -v adapter="$adapter" <<'SQL' || { echo "Error: Could not fetch adapter data" >&2; exit 1; }
+SELECT id, name, base_model, quantization, vram_mb, max_context, throughput_toks, load_time_ms, best_score, best_role FROM model_registry.get_adapter(:'adapter');
+SQL
+    )
 
     if [[ -z "$data" ]]; then
         echo "Error: Adapter '$adapter' not found." >&2

--- a/scripts/finetune/registry-db.sql
+++ b/scripts/finetune/registry-db.sql
@@ -6,6 +6,11 @@
 -- DROP SCHEMA IF EXISTS model_registry CASCADE;
 
 -- 1. insert_adapter
+-- Get-or-create-Semantik (T004445 Review-Fix): existiert der Adapter schon, bleibt
+-- er UNVERAENDERT — eval-runner/stat-collector rufen diese Funktion mit
+-- Platzhalterwerten ('unknown', NULL) auf und duerfen registrierte Metadaten
+-- (base_model, quantization) nicht ueberschreiben. Nur die Neuanlage setzt
+-- die uebergebenen Werte.
 CREATE OR REPLACE FUNCTION model_registry.insert_adapter(
   p_name TEXT, 
   p_base_model TEXT, 
@@ -14,12 +19,12 @@ CREATE OR REPLACE FUNCTION model_registry.insert_adapter(
 DECLARE
   v_id INT;
 BEGIN
-  INSERT INTO model_registry.adapters (name, base_model, quantization)
-  VALUES (p_name, p_base_model, p_quantization)
-  ON CONFLICT (name) DO UPDATE 
-    SET base_model = EXCLUDED.base_model,
-        quantization = EXCLUDED.quantization
-  RETURNING id INTO v_id;
+  SELECT id INTO v_id FROM model_registry.adapters WHERE name = p_name;
+  IF v_id IS NULL THEN
+    INSERT INTO model_registry.adapters (name, base_model, quantization)
+    VALUES (p_name, p_base_model, p_quantization)
+    RETURNING id INTO v_id;
+  END IF;
   RETURN v_id;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
@@ -140,7 +145,7 @@ BEGIN
   ) es ON TRUE
   WHERE a.name = p_name;
 END;
-$$ LANGUAGE plpgsql VOLATILE;
+$$ LANGUAGE plpgsql STABLE;
 
 -- 7. list_adapters
 CREATE OR REPLACE FUNCTION model_registry.list_adapters(
@@ -172,5 +177,5 @@ BEGIN
     AND (p_min_score IS NULL OR es.score >= p_min_score)
   ORDER BY es.score DESC NULLS LAST;
 END;
-$$ LANGUAGE plpgsql VOLATILE;
+$$ LANGUAGE plpgsql STABLE;
 

--- a/scripts/finetune/stat-collector.sh
+++ b/scripts/finetune/stat-collector.sh
@@ -26,7 +26,7 @@ Options:
   --json             Report als JSON auf stdout (Default: menschenlesbar)
   --help             Zeige Hilfe
 EOF
-    exit 1
+    exit "${1:-1}"
 }
 
 registry_psql() {
@@ -47,7 +47,7 @@ while [[ $# -gt 0 ]]; do
         --db-url) DB_URL="$2"; shift 2 ;;
         --dry-run) DRY_RUN=true; shift ;;
         --json) JSON_OUTPUT=true; shift ;;
-        --help) usage ;;
+        --help) usage 0 ;;
         *) echo "Unknown option: $1" >&2; usage ;;
     esac
 done
@@ -148,16 +148,22 @@ fi
 
 # --- DB-Update (wenn nicht --dry-run) ---
 if [[ "$DRY_RUN" == "false" ]]; then
-    # a. insert_adapter
-    ADAPTER_ID=$(registry_psql -t -A -c "SELECT model_registry.insert_adapter('$ADAPTER', 'unknown', NULL);" || echo "")
+    # a. insert_adapter — get-or-create; Werte als psql-Variablen, SQL ueber
+    # stdin (psql ersetzt :'var' nur bei stdin/-f, T004445 Review-Fix)
+    ADAPTER_ID=$(registry_psql -t -A -v adapter="$ADAPTER" <<'SQL' || echo ""
+SELECT model_registry.insert_adapter(:'adapter', 'unknown', NULL);
+SQL
+    )
     if [[ -z "$ADAPTER_ID" ]]; then
         echo "Error: DB update (insert_adapter) failed" >&2
         exit 1
     fi
 
-    # b. upsert_stat_requirements
+    # b. upsert_stat_requirements — Messwerte durch to_sql_val auf NULL|numerisch
+    # normalisiert; NULL wird als LEERER String an psql gegeben, damit
+    # NULLIF(:'vram','') zu echtem SQL-NULL wird (T004445 Review-Fix)
     to_sql_val() {
-        if [[ "$1" == "null" || "$1" == "NULL" ]]; then echo "NULL"; else echo "$1"; fi
+        if [[ "$1" == "null" || "$1" == "NULL" || -z "$1" ]]; then echo ""; else echo "$1"; fi
     }
 
     SQL_VRAM=$(to_sql_val "$VRAM")
@@ -165,10 +171,15 @@ if [[ "$DRY_RUN" == "false" ]]; then
     SQL_MAX_CTX=$(to_sql_val "$MAX_CONTEXT")
     SQL_LOAD=$(to_sql_val "$LOAD_TIME")
 
-    registry_psql -c "SELECT model_registry.upsert_stat_requirements('$ADAPTER_ID', $SQL_VRAM, $SQL_MAX_CTX, $SQL_THROUGHPUT, $SQL_LOAD);" || {
+    if ! registry_psql -v adapter_id="$ADAPTER_ID" \
+      -v vram="$SQL_VRAM" -v maxctx="$SQL_MAX_CTX" \
+      -v throughput="$SQL_THROUGHPUT" -v loadms="$SQL_LOAD" <<'SQL'
+SELECT model_registry.upsert_stat_requirements(:'adapter_id'::int, NULLIF(:'vram','')::int, NULLIF(:'maxctx','')::int, NULLIF(:'throughput','')::float, NULLIF(:'loadms','')::int);
+SQL
+    then
         echo "Error: DB update (upsert_stat_requirements) failed" >&2
         exit 1
-    }
+    fi
 fi
 
 exit 0

--- a/tests/spec/finetune/model-registry.bats
+++ b/tests/spec/finetune/model-registry.bats
@@ -15,14 +15,17 @@ setup() {
 #!/bin/bash
 LOG_FILE="$TMPD/psql-calls.log"
 echo "\$*" >> "\$LOG_FILE"
+# SQL kommt seit T004445 ueber stdin (psql :'var' ersetzt nur bei stdin/-f)
+STDIN_SQL="\$(cat)"
+[ -n "\$STDIN_SQL" ] && echo "\$STDIN_SQL" >> "\$LOG_FILE"
 
 TA=""
 CMD=""
-for arg in "\$@"; do
+for arg in "\$@" "\$STDIN_SQL"; do
   [ "\$arg" = "-t" ] && TA="\$TA-t"
   [ "\$arg" = "-A" ] && TA="\$TA-A"
 done
-for arg in "\$@"; do
+for arg in "\$@" "\$STDIN_SQL"; do
   case "\$arg" in
     *insert_adapter*) CMD="insert_adapter" ;;
     *get_adapter*)    CMD="get_adapter" ;;
@@ -99,8 +102,10 @@ teardown() {
   run bash "$CLI" register my-adapter gemma-4-9b-it --quant Q8_0
   [ "$status" -eq 0 ]
   grep -q "insert_adapter" "$TMPD/psql-calls.log"
-  grep -q "'my-adapter'" "$TMPD/psql-calls.log"
-  grep -q "'Q8_0'" "$TMPD/psql-calls.log"
+  # Werte als psql-Variablen (injection-sicher, T004445)
+  grep -q "name=my-adapter" "$TMPD/psql-calls.log"
+  grep -q "base_model=gemma-4-9b-it" "$TMPD/psql-calls.log"
+  grep -q "quant=Q8_0" "$TMPD/psql-calls.log"
 }
 
 @test "register mit Provenienz ruft upsert_provenance auf" {
@@ -108,10 +113,10 @@ teardown() {
   run bash "$CLI" register my-adapter gemma-4-9b-it --corpus "wiki" --lora-rank 16 --lora-alpha 32 --git-commit "abc1234"
   [ "$status" -eq 0 ]
   grep -q "upsert_provenance" "$TMPD/psql-calls.log"
-  grep -q "wiki" "$TMPD/psql-calls.log"
-  grep -q "16" "$TMPD/psql-calls.log"
-  grep -q "32" "$TMPD/psql-calls.log"
-  grep -q "abc1234" "$TMPD/psql-calls.log"
+  grep -q "corpus=wiki" "$TMPD/psql-calls.log"
+  grep -q "rank=16" "$TMPD/psql-calls.log"
+  grep -q "alpha=32" "$TMPD/psql-calls.log"
+  grep -q "git_commit=abc1234" "$TMPD/psql-calls.log"
 }
 
 @test "eval ohne --dry-run: Score landet in upsert_eval_score-Aufruf" {
@@ -146,7 +151,8 @@ teardown() {
   run bash "$CLI" list --role scout --min-score 0.7
   [ "$status" -eq 0 ]
   grep -q "list_adapters" "$TMPD/psql-calls.log"
-  grep -q "'scout'" "$TMPD/psql-calls.log"
+  grep -q "role=scout" "$TMPD/psql-calls.log"
+  grep -q "min_score=0.7" "$TMPD/psql-calls.log"
   [[ "$output" == *"name"* ]]
 }
 


### PR DESCRIPTION
## Summary

Review-Fixes aus dem Code-Review von T002629 (PR #4371/#4375). Die Findings waren vor dem Merge nicht mehr einbringbar (paralleler Merge), jetzt als eigenständiges Follow-up.

### Fixes

**CRITICAL — base_model/quantization-Clobbering:**
- `registry-db.sql`: `insert_adapter` auf get-or-create-Semantik umgestellt (existierende Adapter bleiben unverändert — eval/stats mit Platzhalterwerten überschreiben registrierte Metadaten nicht mehr). Verifiziert gegen Dev-DB: register → eval behält `base_model=gemma-4-9b-it`.

**MAJOR — SQL-Injection / Quote-Bruch:**
- Alle DB-Aufrufe (`model-registry.sh` register/list/export-loadout, `eval-runner.sh`, `stat-collector.sh`) auf psql-Variablen (`-v name=...` + `:'name'`) + SQL über stdin umgestellt. psql ersetzt `:'var'` nur bei stdin/-f, nicht bei `-c` (empirisch verifiziert). Namen mit Quotes (z.B. `O'Brien`) funktionieren jetzt.

**MAJOR — CWD-relative Pfade:**
- `eval-runner.sh`: `FINETUNE_DIR` vor erster Nutzung berechnet; Testset-Default und eval_scoring-Aufruf absolut.

**MINOR:**
- `--help` Exit 0 in eval-runner/stat-collector (konsistent mit CLI)
- Rollen-Whitelist scout|review-lens|commit-msg|triage (Tippfehler abgefangen)
- Migration: CHECK-Constraint score 0..1 (idempotent per ALTER TABLE ADD CONSTRAINT IF NOT EXISTS nachgezogen), ALTER DEFAULT PRIVILEGES für zukünftige Tabellen/Funktionen
- `get_adapter`/`list_adapters` auf `STABLE`

### Test Plan

- `bats tests/spec/finetune/model-registry.bats` — 12/12 grün (Assertions auf psql-Variablen-Form angepasst, Fake-psql liest stdin)
- `bats tests/spec/unsloth-eval-harness/` — 21/21 grün (Regression)
- E2E gegen Dev-DB (k3d): register mit `O'Brien-adapter` → eval → stats → list → export-loadout, inkl. CHECK-Constraint-Verifikation (score=1.5 → ERROR)
- `task freshness:check` ✓
- `task workspace:validate` ✓