### PR TITLE
chore(ci): allow external execution of test:unit:quality-loop [T004531]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -585,7 +585,6 @@ tasks:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/test-tasks-node-deps.bats
 
   test:unit:quality-loop:
-    internal: true
     cmds:
       - ./tests/unit/lib/bats-core/bin/bats tests/unit/quality-loop.bats
 


### PR DESCRIPTION
## Summary
- Remove `internal: true` from `test:unit:quality-loop` in `Taskfile.yml` so external callers like the scheduled GitHub Actions workflow `.github/workflows/quality-loop.yml` can execute it.

## Test Plan
- Run `task test:unit:quality-loop` locally (passed).
- Quality gates and freshness verified.