### PR TITLE
chore(ci): sanction helpContent.ts in s1 code quality ignore list [T004532]

### DIFF
--- a/docs/code-quality/baseline.json
+++ b/docs/code-quality/baseline.json
@@ -3,56 +3,49 @@
     "gate": "S1",
     "path": "website/src/components/assistant/QuestionnaireView.svelte",
     "metric": 1001,
-    "detail": "1001 lines > 500 limit (.svelte)",
-    "frozen_at": "224a9e077"
+    "detail": "1001 lines > 800 limit (.svelte)",
+    "frozen_at": "e23dcebed"
   },
   "S1:website/src/components/inbox/InboxApp.svelte": {
     "gate": "S1",
     "path": "website/src/components/inbox/InboxApp.svelte",
     "metric": 954,
-    "detail": "954 lines > 500 limit (.svelte)",
-    "frozen_at": "224a9e077"
+    "detail": "954 lines > 800 limit (.svelte)",
+    "frozen_at": "e23dcebed"
   },
   "S1:website/src/components/inbox/InboxDetail.svelte": {
     "gate": "S1",
     "path": "website/src/components/inbox/InboxDetail.svelte",
     "metric": 837,
-    "detail": "837 lines > 500 limit (.svelte)",
-    "frozen_at": "224a9e077"
-  },
-  "S1:website/src/lib/helpContent.ts": {
-    "gate": "S1",
-    "path": "website/src/lib/helpContent.ts",
-    "metric": 902,
-    "detail": "902 lines > 600 limit (.ts)",
-    "frozen_at": "224a9e077"
+    "detail": "837 lines > 800 limit (.svelte)",
+    "frozen_at": "e23dcebed"
   },
   "S1:website/src/pages/admin/[clientId].astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/[clientId].astro",
     "metric": 745,
-    "detail": "745 lines > 400 limit (.astro)",
-    "frozen_at": "224a9e077"
+    "detail": "745 lines > 600 limit (.astro)",
+    "frozen_at": "e23dcebed"
   },
   "S1:website/src/pages/admin/fragebogen/[assignmentId].astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/fragebogen/[assignmentId].astro",
     "metric": 625,
-    "detail": "625 lines > 400 limit (.astro)",
-    "frozen_at": "224a9e077"
+    "detail": "625 lines > 600 limit (.astro)",
+    "frozen_at": "e23dcebed"
   },
   "S1:website/src/pages/admin/projekte/[id].astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/projekte/[id].astro",
     "metric": 923,
-    "detail": "923 lines > 400 limit (.astro)",
-    "frozen_at": "224a9e077"
+    "detail": "923 lines > 600 limit (.astro)",
+    "frozen_at": "e23dcebed"
   },
   "S1:website/src/pages/admin/termine.astro": {
     "gate": "S1",
     "path": "website/src/pages/admin/termine.astro",
     "metric": 772,
-    "detail": "772 lines > 400 limit (.astro)",
-    "frozen_at": "224a9e077"
+    "detail": "772 lines > 600 limit (.astro)",
+    "frozen_at": "e23dcebed"
   }
 }

--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -71,6 +71,9 @@ s1:
     .php: 600     # war 400
   ignore:
     - "website/src/lib/system-test-seed-data.ts"
+    # helpContent.ts is a static copy/dictionary catalog defining contextual help text
+    # and action checklists for portal and admin routes. Static text catalog.
+    - "website/src/lib/helpContent.ts"
     # pipeline.js is a single monolithic Claude Code Workflow script: the harness
     # forbids top-level imports-before-`meta` and dynamic import(), so it cannot be
     # safely split into modules (see T000460). It is a sanctioned exception to the


### PR DESCRIPTION
## Summary
- Add `website/src/lib/helpContent.ts` to `s1.ignore` in `docs/code-quality/gates.yaml` as it is a static copy/dictionary catalog.
- Re-froze baseline into `docs/code-quality/baseline.json` (7 remaining violations).

## Test Plan
- Ran `task test:changed && task freshness:regenerate && task freshness:check` (all gates passed).