### PR TITLE
fix(skills): JSON-Polling via gh statt gh-axi + Archiv vor Branch-Löschung [T004612]

### DIFF
--- a/.claude/skills/dev-flow-chore/SKILL.md
+++ b/.claude/skills/dev-flow-chore/SKILL.md
@@ -158,16 +158,16 @@ Rufe `commit-commands:commit-push-pr` auf (Claude Code slash-command) oder führ
 ## Schritt 5: Merge wenn CI grün
 
 **`git-workflow` Schritt 5–6** (SSOT): CI-Fix-Loop bis grün, dann aus dem Haupt-Repo
-`gh pr merge --auto --squash --delete-branch`.
+`gh pr merge --auto --squash` (kein `--delete-branch` — Löschung in Schritt 6, T004612).
 
 ## Schritt 6: Worktree & Branch bereinigen
 
 **`git-workflow` Schritt 7** (SSOT): Lock-Release
 ([session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md)),
-dann `git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug>` im Haupt-Repo.
+dann `git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug> && git push origin --delete chore/<slug>` im Haupt-Repo.
 
 Beim Test-only-Kurzpfad (Schritt 1) gibt es keinen Worktree zu entfernen — nur
-`bash scripts/agent-lock.sh release main-checkout` und `git checkout main && git branch -D chore/<slug>`.
+`bash scripts/agent-lock.sh release main-checkout`, `git checkout main`, dann `git branch -D chore/<slug>` und `git push origin --delete chore/<slug>`.
 
 ## Schritt 7: Deploy (falls nötig)
 

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -84,7 +84,7 @@ Spawne den Subagenten, provisioniert gemäß [subagent-provisioning](file:///hom
    - Bei Kompilier-/Testfehlern: diagnostiziere und fixe systematisch (Logs lesen, Fehler eingrenzen, Hypothese testen, fixen, Re-Test).
   - **PFLICHT vor PR-Erstellung — Freshness-Artefakte regenerieren und committen** (sonst schlägt CI mit "stale artifact" fehl; `executing-plans` → `finishing-a-development-branch` überspringt diesen Schritt). Befehle + Artefakt-Pfadliste (SSOT): [verification-block](file:///home/patrick/Bachelorprojekt/.claude/skills/references/verification-block.md) — der Subagent MUSS die Datei lesen und den `git add`-Block daraus verwenden.
   - **Hintergrund-Monitore für lange Test-Runs verboten [T001969 Mishap 1].** Während der Verifikation (lange `task test:changed`/`gh run watch`/CI-Polls) **keine** Background-Tasks starten, auf deren Output der Subagent in einer Monitor-Schleife wartet ("I'll wait for the monitor"). Stattdessen synchron mit explizitem Timeout ausführen: `timeout 600 task test:changed` und auf das Resultat warten. Bei Stop-Events: Arbeit fortsetzen oder an den Orchestrator eskalieren — nicht auf einen Monitor-Loop warten.
-  - Erstelle einen PR und fordere Auto-Merge an (`gh pr merge --auto --squash --delete-branch`, Schritt 5).
+  - Erstelle einen PR und fordere Auto-Merge an (`gh pr merge --auto --squash` — KEIN `--delete-branch`, der Branch wird erst nach dem OpenSpec-Archiv gelöscht, T004612; Schritt 5).
   - **ENDE (T002365):** Melde Ergebnis zurück — CI-Fix-Schleife (5.5), Merge-Wait, Ticket-Abschluss und
     Plan-Archivierung laufen im Orchestrator. **Der Worktree wird NICHT von dir entfernt** (T002352-M1),
     das ist Orchestrator-Aufgabe (Schritt 7.5). Notification abwarten, dann bei Schritt 5.5 weiter — nicht Schritt 8.
@@ -186,7 +186,10 @@ Rufe `commit-commands:commit-push-pr` auf (Claude Code slash-command) oder führ
 
 ```bash
 # Auto-Merge sofort anfordern — GitHub merged selbstständig, sobald Required Checks grün sind.
-(cd "$MAIN_REPO" && gh pr merge --auto --squash --delete-branch)
+# KEIN --delete-branch (T004612): Schritt 7 (Plan-/OpenSpec-Archiv) braucht den Branch noch —
+# gelöscht wird er erst in Schritt 7.5, NACH der Archivierung. delete_branch_on_merge ist
+# repo-seitig deaktiviert; verwaiste Branches räumt branch-reaper.sh ab.
+(cd "$MAIN_REPO" && gh pr merge --auto --squash)
 ```
 
 ## Schritt 5.5: CI/CD-Fix-Schleife (Orchestrator-Zuständigkeit, T002365)

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -8,8 +8,9 @@ description: 'Use whenever committing, pushing, creating a PR, or finishing work
 **Sage zu Beginn:** "Ich nutze git-workflow für den Commit/PR-Ablauf."
 
 Dieser Skill ist die **SSOT für Commit → Push → PR → Merge → Cleanup** — die `dev-flow-*`-Skills
-verweisen auf die Schritte hier statt sie zu duplizieren. Für read/view-GitHub-Flows den Wrapper
-`gh-axi` bevorzugen ([gh-axi](file:///home/patrick/Bachelorprojekt/.claude/skills/references/gh-axi.md)).
+verweisen auf die Schritte hier statt sie zu duplizieren. Für read/view-GitHub-Flows (Anzeige) den
+Wrapper `gh-axi` bevorzugen; sobald `--json`/`-q`/Polling/Mutation im Spiel ist: `gh` direkt (T004612)
+([gh-axi](file:///home/patrick/Bachelorprojekt/.claude/skills/references/gh-axi.md)).
 
 ---
 
@@ -246,11 +247,13 @@ Kurzfassung:
 
 ```bash
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
-(cd "$MAIN_REPO" && gh pr merge --auto --squash --delete-branch)
+(cd "$MAIN_REPO" && gh pr merge --auto --squash)
 ```
 
 - **Immer `--squash`** — hält `main`-History sauber (Entwicklungsregel)
-- **Immer `--delete-branch`** — Branch-Leichen vermeiden
+- **KEIN `--delete-branch` (T004612)** — das Post-Merge-Archiv (OpenSpec, Schritt 7) braucht den
+  Branch noch; gelöscht wird er erst im Cleanup NACH der Archivierung.
+  `delete_branch_on_merge` ist repo-seitig deaktiviert; branch-reaper.sh räumt Verwaiste ab.
 - **`--auto`** — mergt automatisch wenn alle Required Checks grün sind
 - **Race-Hinweis:** `--auto` kehrt sofort zurück; der eigentliche Merge passiert asynchron. CI-Läufe, die durch `edited`-Events (PR-Titel-Edit) getriggert wurden, können noch laufen. `cancel-in-progress` in `ci.yml` wurde so angepasst, dass `edited`-Runs keine laufenden CI-Jobs abbrechen (T002248).
 
@@ -269,10 +272,12 @@ cd "$MAIN_REPO"
 git worktree remove "$WORKTREE_PATH"
 git worktree prune
 
-# Der Remote-Branch wurde durch `gh pr merge --squash --delete-branch` bereits
-# gelöscht — der lokale Ref bleibt aber übrig, weil der Squash-Commit auf main
-# ein neuer Commit ist und Git den Branch nicht als "merged" erkennen kann.
-# `git branch -d` würde daher fehlschlagen; `-D` ist nötig.
+# T004612: der Merge löscht den Remote-Branch NICHT mehr (kein --delete-branch,
+# delete_branch_on_merge=false) — die Archivierung (Schritt 7) brauchte ihn. Erst
+# hier, NACH dem Archiv, remote + lokal löschen:
+git push origin --delete "$BRANCH_NAME"
+# Der Squash-Commit auf main ist ein neuer Commit — Git erkennt den Branch nicht
+# als "merged", `git branch -d` würde fehlschlagen; `-D` ist nötig.
 if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" 2>/dev/null; then
   git branch -D "$BRANCH_NAME"
 fi

--- a/.claude/skills/references/dev-flow-execute-phases.md
+++ b/.claude/skills/references/dev-flow-execute-phases.md
@@ -307,11 +307,18 @@ Push-Verification (T001268) und PR-Creation-Verification (T001331). Vollständig
 
 ## Schritt 7.5: Worktree & Branch bereinigen
 
+> **Reihenfolge (T004612):** Dieser Schritt läuft NACH Schritt 7 (Archiv) — der Fix-PR-Merge
+> (Schritt 5) löscht den Branch bewusst NICHT mehr (`--delete-branch` entfernt,
+> `delete_branch_on_merge=false`), damit die Archivierung ihn noch vorfindet.
+> Der Archiv-Branch (`chore/plan-archive-*`) ist davon unberührt — sein eigener Merge behält
+> sein `--delete-branch` (plan-archive-steps).
+
 Lösche den lokalen Worktree und Branch (im Haupt-Repo ausführen):
 Claims freigeben VOR dem Worktree-Remove ([session-coordination](file:///home/patrick/Bachelorprojekt/.claude/skills/references/session-coordination.md)), dann:
 ```bash
 git worktree remove "$MAIN_REPO/.worktrees/<slug>" --force
 git branch -D "<branch>"
+git push origin --delete "<branch>"   # remote: der Merge löscht nicht mehr (T004612)
 ```
 
 

--- a/.claude/skills/references/gh-axi.md
+++ b/.claude/skills/references/gh-axi.md
@@ -1,6 +1,6 @@
 # gh-axi — GitHub CLI Wrapper
 
-`gh-axi` ist ein Ergonomie-Wrapper um die `gh` CLI. **Alle Agents sollen `gh-axi` statt `gh` direkt verwenden**, sofern ein passendes Sub-Kommando existiert. (Framework-agnostisch — funktioniert in Claude Code, opencode und agy gleichermaßen.)
+`gh-axi` ist ein Ergonomie-Wrapper um die `gh` CLI. **Für die menschliche Anzeige (Read/View-Flows) sollen alle Agents `gh-axi` statt `gh` verwenden**, sofern ein passendes Sub-Kommando existiert. (Framework-agnostisch — funktioniert in Claude Code, opencode und agy gleichermaßen.)
 
 Binary: `~/.npm-global/bin/gh-axi`  
 Repo-Kontext: wird automatisch aus dem aktuellen Git-Checkout abgeleitet (kein `-R` nötig).
@@ -18,9 +18,21 @@ gh-axi run view --job 789012 --log-failed  # Fehlgeschlagene Log-Zeilen für ein
 gh-axi setup hooks               # Optionale Agent-Session-Hooks installieren
 ```
 
-### Wann `gh` statt `gh-axi`
+### Wann `gh` statt `gh-axi` [T004612]
 
-`gh-axi` deckt die häufigen read/view-Flows ab. Für Operationen ohne `gh-axi`-Pendant (z. B. `gh pr create`, `gh pr merge`, `gh api`) direkt `gh` nutzen — die SessionStart-Hook-Ausgabe zeigt den verfügbaren Befehlssatz.
+`gh-axi` deckt die häufigen read/view-Flows **für menschliche Augen** ab. Sobald die Antwort
+**maschinell weiterverarbeitet** wird, ist `gh` Pflicht:
+
+- **`--json`, `-q`, `--jq` und jede `… | jq`-Pipeline → `gh`.**
+  `gh-axi` liefert TOON-Text und **ignoriert `--json` stillschweigend mit Exit 0** — die
+  Pipeline läuft falsch-leer weiter, ohne dass irgendwo ein Fehler auftaucht. Beleg und
+  Reproduktion: Mishap-Rollup T003533, Eintrag 2026-08-11 08:04 #6
+  (`gh-axi pr list --state merged --limit 1 --json number` → TOON-Text, exit=0).
+- **Polling-Loops und Mutationen → `gh`:** `pr checks`, Merge-Wait-Loops, CI-Watch,
+  `pr create`, `pr merge`, `gh api`. Vorbilder: `scripts/devflow-ci-watch.sh` und
+  `scripts/factory/pr-babysit-ticket.sh` nutzen durchgehend `gh`.
+- Operationen ohne `gh-axi`-Pendant ohnehin via `gh` — die SessionStart-Hook-Ausgabe zeigt den
+  verfügbaren Befehlssatz.
 
 ### Achtung: `gh pr edit --title` — GraphQL-Deprecation [T002042, T002048]
 

--- a/.claude/skills/references/git-workflow-procedures.md
+++ b/.claude/skills/references/git-workflow-procedures.md
@@ -77,7 +77,7 @@ gh api -X PATCH "repos/{owner}/{repo}/pulls/<n>" -f title="<neuer Titel>"
 | 3 | `git push -u origin <branch>` | Einmalig, danach plain `git push` |
 | 4 | `bash scripts/preflight-pr-scope.sh "<PR title>"` + `gh pr create` | Einmal pro PR |
 | 5 | CI Fix Loop | Bis alle Required Checks grün |
-| 6 | `gh pr merge --auto --squash --delete-branch` | Wenn CI grün |
+| 6 | `gh pr merge --auto --squash` (kein `--delete-branch` — Archiv läuft vor der Löschung, T004612) | Wenn CI grün |
 | 7 | `git worktree remove` + `agent-lock release` | Nur bei Worktree-Arbeit |
 
 ## Häufige Fehler

--- a/.claude/skills/references/plan-archive-steps.md
+++ b/.claude/skills/references/plan-archive-steps.md
@@ -2,6 +2,12 @@
 
 Vollständige Mechanik zur Archivierung von Plan & OpenSpec.
 
+> **Reihenfolge-Garantie (T004612):** Schritt 7 läuft VOR Schritt 7.5 (Worktree/Branch-Löschung),
+> und der Fix-PR-Merge (Schritt 5) löscht den Branch NICHT mehr (`--delete-branch` entfernt,
+> `delete_branch_on_merge=false` repo-seitig). Der Fix-Branch existiert zum Archivzeitpunkt also
+> noch — ein Neu-Anlegen nach Auto-Delete (beobachtet am 2026-08-14, Archiv-PR #4393) entfällt.
+> Gelöscht wird er erst in 7.5, NACH diesem Schritt.
+
 ```bash
 SLUG="<slug>"
 BRANCH="feature/<slug>" # oder fix/<slug>

--- a/.claude/skills/references/repo-hygiene-ops.md
+++ b/.claude/skills/references/repo-hygiene-ops.md
@@ -163,8 +163,8 @@ git fetch --prune                                                  # gone remote
 >
 > `--merged` verfehlt squash-gemergte Branches. Dieses Repo mergt via squash-and-merge
 > (Dev-Regel 3) — der Branch-Tip ist danach KEIN Ancestor von `main`, `git branch -d` verweigert.
-> Erkennung: Upstream ist **[gone]** (von `gh pr merge --delete-branch` gelöscht) + PR nachweislich
-> gemergt → force-delete:
+> Erkennung: Upstream ist **[gone]** (seit T004612 vom Reaper bzw. Schritt 7.5 gelöscht — der
+> Merge-Flow löscht nicht mehr) + PR nachweislich gemergt → force-delete:
 > ```bash
 > git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads \
 >   | awk '$2 == "[gone]" {print $1}' \
@@ -285,7 +285,9 @@ TICKET_ID=$(printf '%s %s' "$TITLE" "$BRANCH" | grep -oiE 'T[0-9]{6}' | head -1 
 
 * **Merge (mergeable, CI grün, kein Draft):**
   ```bash
-  gh pr merge <number> --squash --delete-branch
+  # KEIN --delete-branch (T004612): das OpenSpec-Archiv läuft nach dem Merge und braucht
+  # den Branch noch; Verwaiste räumt branch-reaper.sh ab.
+  gh pr merge <number> --squash
   ```
   > **Exit 1 nach Squash-Merge ist KEIN Fehler** (`not possible to fast-forward` — der PR ist
   > trotzdem gemergt). **Immer per Timestamp verifizieren, nie per Exit-Code:**
@@ -597,7 +599,7 @@ Aus den Metriken werden die drei wirkungsvollsten Aktionen abgeleitet:
 | Rang | Bedingung | Empfehlung |
 |------|-----------|------------|
 | 1 | `>5 stale Worktrees` ODER `>10 [gone]-Branches` | **Massen-Cleanup**: `repo-hygiene` §1+§2 vollständig ausführen. Vorher `bash scripts/agent-lock.sh reap`. Geschätzte Zeit: 2–5 min. |
-| 2 | `≥1 PR mit CI=green, kein Draft, reviewDecision=APPROVED` | **PR mergen**: `gh pr merge --squash --delete-branch`. Ticket schließen nicht vergessen (§3). |
+| 2 | `≥1 PR mit CI=green, kein Draft, reviewDecision=APPROVED` | **PR mergen**: `gh pr merge --squash` (kein `--delete-branch` — Archiv läuft nach dem Merge, T004612). Ticket schließen nicht vergessen (§3). |
 | 3 | `Factory queue_depth > 3` | **Factory-Health check**: `mcp__factory-mcp__factory_ask({ question: "Sind alle Worker gesund? Gibt es blockierte Jobs?" })`. Ggf. `mcp__factory-mcp__factory_trigger({})`. |
 | 4 | `≥1 Worktree >30d ohne Commit` | **Worktree entsorgen**: `git worktree remove --force` nach Allowlist-Check (§1). |
 | 5 | `≥3 PRs offen vom selben Author` | **PR-Stau**: Author pingen oder PRs bündeln (wenn thematisch verwandt). |

--- a/.opencode/prompts/orchestrator.md
+++ b/.opencode/prompts/orchestrator.md
@@ -23,7 +23,7 @@ Follow the Bachelorprojekt workflow rules from AGENTS.md:
 - **Branches**: `feature/*`, `fix/*`, `chore/*`, `docs/*`. Never push directly to `main`.
 - **Before committing**: inspect `git status`, `git diff`, `git log --oneline -10`. Stage only intended files. Never commit secrets.
 - **Commits**: Conventional Commits format. If hooks reject, fix and recommit (no amend).
-- **PRs**: Create via `gh-axi`. Verify status, diff, remote tracking, and base-branch diff first. Respect the `pr-ready` gate — no auto-merge during the executor trial.
+- **PRs**: Create via `gh` (mutation — `gh-axi` is display-only, T004612). Verify status, diff, remote tracking, and base-branch diff first. Respect the `pr-ready` gate — no auto-merge during the executor trial.
 - **CI gate**: Run `task test:changed` + `task freshness:check` + `task workspace:validate` before merge.
 - **Merge = closure**: On green auto-merge, the ticket closes. Prod deploy is decoupled.
 

--- a/.opencode/skills/dev-flow/DEV-FLOW.SKILL.md
+++ b/.opencode/skills/dev-flow/DEV-FLOW.SKILL.md
@@ -28,7 +28,7 @@ git checkout -b feature/t001xxx
 
 # 3. Verify & Merge
 task test:changed
-gh-axi pr merge --auto --squash
+gh pr merge --auto --squash   # Mutation → gh (gh-axi ist Anzeige-only); kein --delete-branch (T004612)
 ```
 
 ## Freshness Guards

--- a/.opencode/skills/opencode-flow-chore/SKILL.md
+++ b/.opencode/skills/opencode-flow-chore/SKILL.md
@@ -71,7 +71,8 @@ Delegate to **`opencode-git-workflow` Steps 2–6** (SSOT):
 ## Schritt 5: Merge wenn CI grün
 
 ```bash
-(cd "$MAIN_REPO" && gh-axi pr merge --auto --squash --delete-branch)
+# KEIN --delete-branch (T004612): Löschung erfolgt explizit in Schritt 6 nach dem Merge.
+(cd "$MAIN_REPO" && gh pr merge --auto --squash)
 ```
 
 ## Schritt 6: Worktree & Branch bereinigen
@@ -79,6 +80,7 @@ Delegate to **`opencode-git-workflow` Steps 2–6** (SSOT):
 Lock-Release, dann:
 ```bash
 git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug>
+git push origin --delete chore/<slug>
 ```
 
 ## Schritt 7: Deploy (falls nötig)

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -258,7 +258,7 @@ bash scripts/admin-menu-gate.sh
 Vor dem PR-Merge muss eine unabhängige Überprüfung stattfinden:
 
 ```bash
-delegate(prompt: "Review this PR's changes for bugs, security issues, and style. PR: $(gh-axi pr view --json url -q '.url')", agent: "explore")
+delegate(prompt: "Review this PR's changes for bugs, security issues, and style. PR: $(gh pr view --json url -q '.url')", agent: "explore")
 ```
 
 Behebe alle gefundenen Probleme und stelle sicher, dass der Reviewer "Approved" gibt, bevor du fortfährst.
@@ -269,7 +269,7 @@ Delegate to `opencode-git-workflow` Steps 2–6:
 
 ```bash
 bash scripts/preflight-pr-scope.sh "<type>(<scope>): <subject> [$TICKET_ID]"
-gh-axi pr create --title "<type>(<scope>): <subject> [$TICKET_ID]" --body "..."
+gh pr create --title "<type>(<scope>): <subject> [$TICKET_ID]" --body "..."
 ```
 
 > **⚠️ M1-Lesson (T001899):** Auto-Merge **nicht** vor dem ersten Implementierungs-Push aktivieren.
@@ -283,7 +283,7 @@ Nachdem der PR gepusht ist, überwache CI und behebe Fehler — Auto-Merge ist b
 (Schritt 5) und greift, sobald die Required Checks grün sind.
 
 ```bash
-bash scripts/devflow-ci-watch.sh "$TICKET_ID" "$(gh-axi pr view --json url -q '.url')"
+bash scripts/devflow-ci-watch.sh "$TICKET_ID" "$(gh pr view --json url -q '.url')"
 ```
 
 `devflow-ci-watch.sh` prüft `mergeStateStatus` bereits **vor** dem CI-Poll-Loop und rebased bei
@@ -308,19 +308,21 @@ bash scripts/ticket.sh assert-phase-chain --id "$TICKET_ID"
 
 Dann Auto-Merge anfordern:
 ```bash
-(cd "$MAIN_REPO" && gh-axi pr merge --auto --squash --delete-branch)
+# KEIN --delete-branch (T004612): Schritt 7 (OpenSpec-Archiv) läuft nach dem Merge
+# und braucht den Branch noch; gelöscht wird er im Cleanup NACH der Archivierung.
+(cd "$MAIN_REPO" && gh pr merge --auto --squash)
 ```
 
 ## Schritt 6.4: Auf Merge warten
 
-`gh-axi pr merge --auto` kehrt sofort zurück — Merge passiert asynchron:
+`gh pr merge --auto` kehrt sofort zurück — Merge passiert asynchron:
 
 ```bash
-PR_NUM=$(gh-axi pr view --json number -q '.number')
+PR_NUM=$(gh pr view --json number -q '.number')
 MAX_MERGE_WAIT_MIN="${MAX_MERGE_WAIT_MIN:-15}"
 WAIT_START=$(date +%s)
 while true; do
-  MERGE_STATE=$(gh-axi pr view "$PR_NUM" --json mergeStateStatus,state -q '.state + "|" + .mergeStateStatus' 2>/dev/null || echo "UNKNOWN|UNKNOWN")
+  MERGE_STATE=$(gh pr view "$PR_NUM" --json mergeStateStatus,state -q '.state + "|" + .mergeStateStatus' 2>/dev/null || echo "UNKNOWN|UNKNOWN")
   STATE="${MERGE_STATE%%|*}"
   case "$STATE" in
     MERGED) break ;;

--- a/.opencode/skills/opencode-git-workflow/SKILL.md
+++ b/.opencode/skills/opencode-git-workflow/SKILL.md
@@ -7,7 +7,7 @@ description: Use whenever committing, pushing, creating a PR, or finishing work 
 
 **Sage zu Beginn:** "Ich nutze opencode-git-workflow für den Commit/PR-Ablauf."
 
-Dieser Skill ist die **SSOT für Commit → Push → PR → Merge → Cleanup** in opencode. Die `opencode-flow-*`-Skills verweisen auf die Schritte hier statt sie zu duplizieren. Für GitHub-Read/View-Flows `gh-axi` bevorzugen (Repos: `Paddione/Bachelorprojekt`).
+Dieser Skill ist die **SSOT für Commit → Push → PR → Merge → Cleanup** in opencode. Die `opencode-flow-*`-Skills verweisen auf die Schritte hier statt sie zu duplizieren. Für GitHub-Read/View-Flows (Anzeige) `gh-axi` bevorzugen; sobald `--json`/`-q`/Polling/Mutation im Spiel ist: `gh` direkt (T004612, Repos: `Paddione/Bachelorprojekt`).
 
 ---
 
@@ -154,13 +154,13 @@ bash scripts/preflight-pr-scope.sh "<type>(<scope>): <subject> [<TICKET_EXT_ID>]
 
 > **Titel nachträglich editieren (REST-Fallback):**
 > ```bash
-> gh-axi api -X PATCH "repos/{owner}/{repo}/pulls/<n>" -f title="<neuer Titel>"
+> gh api -X PATCH "repos/{owner}/{repo}/pulls/<n>" -f title="<neuer Titel>"
 > ```
 
 ### PR anlegen
 
 ```bash
-gh-axi pr create \
+gh pr create \
   --title "<type>(<scope>): <subject> [<TICKET_EXT_ID>]" \
   --body "$(cat <<'EOF'
 ## Summary
@@ -182,7 +182,7 @@ EOF
 Nachdem der PR gepusht ist: CI überwachen und Fehler beheben **bevor** gemergt wird. SSOT: `.claude/skills/references/ci-fix-loop.md`.
 
 Kurzfassung:
-1. `gh-axi pr checks <n> --watch` — warten bis alle Required Checks grün sind
+1. `gh pr checks <n> --watch` — warten bis alle Required Checks grün sind
 2. Bei Fehler: Log lesen, lokal fixen, committen, pushen — Loop wiederholen
 3. Bei `CONFLICTING` PR-Status: `git fetch origin main && git rebase origin/main` → push
 4. Bei `CONFLICTING` nach Auto-Regen: `git fetch origin main && git rebase origin/main && task freshness:regenerate && git add <regenerierte> && git rebase --continue && git push --force-with-lease`
@@ -199,11 +199,13 @@ Kurzfassung:
 
 ```bash
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
-(cd "$MAIN_REPO" && gh-axi pr merge --auto --squash --delete-branch)
+(cd "$MAIN_REPO" && gh pr merge --auto --squash)
 ```
 
 - **Immer `--squash`**
-- **Immer `--delete-branch`**
+- **KEIN `--delete-branch` (T004612)** — das Post-Merge-OpenSpec-Archiv (Schritt 7) braucht den
+  Branch noch; gelöscht wird er erst im Cleanup NACH der Archivierung.
+  `delete_branch_on_merge` ist repo-seitig deaktiviert.
 - **`--auto`** — mergt automatisch wenn alle Required Checks grün sind
 - **Race-Hinweis:** `--auto` kehrt sofort zurück; der eigentliche Merge passiert asynchron. CI-Läufe, die durch `edited`-Events (PR-Titel-Edit) getriggert wurden, können noch laufen. `cancel-in-progress` in `ci.yml` wurde so angepasst, dass `edited`-Runs keine laufenden CI-Jobs abbrechen (T002248).
 
@@ -213,11 +215,14 @@ MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 
 ```bash
 WORKTREE_PATH="$(git rev-parse --show-toplevel)"
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 
 cd "$MAIN_REPO"
 git worktree remove "$WORKTREE_PATH"
 git worktree prune
+# Remote-Branch erst NACH der Archivierung löschen (T004612 — der Merge löscht nicht mehr):
+git push origin --delete "$BRANCH_NAME"
 ```
 
 Agent-Lock freigeben VOR dem Worktree-Remove.
@@ -248,9 +253,9 @@ bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 | 2 | Conventional Commit + Ticket-ID | Jeder Commit |
 | 2 | Commit-Verifikation (HEAD_SHA != BASE_SHA) | Nach jedem Commit in Worktrees |
 | 3 | `git push -u origin <branch>` | Einmalig, danach plain `git push` |
-| 4 | `preflight-pr-scope.sh` + `gh-axi pr create` | Einmal pro PR |
+| 4 | `preflight-pr-scope.sh` + `gh pr create` | Einmal pro PR |
 | 5 | CI Fix Loop | Bis alle Required Checks grün |
-| 6 | `gh-axi pr merge --auto --squash --delete-branch` | Wenn CI grün |
+| 6 | `gh pr merge --auto --squash` (kein `--delete-branch`, T004612) | Wenn CI grün |
 | 7 | `git worktree remove` + Lock-Release | Nur bei Worktree-Arbeit |
 
 ---
@@ -260,7 +265,7 @@ bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 | Fehler | Diagnose | Fix |
 |--------|----------|-----|
 | Commit landet nicht (git-crypt) | `git rev-parse HEAD == BASE_SHA` | `git status`, dann erneut committen |
-| CI startet nie | `gh-axi pr view <n> --json mergeStateStatus` → `CONFLICTING` | `git rebase origin/main` |
+| CI startet nie | `gh pr view <n> --json mergeStateStatus` → `CONFLICTING` | `git rebase origin/main` |
 | Stale artifact in CI | `task freshness:check` lokal rot | `task freshness:regenerate && git add && git commit` |
 | PR-Scope invalid | `preflight-pr-scope.sh` Exit 1 | Scope korrigieren, neu prüfen |
 | Falscher Cluster gedeployt | `ENV=` vergessen gesetzt | Immer `ENV=mentolder` / `ENV=korczewski` explizit |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Dispatch: `bash scripts/plan-context.sh <role> --with-openspec` → prepend as `
 Also prepend the curated toolset: `bash scripts/toolset-context.sh <role>` → wrap as `<toolset>`.
 It renders every tool the role may use from `docs/agent-guide/registry/capabilities.yaml`, with
 `use_when` / `avoid_when` / `fallback` / deep reference, so a subagent reaches for the canonical
-path (`gh-axi`, not `gh`) instead of guessing. Harness-neutral — plain bash plus `node -e`.
+path (`gh-axi` for display; `gh` for `--json`/polling/mutations — T004612) instead of guessing. Harness-neutral — plain bash plus `node -e`.
 
 > ⚠ `toolset-context.sh` is **fail-closed** on an unknown role: non-zero exit, no output. It
 > deliberately differs from `plan-context.sh`, whose silent `__ALL__` fallback disables the role

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,10 @@ Before responding to any request, check these signals and delegate to the named 
 
 > **MCP-Schnellweg:** Welcher MCP-Server wann bevorzugt wird (statt `kubectl exec … psql`), steht in [`.claude/skills/references/mcp-tool-guide.md`](.claude/skills/references/mcp-tool-guide.md) — inkl. Portforward-Guard und der kubectl-Pflicht für DDL/Superuser/Writes.
 
-> **gh-axi:** Bevorzugter GitHub-CLI-Wrapper für alle Agents (`gh-axi` statt `gh`). Kommando-Referenz: [`.claude/skills/references/gh-axi.md`](.claude/skills/references/gh-axi.md).
+> **gh-axi:** Bevorzugter GitHub-CLI-Wrapper für Anzeige/Read-Flows (`gh-axi` statt `gh`).
+> **Maschinelles Parsen, Polling und Mutationen (T004612):** `--json`, `-q`, `--jq`,
+> `pr checks`/`pr merge`/`gh api` → immer `gh` direkt — gh-axi liefert TOON-Text und ignoriert
+> `--json` still mit Exit 0. Kommando-Referenz: [`.claude/skills/references/gh-axi.md`](.claude/skills/references/gh-axi.md).
 
 **Before dispatching any agent, inject active plan context:**
 Run `bash scripts/plan-context.sh <role> --with-openspec` and prepend output to the agent prompt wrapped in `<active-plans>` tags. If the script produces no output, omit the block entirely. `--with-openspec` auto-loads the SSOT spec(s) for any files changed vs main — omit only when explicitly told to skip OpenSpec context.

--- a/QWEN.md
+++ b/QWEN.md
@@ -238,7 +238,7 @@ Before responding, check signals and delegate to the named domain agent:
 - **Agent coordination** — `scripts/agent-lock.sh` (claim/release/reap), `scripts/agent-msg.sh` (messaging)
 - **Agent routing maps** — generated grep-able maps in `docs/agent-guide/maps/`: `goals-map.md` (intention → path → tier → guardrails), `tools-map.md`, `danger-map.md`. Regenerate via `task agent-guide:maps`.
 - **Brain Wiki** — knowledge base ingested from openspec, runbooks, ADRs (`scripts/brain-ingest.sh`)
-- **gh-axi** — preferred GitHub CLI wrapper (use `gh-axi` instead of `gh`). Reference: `.claude/skills/references/gh-axi.md`
+- **gh-axi** — preferred GitHub CLI wrapper for display/read flows (use `gh-axi` instead of `gh`). Machine parsing (`--json`/`-q`/`--jq`), polling and mutations → `gh` directly (T004612). Reference: `.claude/skills/references/gh-axi.md`
 
 ## CI/CD
 

--- a/docs/agent-guide/maps/toolset-map.md
+++ b/docs/agent-guide/maps/toolset-map.md
@@ -10,8 +10,9 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
 ## Fähigkeit: `github`
 
 - **`cli:gh-axi`** — Status `canonical` · Tier `caution`
-  - _Wann:_ Alle GitHub-Operationen: PRs, Issues, Runs, Releases, Labels.
-  - _Fallback:_ `gh (nur wenn gh-axi ein Kommando nicht abdeckt)`
+  - _Wann:_ GitHub-Read/View-Flows zur Anzeige: PRs, Issues, Runs, Releases, Labels.
+  - _Nicht:_ Antwort wird maschinell geparst (--json/-q/--jq, jq-Pipelines), Polling-Loops oder Mutationen — gh-axi liefert TOON-Text und ignoriert --json still mit Exit 0 (T004612); dort gh direkt.
+  - _Fallback:_ `gh (maschinelles Parsen, Polling, Mutationen, nicht abgedeckte Kommandos)`
   - _Rollen:_ `all`
   - _Tiefe:_ `.claude/skills/references/gh-axi.md`
 - **`mcp:github-mcp`** — Status `suppressed`
@@ -106,10 +107,8 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
 
 ## Fähigkeit: `externes-task-management`
 
-- **`mcp:task-master-ai`** — Status `canonical` · Tier `caution`
-  - _Wann:_ PRD-getriebene Task-Zerlegung und Autopilot ausserhalb des Ticket-Systems.
-  - _Nicht:_ Reguläre Repo-Tickets — dafür ticket-mcp und die dev-flow-Skills.
-  - _Rollen:_ `orchestrator`
+- **`mcp:task-master-ai`** — Status `suppressed`
+  - _Grund:_ Kein erreichbarer Server: task-master-ai existiert weder in docs/agent-guide/registry/mcp.yaml noch in .opencode/opencode.jsonc. PRD-getriebene Task-Zerlegung laeuft ueber ticket-mcp und die dev-flow-/opencode-flow-Skills.
 
 ## Fähigkeit: `mishap-erfassung`
 

--- a/docs/agent-guide/registry/capabilities.yaml
+++ b/docs/agent-guide/registry/capabilities.yaml
@@ -35,8 +35,9 @@ capabilities:
   github:
     cli:gh-axi:
       state: canonical
-      use_when: "Alle GitHub-Operationen: PRs, Issues, Runs, Releases, Labels."
-      fallback: "gh (nur wenn gh-axi ein Kommando nicht abdeckt)"
+      use_when: "GitHub-Read/View-Flows zur Anzeige: PRs, Issues, Runs, Releases, Labels."
+      avoid_when: "Antwort wird maschinell geparst (--json/-q/--jq, jq-Pipelines), Polling-Loops oder Mutationen — gh-axi liefert TOON-Text und ignoriert --json still mit Exit 0 (T004612); dort gh direkt."
+      fallback: "gh (maschinelles Parsen, Polling, Mutationen, nicht abgedeckte Kommandos)"
       roles: [all]
       tier: caution
       deep_ref: ".claude/skills/references/gh-axi.md"

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 982,
+      "file_count": 983,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -424,6 +424,7 @@
         "tests/spec/ci-cd/freshness-regen-rebase-guard.bats",
         "tests/spec/ci-cd/generated-artifacts-registry.bats",
         "tests/spec/ci-cd/ghcr-digest-auth.bats",
+        "tests/spec/ci-cd/git-flow-poll-and-branch-order.bats",
         "tests/spec/ci-cd/main-direct-push-guard.bats",
         "tests/spec/ci-cd/mishap-t002425.bats",
         "tests/spec/ci-cd/pr-refresh-batch.bats",

--- a/scripts/brain-bootstrap.sh
+++ b/scripts/brain-bootstrap.sh
@@ -65,8 +65,8 @@ if [[ "$CREATE_REMOTE" -eq 1 ]]; then
   : "${COLLABORATOR:?--collaborator <handle> required for --create-remote}"
   work="$(mktemp -d)"
   seed "$work"
-  gh_bin() { command -v gh-axi >/dev/null 2>&1 && echo gh-axi || echo gh; }
-  "$(gh_bin)" repo create Paddione/brain --private --disable-wiki || true
+  # Mutation → gh direkt (gh-axi ist Anzeige-only, T004612)
+  gh repo create Paddione/brain --private --disable-wiki || true
   (
     cd "$work"
     git init -q

--- a/scripts/branch-reaper.sh
+++ b/scripts/branch-reaper.sh
@@ -7,10 +7,12 @@
 #   bash scripts/branch-reaper.sh --sweep [--dry-run] [--remote ...]   # loeschender Sweep
 #
 # Warum es dieses Skript gibt:
-#   `delete_branch_on_merge=true` und `gh pr merge --delete-branch` greifen nur, wenn der
-#   Branch SELBST gemergt wird. Plan- und Factory-Branches laufen aber häufig über einen
-#   Sammel-PR nach main — auf ihrem eigenen Ref findet nie ein Merge-Event statt, also räumt
-#   sie niemand ab. Am 2026-08-01 lagen so 24 PR-lose Branches auf origin.
+#   Seit T004612 löscht der Merge-Flow Branches bewusst NICHT mehr (delete_branch_on_merge=false,
+#   kein --delete-branch im Fix-PR-Merge — das OpenSpec-Archiv braucht den Branch nach dem Merge).
+#   Der Reaper ist damit nicht mehr nur Netz für Sammel-PR-Branches (Plan- und Factory-Branches
+#   laufen über einen Sammel-PR nach main — auf ihrem eigenen Ref findet nie ein Merge-Event
+#   statt), sondern der reguläre Aufräumer für ALLE gemergten Branches. Am 2026-08-01 lagen so
+#   24 PR-lose Branches auf origin.
 #
 # Löschkriterium — ALLE vier Bedingungen müssen gelten:
 #   1. Branch trägt die Ticket-ID im Namen (case-insensitiv)

--- a/scripts/factory/pipeline-pattern.md
+++ b/scripts/factory/pipeline-pattern.md
@@ -307,7 +307,7 @@ phase('Deploy')
 await agent(`
   Create PR from feature branch, merge via squash-and-merge, deploy:
   1. gh pr create --title "${args.title}" --body "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-  2. gh pr merge --squash --delete-branch
+  2. gh pr merge --squash  # KEIN --delete-branch: das OpenSpec-Archiv läuft nach dem Merge (T004612)
   3. Determine correct deploy task (use task-oracle.sh) and execute
   4. Update ticket status to 'done'
   5. Write Lessons-Learned using the template

--- a/scripts/factory/pr-babysit-ticket.sh
+++ b/scripts/factory/pr-babysit-ticket.sh
@@ -9,7 +9,9 @@
 #     (classify_failure <ci-log-file> — echoes exactly one class).
 #   - polling cadence, `gh pr checks` overview and the job-level step diagnosis
 #     are the SSOT of .claude/skills/references/ci-fix-loop.md (read there).
-# GitHub CLI runs through the preferred wrapper gh-axi (gh fallback).
+# GitHub CLI: every poll is machine-parsed (`--json | jq`) and therefore MUST run
+# through plain `gh` — gh-axi (TOON format) silently ignores `--json` with exit 0
+# (Mishap-Rollup T003533, Eintrag 2026-08-11 08:04 #6; Fix T004612).
 #
 #   bash scripts/factory/pr-babysit-ticket.sh T002074 123
 # Exit 0 = merged / all green; exit 1 = red after MAX_CI_ATTEMPTS.
@@ -21,8 +23,11 @@ REPO="${REPO:-/home/patrick/Bachelorprojekt}"
 MAX_CI_ATTEMPTS="${MAX_CI_ATTEMPTS:-5}"
 POLL_INTERVAL="${POLL_INTERVAL:-20}"
 
-# Prefer the gh-axi wrapper; fall back to plain gh.
-GH="gh"; command -v gh-axi >/dev/null 2>&1 && GH="gh-axi"
+# FEST `gh` — NICHT gh-axi: dieser Loop parsed jede Antwort mit `--json | jq`.
+# gh-axi liefert TOON-Text und ignoriert `--json` still mit Exit 0 — der
+# Babysitter sähe sonst jede Check-Liste als leer und bräche mit falschem
+# Befund ab (T004612).
+GH="gh"
 
 # shellcheck source=/dev/null
 source "$REPO/scripts/factory/classify-failure.sh"
@@ -55,8 +60,11 @@ _on_merged() {
 
 # Queue auto-merge (squash). Only ever called AFTER a full re-check confirms no
 # known-red check remains (green or pending are ok).
+# KEIN --delete-branch (T004612): das Post-Merge-OpenSpec-Archiv (dev-flow Schritt 7)
+# braucht den Branch noch; delete_branch_on_merge ist repo-seitig deaktiviert.
+# Verwaiste Branches räumt branch-reaper.sh ab (Ticket-Kriterium + reaped-Tag).
 _queue_automerge() {
-  "$GH" pr merge "$PR" --squash --auto --delete-branch 2>/dev/null || true
+  "$GH" pr merge "$PR" --squash --auto 2>/dev/null || true
 }
 
 attempt=0

--- a/scripts/weekly-dep-schema-audit.sh
+++ b/scripts/weekly-dep-schema-audit.sh
@@ -84,7 +84,7 @@ Changes:
 
 # Set auto-merge
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
-(cd "$MAIN_REPO" && gh pr merge --auto --squash --delete-branch 2>/dev/null) || true
+(cd "$MAIN_REPO" && gh pr merge --auto --squash 2>/dev/null) || true   # kein --delete-branch: Post-Merge-Archiv (T004612)
 
 # Cleanup
 cd "$MAIN_REPO"

--- a/tests/spec/ci-cd/git-flow-poll-and-branch-order.bats
+++ b/tests/spec/ci-cd/git-flow-poll-and-branch-order.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# tests/spec/ci-cd/git-flow-poll-and-branch-order.bats
+#
+# Prüfmodus: Source-Grep auf Konventionen — die dokumentierte Ausnahme der
+# Test-Resultats-Konvention [T002448-M4], weil die Zusicherungen in
+# Skill-Referenzen und Skript-Konfiguration sitzen, nicht im Laufzeitverhalten:
+#   1. Machine-Parsing-Flows pollen über `gh`, nicht über `gh-axi`
+#      (gh-axi liefert TOON-Text und ignoriert `--json` still mit Exit 0 —
+#      Mishap-Rollup T003533, Eintrag 2026-08-11 08:04 #6; Fix T004612).
+#   2. Fix-PR-Merges tragen kein `--delete-branch` — die OpenSpec-Archivierung
+#      (dev-flow Schritt 7) läuft NACH dem Merge und braucht den Branch noch;
+#      gelöscht wird erst in Schritt 7.5. Einzige Ausnahme: der Archiv-PR-Merge
+#      in plan-archive-steps.md (dessen Wegwerf-Branch hängt an nichts mehr).
+#   3. Die gh-axi-Referenz dokumentiert die JSON/Polling-Regel (Drift-Schutz).
+
+setup() {
+  REPO="$(git rev-parse --show-toplevel)"
+}
+
+@test "pr-babysit-ticket.sh pollt maschinell über gh statt gh-axi (T004612)" {
+  # Positiv-Anker zuerst: der Resolver ist fest auf gh gesetzt
+  run grep -n '^GH="gh"$' "$REPO/scripts/factory/pr-babysit-ticket.sh"
+  [ "$status" -eq 0 ]
+  # Negativ-Aussage: kein gh-axi-Fallback mehr im Resolver
+  run grep -n 'command -v gh-axi' "$REPO/scripts/factory/pr-babysit-ticket.sh"
+  [ "$status" -ne 0 ]
+}
+
+@test "Fix-PR-Merges ohne --delete-branch — einzige Ausnahme ist der Archiv-PR (T004612)" {
+  # Positiv-Anker: der Archiv-PR-Merge in plan-archive-steps.md trägt sein --delete-branch weiter
+  run grep -n 'gh pr merge --auto --squash --delete-branch "\$ARCHIVE_PR_URL"' \
+    "$REPO/.claude/skills/references/plan-archive-steps.md"
+  [ "$status" -eq 0 ]
+  # Negativ-Aussage: alle übrigen pr-merge-Befehle in Skills/Skripten ohne --delete-branch.
+  # Kommentare (#) und Backticks begrenzen die Zeile — Treffer nur über echte Befehlsspannen.
+  run bash -c "git -C '$REPO' grep -E -n 'pr merge[^#\`]*--delete-branch' -- '.claude/skills' '.opencode/skills' 'scripts' | grep -v 'plan-archive-steps.md'"
+  [ "$status" -ne 0 ]
+}
+
+@test "gh-axi-Referenz schreibt die JSON/Polling-Regel fest (T004612)" {
+  run grep -n 'maschinell weiterverarbeitet' "$REPO/.claude/skills/references/gh-axi.md"
+  [ "$status" -eq 0 ]
+  run grep -n 'ignoriert.*--json.*still' "$REPO/.claude/skills/references/gh-axi.md"
+  [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2484,6 +2484,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/git-flow-poll-and-branch-order",
+    "file": "tests/spec/ci-cd/git-flow-poll-and-branch-order.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/main-direct-push-guard",
     "file": "tests/spec/ci-cd/main-direct-push-guard.bats",
     "category": "ci-cd",


### PR DESCRIPTION
## Summary

Zwei Git-Flow-Defekte behoben (beobachtet 2026-08-14; Belege im Mishap-Rollup T003533):

1. **gh-axi kann kein `--json`** — TOON-Text, Flag wird still ignoriert, Exit 0. Machine-Parsing/Polling/Mutationen laufen jetzt durchgehend über `gh`:
   - `scripts/factory/pr-babysit-ticket.sh`: `GH` fest auf `gh` (vorher gh-axi-Fallback → jq bekam YAML → falscher Befund „LEERE Check-Liste")
   - opencode-Flows: `pr checks`/`pr merge`/`pr view --json` auf `gh` umgestellt, `gh-axi api` (existiert nicht) → `gh api`
   - `gh-axi.md`-Referenz, CLAUDE.md, AGENTS.md, capabilities.yaml, QWEN.md, orchestrator-Prompt qualifiziert: gh-axi nur für Anzeige

2. **Branch-Löschung läuft dem OpenSpec-Archiv voraus** — Repo-Setting `delete_branch_on_merge` war an, alle Merge-Flows trugen `--delete-branch`. Der Branch verschwand beim Merge, obwohl Schritt 7 (Archiv) ihn noch brauchte — für Archiv-PR #4393 musste er neu erstellt werden.
   - **Neue Reihenfolge:** Merge ohne `--delete-branch` → Schritt 7 Archiv → Schritt 7.5 löscht Branch explizit (remote + lokal)
   - **Repo-Setting:** `delete_branch_on_merge=false` (per API gesetzt)
   - `branch-reaper.sh` bleibt das Netz für verwaiste Branches

## Test Plan

- [x] Neuer Guard `tests/spec/ci-cd/git-flow-poll-and-branch-order.bats` — RED→GREEN belegt (fand 3 Rest-Verletzungen: dev-flow-chore, Implementer-Promptzeile, opencode-flow-chore)
- [x] Komplette ci-cd-BATS-Suite (309+ Tests) grün
- [x] `task agents:toolset:check` grün, toolset-Unit-Tests (registry/sync) grün
- [x] `bash -n` auf alle geänderten Shell-Skripte
- [x] Freshness-Artefakte regeneriert + committet
- [ ] CI grün

[T004612]
