### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 985,
+      "file_count": 986,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -832,6 +832,7 @@
         "tests/spec/website-interfaces.bats",
         "tests/spec/workspace-deploy-secrets-scope.bats",
         "tests/spec/workspace-deploy.bats",
+        "tests/spec/worktree-create-real-path-T004604.bats",
         "tests/spec/worktree-divergence-guard-T002387.bats",
         "tests/spec/worktree-divergence-guard/stash-restore-visible.bats",
         "tests/sql/software-history.sql",
@@ -3379,7 +3380,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 724,
+      "file_count": 725,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3830,6 +3831,7 @@
         "scripts/lib/ticket-help.sh",
         "scripts/lib/ticket-links.sh",
         "scripts/lib/vda-core.sh",
+        "scripts/lib/worktree-real-path.sh",
         "scripts/lib/wt-hygiene-measure.sh",
         "scripts/lib/zielfamilien-audit.sh",
         "scripts/lint-workflows.sh",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31783457157).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
