### PR TITLE
fix(security): alibaba token-plan key via opencode auth statt plaintext [T004808]

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -126,3 +126,25 @@
   description = "JSON Web Token (JWT)"
   regex = '''eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+'''
   tags = ["key", "jwt"]
+
+# API-Keys mit Trennzeichen [T004808]: Die schmalen Regeln oben erfassen
+# Formate mit Punkten/Bindestrichen nicht — der Alibaba-Token-Plan-Key
+# ("sk-sp-H.HHIHP.RTMh…") lief trotz Hook, lokalem Scan und CI durch, weil
+# openai-api-key (sk-[A-Za-z0-9]{20,}) an den Trennzeichen scheitert.
+#
+# Die Default-gitleaks-Regel generic-api-key (entropy 3.5) fängt ihn zwar,
+# erzeugte beim Repo-Scan aber 174 Funde — PublicKeys in
+# wireguard/wg-mesh-nodes.yaml, Env-Var-Namen (OAUTH2_PROXY_COOKIE_SECRET),
+# verschlüsselte SealedSecret-Blobs und die deklarierten dev-only-Werte aus
+# k3d/secrets.yaml. MESSUNG (2026-08-14, Stand main = fe4edc32b):
+#   gitleaks detect --config <generic-api-key-config> --no-git → 174 leaks.
+# Deshalb hier eine gezielte Regel fuer das sk-…-Format mit kurzem
+# Buchstaben-Praefix und Bindestrich (sk-sp-, sk-live-): Stripe-Test-Keys
+# (sk_test_…, sk_live_…, 4 Buchstaben + Unterstrich) matchen bewusst nicht.
+[[rules]]
+  id = "sk-separated-api-key"
+  description = "API key with sk- prefix and dashed segments"
+  regex = '''sk-[a-z]{2,3}-[A-Za-z0-9._-]{40,}'''
+  tags = ["key", "api"]
+
+

--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -92,13 +92,16 @@
 
     // ── Alibaba Cloud International (Token Plan) ───────────────────────
     // OpenAI-compatible Endpoint für Qwen/Claude Modelle via Alibaba MaaS.
-    // API-Key: sk-sp-H.HHIHP.RTMh.MEUCID2HdR5jagyJmgArzQBJ8RP5rHTa4NIS5ZpEqf_s-zqsAiEAtPWMVMHcXWqx8RuWvmJSZXl48U2zj6qeQeDGTG0OYbQ
+    // Kein "apiKey" hier [2026-08-14, T004808]: Der Key stand plaintext im
+    // Repo und ist als kompromittiert zu behandeln (Rotation offen). Er
+    // liegt jetzt in ~/.local/share/opencode/auth.json — so hält es der
+    // opencode-go-Provider unten ebenfalls; ohne apiKey-Feld greift opencode
+    // genau dort zu.
     // baseURL: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
     "alibaba-intl": {
       "npm": "@ai-sdk/openai-compatible",
       "name": "Alibaba Cloud International (Token Plan, MaaS)",
       "options": {
-        "apiKey": "sk-sp-H.HHIHP.RTMh.MEUCID2HdR5jagyJmgArzQBJ8RP5rHTa4NIS5ZpEqf_s-zqsAiEAtPWMVMHcXWqx8RuWvmJSZXl48U2zj6qeQeDGTG0OYbQ",
         "baseURL": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
       },
       "models": {

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 988,
+      "file_count": 990,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -735,6 +735,8 @@
         "tests/spec/secrets-deploy-automation.bats",
         "tests/spec/secrets-deploy-automation/schema-dev-secrets-sync.bats",
         "tests/spec/security.bats",
+        "tests/spec/security/alibaba-token-key-guard.bats",
+        "tests/spec/security/fixtures/alibaba-token-key-leak.txt",
         "tests/spec/sessions-server.bats",
         "tests/spec/sidekick-assistant.bats",
         "tests/spec/software-factory/_sf_common.bash",

--- a/tests/spec/security/alibaba-token-key-guard.bats
+++ b/tests/spec/security/alibaba-token-key-guard.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Prüfmodus: Output-Verifikation (Test 1) — führt gitleaks tatsächlich gegen
+# eine Fixture aus und prüft dessen Ergebnis. Source-Inspektion (Test 2) —
+# Konfigurations-Konvention, deren Ergebnis sich ausschließlich im Dateitext
+# manifestiert (T002448-M4-Ausnahme für Querschnittstests).
+#
+# Hintergrund: T004808 — der Alibaba-Token-Plan-Key (Format "sk-sp-…") stand
+# plaintext in .opencode/agent-models.jsonc. Die Repo-gitleaks-Config mit
+# schmalen Custom-Regeln (openai-api-key = sk-[A-Za-z0-9]{20,}) matcht das
+# Format wegen Punkten/Bindestrichen nicht; Default-gitleaks fängt es über
+# generic-api-key. Test 1 stellt sicher, dass die Config das Format erfasst;
+# Test 2, dass der Key nicht erneut ins Repo gelangt. Der fail-closed-Gate in
+# CI ist der security-scan-Job — dort läuft gitleaks mit genau dieser Config.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  GITLEAKS_CONFIG="$REPO_ROOT/.gitleaks.toml"
+}
+
+@test "gitleaks-Config erfasst das Alibaba-Token-Format (sk-separated-api-key)" {
+  command -v gitleaks >/dev/null || skip "gitleaks nicht installiert (CI: security-scan-Job deckt den Scan ab)"
+
+  # Positiv-Anker: ein plaintext-Key im sk-sp-…-Format MUSS einen Fund auslösen.
+  # Die Fixture liegt im allowlisted Pfad tests/spec/security/fixtures/ (der
+  # Repo-Scan soll sie nicht sehen). Für den Scan wird sie nach
+  # $BATS_TEST_TMPDIR kopiert — dort wirkt die Allowlist nicht.
+  cp "$REPO_ROOT/tests/spec/security/fixtures/alibaba-token-key-leak.txt" "$BATS_TEST_TMPDIR/"
+  run gitleaks detect --config "$GITLEAKS_CONFIG" --no-git \
+    --source "$BATS_TEST_TMPDIR/alibaba-token-key-leak.txt" 2>&1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"leaks found"* ]]
+}
+
+@test "agent-models.jsonc enthält keinen plaintext sk-API-Key" {
+  AGENT_MODELS="$REPO_ROOT/.opencode/agent-models.jsonc"
+
+  # Positiv-Anker: der alibaba-intl-Provider ist definiert.
+  grep -q '"alibaba-intl"' "$AGENT_MODELS"
+
+  # Negativ: kein sk-…-Token und kein apiKey-Feld mit sk-…-Wert mehr im Repo.
+  ! grep -Eq 'sk-[A-Za-z0-9._-]{20,}' "$AGENT_MODELS"
+  ! grep -Eq '"apiKey"[[:space:]]*:[[:space:]]*"sk-' "$AGENT_MODELS"
+}

--- a/tests/spec/security/fixtures/alibaba-token-key-leak.txt
+++ b/tests/spec/security/fixtures/alibaba-token-key-leak.txt
@@ -1,0 +1,6 @@
+# Fake-Key im Format des Alibaba Cloud Intl Token Plans ("sk-sp-…").
+# Rein synthetisch — Positiv-Anker für den Guard-Test in ../alibaba-token-key-guard.bats.
+# Dieser Pfad liegt unter tests/spec/security/fixtures/ und ist damit über die
+# gitleaks-Allowlist (tests/.*fixtures/.*) vom Repo-Scan ausgenommen; der Test
+# kopiert die Datei nach $BATS_TEST_TMPDIR und scannt sie dort gezielt.
+apiKey = "sk-sp-K9xR2mQ7vW4nL8pT3jH5dF6gB1cS9eZ2yU8iA4oX7kM0wE3rT5hJ6qN1lV2bC8pD4fG9sA3zY7uI6oP0xW5e"

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -4320,6 +4320,12 @@
     "kind": "shell"
   },
   {
+    "id": "security/alibaba-token-key-guard",
+    "file": "tests/spec/security/alibaba-token-key-guard.bats",
+    "category": "security",
+    "kind": "shell"
+  },
+  {
     "id": "sessions-server",
     "file": "tests/spec/sessions-server.bats",
     "category": "sessions-server",


### PR DESCRIPTION
## Summary

T004808: Der Alibaba-Token-Plan-API-Key (Provider `alibaba-intl`, T004396) stand **plaintext** in `.opencode/agent-models.jsonc` — in einem **öffentlichen** Repo, damit auch in der History. Dieser PR entfernt den Key aus dem Repo und schließt die Guard-Lücke, die ihn durchgelassen hat.

**Änderungen:**

1. **`.opencode/agent-models.jsonc`** — `apiKey`-Feld und Key-Kommentar entfernt. Der Key liegt jetzt im opencode-Credential-Store (`~/.local/share/opencode/auth.json`, Typ `api`) — dasselbe Muster wie die Provider `opencode-go` und `deepseek`. Ohne `apiKey`-Feld greift opencode dort zu. Lokal migriert und per Smoke-Test (`opencode run --model alibaba-intl/qwen3.8-max`) verifiziert.
2. **`.gitleaks.toml`** — neue Regel `sk-separated-api-key` (`sk-[a-z]{2,3}-[A-Za-z0-9._-]{40,}`) für das sk-…-Format mit Trennzeichen, an dem die bestehende `openai-api-key`-Regel (`sk-[A-Za-z0-9]{20,}`) scheitert. Die Default-Regel `generic-api-key` (entropy 3.5) wurde bewusst NICHT übernommen: MESSUNG (2026-08-14, Stand main = fe4edc32b) — `gitleaks detect --config <generic-api-key-config> --no-git` → **174 Funde**, davon 0 echte (WireGuard-PublicKeys, Env-Var-Namen, SealedSecret-Blobs, deklarierte dev-only-Werte). Mit der gezielten Regel: 0 Funde im Repo-Scan.
3. **Guard-Test** `tests/spec/security/alibaba-token-key-guard.bats` (neues Spec-Verzeichnis zur SSOT-Spec `openspec/specs/security.md`):
   - Fixture-Scan: gitleaks mit Repo-Config MUSS einen sk-sp-…-Key in einer Fixture finden (Positiv-Anker, Output-Verifikation).
   - Negativtest: `agent-models.jsonc` enthält keinen plaintext sk-…-Key mehr.
   - `test-inventory.json` regeneriert.

**Offen (menschlicher Schritt, nicht Teil dieses PR):** Rotation des Keys bei Alibaba Cloud — der alte Key bleibt als kompromittiert zu behandeln, bis rotiert. Der Nutzer arbeitet bis dahin bewusst mit dem aktuellen Key (nur eben nicht mehr im Repo).

## Test Plan

- [x] `tests/unit/lib/bats-core/bin/bats tests/spec/security/` — 2 ok (RED vor dem Fix verifiziert: Config erkannte das Format nicht, Key war noch plaintext)
- [x] `gitleaks detect --config .gitleaks.toml --no-git` — 0 Leaks (CI-Äquivalent des security-scan-Jobs)
- [x] Betroffene Nachbarsuiten (secret-rotation, pre-commit-freshness, brain-foundation): 68 ok, 0 not ok
- [x] `task freshness:check` grün
- [x] Smoke-Test: `opencode run --model alibaba-intl/qwen3.8-max "Antworte nur mit: ok"` → `ok`
