### PR TITLE
fix(scripts): bge-Embed-Backup via LM Link, CPU-Loadouts aus Erstposition [T005557]

### DIFF
--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -126,6 +126,7 @@
     },
     {
       "slug": "bge-embed-cpu",
+      "enabled": false,
       "label": "bge-m3 · Embedding, CPU-gebunden",
       "model": "gpustack/bge-m3-GGUF/bge-m3-Q8_0.gguf",
       "port": 8095,
@@ -166,7 +167,7 @@
         "-t",
         "4"
       ],
-      "notes": "Erstes Glied der Rollenkette 'embed' (T003205): der Proxy startet es bei Bedarf, der Cluster-Forward (:8081) ist der Rueckfall. Spiegelt die Cluster-Args aus k3d/llm-gpu.yaml (bge-embed): -ngl 0, CUDA_VISIBLE_DEVICES=\"\", -b/-ub 8192, -np 4, --embeddings. Zusaetzlich -t 4: der Host hat 6 Kerne, zwei bleiben fuer das Dataloading eines parallel laufenden Finetunings frei (T002587)."
+      "notes": "ABGESCHALTET (2026-08-14, enabled: false): User-Vorgabe, bge laeuft ausschliesslich auf PK-L-1 via LM Link — kein CPU-Start auf dem Desktop mehr. Der on-demand-Start der Kette (T003205) hatte den am selben Tag manuell gestoppten Server bei der naechsten Anfrage wieder hochgefahren (Prozess auf :8095 seit 16:39). Aus der Rollenkette 'embed' genommen; die Backup-Rolle der Kette uebernimmt LM Studio auf http://127.0.0.1:1234 (LM Link). Loadout bleibt als Referenz stehen. Args gespiegelt von k3d/llm-gpu.yaml (bge-embed): -ngl 0, CUDA_VISIBLE_DEVICES=\"\", -b/-ub 8192, -np 4, --embeddings. Zusaetzlich -t 4: der Host hat 6 Kerne, zwei bleiben fuer das Dataloading eines parallel laufenden Finetunings frei (T002587)."
     },
     {
       "slug": "bge-rerank-cpu",
@@ -210,7 +211,7 @@
         "-t",
         "4"
       ],
-      "notes": "Windows-Tasks deaktiviert (T002729): die vier Scheduled Tasks unter \\Llama\\ (darunter der llama-server auf :8096) sind deaktiviert, XML-Backups liegen unter C:\\Users\\PatrickKorczewski\\llama-tasks-backup\\. Reaktivierung mit Enable-ScheduledTask -TaskPath '\\Llama\\' -TaskName '<name>' (elevated). :8096 ist damit frei; erstes Glied der Rollenkette 'rerank' (T003205) — der Proxy startet es bei Bedarf, der Cluster-Forward (:8093) ist der Rueckfall. Args gespiegelt von k3d/llm-gpu.yaml (bge-rerank). Keine exclusiveGroup: die Gruppe modellierte VRAM-Exklusivität, dieses Loadout belegt kein VRAM — Verweis auf tests/spec/local-llm-proxy/bge-cpu-parallel-start.bats."
+      "notes": "Windows-Tasks deaktiviert (T002729): die vier Scheduled Tasks unter \\Llama\\ (darunter der llama-server auf :8096) sind deaktiviert, XML-Backups liegen unter C:\\Users\\PatrickKorczewski\\llama-tasks-backup\\. Reaktivierung mit Enable-ScheduledTask -TaskPath '\\Llama\\' -TaskName '<name>' (elevated). :8096 ist damit frei; seit 2026-08-14 ZWEITES Glied der Rollenkette 'rerank': der Cluster-Forward (:8093) ist Erstglied, dieser Loadout startet nur noch als Rueckfall, wenn der Forward nicht antwortet — User-Vorgabe, kein bge-Prozess soll dauerhaft auf der Desktop-CPU laufen (bge laeuft auf PK-L-1 via LM Link). Args gespiegelt von k3d/llm-gpu.yaml (bge-rerank). Keine exclusiveGroup: die Gruppe modellierte VRAM-Exklusivität, dieses Loadout belegt kein VRAM — Verweis auf tests/spec/local-llm-proxy/bge-cpu-parallel-start.bats."
     },
     {
       "slug": "unsloth-studio",
@@ -432,14 +433,14 @@
   "roles": {
     "embed": {
       "chain": [
-        "loadout:bge-embed-cpu",
-        "http://127.0.0.1:8081"
+        "http://127.0.0.1:8081",
+        "http://127.0.0.1:1234"
       ]
     },
     "rerank": {
       "chain": [
-        "loadout:bge-rerank-cpu",
-        "http://127.0.0.1:8093"
+        "http://127.0.0.1:8093",
+        "loadout:bge-rerank-cpu"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- `roles.embed.chain` in `scripts/llm/loadouts.json`: Fleet-Forward (`:8081`) zuerst, LM Studio (`:1234`, LM Link) als Backup; `loadout:bge-embed-cpu` aus der Kette genommen und auf `enabled: false` gesetzt.
- `roles.rerank.chain` umgedreht: Fleet-Forward (`:8093`) zuerst, `bge-rerank-cpu` nur noch als Rückfall — LM Studio kann kein Rerank-Backup sein (`/v1/rerank` antwortet 200 mit Error-Body).
- Grund: Am 2026-08-14 wurden die bge-CPU-Server auf dem Desktop gestoppt (Vorgabe: bge läuft ausschließlich auf PK-L-1 via LM Link), aber der on-demand-Start der alten Kette (T003205) fuhr den gestoppten Embed-Server bei der nächsten Anfrage wieder hoch. Lokal zusätzlich behoben (kein Repo-Change): stale systemd-Drop-in `bge-mcp.service.d/10-gpu-embed.conf` entfernt, der `LLM_EMBED_URL` auf den toten Port 8095 pinnte.

## Test Plan
- [x] `node --test scripts/llm-proxy/bge-routes.test.mjs scripts/llm-proxy/loadouts.test.mjs scripts/llm-proxy/server.test.mjs scripts/llm-proxy/runner.test.mjs` → 87 pass, 0 fail
- [x] `tests/unit/lib/bats-core/bin/bats -r tests/spec/local-llm-proxy*` → 0 failures
- [x] `node scripts/llm/loadouts-format.mjs --check scripts/llm/loadouts.json` → kanonisch
- [x] Live: Embed/Rerank über den llm-proxy antworten über Fleet (`x-llm-proxy-bge-upstream: :8081`/`:8093`), kein CPU-Prozess startet mehr
- [x] Failover-Beweis: `routeRequest` mit toter erster URL → `upstream: http://127.0.0.1:1234`, dims 1024
- [x] E2E über den bge-mcp-Shim (`:13005`): `bge_embed` (dims 1024) + `bge_rerank` grün

🤖 [T005557]
🤖 Generated with [Claude Code](https://claude.com/claude-code)