### PR TITLE
feat(scripts): LM-Studio-Autoload für bge-m3 via systemd-User-Timer [T005594]

### DIFF
--- a/scripts/lm-studio/lmstudio-bge-autoload.service
+++ b/scripts/lm-studio/lmstudio-bge-autoload.service
@@ -1,0 +1,18 @@
+# scripts/lm-studio/lmstudio-bge-autoload.service
+# systemd-USER-Service (oneshot): laedt bge-m3 in LM Studio nach, falls es
+# entladen wurde (GUI-Default-TTL 1h Idle, manuelles unload, Neustart).
+# Die eigentliche Logik liegt in lmstudio-bge-autoload.sh — diese Unit ist
+# nur der systemd-Aufhaenger, damit der Timer sie im User-Kontext startet.
+#
+# Symlink zum Aktivieren:
+#   ln -sf $PWD/scripts/lm-studio/lmstudio-bge-autoload.service ~/.config/systemd/user/
+#   ln -sf $PWD/scripts/lm-studio/lmstudio-bge-autoload.timer ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now lmstudio-bge-autoload.timer
+
+[Unit]
+Description=LM Studio: bge-m3 nachladen, falls entladen (TTL/Neustart)
+
+[Service]
+Type=oneshot
+ExecStart=/home/patrick/Bachelorprojekt/scripts/lm-studio/lmstudio-bge-autoload.sh

--- a/scripts/lm-studio/lmstudio-bge-autoload.sh
+++ b/scripts/lm-studio/lmstudio-bge-autoload.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# scripts/lm-studio/lmstudio-bge-autoload.sh
+#
+# T005594 — haelt bge-m3 in LM Studio geladen, damit das Embed-Backup-Glied
+# der llm-proxy-Kette (T005557) nach TTL-Ablauf oder LM-Studio-Neustart
+# wieder verfuegbar ist. LM Studio 0.4.21 hat KEINE native Auto-Load-Option
+# (`lms load` kennt kein --persist); entladen wird das Modell durch die
+# GUI-Default-TTL (1h Idle, `lms ps` zeigt "45m/1h") oder manuell — dieser
+# Lauf ist das Sicherheitsnetz dafuer.
+#
+# Idempotent und still: laeuft LM Studio nicht, endet das Skript ohne Aktion
+# (der Timer versucht es beim naechsten Tick wieder). Der TCP-Check zuerst
+# ist bewusst: ohne ihn wuerde `lms ps` unter systemd moeglicherweise die
+# GUI-App zu starten versuchen, fuer die dort kein DISPLAY existiert.
+#
+# Aufgerufen vom systemd-User-Timer lmstudio-bge-autoload.timer; manuell:
+#   bash scripts/lm-studio/lmstudio-bge-autoload.sh
+
+set -euo pipefail
+
+LMS="$HOME/.lmstudio/bin/lms"
+MODEL="text-embedding-bge-m3"
+API_PORT=1234
+
+# 1) LM-Studio-API-Server erreichbar? Sonst still beenden.
+if ! (exec 3<>"/dev/tcp/127.0.0.1/${API_PORT}") 2>/dev/null; then
+  exit 0
+fi
+
+# 2) Modell bereits geladen? `lms ps --json` liefert eine Liste mit
+#    `identifier`-Feldern. Ist `lms ps` selbst kaputt, ist der Load-Versuch
+#    in Schritt 3 die beste Recovery — derselbe Pfad wie "nicht geladen".
+if "$LMS" ps --json 2>/dev/null | python3 -c "
+import json, sys
+try:
+    loaded = [m.get('identifier', '') for m in json.load(sys.stdin)]
+except Exception:
+    sys.exit(1)
+sys.exit(0 if '$MODEL' in loaded else 1)
+"; then
+  exit 0
+fi
+
+# 3) Nachladen. -y ist Pflicht: ohne TTY haengt `lms load` am interaktiven
+#    Device-Prompt, wenn das Modell auf mehreren LM-Link-Geraeten existiert
+#    (beobachtet 2026-08-14, siehe Memory lm-studio-wsl-lmlink).
+"$LMS" load -y "$MODEL"

--- a/scripts/lm-studio/lmstudio-bge-autoload.timer
+++ b/scripts/lm-studio/lmstudio-bge-autoload.timer
@@ -1,0 +1,23 @@
+# scripts/lm-studio/lmstudio-bge-autoload.timer
+# systemd-USER-Timer: stoesst lmstudio-bge-autoload.service alle 3 Minuten an.
+#
+# WARUM EIN TIMER STATT EINES START-HOOKS
+# LM Studio laeuft als GUI-App (DISPLAY=:0, WSLg) und startet nicht ueber
+# systemd — es gibt also keinen Unit-Lifecycle, an den sich ein
+# `ExecStartPost` haengen liesse. Der Timer deckt stattdessen JEDEN Fall ab:
+# LM-Studio-Neustart, TTL-Entladung (1h Idle), manuelles unload. Das Skript
+# ist idempotent; laeuft LM Studio nicht, beendet es sich still.
+#
+# Persistent=true: verpasste Laeufe (z. B. Rechner aus) werden nachgeholt.
+
+[Unit]
+Description=Timer: bge-m3 in LM Studio geladen halten
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=3min
+Persistent=true
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Neues Setup `scripts/lm-studio/`: systemd-User-Timer (`lmstudio-bge-autoload.timer`, alle 3 min, Persistent) + oneshot-Service + idempotentes Skript `lmstudio-bge-autoload.sh`.
- Das Skript hält `text-embedding-bge-m3` in LM Studio geladen: TCP-Check auf `:1234` (LM Studio läuft nicht → stiller Exit, nächster Tick versucht es wieder), dann `lms ps --json`-Check, sonst `lms load -y`.
- Warum: LM Studio 0.4.21 hat keine native Auto-Load-Option; die GUI-Default-TTL (1h Idle) entlädt das Modell — ab dann wäre das Embed-Backup-Glied der llm-proxy-Kette aus T005557 ohne Modell.

## Test Plan
- [x] No-op-Pfad: Skript bei geladenem Modell → exit 0, keine Ausgabe
- [x] Nachlade-Beweis über die Unit: `lms unload text-embedding-bge-m3` → `systemctl --user start lmstudio-bge-autoload.service` → `lms ps --json` zeigt das Modell wieder
- [x] Timer aktiv: `systemctl --user list-timers lmstudio-bge-autoload.timer` (3min-Intervall)
- [x] `task freshness:check` grün

🤖 [T005594]
🤖 Generated with [Claude Code](https://claude.com/claude-code)