### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3396,7 +3396,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 730,
+      "file_count": 731,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3956,6 +3956,7 @@
         "scripts/openspec-half-archive-check.sh",
         "scripts/openspec-header-inject.sh",
         "scripts/openspec-main-staging-guard.sh",
+        "scripts/openspec-merge-truncation.test.ts",
         "scripts/openspec-merge.mjs",
         "scripts/openspec-merge.test.ts",
         "scripts/openspec-status-map.sh",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31826004560).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
