### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1003,
+      "file_count": 1004,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -23,6 +23,7 @@
         "tests/e2e/lib/health-assertions.test.ts",
         "tests/e2e/lib/health-assertions.ts",
         "tests/e2e/lib/nav-graph.ts",
+        "tests/e2e/lib/sdlc-guard.ts",
         "tests/e2e/lib/sweep-guard.public.spec.ts",
         "tests/e2e/lib/sweep-guard.ts",
         "tests/e2e/lib/visual-sweep-helpers.ts",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31828897322).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
