### PR TITLE
chore(ci): kubeconfig writes via umask 077 + chmod 700 absichern [T005902]

### DIFF
--- a/.github/workflows/build-brett.yml
+++ b/.github/workflows/build-brett.yml
@@ -93,6 +93,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/brett -n workspace
@@ -118,6 +120,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/brett -n workspace-korczewski

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -94,6 +94,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/docs -n workspace
@@ -118,6 +120,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/docs -n workspace-korczewski

--- a/.github/workflows/build-mediaviewer-widget.yml
+++ b/.github/workflows/build-mediaviewer-widget.yml
@@ -85,6 +85,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/mediaviewer-widget -n workspace
@@ -109,6 +111,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl rollout restart deployment/mediaviewer-widget -n workspace-korczewski

--- a/.github/workflows/build-mentolder-web.yml
+++ b/.github/workflows/build-mentolder-web.yml
@@ -82,6 +82,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 

--- a/.github/workflows/build-videovault.yml
+++ b/.github/workflows/build-videovault.yml
@@ -98,6 +98,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl set image deployment/videovault videovault="${IMAGE}:${SHA_TAG}" -n workspace
@@ -124,6 +126,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
           kubectl set image deployment/videovault videovault="${IMAGE}:${SHA_TAG}" -n workspace-korczewski

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -177,6 +177,8 @@ jobs:
           curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
             | bash -s -- 5.4.3 /usr/local/bin
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 
@@ -336,6 +338,8 @@ jobs:
           curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" \
             | bash -s -- 5.4.3 /usr/local/bin
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 

--- a/.github/workflows/health-goals.yml
+++ b/.github/workflows/health-goals.yml
@@ -81,6 +81,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 

--- a/.github/workflows/quality-loop.yml
+++ b/.github/workflows/quality-loop.yml
@@ -46,6 +46,8 @@ jobs:
           curl -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" \
             -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
           mkdir -p ~/.kube
+          umask 077
+          chmod 700 ~/.kube
           echo "$KUBECONFIG_DATA" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 


### PR DESCRIPTION
## Summary

Security-Hardening (Fund der automatisierten Security-Review, MEDIUM): Der Kubeconfig-Write lief in 9 Workflows als Redirect mit Default-Umask — `~/.kube/config` existierte dadurch kurzzeitig mit 0644 (TOCTOU-Fenster), bis das nachfolgende `chmod 600` griff.

Fix an allen 13 Stellen auf `main` (8 Dateien): `umask 077` vor dem Redirect + `chmod 700 ~/.kube`; das explizite `chmod 600` bleibt als zweite Verteidigungslinie.

## Test Plan

- YAML-Parse aller 8 geänderten Workflows: OK
- `task test:changed`: grün (inkl. `lint:workflows`/actionlint, quality gate, runtime-drift-check)
- `task freshness:check`: grün

## Hinweis

Das Review-Flag traf zusätzlich `.github/workflows/e2e.yml` im Haupt-Checkout — diese Datei enthält den Kubeconfig-Write nur auf dem ungemergten E2E-Branch (`feature/e2e-oidc-otac-login-T003163`), nicht auf `main`. Nach dessen Merge dieselbe Härtung dort nachziehen.
