### PR TITLE
fix(website): mirror http/https startUrl guard in collection create path [T005900]

### DIFF
--- a/website/src/components/admin/WebCrawlSourceModal.svelte
+++ b/website/src/components/admin/WebCrawlSourceModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import AdminModal from './ui/AdminModal.svelte';
+  import { safeHttpUrl } from '../../lib/safe-url';
 
   let {
     onCreated,
@@ -46,18 +47,15 @@
   async function submit() {
     busy = true; error = null; info = null;
     try {
-      let parsedUrl: URL;
-      try { parsedUrl = new URL(startUrl.trim()); } catch {
-        error = 'Bitte eine gültige URL eingeben (z.B. https://example.com).';
-        return;
-      }
-      if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
-        error = 'Nur http:// und https:// URLs sind erlaubt.';
+      // T005900: ein gemeinsamer Guard — nur http/https ergeben einen Link
+      const parsedUrl = safeHttpUrl(startUrl.trim());
+      if (!parsedUrl) {
+        error = 'Bitte eine gültige http:// oder https:// URL eingeben (z.B. https://example.com).';
         return;
       }
 
       const crawlConfig = {
-        startUrl:       parsedUrl.href,
+        startUrl:       parsedUrl,
         maxDepth:       Number(maxDepth) || 3,
         maxPages:       Number(maxPages) || 200,
         includePattern: includePattern.trim() || undefined,

--- a/website/src/lib/safe-url.test.ts
+++ b/website/src/lib/safe-url.test.ts
@@ -13,8 +13,20 @@ describe('safeHttpUrl', () => {
     expect(safeHttpUrl('http://example.com/docs')).toBe('http://example.com/docs');
   });
 
+  it('normalizes the href for a bare https origin', () => {
+    expect(safeHttpUrl('https://example.com')).toBe('https://example.com/');
+  });
+
   it('returns null for a javascript: scheme', () => {
     expect(safeHttpUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  it('returns null for a case-variant javascript: scheme', () => {
+    expect(safeHttpUrl('JaVaScRiPt:alert(1)')).toBeNull();
+  });
+
+  it('returns null for a whitespace-prefixed javascript: scheme', () => {
+    expect(safeHttpUrl(' javascript:alert(1)')).toBeNull();
   });
 
   it('returns null for a data: scheme', () => {

--- a/website/src/pages/api/admin/knowledge/collections/[id]/crawl-config.ts
+++ b/website/src/pages/api/admin/knowledge/collections/[id]/crawl-config.ts
@@ -18,7 +18,7 @@ export const PATCH: APIRoute = async ({ request, params }) => {
 
   const body = await request.json() as Partial<CrawlConfig>;
 
-  if (!body.startUrl?.trim()) {
+  if (typeof body.startUrl !== 'string' || !body.startUrl.trim()) {
     return new Response(JSON.stringify({ error: 'startUrl erforderlich' }), { status: 400 });
   }
 

--- a/website/src/pages/api/admin/knowledge/collections/index.ts
+++ b/website/src/pages/api/admin/knowledge/collections/index.ts
@@ -29,15 +29,25 @@ export const POST: APIRoute = async ({ request }) => {
   const source = body.source === 'web_crawl' ? 'web_crawl' : 'custom';
 
   if (source === 'web_crawl') {
-    if (!body.crawlConfig?.startUrl?.trim()) {
+    const rawStart = body.crawlConfig?.startUrl;
+    if (typeof rawStart !== 'string' || !rawStart.trim()) {
       return new Response(
         JSON.stringify({ error: 'crawlConfig.startUrl erforderlich für web_crawl' }),
         { status: 400 },
       );
     }
-    try { new URL(body.crawlConfig.startUrl); } catch {
+    let parsedUrl: URL;
+    try { parsedUrl = new URL(rawStart.trim()); } catch {
       return new Response(
         JSON.stringify({ error: 'crawlConfig.startUrl ist keine gültige URL' }),
+        { status: 400 },
+      );
+    }
+    // T005900: javascript:/data:/… sind parsebar, aber kein Link-Schema für einen
+    // Crawl-Ausgangspunkt — nur http/https persistieren (Stored-XSS-Vektor).
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return new Response(
+        JSON.stringify({ error: 'crawlConfig.startUrl muss http/https sein' }),
         { status: 400 },
       );
     }


### PR DESCRIPTION
Follow-up zu #4486 (gemergt 2026-08-14): Die Review-Punkte (Important 1+2, Minor 4) kamen nach dem Merge des PRs an — dieser PR liefert sie nach.

Refs T005900

## Änderungen
- **POST /api/admin/knowledge/collections** (Important 1): Protokoll-Guard nach dem `new URL()`-Check — nur `http:`/`https:` werden persistiert, sonst 400 vor der Persistenz. Ein `javascript:`-Wert konnte beim Erstellen einer Sammlung gespeichert werden (floss in DB + Crawler); der Render-Guard hat den XSS geschlossen, die Persistenz-Lücke blieb.
- **WebCrawlSourceModal.svelte** (Important 1): lokale Protokoll-Check-Duplikation entfernt, nutzt den gemeinsamen `safeHttpUrl`-Helper (eine Quelle der Wahrheit, href-Normalisierung).
- **crawl-config.ts** (Minor 4): `typeof body.startUrl === 'string'`-Guard — non-string startUrl war ein 500 statt 400.
- **safe-url.test.ts** (Important 2): Bypass-Klassen eingefroren — `JaVaScRiPt:`-Case-Variante, Whitespace-Variante, href-Normalisierung (`https://example.com` → `https://example.com/`).

## Verifikation
- strip-types-Smoke: 10/10 Behavior-Cases grün (inkl. Bypass-Klassen)
- `task test:changed` grün (52/52 BATS-Subtests)
- `npx astro check` 0 errors / 0 warnings
- `bash scripts/openspec.sh validate wissenhub-safe-url` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)