### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1010,
+      "file_count": 1011,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -787,6 +787,7 @@
         "tests/spec/software-factory/retry-and-build-loop.bats",
         "tests/spec/software-factory/retry-limit.bats",
         "tests/spec/software-factory/sandbox-egress.bats",
+        "tests/spec/software-factory/schedule-blocker-gate-hardening.bats",
         "tests/spec/software-factory/schedule-blocker-gate.bats",
         "tests/spec/software-factory/scheduling-cleanup-guard.bats",
         "tests/spec/software-factory/scheduling.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31842116870).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
