### PR TITLE
docs: verify/done-Konvention in Finetune-Docs nachziehen [T006330]

### DIFF
--- a/.claude/skills/finetune-run/SKILL.md
+++ b/.claude/skills/finetune-run/SKILL.md
@@ -48,7 +48,7 @@ Plugin.
    ```bash
    task finetune:traces ROWS_JSON=<mcp-postgres-export.json> OUT=<jsonl>
    ```
-   Nur erfolgreiche Ticket-Laeufe (verify/pass) werden uebernommen; Secret-Muster werden
+   Nur erfolgreiche Ticket-Laeufe (verify/done) werden uebernommen; Secret-Muster werden
    redigiert. `ROWS_JSON` kommt aus einem vorgeschalteten `mcp__mcp-postgres__query`-Aufruf
    (siehe `.claude/skills/references/mcp-tool-guide.md`) — dieses Skript baut selbst keine
    DB-Verbindung auf.

--- a/scripts/finetune/README.md
+++ b/scripts/finetune/README.md
@@ -85,7 +85,7 @@ laufenden Factory-Slots gehoert nicht in einen Trainingslauf.
 vorgeschalteten `mcp__mcp-postgres__query`-Aufruf gegen `tickets.factory_phase_events`
 (siehe `.claude/skills/references/mcp-tool-guide.md`), als JSON-Datei via `--rows-json`
 uebergeben (`--fixture` ist der identische Pfad fuer Tests). Nur Ticket-Laeufe mit einem
-`verify`/`pass`-Event werden uebernommen; bekannte Secret-Muster im `detail`-Feld werden vor
+`verify`/`done`-Event werden uebernommen; bekannte Secret-Muster im `detail`-Feld werden vor
 dem Schreiben redigiert.
 
 ## Trainingsartefakte


### PR DESCRIPTION
## Summary

Folge-Fix zu T006282 (PR #4524): Der gemergte Fix hat Code und BATS-Tests auf die `verify`/`done`-Konvention umgestellt, aber zwei kanonische Docs trugen die veraltete `verify`/`pass`-Konvention weiter (Review-Befund, Important):

- `scripts/finetune/README.md` — Collector-Beschreibung
- `.claude/skills/finetune-run/SKILL.md` — wird via capabilities.yaml in Agent-Prompts injiziert

Beide Zeilen jetzt auf `verify`/`done`.

## Test Plan

- Diff ist exakt die zwei vom Review (PR #4524) verordneten Zeilen: `git show --stat HEAD` → 2 files, 2 insertions, 2 deletions.
- Breiter Nach-Check auf verbliebene `verify/pass`-Stellen: `grep -rn 'verify/pass' scripts/finetune .claude/skills/finetune-run` → 0 Treffer.
- CI-Gates (commitlint, freshness) laufen im PR.

Closes T006330