### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1025,
+      "file_count": 1026,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -336,6 +336,7 @@
         "tests/spec/.spec-runtime.tsv",
         "tests/spec/active-sessions-hub.bats",
         "tests/spec/active-sessions-hub/agent-lock-main-checkout-reclaim.bats",
+        "tests/spec/active-sessions-hub/agent-lock-release-cwd.bats",
         "tests/spec/active-sessions-hub/agent-lock-scope-regelwerk.bats",
         "tests/spec/active-sessions-hub/claim-persistence-verified-T002826.bats",
         "tests/spec/active-sessions-hub/lock-ownership-cwd-independent-T003110.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31857312896).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
