### PR TITLE
fix(ci): ignore spec-junit-shard-* in .gitignore [T006368]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vitest-junit-report/
 scripts/deep.sh
 # bats junit-Reporte (BATS_JUNIT_DIR, [T003025]) — CI-artefakt, nie committen
 junit-report/
+spec-junit-shard-*/
 website-dist/
 .lighthouseci/
 # Windows Lighthouse cache dirs (cross-platform artifact, literal backslash names)

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1028,
+      "file_count": 1029,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -476,6 +476,7 @@
         "tests/spec/dev-flow-plan.bats",
         "tests/spec/dev-flow-plan/domains-vocabulary.bats",
         "tests/spec/dev-flow-plan/guard-parity.bats",
+        "tests/spec/dev-flow-plan/junit-shard-ignore.bats",
         "tests/spec/dev-flow-plan/plan-commit-scope-guard.bats",
         "tests/spec/dev-flow-plan/plan-intel-risks-dedupe.bats",
         "tests/spec/dev-flow-plan/plan-lint-b1b-prose-path.bats",

--- a/tests/spec/dev-flow-plan/junit-shard-ignore.bats
+++ b/tests/spec/dev-flow-plan/junit-shard-ignore.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# tests/spec/dev-flow-plan/junit-shard-ignore.bats
+# Ticket: T006368 — spec-junit-shard-*-Artefakte in .gitignore aufnehmen
+
+setup() {
+  export REPO_ROOT="$BATS_TEST_DIRNAME/../../.."
+}
+
+@test "spec-junit-shard-1/report.xml is ignored by git" {
+  cd "$REPO_ROOT"
+  run git check-ignore -q spec-junit-shard-1/report.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "spec-junit-shard-4/report.xml is ignored by git" {
+  cd "$REPO_ROOT"
+  run git check-ignore -q spec-junit-shard-4/report.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "junit-report/report.xml remains ignored by git" {
+  cd "$REPO_ROOT"
+  run git check-ignore -q junit-report/report.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "vitest-junit-report/report.xml remains ignored by git" {
+  cd "$REPO_ROOT"
+  run git check-ignore -q vitest-junit-report/report.xml
+  [ "$status" -eq 0 ]
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -2796,6 +2796,12 @@
     "kind": "shell"
   },
   {
+    "id": "dev-flow-plan/junit-shard-ignore",
+    "file": "tests/spec/dev-flow-plan/junit-shard-ignore.bats",
+    "category": "dev-flow-plan",
+    "kind": "shell"
+  },
+  {
     "id": "dev-flow-plan/plan-commit-scope-guard",
     "file": "tests/spec/dev-flow-plan/plan-commit-scope-guard.bats",
     "category": "dev-flow-plan",


### PR DESCRIPTION
Closes T006368. Ignoriert spec-junit-shard-* JUnit-Artefakte in .gitignore, um verwaiste Artefakte bei Worktree-Cleanups zu verhindern.