### PR TITLE
chore(test): ignore spec-junit-shard-* bats junit artifacts [T006368]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vitest-junit-report/
 scripts/deep.sh
 # bats junit-Reporte (BATS_JUNIT_DIR, [T003025]) — CI-artefakt, nie committen
 junit-report/
+spec-junit-shard-*/
 website-dist/
 .lighthouseci/
 # Windows Lighthouse cache dirs (cross-platform artifact, literal backslash names)


### PR DESCRIPTION
## Summary
- `.gitignore` um `spec-junit-shard-*/` erweitert (JUnit-Ignore-Block neben `junit-report/`, BATS_JUNIT_DIR [T003025]).
- BATS-Shard-Läufe erzeugen `spec-junit-shard-1..4/report.xml` (untracked); ohne Ignore-Eintrag blockieren diese Nicht-Allowlist-Artefakte den worktree-clean-check und verhindern Worktree-Removes.

## Test Plan
- [x] `git check-ignore spec-junit-shard-1/report.xml` → ignoriert (rc=0), ebenso `spec-junit-shard-4/report.xml`
- [x] Bestehende Muster unverändert: `junit-report/` und `vitest-junit-report/` weiterhin ignoriert
- [x] BATS-Guards grün: worktrees-not-tracked, test-inventory-coverage, lockfile-drift (13 ok)
- [x] `task freshness:check` grün (rc=0)
- [ ] CI grün

🤖 [T006368]