### PR TITLE
chore(plans): SSOT-Delta-Nachholung für guard-warn-assertion [T006031]

### DIFF
--- a/openspec/specs/software-factory.md
+++ b/openspec/specs/software-factory.md
@@ -3366,6 +3366,29 @@ is not a blocker.
 - **THEN** the candidate is not treated as blocked and proceeds through the scheduling
   gates
 
+### Requirement: Blocker-gate WARN assertions are line-scoped
+
+The blocker-gate guard tests SHALL assert the hold-WARN by matching the specific
+`open blockers:` line and the blocker id within that line, not by unqualified greps over the
+full command output — a positive match on the plan JSON or an unrelated future WARN must
+never satisfy the assertion (T002448-M4 output-verification convention). The pool-busy
+pre-check SHALL treat a non-numeric `slots.sh count` result as busy (fail-closed skip)
+instead of silently proceeding against a possibly occupied pool.
+
+#### Scenario: hold-WARN assertion matches the WARN line only
+
+- **GIVEN** the hardening guard runs against a schedule.sh output where the candidate was
+  held with a WARN
+- **WHEN** the WARN assertion is evaluated
+- **THEN** it matches the `open blockers:` line and the blocker id within that line — and
+  fails when the WARN line is absent even if the blocker id appears elsewhere in the output
+
+#### Scenario: pool-busy pre-check fails closed on a broken count
+
+- **GIVEN** `slots.sh count` produces no numeric value (error output)
+- **WHEN** the guard's pool-busy pre-check runs
+- **THEN** the test skips instead of proceeding against an unknown pool state
+
 ## Testszenarien
 
 <!-- merged from BATS unit tests and Playwright e2e tests -->
@@ -5321,3 +5344,5 @@ The system SHALL enforce authentication on all coaching-session pages and API en
 <!-- merged from change delta software-factory.md (7cc5f195b2c6) -->
 
 <!-- merged from change delta software-factory.md (51477492d96c) -->
+
+<!-- merged from change delta software-factory.md (faf59d84b06d) -->


### PR DESCRIPTION
## Was

PR #4567 hatte das Change-Verzeichnis nach `openspec/changes/archive/2026-08-15-guard-warn-assertion/` verschoben und `openspec-status.json` committet — aber das Delta gelangte nie in die SSOT `openspec/specs/software-factory.md`. Das ist die Halb-Archiv-Klasse, vor der der openspec-half-archive-check warnt.

Dieser PR holt das SSOT-Merge nach:

- Requirement `Blocker-gate WARN assertions are line-scoped` inkl. beider Szenarien in die SSOT aufgenommen (Inhalt identisch mit dem archivierten Delta).
- Merge-Marker am Dateiende ergänzt.

Kein weiterer Datei-Change nötig: `openspec-status.json` war via #4567 bereits konsistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)