### PR TITLE
fix(scripts): finalize review fixes — step-10 skip, restore diagnostics [T006791]

### DIFF
--- a/openspec/changes/post-merge-finalize-archive-branch-restore/design.md
+++ b/openspec/changes/post-merge-finalize-archive-branch-restore/design.md
@@ -15,12 +15,19 @@ Archiv-Branch `chore/plan-archive-<slug>-<ticket>` statt auf dem vorherigen Bran
 Betroffen ist der geteilte Arbeitsbaum: `ARCHIVE_DIR` ist entweder der Worktree
 (`$WORKTREE`) oder das **Haupt-Checkout** (`$REPO_DIR`) — T002357-Fallenklasse.
 
-**Beleg:** `git show origin/main:scripts/devflow-post-merge-finalize.sh | grep -c
-ARCHIVE_PREV_BRANCH` → 0. Die Archiv-Sektion (Z. 216–246) läuft in einer Subshell mit
-`git checkout -B "$ARCHIVE_BRANCH" origin/main` (Z. 229) ohne Restore. Der
-BATS-Guard `tests/spec/agent-skills/post-merge-finalize-guards.bats` Assertion 5
-(ARCHIVE_PREV_BRANCH) ist gegen main rot; auf main liegt sie als `skip` mit Verweis auf
-T006791 (via PR #4579).
+**Beleg (MESSUNG, T002717 — Stand vor PR #4586):**
+
+```bash
+# Stand, gegen den gemessen wurde: main vor dem Fix-Merge (chore: auto-regenerate
+# freshness artifacts (#4584)); nach PR #4586 ist die Variable auf main vorhanden.
+PRE=8422d5b3993124642beec769264b891acc178960
+git show "$PRE:scripts/devflow-post-merge-finalize.sh" | grep -c ARCHIVE_PREV_BRANCH   # → 0
+```
+
+Die Archiv-Sektion lief in einer Subshell mit `git checkout -B "$ARCHIVE_BRANCH"
+origin/main` ohne Restore. Der BATS-Guard
+`tests/spec/agent-skills/post-merge-finalize-guards.bats` Assertion 5
+(ARCHIVE_PREV_BRANCH) lag gegen main als `skip` mit Verweis auf T006791 (via PR #4579).
 
 **Hypothese vs. Ursache:** Die Ticket-Beschreibung nennt als Ursache „Restore fehlt".
 Verifiziert: Der T006348-Plan (Befund 2) deklarierte zwei Teile — (a) ls-remote-Skip
@@ -28,18 +35,67 @@ Verifiziert: Der T006348-Plan (Befund 2) deklarierte zwei Teile — (a) ls-remot
 (NICHT implementiert). Der Fix ist damit nicht eine neue Erfindung, sondern die
 nachgeholte Hälfte einer dokumentierten Entscheidung.
 
-## Fix-Ansatz
+## Fix-Ansatz (Stand: PR #4586 + Review-Fixes PR #4596)
 
-1. Vor der Archiv-Sektion (im `else`-Zweig, nach dem ls-remote-Skip) den aktuellen
-   Branch merken:
-   `ARCHIVE_PREV_BRANCH="$(git -C "$ARCHIVE_DIR" rev-parse --abbrev-ref HEAD)"`.
-2. In der Subshell eine EXIT-Trap registrieren, die den Branch zurückschaltet —
-   `trap` deckt den Happy-Path (nach Push/PR) UND die Fehlerpfade ab (gh pr create /
-   gh pr merge FATAL → Subshell exit 1): In jedem Fall endet die Subshell auf dem
-   gemerkten Branch.
-3. No-op-Schutz: Restore nur, wenn `HEAD != ARCHIVE_PREV_BRANCH`.
-4. Restore-Fehler → `FATAL`-Meldung auf stderr und Exit 1 (kein stiller Erfolg,
-   kein Ticket-`done` mit gewechseltem Arbeitsbaum).
+### 1. Capture vor der Sektion (im `else`-Zweig, nach dem ls-remote-Skip)
+
+```bash
+ARCHIVE_PREV_BRANCH="$(git -C "$ARCHIVE_DIR" rev-parse --abbrev-ref HEAD)"
+ARCHIVE_PREV_SHA="$(git -C "$ARCHIVE_DIR" rev-parse HEAD 2>/dev/null || true)"
+```
+
+Die SHA zusätzlich merken: auf detached HEAD liefert `rev-parse --abbrev-ref HEAD`
+nur `"HEAD"` und wäre als Restore-Ziel unbrauchbar — der Restore holt den Zustand
+dann per `git checkout --detach "$ARCHIVE_PREV_SHA"` zurück (Code-Review PR #4586,
+Finding 9).
+
+### 2. Subshell-EXIT-Trap mit Ownership-Guard
+
+In der Sektions-Subshell wird eine Trap registriert, die bei **jedem** Subshell-Exit
+läuft — Happy-Path (nach Push/PR) UND Fehlerpfade (gh pr create / gh pr merge FATAL
+→ exit 1):
+
+- **Ownership-Guard (T002357):** Restore nur, wenn `HEAD == $ARCHIVE_BRANCH` —
+  hat eine parallele Session zwischenzeitlich den Branch gewechselt, bleibt deren
+  Wechsel unangetastet (WARN statt Restore). Ohne den Guard wäre der Restore selbst
+  eine T002357-Verletzung (Code-Review PR #4586, Finding 8).
+- **Restore-Fehler:** `FATAL` auf stderr + `git status --short`-Dump (zeigt, welche
+  Änderungen den Wechsel blockieren) + Hinweis, dass ein ggf. noch gehaltener
+  agent-lock manuell geräumt werden muss; Exit 1 (kein stiller Erfolg, kein
+  Ticket-`done` mit gewechseltem Arbeitsbaum).
+
+### 3. Order-Swap in der Sektion (Code-Review PR #4586, Findings 1/3/4/7)
+
+Neue Reihenfolge — **erst** auf den Archiv-Branch wechseln, **dann** archivieren
+und direkt auf dem Archiv-Branch committen:
+
+```bash
+git fetch origin main
+git checkout -B "$ARCHIVE_BRANCH" origin/main
+bash scripts/openspec.sh archive "$SLUG"
+task freshness:regenerate >/dev/null 2>&1 || true
+git add <openSpec-Artefakte>
+git commit -m "chore(plans): archive $SLUG → postgres + openspec/archive [$TICKET_ID]"
+git push -u origin "$ARCHIVE_BRANCH"
+```
+
+Eliminiert drei Fehlerklassen des ursprünglichen Ansatzes (Commit auf dem
+Pre-Switch-Branch, dann cherry-pick):
+1. **Kein Streu-Commit:** Der Archiv-Commit landet nie auf dem Arbeitsbaum-Branch
+   der parallelen Session (empirisch belegt im Review: Commit erschien auf PREV).
+2. **Kein cherry-pick:** entfällt komplett — kein Konfliktrisiko, kein
+   „already applied"-Fehler nach Rebase, kein post-checkout-Hook-Dirty-Tree.
+3. **Push-Berechtigung:** Der Push läuft auf dem frisch von `origin/main`
+   abgezweigten Branch (T002256) — kein Rebase des bereits gepushten Branches.
+
+### 4. Schritt 10: ausgecheckter Branch ist kein Fehler (Review-Finding 2)
+
+Der Restore stellt den Haupt-Checkout auf den Ticket-Branch `$BRANCH` zurück. Ein
+danach ausgecheckter Branch ist nicht löschbar (`cannot delete branch used by
+worktree`) — der Delete-Block überspringt diesen Fall mit `mark_skip` (lokaler
+Branch bleibt als Arbeitsbaum-Zustand erhalten, Remote-Delete via branch-reaper)
+statt mit `ERROR ... exit 1`. Ohne diese Anpassung endete jeder Finalize-Lauf im
+Main-Checkout-Fall dauerhaft rot — der Batch-Pfad wäre permanent gebrochen.
 
 ### Warum Subshell-Trap statt Restore im Hauptfluss?
 
@@ -54,18 +110,30 @@ kaputt). Die Trap läuft bei jedem Subshell-Exit.
 
 | Fall | Verhalten |
 |---|---|
-| Archiv-Branch existiert bereits remote | ls-remote-Skip — kein Branch-Wechsel, PREV wird nicht gemerkt, keine Subshell, kein Restore |
-| Fehler VOR `git checkout -B` (openspec.sh archive, commit) | kein Branch-Wechsel; Trap-Restore ist No-op (HEAD == PREV) |
-| Fehler NACH `git checkout -B` (cherry-pick, push, pr create, merge) | Trap restauriert trotzdem; Subshell-Exit-Code bleibt 1 |
+| Archiv-Branch existiert bereits remote | ls-remote-Skip — kein Branch-Wechsel, kein Capture, keine Subshell, kein Restore |
+| Fehler bei fetch/`checkout -B` (vor dem Wechsel) | HEAD == PREV; Trap-Restore ist No-op (Ownership-Guard greift nicht, WARN-Zweig schweigt) |
+| Fehler NACH `checkout -B` (archive, commit, push, pr create, merge) | Trap restauriert trotzdem; Subshell-Exit-Code bleibt 1; `git status --short` im Restore-Fehlerfall |
+| HEAD war detached | SHA-Capture + Restore via `git checkout --detach "$SHA"` |
 | `ARCHIVE_DIR == $REPO_DIR` (Haupt-Checkout) | `git -C "$ARCHIVE_DIR"` wirkt auf denselben Checkout — Restore greift |
 | `ARCHIVE_DIR == $WORKTREE` | `git -C "$WORKTREE"` — geteiltes .git, Restore greift |
-| Restore schlägt fehl (z. B. PREV-Branch zwischenzeitlich gelöscht) | `FATAL` auf stderr, Skript endet mit Exit 1 — kein falsches done |
+| Paralleler Wechsel während der Sektion | Ownership-Guard: WARN, kein Restore — der fremde Wechsel bleibt unangetastet (T002357) |
+| Restore-Ziel zwischenzeitlich gelöscht / Checkout blockiert | `FATAL` + status-Dump + Lock-Hinweis auf stderr, Skript endet mit Exit 1 — kein falsches done |
+| Restore stellt Haupt-Checkout auf $BRANCH, Schritt 10 will `branch -D $BRANCH` | mark_skip: ausgecheckter Branch ist nicht löschbar; lokaler Branch bleibt, Remote via branch-reaper |
 
 ## Test-Strategie
 
 - Assertion 5 in `tests/spec/agent-skills/post-merge-finalize-guards.bats`:
-  `skip` entfernen → `grep -qF 'ARCHIVE_PREV_BRANCH' "$FINALIZE"` (Source-Grep-Modus,
-  dokumentierte Ausnahme von T002448-M4: der Laufzeitpfad braucht Cluster/DB).
-- Rot-Grün: Assertion rot gegen main (Variable fehlt), grün nach dem Fix.
-- Lokale Verifikation: `bats tests/spec/agent-skills/post-merge-finalize-guards.bats`
-  (8 Tests grün).
+  `skip` entfernt, prüft seit dem Review-Fix (PR #4596) zwei Signale —
+  `ARCHIVE_PREV_BRANCH` (Capture) **und** `trap _restore_prev_branch EXIT`
+  (Restore-Mechanismus). Die reine Capture-Variable wäre vakuos: ein Refactor,
+  der die Trap entfernt, muss rot werden (Code-Review PR #4586, Finding 11).
+- Zeilennummern-Kommentare in der BATS-Datei entfernt — Positionsangaben sind
+  T003104-Fehlerklasse (Dokumentposition ist kein stabiles Signal).
+- Zusätzlich zur Source-Grep-Absicherung wurde die Restore-Mechanik isoliert in
+  einem Bare-Git-Repo mit Fake-openspec.sh verifiziert (Code-Review PR #4586) —
+  ein voller BATS-Runtime-Test bleibt unmöglich: die Sektion ist nicht als
+  Funktion isolierbar und Schritt 1 (ticket.sh get) braucht die Ticket-DB.
+- Lokale Verifikation: `tests/unit/lib/bats-core/bin/bats
+  tests/spec/agent-skills/post-merge-finalize-guards.bats` (8 Tests grün).
+- Live-Verifikation: Finalize-Lauf für T006791 aus dem Haupt-Checkout nach dem
+  Merge (Archiv-Sektion mit Restore + Schritt-10-Skip).

--- a/openspec/changes/post-merge-finalize-archive-branch-restore/proposal.md
+++ b/openspec/changes/post-merge-finalize-archive-branch-restore/proposal.md
@@ -11,15 +11,25 @@ Auf main wechselt die Archiv-Sektion weiterhin per `git checkout -B
 oder Haupt-Checkout) ohne Rückkehr — T002357-Fallenklasse: parallele Sessions im
 geteilten Checkout laufen danach auf dem falschen Branch weiter.
 
-Beleg: `git show origin/main:scripts/devflow-post-merge-finalize.sh | grep -c
-ARCHIVE_PREV_BRANCH` → 0. Der BATS-Guard Assertion 5 (ARCHIVE_PREV_BRANCH) liegt
-als `skip` auf main (via PR #4579) und verweist auf dieses Ticket.
+Beleg (MESSUNG, T002717 — Stand vor PR #4586, nachstellbar):
+
+```bash
+PRE=8422d5b3993124642beec769264b891acc178960   # main vor dem Fix-Merge
+git show "$PRE:scripts/devflow-post-merge-finalize.sh" | grep -c ARCHIVE_PREV_BRANCH   # → 0
+```
+
+Der BATS-Guard Assertion 5 (ARCHIVE_PREV_BRANCH) lag als `skip` auf main (via PR
+#4579) und verweist auf dieses Ticket.
 
 ## What
 
 Das Finalize-Skript merkt vor der Archiv-Sektion den aktuellen Branch
-(`ARCHIVE_PREV_BRANCH`) und stellt ihn nach der Sektion wieder her — auch auf
-Fehlerpfaden innerhalb der Sektion (Trap in der Subshell). Der BATS-Guard
-Assertion 5 wird von `skip` auf eine echte Assertion zurückgestellt.
+(`ARCHIVE_PREV_BRANCH`, plus SHA für detached HEAD) und stellt ihn nach der
+Sektion wieder her — auch auf Fehlerpfaden innerhalb der Sektion (EXIT-Trap in
+der Subshell mit Ownership-Guard gegen parallele Wechsel). Die Sektion wechselt
+per Order-Swap zuerst auf den Archiv-Branch (von origin/main) und committet die
+Archivierung direkt dort — kein Streu-Commit, kein cherry-pick. Der BATS-Guard
+Assertion 5 wird von `skip` auf eine echte Assertion zurückgestellt (Capture-
+Signal plus Trap-Signal).
 
 _Ticket: T006791_

--- a/openspec/changes/post-merge-finalize-archive-branch-restore/tasks.md
+++ b/openspec/changes/post-merge-finalize-archive-branch-restore/tasks.md
@@ -18,12 +18,16 @@ auch auf Fehlerpfaden. Der BATS-Guard Assertion 5
 (`tests/spec/agent-skills/post-merge-finalize-guards.bats`) wird von `skip` auf eine echte
 Assertion zurückgestellt (im Stage-Commit bereits geschehen).
 
-**Architecture:** Der Fix lebt in der Archiv-Sektion (Z. ~209–246): PREV-Merken im
-Hauptfluss vor der Subshell, Restore als EXIT-Trap IN der Subshell. Die Trap deckt sowohl den
-Happy-Path (nach Push/PR) als auch die Fehlerpfade (`gh pr create`/`gh pr merge` FATAL →
-Subshell-Exit 1) ab — die naheliegende Restore-Nach-der-Subshell-Variante liefe bei
-`set -euo pipefail`-Abbruch nie und hinterließe genau im Fehlerfall den gewechselten
-Arbeitsbaum (T002357-Fallenklasse, siehe design.md).
+**Architecture:** Der Fix lebt in der Archiv-Sektion: PREV-Merken (Branch + SHA für
+detached HEAD) im Hauptfluss vor der Subshell, Restore als EXIT-Trap IN der Subshell mit
+Ownership-Guard (Restore nur, wenn der Baum auf dem Archiv-Branch steht — parallele
+Wechsel bleiben unangetastet). Die Sektion wechselt per Order-Swap (Review PR #4586)
+zuerst auf den Archiv-Branch von origin/main und committet die Archivierung direkt dort —
+kein Streu-Commit, kein cherry-pick. Die Trap deckt sowohl den Happy-Path (nach Push/PR)
+als auch die Fehlerpfade (`gh pr create`/`gh pr merge` FATAL → Subshell-Exit 1) ab — die
+naheliegende Restore-Nach-der-Subshell-Variante liefe bei `set -euo pipefail`-Abbruch nie
+und hinterließe genau im Fehlerfall den gewechselten Arbeitsbaum (T002357-Fallenklasse,
+siehe design.md).
 
 **Tech Stack:** Bash (Skript-Subshell), git (`git -C "$ARCHIVE_DIR" rev-parse`,
 `git checkout`), BATS (vendored, `tests/unit/lib/bats-core/bin/bats`).
@@ -34,12 +38,15 @@ Arbeitsbaum (T002357-Fallenklasse, siehe design.md).
 ## Global Constraints
 
 - Kein Verhalten der Archiv-Sektion selbst ändern (Archive-Commit, checkout -B,
-  cherry-pick, push, gh pr create/merge bleiben unverändert) — nur PREV-Merken + Restore.
+  push, gh pr create/merge bleiben unverändert) — nur PREV-Merken + Restore +
+  Order-Swap der Commit-Reihenfolge (cherry-pick entfällt komplett).
 - Der Restore darf den Subshell-Exit-Code nicht verschlucken: Fehler in der Sektion
-  enden weiterhin mit Exit 1, ein Restore-Fehler ebenfalls (FATAL auf stderr).
+  enden weiterhin mit Exit 1, ein Restore-Fehler ebenfalls (FATAL auf stderr +
+  status-Dump).
 - BATS-Guard Assertion 5 bleibt im Source-Grep-Modus (dokumentierte Ausnahme von
   T002448-M4: der Laufzeitpfad braucht Cluster/DB) — die Datei dokumentiert den Modus
-  bereits im Header.
+  bereits im Header; die Restore-Mechanik wurde zusätzlich isoliert in einem
+  Bare-Git-Repo + Fake-openspec.sh verifiziert (Code-Review PR #4586).
 - Positiv-Anker (Test 4, `refs/heads/$ARCHIVE_BRANCH`) bleibt unangetastet.
 
 ## File Structure
@@ -68,44 +75,18 @@ tests/unit/lib/bats-core/bin/bats tests/spec/agent-skills/post-merge-finalize-gu
 # Variable im Skript noch nicht existiert (verifiziert am 2026-08-15 gegen main).
 ```
 
-### Task 2: [x] Fix implementieren — ARCHIVE_PREV_BRANCH merken + Restore-Trap
+### Task 2: [x] Fix implementieren — ARCHIVE_PREV_BRANCH merken + Restore-Trap (Order-Swap)
 
 Datei: `scripts/devflow-post-merge-finalize.sh`, Archiv-Sektion (`if [[ -n "${ARCHIVE_DIR:-}" ]]`).
-
-Schritt 2.1 — PREV im Hauptfluss merken, direkt vor der Subshell (im `else`-Zweig nach dem
-ls-remote-Skip, vor `(`):
-
-```bash
-      # T006791: Vor der Archiv-Sektion den aktuellen Branch merken — die Sektion
-      # wechselt per checkout -B den Branch des geteilten Arbeitsbaums (Worktree
-      # oder Haupt-Checkout); der Restore in der Subshell-Trap stellt ihn nach der
-      # Sektion wieder her (auch auf Fehlerpfaden, T002357-Fallenklasse).
-      ARCHIVE_PREV_BRANCH="$(git -C "$ARCHIVE_DIR" rev-parse --abbrev-ref HEAD)"
-```
-
-Schritt 2.2 — Restore-Trap als ersten Befehl IN der Subshell (nach `cd "$ARCHIVE_DIR"`,
-vor `bash scripts/openspec.sh archive "$SLUG"`):
-
-```bash
-        # T006791: Restore bei jedem Sektions-Ende — Happy-Path (nach Push/PR) und
-        # Fehlerpfade (Subshell exit 1) hinterlassen den Arbeitsbaum auf dem
-        # gemerkten Branch. No-op, wenn kein Wechsel stattfand; Restore-Fehler
-        # enden mit Exit 1 statt still Erfolg zu melden.
-        _restore_prev_branch() {
-          local _prev_rc=$?
-          if [[ -n "$ARCHIVE_PREV_BRANCH" ]] && \
-             [[ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)" != "$ARCHIVE_PREV_BRANCH" ]]; then
-            if git checkout "$ARCHIVE_PREV_BRANCH" >/dev/null 2>&1; then
-              echo "Schritt 8: Branch-Restore auf $ARCHIVE_PREV_BRANCH nach Archiv-Sektion (T006791)"
-            else
-              echo "FATAL: Branch-Restore auf $ARCHIVE_PREV_BRANCH fehlgeschlagen — Arbeitsbaum bleibt auf $ARCHIVE_BRANCH (T006791)" >&2
-              _prev_rc=1
-            fi
-          fi
-          exit "$_prev_rc"
-        }
-        trap _restore_prev_branch EXIT
-```
+Umgesetzter Stand (PR #4586 + Review-Fixes): siehe design.md — Capture von Branch + SHA
+im Hauptfluss vor der Subshell; EXIT-Trap `_restore_prev_branch` in der Subshell mit
+Ownership-Guard (`HEAD == $ARCHIVE_BRANCH` → Restore; sonst WARN bei parallelem Wechsel);
+Restore-Fehler → FATAL + `git status --short` + Lock-Hinweis, Exit 1. Sektion im
+Order-Swap: erst `git fetch origin main` + `git checkout -B "$ARCHIVE_BRANCH" origin/main`,
+dann `bash scripts/openspec.sh archive "$SLUG"` + `task freshness:regenerate` + Commit
+direkt auf dem Archiv-Branch + `git push -u`. Schritt 10 überspringt den Delete, wenn
+der Ticket-Branch nach dem Restore im Haupt-Checkout ausgecheckt ist (mark_skip statt
+ERROR/exit 1 — Review-Finding 2, sonst wäre jeder Main-Checkout-Lauf dauerhaft rot).
 
 Erwartung: `mark_ok "Schritt 8: OpenSpec-Change archiviert (Archiv-PR erstellt)"` bleibt
 unverändert; im Normal-Lauf erscheint zusätzlich die Restore-Meldung der Trap.
@@ -135,3 +116,20 @@ git push origin fix/devflow-post-merge-finalize-archive-restore-T006791
   Parent-Slug `agent-skills.md` benannt (T001304).
 - Der Commit-msg-Guard (`check-commit-vs-diff.sh`) verlangt hier `fix(scripts):`, weil der
   Diff Production-Code (Skript) + Tests enthält.
+
+### Task 5: [x] Review-Fixes PR #4596 (nachgeholt, da PR #4586 vor Fertigstellung auto-gemergt)
+
+Code-Review zu PR #4586 lieferte 15 Findings; die Kern-Fixes (Order-Swap,
+Ownership-Guard, detached-HEAD-SHA) waren bereits im gemergten Stand, die folgenden
+kamen als Follow-up-PR #4596 auf main:
+
+- Schritt 10: ausgecheckter Ticket-Branch nach Restore → `mark_skip` statt
+  `ERROR ... exit 1` (Finding 2 — ohne Fix wäre der Batch-Pfad permanent rot).
+- FATAL-Meldungen präzisiert: keine Behauptung über den Ist-Zustand des Baums,
+  Lock-Räum-Hinweis (Findings 6/12); `git status --short`-Dump bei Restore-Fehler
+  (Finding 5).
+- BATS Assertion 5 geschärft: prüft zusätzlich `trap _restore_prev_branch EXIT`
+  (Finding 11 — die reine Capture-Variable wäre vakuos).
+- Stale Zeilennummern-Kommentare in der BATS-Datei entfernt (Finding 13, T003104).
+- design.md/proposal.md: Fix-Ansatz auf Order-Swap aktualisiert, Belege mit
+  T002717-Pin (8422d5b39) nachstellbar gemacht (Finding 15).

--- a/scripts/devflow-post-merge-finalize.sh
+++ b/scripts/devflow-post-merge-finalize.sh
@@ -216,28 +216,64 @@ if [[ -n "${ARCHIVE_DIR:-}" ]]; then
     # T006791: Vor der Archiv-Sektion den aktuellen Branch merken — die Sektion
     # wechselt per checkout -B den Branch des geteilten Arbeitsbaums (Worktree
     # oder Haupt-Checkout); der Restore in der Subshell-Trap stellt ihn nach der
-    # Sektion wieder her (auch auf Fehlerpfaden, T002357-Fallenklasse).
+    # Sektion wieder her (auch auf Fehlerpfaden, T002357-Fallenklasse). Zusaetzlich
+    # die SHA merken: auf detached HEAD liefert rev-parse --abbrev-ref HEAD nur
+    # "HEAD" und waere als Restore-Ziel unbrauchbar (Code-Review PR #4586).
     ARCHIVE_PREV_BRANCH="$(git -C "$ARCHIVE_DIR" rev-parse --abbrev-ref HEAD)"
+    ARCHIVE_PREV_SHA="$(git -C "$ARCHIVE_DIR" rev-parse HEAD 2>/dev/null || true)"
     (
       cd "$ARCHIVE_DIR"
       # T006791: Restore bei jedem Sektions-Ende — Happy-Path (nach Push/PR) und
       # Fehlerpfade (Subshell exit 1) hinterlassen den Arbeitsbaum auf dem
-      # gemerkten Branch. No-op, wenn kein Wechsel stattfand; Restore-Fehler
-      # enden mit Exit 1 statt still Erfolg zu melden.
+      # gemerkten Branch. Ownership-Guard (Code-Review PR #4586): Restore nur,
+      # wenn der Arbeitsbaum tatsaechlich auf dem Archiv-Branch steht — hat eine
+      # parallele Session zwischenzeitlich gewechselt (T002357), bleibt deren
+      # Wechsel unangetastet (WARN statt Restore). Detached HEAD wird ueber die
+      # gemerkte SHA zurueckgeholt (--detach). Restore-Fehler enden mit Exit 1
+      # statt still Erfolg zu melden.
       _restore_prev_branch() {
         local _prev_rc=$?
-        if [[ -n "$ARCHIVE_PREV_BRANCH" ]] && \
-           [[ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)" != "$ARCHIVE_PREV_BRANCH" ]]; then
-          if git checkout "$ARCHIVE_PREV_BRANCH" >/dev/null 2>&1; then
-            echo "Schritt 8: Branch-Restore auf $ARCHIVE_PREV_BRANCH nach Archiv-Sektion (T006791)"
-          else
-            echo "FATAL: Branch-Restore auf $ARCHIVE_PREV_BRANCH fehlgeschlagen — Arbeitsbaum bleibt auf $ARCHIVE_BRANCH (T006791)" >&2
-            _prev_rc=1
+        local _cur_branch
+        _cur_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+        if [[ "$_cur_branch" == "$ARCHIVE_BRANCH" ]]; then
+          if [[ "$ARCHIVE_PREV_BRANCH" == "HEAD" && -n "$ARCHIVE_PREV_SHA" ]]; then
+            if git checkout --detach "$ARCHIVE_PREV_SHA" >/dev/null 2>&1; then
+              echo "Schritt 8: Branch-Restore auf detached $ARCHIVE_PREV_SHA ausgefuehrt (T006791)"
+            else
+              # Code-Review PR #4586 (Finding 12): nicht behaupten, wo der Baum
+              # steht — der Restore kann aus unverwandtem Grund scheitern; der
+              # Zustand ist zu pruefen. Lock-Hinweis (Finding 6): bei Restore-
+              # Fehler bricht das Skript hier ab und der Lock bleibt zurueck.
+              echo "FATAL: Branch-Restore (detached) fehlgeschlagen — Arbeitsbaum-Zustand manuell pruefen, Lock ggf. raeumen (T006791)" >&2
+              _restore_failed=1
+            fi
+          elif [[ "$ARCHIVE_PREV_BRANCH" != "HEAD" ]]; then
+            if git checkout "$ARCHIVE_PREV_BRANCH" >/dev/null 2>&1; then
+              echo "Schritt 8: Branch-Restore auf $ARCHIVE_PREV_BRANCH ausgefuehrt (T006791)"
+            else
+              echo "FATAL: Branch-Restore auf $ARCHIVE_PREV_BRANCH fehlgeschlagen — Arbeitsbaum-Zustand manuell pruefen, Lock ggf. raeumen (T006791)" >&2
+              _restore_failed=1
+            fi
           fi
+          # Code-Review PR #4586 (Finding 5): Restore-Fehler aufklären — status
+          # zeigt, welche Änderungen den Wechsel blockieren (z. B. staged Move
+          # zwischen openspec.sh archive und git commit bei pre-commit-Fehler).
+          if [[ "${_restore_failed:-0}" == 1 ]]; then
+            git status --short >&2
+          fi
+        elif [[ "$_cur_branch" != "$ARCHIVE_PREV_BRANCH" ]]; then
+          echo "WARN: Arbeitsbaum steht auf $_cur_branch statt $ARCHIVE_BRANCH — paralleler Wechsel, Restore uebersprungen (T006791)" >&2
         fi
         exit "$_prev_rc"
       }
       trap _restore_prev_branch EXIT
+      # Order-Swap (Code-Review PR #4586): ERST auf den Archiv-Branch wechseln
+      # (von origin/main abzweigen, T002256), DANN archivieren und direkt auf
+      # dem Archiv-Branch committen — kein Streu-Commit auf dem Pre-Switch-
+      # Branch, kein cherry-pick (der auf einem dirty Baum oder einem bereits
+      # gemergten Commit verweigern kann).
+      git fetch origin main
+      git checkout -B "$ARCHIVE_BRANCH" origin/main
       bash scripts/openspec.sh archive "$SLUG"
       # Freshness: openspec.sh regeneriert openspec-status.json nach dem Move —
       # Regeneration und explizites Staging nach plan-archive-steps (T002252).
@@ -245,12 +281,6 @@ if [[ -n "${ARCHIVE_DIR:-}" ]]; then
       git add openspec/changes/ openspec/changes/archive/ openspec/specs/ website/src/data/openspec-status.json
       git add -u -- website/src/data website/src/lib website/public/learning-assets docs
       git commit -m "chore(plans): archive $SLUG → postgres + openspec/archive [$TICKET_ID]"
-      ARCHIVE_COMMIT="$(git rev-parse HEAD)"
-      # Der Archiv-Branch MUSS von origin/main abzweigen, nicht vom Fix-Branch
-      # (T002256) — squash-and-merge hinterlaesst den Fix-Branch am Pre-Squash-Stand.
-      git fetch origin main
-      git checkout -B "$ARCHIVE_BRANCH" origin/main
-      git cherry-pick "$ARCHIVE_COMMIT"
       git push -u origin "$ARCHIVE_BRANCH"
       # PR-Erstellung mit Assert (verhindert ungebuendelte Archiv-Branches, T001331)
       ARCHIVE_PR_URL="$(gh pr create \
@@ -305,7 +335,14 @@ else
 fi
 
 if git -C "$REPO_DIR" show-ref --verify --quiet "refs/heads/$BRANCH"; then
-  if git -C "$REPO_DIR" branch -D "$BRANCH"; then
+  if [[ "$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)" == "$BRANCH" ]]; then
+    # T006791: Der Restore hat den geteilten Haupt-Checkout auf $BRANCH
+    # zurueckgestellt — ein ausgecheckter Branch ist nicht loeschbar
+    # ("cannot delete branch used by worktree"). Der lokale Branch bleibt als
+    # Arbeitsbaum-Zustand erhalten; der Remote-Branch wird vom branch-reaper
+    # unten entfernt (Code-Review PR #4586, Finding 2).
+    mark_skip "Schritt 10: lokaler Branch $BRANCH ist im Haupt-Checkout ausgecheckt (Restore) — bleibt erhalten, Remote-Delete via branch-reaper"
+  elif git -C "$REPO_DIR" branch -D "$BRANCH"; then
     mark_ok "Schritt 10: lokaler Branch $BRANCH entfernt"
   else
     echo "ERROR: Schritt 10 — lokaler Branch $BRANCH nicht loeschbar." >&2

--- a/tests/spec/agent-skills/post-merge-finalize-guards.bats
+++ b/tests/spec/agent-skills/post-merge-finalize-guards.bats
@@ -7,6 +7,10 @@
 # benötigt Cluster-/DB-Zugriff (Schritt 1: ticket.sh get), der in CI nicht
 # existiert; die Guard-Logik manifestiert sich ausschließlich im Quelltext
 # (gleiche Ausnahme wie Tests 1–3 in tests/spec/agent-skills/executor-post-merge-death.bats).
+# T006791: Die Restore-Mechanik der Archiv-Sektion wurde zusätzlich isoliert
+# verifiziert (Bare-Git-Repo + Fake-openspec.sh, Code-Review PR #4586) — ein
+# voller BATS-Runtime-Test bleibt unmöglich, weil die Sektion nicht als Funktion
+# isolierbar ist und Schritt 1 (ticket.sh get) die Ticket-DB braucht.
 #
 # Regression für T006348: Review-Befunde aus PR #4539 (T006284, gemergt 1cab10192) —
 #   (1) Merge-Status-Guard fehlt im --pr-Pfad: Closure-Schritte laufen für jede
@@ -16,8 +20,8 @@
 #       Archiv-PR noch offen" wiederholt die Archivierung (checkout -B wechselt
 #       den Branch des geteilten Arbeitsbaums, Push kollidiert, gh pr create
 #       endet FATAL, Schritt 10 wird nie erreicht).
-#   (3) cwd-Abhängigkeit: Plan-Pfad-Prüfung relativ (Z. 176), branch-reaper
-#       ohne --repo (Z. 286) — nur bei cwd=REPO_DIR korrekt.
+#   (3) cwd-Abhängigkeit: Plan-Pfad-Prüfung relativ, branch-reaper ohne --repo
+#       — nur bei cwd=REPO_DIR korrekt.
 
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
@@ -34,7 +38,7 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-# Rot heute: der --pr-Pfad (Z. 60/135) setzt PR_NUM ohne State-Prüfung — `gh pr
+# Rot heute: der --pr-Pfad setzt PR_NUM ohne State-Prüfung — `gh pr
 # view` und `--json state` kommen im Skript nirgends vor; grün nach dem Fix:
 # der Merge-Status-Guard vor den Closure-Schritten (4–6) prüft den PR-State
 # per `gh pr view "$PR_NUM" --json state -q .state` und schließt nur bei
@@ -46,44 +50,49 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
-# Rot heute: Schritt 8 (Z. 196–227) wiederholt die Archiv-Sektion, ohne zu
-# prüfen, ob der Archiv-Branch bereits auf origin existiert (das ls-remote in
-# Z. 229 dient nur der Push-Verifikation und nutzt kein --exit-code); grün
-# nach dem Fix: der Idempotenz-Skip vor der Archiv-Sektion prüft per
+# Rot heute: Schritt 8 wiederholt die Archiv-Sektion, ohne zu prüfen, ob der
+# Archiv-Branch bereits auf origin existiert (das ls-remote diente nur der
+# Push-Verifikation und nutzte kein --exit-code); grün nach dem Fix: der
+# Idempotenz-Skip vor der Archiv-Sektion prüft per
 # `git ls-remote --exit-code origin "refs/heads/$ARCHIVE_BRANCH"`.
 @test "T006348: Archiv-Sektion ist idempotent (ls-remote --exit-code auf den Archiv-Branch)" {
   run grep -qF -- '--exit-code' "$FINALIZE"
   [ "$status" -eq 0 ]
 }
 
-# Positiv-Anker für Test 5: Das Skript kennt den Archiv-Branch-Ref bereits
-# (Z. 216/229) — der Restore-Mechanismus baut auf derselben Variable auf.
+# Positiv-Anker für Test 5: Das Skript kennt den Archiv-Branch-Ref bereits —
+# der Restore-Mechanismus baut auf derselben Variable auf.
 @test "T006348: Archiv-Branch-Ref ist im Skript bekannt (Anker)" {
   run grep -qF 'refs/heads/$ARCHIVE_BRANCH' "$FINALIZE"
   [ "$status" -eq 0 ]
 }
 
 # Rot vor T006791: nach der Archiv-Sektion blieb der Arbeitsbaum auf dem
-# Archiv-Branch stehen (git checkout -B, Z. 218 — wechselt den Branch des
-# geteilten Arbeitsbaums paralleler Sessions); grün nach dem Fix (T006791):
-# das Skript merkt sich den vorherigen Branch (ARCHIVE_PREV_BRANCH) vor der
-# Archiv-Sektion und restauriert ihn nach der Sektion (Restore greift auch auf
-# Fehlerpfaden, T002357-Fallenklasse).
+# Archiv-Branch stehen (git checkout -B wechselt den Branch des geteilten
+# Arbeitsbaums paralleler Sessions); grün nach dem Fix (T006791): das Skript
+# merkt sich den vorherigen Branch (ARCHIVE_PREV_BRANCH) vor der Archiv-Sektion
+# und registriert in der Sektions-Subshell eine EXIT-Trap (trap
+# _restore_prev_branch EXIT), die ihn auch auf Fehlerpfaden wiederherstellt
+# (T002357-Fallenklasse). Assertion auf das Trap-Signal statt nur auf die
+# Variable: die Capture-Zeile allein (ARCHIVE_PREV_BRANCH=...) wäre vakuos —
+# ein Refactor, der die Trap entfernt, muss rot werden (Code-Review PR #4586).
 @test "T006348: Skript restauriert den Arbeitsbaum-Branch nach der Archiv-Sektion" {
   run grep -qF 'ARCHIVE_PREV_BRANCH' "$FINALIZE"
+  [ "$status" -eq 0 ]
+  run grep -qF 'trap _restore_prev_branch EXIT' "$FINALIZE"
   [ "$status" -eq 0 ]
 }
 
 # Rot heute: das Skript wechselt sein cwd nie (nur die Schritt-8-Subshell
-# wechselt in ARCHIVE_DIR) — die relative Plan-Pfad-Prüfung (Z. 176) gilt nur
-# bei cwd=REPO_DIR; grün nach dem Fix: cd "$REPO_DIR" zu Skriptbeginn.
+# wechselt in ARCHIVE_DIR) — die relative Plan-Pfad-Prüfung galt nur bei
+# cwd=REPO_DIR; grün nach dem Fix: cd "$REPO_DIR" zu Skriptbeginn.
 @test "T006348: Skript ist cwd-unabhängig (cd \$REPO_DIR zu Skriptbeginn)" {
   run grep -qF 'cd "$REPO_DIR"' "$FINALIZE"
   [ "$status" -eq 0 ]
 }
 
-# Positiv-Anker für Test 8: Der branch-reaper-Aufruf existiert (Z. 286) —
-# die Aussage "mit --repo" wäre ohne den Anker vakuos, wenn der Aufruf fehlte.
+# Positiv-Anker für Test 8: Der branch-reaper-Aufruf existiert — die Aussage
+# "mit --repo" wäre ohne den Anker vakuos, wenn der Aufruf fehlte.
 @test "T006348: branch-reaper-Aufruf existiert (Anker)" {
   run grep -qF 'branch-reaper.sh' "$FINALIZE"
   [ "$status" -eq 0 ]
@@ -92,7 +101,7 @@ setup() {
 # Rot heute: branch-reaper.sh wird ohne --repo aufgerufen (Default cwd);
 # grün nach dem Fix: die T006348-Implementierung löst die cwd-Abhängigkeit
 # per absolutem Skript-Pfad (bash "$REPO_DIR/scripts/branch-reaper.sh") statt
-# eines --repo-Flags (Z. 298 auf main).
+# eines --repo-Flags.
 @test "T006348: branch-reaper-Aufruf ist cwd-unabhängig (absoluter Skript-Pfad)" {
   run grep -qF 'bash "$REPO_DIR/scripts/branch-reaper.sh"' "$FINALIZE"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Nacharbeit zum Code-Review von PR #4586 (15 Findings): PR #4586 wurde vor Fertigstellung der Review-Fixes auto-gemergt — dieser PR holt die restlichen Findings auf main nach.

**Was ist drin:**
- **Schritt 10** (Finding 2): Nach dem Branch-Restore (T006791) ist der Ticket-Branch im Haupt-Checkout ausgecheckt und nicht loeschbar — der Delete-Block ueberspringt diesen Fall mit mark_skip statt ERROR/exit 1. Ohne diesen Fix endete jeder Finalize-Lauf im Main-Checkout-Fall dauerhaft rot (Batch-Pfad permanent gebrochen).
- **Restore-Diagnostik** (Findings 5/6/12): FATAL-Meldungen behaupten keinen Ist-Zustand mehr, weisen auf manuelle Lock-Raeumung hin; bei Restore-Fehler wird git status --short ausgegeben.
- **BATS Assertion 5** (Finding 11): prueft zusaetzlich trap _restore_prev_branch EXIT — die reine Capture-Variable waere vakuos (ein Refactor, der die Trap entfernt, muss rot werden).
- **Zeilennummern-Kommentare** (Finding 13): entfernt — Dokumentposition ist keine stabile Assertion (T003104).
- **design.md/proposal.md/tasks.md** (Finding 15): Fix-Ansatz auf den umgesetzten Order-Swap aktualisiert, Belege mit T002717-Pin (8422d5b39) nachstellbar.

**Verifikation:** BATS 8/8 gruen, task test:changed 52/52, task openspec:validate OK, bash -n OK.

**Hinweis:** Der Restore-Mechanismus selbst (Order-Swap, Ownership-Guard, detached-HEAD) war bereits in PR #4586 enthalten.