### PR TITLE
chore(scripts): pk-device LM Studio startup and SSH bootstrap scripts [T006842]

### DIFF
--- a/scripts/llm/pk-devices/deploy-to-devices.sh
+++ b/scripts/llm/pk-devices/deploy-to-devices.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Deploy der LM-Studio-Startup-Scripts auf PK-Tablet und PK-L-1 (nach SSH-Bootstrap).
+# Aufruf: deploy-to-devices.sh <user> <ip-tablet> <ip-laptop>
+#   <user>        Windows-Benutzername (Ausgabe des pk-ssh-bootstrap.ps1)
+#   <ip-tablet>   IP des PK-Tablet
+#   <ip-laptop>   IP des PK-L-1
+set -euo pipefail
+
+USER_WIN="${1:?Windows-Username fehlt (Bootstrap-Ausgabe 'ssh <user>@<ip>')}"
+IP_TABLET="${2:?IP des PK-Tablet fehlt}"
+IP_LAPTOP="${3:?IP des PK-L-1 fehlt}"
+
+KEY="$HOME/.ssh/pk-devices"
+SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# SSH-Config-Eintraege (fuer spaetere Wartung)
+ssh_config_block() {
+  cat <<EOF
+
+Host pk-tablet pk-l-1
+    User $USER_WIN
+    IdentityFile $KEY
+    StrictHostKeyChecking accept-new
+
+Host pk-tablet
+    HostName $IP_TABLET
+
+Host pk-l-1
+    HostName $IP_LAPTOP
+EOF
+}
+if ! grep -q '^Host pk-tablet$' "$HOME/.ssh/config" 2>/dev/null; then
+  ssh_config_block >> "$HOME/.ssh/config"
+  echo "ssh config: Eintraege fuer pk-tablet/pk-l-1 angelegt."
+else
+  echo "ssh config: Eintraege existieren bereits (nicht ueberschrieben)."
+fi
+
+deploy_one() {
+  local name="$1" ip="$2" script="$3"
+  echo "=== $name ($ip) ==="
+  ssh -i "$KEY" -o BatchMode=yes -o ConnectTimeout=5 "$USER_WIN@$ip" \
+    'powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path C:\pk-device | Out-Null"' \
+    && echo "  Verzeichnis C:\pk-device ok"
+  scp -i "$KEY" -o BatchMode=yes "$SCRIPTS_DIR/$script" "$USER_WIN@$ip:C:/pk-device/" \
+    && echo "  $script kopiert"
+  ssh -i "$KEY" -o BatchMode=yes "$USER_WIN@$ip" \
+    "schtasks /create /tn 'PK-Startup-LLM' /tr 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File C:\\pk-device\\$script' /sc onlogon /f" \
+    && echo "  Autostart-Task 'PK-Startup-LLM' registriert (onlogon)"
+}
+
+deploy_one "pk-tablet" "$IP_TABLET" "pk-tablet-startup.ps1"
+deploy_one "pk-l-1"   "$IP_LAPTOP" "pk-l-1-startup.ps1"
+
+echo ""
+echo "Fertig. Verifikation: http://localhost:18235/v1/models muss beide Slots zeigen."

--- a/scripts/llm/pk-devices/pk-l-1-startup.ps1
+++ b/scripts/llm/pk-devices/pk-l-1-startup.ps1
@@ -1,0 +1,42 @@
+# Startup-Script PK-L-1: Qwen3.5-4B Q6_K via LM Studio (Vulkan)
+# =====================================================================
+# Einmalige GUI-Voraussetzung: LM Studio -> Settings -> Hardware
+# Acceleration -> Vulkan/iGPU aktivieren (seit 0.4.17 default-aus).
+#
+# Autostart-Einrichtung (einmalig, auf dem Laptop):
+#   Win+R -> "shell:startup" -> Verknuepfung auf dieses Script legen
+#   (oder Task Scheduler: Trigger "Bei Anmeldung", Aktion powershell.exe
+#    -ExecutionPolicy Bypass -File <Pfad>\pk-l-1-startup.ps1)
+#
+# Modell-Download (einmalig): unsloth/Qwen3.5-4B-GGUF
+#   Datei: Qwen3.5-4B-Q6_K.gguf (3,28 GiB)
+#   https://hf.co/unsloth/Qwen3.5-4B-GGUF
+#
+# Settings: Context 32768, GPU Offload max (Vulkan), KV-Cache Q8_0,
+#   Flash Attention Auto, Sampling temp 0.7 / top_p 0.8 / top_k 20 /
+#   presence_penalty 1.5. Hinweis: Qwen3.5-GGUF laeuft NICHT in Ollama.
+#   Bei Kauderwelsch-Output: KV-Cache-Typen auf bf16 stellen
+#   (--cache-type-k bf16 --cache-type-v bf16, LM-Studio-Advanced-Feld).
+# =====================================================================
+
+$ErrorActionPreference = "Stop"
+
+# An den tatsaechlichen Modell-Verzeichnisnamen in LM Studio anpassen
+# (mit `lms ls` pruefen; -y bestaetigt Teilnamen-Matches automatisch).
+$ModelId = "Qwen3.5-4B"
+
+$lms = Join-Path $env:USERPROFILE ".lmstudio\bin\lms.exe"
+if (-not (Test-Path $lms)) { $lms = "lms" }
+
+Write-Host "[PK-L-1] Starte LM-Studio-Server auf Port 1234 (bind 0.0.0.0 fuer LM Link) ..."
+& $lms server start --port 1234 --bind 0.0.0.0 -y
+if ($LASTEXITCODE -ne 0) { Write-Warning "server start lieferte Exit $LASTEXITCODE (Server laeuft evtl. bereits)." }
+
+Write-Host "[PK-L-1] Lade Qwen3.5-4B Q6_K (ctx 32768, GPU max) ..."
+& $lms load $ModelId --gpu max --context-length 32768 -y
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "load lieferte Exit $LASTEXITCODE - Modell-ID pruefen: lms ls"
+    exit 1
+}
+
+Write-Host "[PK-L-1] Fertig. Verifikation: http://localhost:1234/v1/models muss $ModelId enthalten."

--- a/scripts/llm/pk-devices/pk-ssh-bootstrap.ps1
+++ b/scripts/llm/pk-devices/pk-ssh-bootstrap.ps1
@@ -1,0 +1,81 @@
+# PK-Device SSH Bootstrap - EINMALIG auf diesem Geraet ausfuehren
+# =====================================================================
+# Ausfuehrung: Datei kopieren, dann Win+X -> Terminal (Administrator) ->
+#   powershell -ExecutionPolicy Bypass -File <Pfad>\pk-ssh-bootstrap.ps1
+# ODER: Rechtsklick -> "Mit PowerShell ausfuehren" in einer Admin-Shell.
+#
+# Was das Script tut:
+#   1. OpenSSH-Server installieren (Windows-Capability)
+#   2. sshd-Dienst auf Automatic stellen und starten
+#   3. Firewall-Regel fuer Port 22 anlegen
+#   4. Public Key der WSL-Maschine (PK-Desktop) hinterlegen
+# Danach kann die WSL-Maschine sich per SSH verbinden und die
+# Startup-Scripts selbst ablegen und registrieren.
+# =====================================================================
+
+$ErrorActionPreference = "Stop"
+
+# --- Admin-Check ------------------------------------------------------
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Host "FEHLER: Als Administrator ausfuehren (Win+X -> Terminal (Administrator))."
+    exit 1
+}
+
+# --- 1/4: OpenSSH-Server installieren ---------------------------------
+Write-Host "[1/4] OpenSSH-Server installieren ..."
+$cap = Get-WindowsCapability -Online | Where-Object { $_.Name -like 'OpenSSH.Server*' }
+if ($cap -and $cap.State -ne 'Installed') {
+    Add-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0' | Out-Null
+    Write-Host "  installiert."
+} else {
+    Write-Host "  bereits vorhanden."
+}
+
+# --- 2/4: sshd-Dienst -------------------------------------------------
+Write-Host "[2/4] sshd-Dienst starten (Automatic) ..."
+Set-Service -Name sshd -StartupType Automatic
+Start-Service -Name sshd
+Write-Host "  laeuft."
+
+# --- 3/4: Firewall ----------------------------------------------------
+Write-Host "[3/4] Firewall-Regel fuer Port 22 ..."
+if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' `
+        -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 | Out-Null
+    Write-Host "  Regel angelegt."
+} else {
+    Write-Host "  Regel existiert."
+}
+
+# --- 4/4: Authorized Key ----------------------------------------------
+Write-Host "[4/4] Public Key hinterlegen ..."
+$keyLine = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM0v5tWJfsMAFno233JIC2Ovrc032XuZYKZfzxzUchDP claude-wsl@PK-Desktop"
+
+# Administratoren-Pfad (gilt bei Admin-Konten, inkl. Microsoft-Konten)
+$adminKeyFile = "C:\ProgramData\ssh\administrators_authorized_keys"
+if (-not (Test-Path $adminKeyFile)) { New-Item -Path $adminKeyFile -ItemType File -Force | Out-Null }
+if (-not (Select-String -Path $adminKeyFile -Pattern 'claude-wsl@PK-Desktop' -Quiet -ErrorAction SilentlyContinue)) {
+    Add-Content -Path $adminKeyFile -Value $keyLine
+}
+icacls $adminKeyFile /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
+
+# User-Pfad (greift bei nicht-administrativer Anmeldung ueber ssh)
+$userKeyDir = Join-Path $env:USERPROFILE ".ssh"
+$userKeyFile = Join-Path $userKeyDir "authorized_keys"
+if (-not (Test-Path $userKeyDir)) { New-Item -Path $userKeyDir -ItemType Directory -Force | Out-Null }
+if (-not (Select-String -Path $userKeyFile -Pattern 'claude-wsl@PK-Desktop' -Quiet -ErrorAction SilentlyContinue)) {
+    Add-Content -Path $userKeyFile -Value $keyLine
+}
+Write-Host "  Key hinterlegt."
+
+# --- Abschluss: Zugangsdaten ausgeben --------------------------------
+$ip = (Get-NetIPAddress -AddressFamily IPv4 |
+    Where-Object { $_.IPAddress -notlike '169.254.*' -and $_.IPAddress -ne '127.0.0.1' } |
+    Select-Object -First 1).IPAddress
+Write-Host ""
+Write-Host "=========================================================="
+Write-Host " FERTIG. Zugang fuer die WSL-Maschine (PK-Desktop):"
+Write-Host "   ssh $env:USERNAME@$ip"
+Write-Host " IP dieses Geraets: $ip"
+Write-Host "=========================================================="

--- a/scripts/llm/pk-devices/pk-tablet-startup.ps1
+++ b/scripts/llm/pk-devices/pk-tablet-startup.ps1
@@ -1,0 +1,39 @@
+# Startup-Script PK-Tablet: Gemma 4 12B UD-IQ3_XXS via LM Studio (Vulkan)
+# =====================================================================
+# Einmalige GUI-Voraussetzung: LM Studio -> Settings -> Hardware
+# Acceleration -> Vulkan/iGPU aktivieren (seit 0.4.17 default-aus).
+#
+# Autostart-Einrichtung (einmalig, auf dem Tablet):
+#   Win+R -> "shell:startup" -> Verknuepfung auf dieses Script legen
+#   (oder Task Scheduler: Trigger "Bei Anmeldung", Aktion powershell.exe
+#    -ExecutionPolicy Bypass -File <Pfad>\pk-tablet-startup.ps1)
+#
+# Modell-Download (einmalig): unsloth/gemma-4-12b-it-GGUF
+#   Datei: gemma-4-12b-it-UD-IQ3_XXS.gguf (4,32 GiB)
+#   https://hf.co/unsloth/gemma-4-12b-it-GGUF
+#
+# Settings: Context 32768, GPU Offload max (Vulkan), KV-Cache Q8_0,
+#   Flash Attention Auto, Sampling temp 1.0 / top_p 0.95 / top_k 64.
+# =====================================================================
+
+$ErrorActionPreference = "Stop"
+
+# An den tatsaechlichen Modell-Verzeichnisnamen in LM Studio anpassen
+# (mit `lms ls` pruefen; -y bestaetigt Teilnamen-Matches automatisch).
+$ModelId = "gemma-4-12b-it"
+
+$lms = Join-Path $env:USERPROFILE ".lmstudio\bin\lms.exe"
+if (-not (Test-Path $lms)) { $lms = "lms" }
+
+Write-Host "[PK-Tablet] Starte LM-Studio-Server auf Port 1234 (bind 0.0.0.0 fuer LM Link) ..."
+& $lms server start --port 1234 --bind 0.0.0.0 -y
+if ($LASTEXITCODE -ne 0) { Write-Warning "server start lieferte Exit $LASTEXITCODE (Server laeuft evtl. bereits)." }
+
+Write-Host "[PK-Tablet] Lade Gemma 4 12B UD-IQ3_XXS (ctx 32768, GPU max) ..."
+& $lms load $ModelId --gpu max --context-length 32768 -y
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "load lieferte Exit $LASTEXITCODE - Modell-ID pruefen: lms ls"
+    exit 1
+}
+
+Write-Host "[PK-Tablet] Fertig. Verifikation: http://localhost:1234/v1/models muss $ModelId enthalten."


### PR DESCRIPTION
## Summary

Geraete-Setup-Scripts fuer die Unterstuetzermodell-Slots aus T006842 (K2-Inbetriebnahme):

- `pk-tablet-startup.ps1` — LM-Studio-Startup PK-Tablet: Gemma 4 12B UD-IQ3_XXS, ctx 32768, GPU max, Port 1234 (bind 0.0.0.0 fuer LM Link)
- `pk-l-1-startup.ps1` — LM-Studio-Startup PK-L-1: Qwen3.5-4B Q6_K, gleiche Basis-Settings (Sampling-Defaults je Modell dokumentiert)
- `pk-ssh-bootstrap.ps1` — einmaliger SSH-Bootstrap (Admin): OpenSSH-Server, sshd-Dienst, Firewall, Public-Key-Ablage (admin- und user-Pfad)
- `deploy-to-devices.sh` — lokales Deploy nach Bootstrap: scp + schtasks (onlogon) je Geraet

## Test Plan

- `bash -n` auf deploy-to-devices.sh: gruen
- PS1-Dateien: ASCII + CRLF verifiziert (Konvention T002495-M7); pwsh-Parser lokal nicht verfuegbar (pwsh fehlt in WSL)
- End-to-End folgt nach Bootstrap auf den Geraeten: ssh-Zugriff, Autostart-Task, Modell-Sichtbarkeit via `http://localhost:18235/v1/models` (K3-Messung aus T006842)