### PR TITLE
chore(scripts): device deploy via ssh bridge with ps1-based autostart registration [T006842]

### DIFF
--- a/scripts/llm/pk-devices/deploy-to-devices.sh
+++ b/scripts/llm/pk-devices/deploy-to-devices.sh
@@ -1,56 +1,40 @@
 #!/usr/bin/env bash
-# Deploy der LM-Studio-Startup-Scripts auf PK-Tablet und PK-L-1 (nach SSH-Bootstrap).
-# Aufruf: deploy-to-devices.sh <user> <ip-tablet> <ip-laptop>
-#   <user>        Windows-Benutzername (Ausgabe des pk-ssh-bootstrap.ps1)
-#   <ip-tablet>   IP des PK-Tablet
-#   <ip-laptop>   IP des PK-L-1
+# Deploy der LM-Studio-Startup-Scripts auf PK-L-1 und PK-Tablet.
+# Verbindung laeuft ueber die Host-Portproxy-Bruecke (127.0.0.1:2201/2202),
+# Ziele und Key stehen in ~/.ssh/config (Aliase pk-l-1 / pk-tablet).
+#
+# Aufruf:
+#   deploy-to-devices.sh            # beide Geraete
+#   deploy-to-devices.sh pk-l-1     # nur ein Geraet
+#
+# schtasks wird NICHT direkt ueber die cmd-Remote-Shell aufgerufen (Quoting
+# zerfaellt an Leerzeichen); stattdessen laeuft register-autostart.ps1 auf
+# dem Geraet (File-Aufruf ohne Leerzeichen = cmd-sicher).
 set -euo pipefail
 
-USER_WIN="${1:?Windows-Username fehlt (Bootstrap-Ausgabe 'ssh <user>@<ip>')}"
-IP_TABLET="${2:?IP des PK-Tablet fehlt}"
-IP_LAPTOP="${3:?IP des PK-L-1 fehlt}"
-
-KEY="$HOME/.ssh/pk-devices"
 SCRIPTS_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-# SSH-Config-Eintraege (fuer spaetere Wartung)
-ssh_config_block() {
-  cat <<EOF
-
-Host pk-tablet pk-l-1
-    User $USER_WIN
-    IdentityFile $KEY
-    StrictHostKeyChecking accept-new
-
-Host pk-tablet
-    HostName $IP_TABLET
-
-Host pk-l-1
-    HostName $IP_LAPTOP
-EOF
-}
-if ! grep -q '^Host pk-tablet$' "$HOME/.ssh/config" 2>/dev/null; then
-  ssh_config_block >> "$HOME/.ssh/config"
-  echo "ssh config: Eintraege fuer pk-tablet/pk-l-1 angelegt."
-else
-  echo "ssh config: Eintraege existieren bereits (nicht ueberschrieben)."
-fi
+TARGETS=("${@:-pk-l-1 pk-tablet}")
 
 deploy_one() {
-  local name="$1" ip="$2" script="$3"
-  echo "=== $name ($ip) ==="
-  ssh -i "$KEY" -o BatchMode=yes -o ConnectTimeout=5 "$USER_WIN@$ip" \
+  local name="$1" script="$2"
+  echo "=== $name ($script) ==="
+  ssh -o BatchMode=yes "$name" \
     'powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path C:\pk-device | Out-Null"' \
-    && echo "  Verzeichnis C:\pk-device ok"
-  scp -i "$KEY" -o BatchMode=yes "$SCRIPTS_DIR/$script" "$USER_WIN@$ip:C:/pk-device/" \
-    && echo "  $script kopiert"
-  ssh -i "$KEY" -o BatchMode=yes "$USER_WIN@$ip" \
-    "schtasks /create /tn 'PK-Startup-LLM' /tr 'powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File C:\\pk-device\\$script' /sc onlogon /f" \
+    && echo "  C:\\pk-device ok"
+  scp -o BatchMode=yes "$SCRIPTS_DIR/$script" "$SCRIPTS_DIR/register-autostart.ps1" "$name:C:/pk-device/" \
+    && echo "  $script + register-autostart.ps1 kopiert"
+  ssh -o BatchMode=yes "$name" \
+    "powershell -NoProfile -ExecutionPolicy Bypass -File C:\\pk-device\\register-autostart.ps1 -ScriptName $script" \
     && echo "  Autostart-Task 'PK-Startup-LLM' registriert (onlogon)"
 }
 
-deploy_one "pk-tablet" "$IP_TABLET" "pk-tablet-startup.ps1"
-deploy_one "pk-l-1"   "$IP_LAPTOP" "pk-l-1-startup.ps1"
+for t in $TARGETS; do
+  case "$t" in
+    pk-l-1)    deploy_one pk-l-1    pk-l-1-startup.ps1 ;;
+    pk-tablet) deploy_one pk-tablet pk-tablet-startup.ps1 ;;
+    *) echo "Unbekanntes Ziel: $t (pk-l-1 | pk-tablet)"; exit 1 ;;
+  esac
+done
 
 echo ""
 echo "Fertig. Verifikation: http://localhost:18235/v1/models muss beide Slots zeigen."

--- a/scripts/llm/pk-devices/register-autostart.ps1
+++ b/scripts/llm/pk-devices/register-autostart.ps1
@@ -1,0 +1,22 @@
+# register-autostart.ps1 - registriert das LM-Studio-Startup-Script als
+# Task-Scheduler-Task (onlogon). Wird vom deploy-to-devices.sh per ssh
+# aufgerufen, weil schtasks-Quoting ueber die cmd-Remote-Shell unzuverlaessig
+# ist (Leerzeichen zerfallen). Als PS1-Datei gibt es kein Quoting-Problem.
+#
+# Aufruf auf dem Geraet:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File C:\pk-device\register-autostart.ps1 -ScriptName pk-l-1-startup.ps1
+param(
+    [string]$ScriptName = "pk-l-1-startup.ps1"
+)
+
+$ErrorActionPreference = "Stop"
+
+$target = "C:\pk-device\$ScriptName"
+if (-not (Test-Path $target)) {
+    Write-Host "FEHLER: $target existiert nicht - erst deployen."
+    exit 1
+}
+
+$tr = "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$target`""
+schtasks /create /tn "PK-Startup-LLM" /tr $tr /sc onlogon /f | Out-Null
+Write-Host "Autostart-Task 'PK-Startup-LLM' registriert (onlogon) fuer $ScriptName"


### PR DESCRIPTION
## Summary

Deploy-Route fuer die PK-Geraete-Startup-Scripts (T006842):

- `deploy-to-devices.sh` routet jetzt ueber die Host-Portproxy-Bruecke (SSH-Aliase pk-l-1/pk-tablet aus ~/.ssh/config, Ports 2201/2202)
- `register-autostart.ps1` ersetzt den schtasks-Aufruf ueber die cmd-Remote-Shell — dessen Quoting zerfiel an Leerzeichen (beobachtet beim ersten Live-Deploy). Die PS1 nimmt den Scriptnamen als Parameter und registriert den onlogon-Task 'PK-Startup-LLM'.

## Test Plan

- Live verifiziert auf PK-L-1: ssh/scp ueber Bruecke 2201, Verzeichnis C:\pk-device angelegt, Scripts kopiert, Task 'PK-Startup-LLM' registriert (Ausgabe 'Autostart-Task registriert (onlogon)')
- End-to-End-Verifikation folgt: Modell erscheint nach Login in http://localhost:18235/v1/models (K3-Messung T006842)