### PR TITLE
chore(deps): biweekly dependency update 2026-08-15 [T006997]

### DIFF
--- a/brett/package-lock.json
+++ b/brett/package-lock.json
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -3188,25 +3188,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3535,6 +3516,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/postgres-array": {

--- a/brett/package.json
+++ b/brett/package.json
@@ -47,7 +47,9 @@
   },
   "overrides": {
     "shell-quote": "^1.8.4",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "nanoid@<3.3.18": "3.3.18",
+    "dompurify@<3.4.13": "3.4.13"
   },
   "allowScripts": {
     "core-js@3.49.0": true,

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -7,12 +7,13 @@ settings:
 overrides:
   yaml: ^2.9.0
   esbuild: ^0.28.1
-  undici: 7.28.0
+  undici: 7.29.0
   ws: 8.21.0
   js-yaml: ^4.1.2
   '@babel/core': '>=7.29.1'
   adm-zip: ^0.6.0
   brace-expansion: '>=5.0.8'
+  nanoid@<3.3.18: 3.3.18
 
 importers:
 
@@ -3260,8 +3261,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4020,8 +4021,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-properties@1.4.1:
@@ -7195,7 +7196,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -7464,7 +7465,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@6.0.0: {}
 
@@ -7766,7 +7767,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8244,7 +8245,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-properties@1.4.1:
     dependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -42,9 +42,10 @@ minimumReleaseAgeExclude:
 overrides:
   yaml: "^2.9.0"
   esbuild: "^0.28.1"
-  undici: "7.28.0"
+  undici: "7.29.0"
   ws: "8.21.0"
   js-yaml: "^4.1.2"
   "@babel/core": ">=7.29.1"
   adm-zip: "^0.6.0"
   brace-expansion: ">=5.0.8"
+  "nanoid@<3.3.18": "3.3.18"


### PR DESCRIPTION
## Summary

Biweekly Security-Advisory-Audit 2026-08-15 (Issue #4618).

**website (pnpm):**
- `nanoid` 3.3.16 → 3.3.18 — CVE-2026-67213 / GHSA-2v37-7h3g-55p8 (transitiv via postcss)
- `undici` 7.28.0 → 7.29.0 — CVE-2026-13697 + Moderate-CVEs (transitiv via jsdom); Override in `pnpm-workspace.yaml` angehoben
- Override `nanoid@<3.3.18` ergänzt (3.x-Linie; direkte Dep `nanoid@^6` unberührt)

**brett (npm):**
- `nanoid` 3.3.16 → 3.3.18 (via vite/postcss)
- `dompurify` 3.4.12 → 3.4.13 — GHSA-55q2-fjhq-7xh7 (via jspdf)
- Overrides `nanoid@<3.3.18` und `dompurify@<3.4.13` ergänzt

## Verifikation

- `pnpm install --frozen-lockfile` (website) und `npm ci` (brett) strikt grün — Lockfiles intern konsistent
- `task test:changed` + `task freshness:check` grün