### PR TITLE
fix(factory): mishap-rollup blockiert — Batch-Inhalt als Blockquote + Lock-Release aus Repo-Root [T007000]

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1038,
+      "file_count": 1039,
       "files": [
         "tests/.gitignore",
         "tests/README.md",
@@ -648,6 +648,7 @@
         "tests/spec/mishap-rollup/generator-cycle-artifacts.bats",
         "tests/spec/mishap-rollup/rollup-container-empty-list-selfheal.bats",
         "tests/spec/mishap-rollup/rollup-cycle-push.bats",
+        "tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats",
         "tests/spec/mishap-t002422.bats",
         "tests/spec/mishap-t002424.bats",
         "tests/spec/mishap-tracking/dedupe-korpus.bats",

--- a/scripts/factory/mishap-rollup.sh
+++ b/scripts/factory/mishap-rollup.sh
@@ -97,6 +97,11 @@ cleanup_wt() {
   # [T005115] Claim zuerst freigeben (best-effort), dann den Worktree entfernen —
   # der Claim-Guard von worktree-clean-check.sh blockiert Fremd-Removes nur, wenn
   # der Lock noch lebt; das eigene Cleanup darf den Lock nie stehen lassen.
+  # [T007000] Vor dem Release aus dem Worktree-cwd heraus: der T006290-cwd-Guard
+  # in agent-lock.sh verweigert Branch-Releases, solange die Shell-cwd im
+  # Worktree des Locks liegt — der Lock blieb live, der naechste Driver-Lauf im
+  # selben Tick hing am claim (beobachtet 2026-08-15, Rollup-Pipeline ~1h blockiert).
+  cd "$REPO" >/dev/null 2>&1 || true
   bash "$REPO/scripts/agent-lock.sh" release branch "$BRANCH" >/dev/null 2>&1 || true
   git -C "$REPO" worktree remove --force "$WT" >/dev/null 2>&1 || true
 }
@@ -197,7 +202,13 @@ Batch-Kommentaren des Container-Tickets "${ROLLUP_TITLE}".
 ## Mishap-Batches
 
 PLANEOF
-  cat "$COMMENTS_FILE"
+  # [T007000] Batch-Inhalt als Blockquote einbetten: plan-lint P2 scannt die
+  # gesamte tasks.md auf Commit-Scope-Vorschreibungen (type(scope):) — Batch-
+  # Kommentare duerfen solche Muster als BEISPIELE enthalten (z.B. feat(llm):
+  # aus einem plan-quality-gates-Mishap). Zeilen mit '>' sind bei P2 explizit
+  # exempt; das Praefix '> ' pro Zeile neutralisiert Beispiele, ohne den Inhalt
+  # zu veraendern (beobachtet: Hard-Fail auf dem 10er-Batch vom 2026-08-15).
+  sed 's/^[[:space:]]*/&> /' "$COMMENTS_FILE"
   cat <<'PLANEOF'
 
 ## Verify (RED → GREEN)

--- a/tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats
+++ b/tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats — T007000
+#
+# Pruefmodus: OUTPUT-VERIFIKATION [T002448-M4]. Regressionsschutz fuer den
+# Generator-Fix: plan-lint P2 scannt die gesamte tasks.md auf Commit-Scope-
+# Vorschreibungen type(scope): — Batch-Kommentare duerfen solche Muster als
+# BEISPIELE enthalten (der 10er-Batch vom 2026-08-15 enthielt feat(llm):/
+# test(llm): aus dem plan-quality-gates-Mishap und brachte den Driver mit
+# plan-lint FAIL zum Stehen).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/factory/mishap-rollup.sh"
+  LINT="$REPO_ROOT/scripts/plan-lint.sh"
+}
+
+# Minimal gueltiger Plan (F1/F2/STRUCT1-3 erfuellt, kein Partial-Modus) mit
+# der Batch-Sektion als Variable — gespiegelt am Generator-Template, damit
+# der Test nur an der P2-Frage scheitern kann.
+_plan() {
+  local batch="$1"
+  cat <<EOF
+---
+title: "test — Implementation Plan"
+ticket_id: T999999
+domains: [factory]
+status: active
+file_locks: []
+shared_changes: false
+batch_id: null
+parent_feature: null
+depends_on_plans: []
+---
+
+# test — Implementation Plan
+
+## File Structure
+
+\`\`\`
+tests/spec/software-factory/example.bats
+\`\`\`
+
+## Mishap-Batches
+
+$batch
+
+## Verify (RED → GREEN)
+
+- [ ] **Failing-Test-Step (RED).**
+
+\`\`\`bash
+tests/unit/lib/bats-core/bin/bats -r tests/spec/software-factory/
+# expected: FAIL (rot — der Fix ist noch nicht implementiert)
+\`\`\`
+
+- [ ] **Fix-Step (GREEN).**
+
+- [ ] **Final Verification.**
+
+\`\`\`bash
+task test:changed; task freshness:regenerate; task freshness:check
+\`\`\`
+EOF
+}
+
+@test "T007000: Generator praefixiert Batch-Zeilen mit '> ' (sed-Transform vorhanden)" {
+  run grep -nF "sed 's/^[[:space:]]*/&> /'" "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T007000: plan-lint P2 exemptet blockquote-Zeilen ('> feat(llm):'-Beispiel passiert)" {
+  local dir="$BATS_TEST_TMPDIR/quoted"; mkdir -p "$dir"
+  _plan "> Beispiel aus einem Batch: der Subagent schrieb feat(llm): statt ops — test(llm): analog" > "$dir/tasks.md"
+  run bash "$LINT" "$dir/tasks.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "T007000: Kontrolle — rohe Scope-Vorschreibung in tasks.md failt weiterhin hart" {
+  local dir="$BATS_TEST_TMPDIR/raw"; mkdir -p "$dir"
+  _plan "Commit-Scope: feat(llm): Beispiel ohne Blockquote" > "$dir/tasks.md"
+  run bash "$LINT" "$dir/tasks.md"
+  [ "$status" -eq 1 ]
+  grep -qF "P2" <<<"$output"
+}

--- a/website/src/data/test-inventory.json
+++ b/website/src/data/test-inventory.json
@@ -3804,6 +3804,12 @@
     "kind": "shell"
   },
   {
+    "id": "mishap-rollup/rollup-plan-lint-scope-examples",
+    "file": "tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats",
+    "category": "mishap-rollup",
+    "kind": "shell"
+  },
+  {
     "id": "mishap-t002422",
     "file": "tests/spec/mishap-t002422.bats",
     "category": "mishap-t002422",


### PR DESCRIPTION
Behebt die Rollup-Pipeline-Blockade vom 2026-08-15 (10er-Batch auf Container T006843 blieb seit ~10:59 in jedem Tick liegen):

1. **plan-lint P2 Hard-Fail:** Batch-Kommentare wurden unverändert in tasks.md eingebettet — Commit-Scope-Beispiele in Mishap-Beschreibungen (`feat(llm):`/`test(llm):`) galten als Vorschreibungen. Fix: Einbettung als Blockquote (`> `-Präfix) — P2 exemptet Zeilen mit `>` per Design.
2. **Lock-Leak:** `cleanup_wt` releaste den Branch-Claim aus dem Worktree-cwd — der T006290-cwd-Guard verweigerte das, der Lock blieb live, der nächste Driver-Lauf hing am claim. Fix: `cd "$REPO"` vor dem Release.

Regressionstest: `tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats` (3 Tests). Mishap-rollup-Spec-Suite lokal grün.