### PR TITLE
chore(infra): GitOps-Audit-Fixes — Loki-CPU, github-token, Grafana-Creds, cosign-Verify [T007035]

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -55,9 +55,12 @@ jobs:
     # laeuft VOR der if:-Auswertung, der Job muss dafuer also nicht einmal
     # ausgefuehrt werden. Genau das passierte 37 Merges lang (T002118).
     # Das Recht bleibt bewusst auf diesen Job begrenzt statt workflowweit.
+    # id-token: write (cosign keyless, T007035): render-fleet-artifact.yml
+    # signiert das OCI-Artefakt — der Aufrufer muss das Callee-Recht decken.
     permissions:
       contents: read
       packages: write
+      id-token: write
     uses: ./.github/workflows/render-fleet-artifact.yml
     secrets: inherit
 

--- a/.github/workflows/render-fleet-artifact.yml
+++ b/.github/workflows/render-fleet-artifact.yml
@@ -40,6 +40,9 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  # Keyless Cosign signing: the GitHub OIDC token proves the workflow identity
+  # to Sigstore (Fulcio/Rekor). Without id-token the `cosign sign` step fails.
+  id-token: write
 
 env:
   OPENSPEC_TELEMETRY: '0'
@@ -112,6 +115,20 @@ jobs:
           flux tag artifact \
             oci://ghcr.io/paddione/fleet-manifests:latest \
             --tag "sha-${GITHUB_SHA}"
+
+      # Keyless supply-chain signing. The signature attaches to the pushed
+      # digest, so both `latest` and `sha-<GITSHA>` resolve to a verified
+      # artifact. The cluster verifies via OCIRepository spec.verify
+      # (flux/clusters/fleet/oci-source.yaml) with the same OIDC identity.
+      - name: Sign OCI artifact (cosign keyless)
+        run: |
+          set -euo pipefail
+          if ! command -v cosign > /dev/null; then
+            curl -sSL "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64" \
+              -o /usr/local/bin/cosign
+            chmod +x /usr/local/bin/cosign
+          fi
+          cosign sign --yes "oci://ghcr.io/paddione/fleet-manifests:latest"
 
       - name: Ping Flux receiver (immediate reconcile)
         if: success()

--- a/flux/clusters/fleet/bootstrap/github-token-sealedsecret.yaml
+++ b/flux/clusters/fleet/bootstrap/github-token-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: github-token
+  namespace: flux-system
+spec:
+  encryptedData:
+    token: AgA/Gp1gBPRdQTEB2w2KCyhyL6hs3rIWJvi/903gSVCB8fOz3bcrNY0s1Rdu5d24apIWDMgu5keFYSnSasgnyqacOZo52DDZ1Cpx4hu9Qf08Ix+CxzvQCN33F2ijsDG9mUSvgEeHaSoL4opavKJq13Hp4tSsY4WoAflgCIAr4azDZdVoVu5bX4/GC0A1TgVRXJjcjsa9m2j4ItyNwSwmbfQIevm++JsoJm4d2l1LNq+oT94K1lQvOP0L0nORqMHNJ2Z/B8XMptfZU8AnTcwLfbpaRYHKlaiBO64xw0Rv5RdSZOr5n42I0YG5t38uukSlSx6DGAEy5XEeNdpZQ1ESujZM0MfMS6g31NIB5vCo4N+H1toIY9SFTgl9sk5OkfinLklRcyN3bnDt7Di9/Z8nPxYzsimMsclMv4JRXeyNtJrlviYqFWjMAQPNiqsoJ2JTAGdTuTCCcgJCoLkXNMr9HHNTNyK1FDaiTSG9IoYbY6Yd/x/WlvRvYnXahVXTx9RM05YjeU2ZRVcwGPEKqgfzsmJmJKA2+cmb0ToWqRyAF1iozvNo39qAcb2PrPm2gYBx5YkzBafzPQDWu8NvRfGXesLIGI+alaDfEfmL59SIjTxJuW169HU5FmvW0JjurflsNgKiP4MEyVksbBVSshNyIbOVPtz47zlv3w59C0LWov+kEAYbfPyzuseDnhA9TlbDvfg4xjSe/QFc9GmTeCesTE5D0419uM2E+/Y94bwvRPuX6z0iyQjQjvnA
+  template:
+    metadata:
+      name: github-token
+      namespace: flux-system

--- a/flux/clusters/fleet/flux-instance.yaml
+++ b/flux/clusters/fleet/flux-instance.yaml
@@ -15,6 +15,10 @@ spec:
   cluster:
     type: kubernetes
     networkPolicy: true
+    # Vertical scaling profile: 5-node fleet with ~150 resources across 10
+    # Kustomizations — medium raises controller concurrency/limits above the
+    # small defaults. [audit 2026-08-15]
+    size: medium
   sync:
     kind: GitRepository
     url: https://github.com/Paddione/Bachelorprojekt

--- a/flux/clusters/fleet/notifications.yaml
+++ b/flux/clusters/fleet/notifications.yaml
@@ -21,14 +21,13 @@ spec:
   eventSources:
     - kind: Kustomization
       name: '*'
-    - kind: HelmRelease
-      name: '*'
     - kind: GitRepository
       name: '*'
     - kind: OCIRepository
       name: '*'
-    - kind: ExternalArtifact
-      name: '*'
   exclusionList:
     - ".*Succeeded.*"
     - ".*Artifact.*"
+  # NOTE: HelmRelease and ExternalArtifact eventSources were removed — no
+  # HelmRelease resources exist and ExternalArtifact requires the source-watcher
+  # component, which is not installed. [audit 2026-08-15]

--- a/flux/clusters/fleet/oci-source.yaml
+++ b/flux/clusters/fleet/oci-source.yaml
@@ -10,3 +10,11 @@ spec:
     tag: latest
   secretRef:
     name: ghcr-auth
+  # Supply-chain verification: every artifact must carry a cosign signature
+  # from the render-fleet-artifact workflow (GitHub Actions OIDC identity,
+  # keyless signing). An unsigned or foreign-signed artifact is rejected.
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/Paddione/Bachelorprojekt/\.github/workflows/render-fleet-artifact\.yml@refs/heads/main$

--- a/k3d/monitoring/loki-rendered.yaml
+++ b/k3d/monitoring/loki-rendered.yaml
@@ -339,7 +339,7 @@ spec:
               mountPath: "/rules"
           resources:
             limits:
-              cpu: 1
+              cpu: 1000m
               memory: 1Gi
             requests:
               cpu: 100m

--- a/k3d/monitoring/values/loki-values.yaml
+++ b/k3d/monitoring/values/loki-values.yaml
@@ -17,7 +17,9 @@ singleBinary:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: 1
+      # String quantity, not bare int — YAML number fails strict schema validation
+      # (flux-schema: "got number, want string"). 1000m == 1 CPU core.
+      cpu: 1000m
       memory: 1Gi
 
 loki:

--- a/prod-fleet/korczewski-jobs/kustomization.yaml
+++ b/prod-fleet/korczewski-jobs/kustomization.yaml
@@ -133,20 +133,6 @@ patches:
       kind: PrometheusRule
       metadata:
         name: delete-rule
-  - target: { group: helm.toolkit.fluxcd.io, version: v2beta1, kind: HelmRelease }
-    patch: |-
-      $patch: delete
-      apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      metadata:
-        name: delete-helmrelease
-  - target: { group: source.toolkit.fluxcd.io, version: v1beta2, kind: HelmRepository }
-    patch: |-
-      $patch: delete
-      apiVersion: source.toolkit.fluxcd.io/v1beta2
-      kind: HelmRepository
-      metadata:
-        name: delete-helmrepo
   - target: { group: cert-manager.io, version: v1, kind: Certificate }
     patch: |-
       $patch: delete

--- a/prod-fleet/mentolder-jobs/kustomization.yaml
+++ b/prod-fleet/mentolder-jobs/kustomization.yaml
@@ -134,20 +134,6 @@ patches:
       kind: PrometheusRule
       metadata:
         name: delete-rule
-  - target: { group: helm.toolkit.fluxcd.io, version: v2beta1, kind: HelmRelease }
-    patch: |-
-      $patch: delete
-      apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      metadata:
-        name: delete-helmrelease
-  - target: { group: source.toolkit.fluxcd.io, version: v1beta2, kind: HelmRepository }
-    patch: |-
-      $patch: delete
-      apiVersion: source.toolkit.fluxcd.io/v1beta2
-      kind: HelmRepository
-      metadata:
-        name: delete-helmrepo
   - target: { group: cert-manager.io, version: v1, kind: Certificate }
     patch: |-
       $patch: delete

--- a/prod/monitoring/grafana-oidc-patch.yaml
+++ b/prod/monitoring/grafana-oidc-patch.yaml
@@ -1,6 +1,13 @@
 # Enable Pocket ID OIDC on Grafana in prod. The OIDC client_secret + admin
 # password come from the `grafana-oidc` SealedSecret. Pocket ID has no groups
 # — the role-attribute-path keys on the boolean isAdmin claim (T000972).
+#
+# The grafana-sc-dashboard sidecar originally authenticated the dashboards
+# reload API (POST /api/admin/provisioning/dashboards/reload) with the chart's
+# default admin/admin (monitoring-grafana secret). Prod's real admin password
+# comes from the grafana-oidc SealedSecret (GRAFANA_ADMIN_PASSWORD), so the
+# sidecar login 401'd and dashboard reloads silently failed. Point the sidecar
+# at the same secret the grafana container uses.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,3 +47,17 @@ spec:
                   key: GRAFANA_ADMIN_PASSWORD
             - name: GF_SERVER_ROOT_URL
               value: "https://grafana.${PROD_DOMAIN}"
+        - name: grafana-sc-dashboard
+          env:
+            - name: REQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-oidc
+                  key: GRAFANA_ADMIN_PASSWORD
+        - name: grafana-sc-datasources
+          env:
+            - name: REQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-oidc
+                  key: GRAFANA_ADMIN_PASSWORD


### PR DESCRIPTION
Behebt die Findings aus dem GitOps-Repo-Audit (2026-08-15) gegen den Fleet-Cluster:

1. **Loki CPU-Schema:** `limits.cpu: 1` (Zahl) → `1000m` (String) in `k3d/monitoring/values/loki-values.yaml` + konsistent im Render-Manifest `loki-rendered.yaml` (minimal gepatcht — `task loki:render` würde die gepinnten Images 3.7.4/quay-sidecar auf Chart-Defaults zurückstufen).
2. **Tote Delete-Patches:** `$patch: delete`-Ziele für HelmRelease v2beta1 / HelmRepository v1beta2 aus beiden Jobs-Overlays entfernt (Kinds existieren nicht mehr).
3. **github-token:** fehlte → Provider `github-status` tot. SealedSecret `flux/clusters/fleet/bootstrap/github-token-sealedsecret.yaml` (strict scope, aktueller Cluster-Key r25bw) + Secret live angelegt. **Verifiziert:** Commit-Status wird gepostet (notification-controller dispatch OK).
4. **Grafana-Sidecar-Creds:** beide Sidecars (`grafana-sc-dashboard` UND `grafana-sc-datasources`) lasen Chart-Default `admin`; jetzt `grafana-oidc`/`GRAFANA_ADMIN_PASSWORD` (SealedSecret live entschlüsselt zur Verifikation).
5. **cosign-Verify:** `render-fleet-artifact.yml` signiert das OCI-Artefakt keyless (id-token: write); `oci-source.yaml` verlangt `spec.verify` mit GH-Actions-OIDC-Issuer/Subject. Erste Revision nach Merge wird signiert.
6. **FluxInstance:** `spec.cluster.size: medium`; `notifications.yaml`: tote eventSources `HelmRelease`/`ExternalArtifact` entfernt.
7. **Dev-Node:** gekko-hetzner-4 live mit `role=dev` gelabelt/tainted (gekko-hetzner-2 aus T002630 nie beigetreten); Dev-Pods schedulen wieder.

## Verifikation
- Alle betroffenen Kustomize-Overlays bauen (`kustomize build` für 10 Pfade), `flux schema validate` 4/4 auf den geänderten fleet-Dateien, `task freshness:check` + `task workspace:validate` grün.
- Live: Provider-Dispatch via GitHub-API bestätigt, Node-Label/Taint bestätigt.

## Bekannte Einschränkungen (Folge-Tickets/Entscheidung nötig)
- **Fleet-Dev-Stack bleibt rot:** `:dev`-Images existieren nicht auf GHCR (403; CI pusht nur `sha-*`/`latest`) und `workspace-secrets`/`ghcr-pull-secret` fehlen in `workspace-dev` → T002630-Umbau oder Produktentscheidung (Dev-Images publizieren bzw. auf `latest` zeigen).
- **DR-Key-Export:** `environments/.secrets/sealed-secrets-key.fleet.yaml` ist hier skip-worktree + git-crypt-Filter nicht konfiguriert → Refresh (3 Cluster-Keys) muss in git-crypt-fähigem Checkout committed werden; bis dahin entschlüsselt nur Key jpx4t neue SealedSecrets.
- **Rollout-Reihenfolge cosign:** Bis zum nächsten signierten Artefakt lehnt source-controller neue Revisionen ab (gewollt; kein Rollback-Pfad nötig, da `latest`-Tag überschrieben wird).

## Test Plan
- Kein Code-/Test-Domain-Scope: Manifest-Validierung (siehe Verifikation) + Live-Befund github-token.
