### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3438,7 +3438,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 752,
+      "file_count": 753,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3941,6 +3941,7 @@
         "scripts/llm/measure-embedding-equivalence.mjs",
         "scripts/llm/ollama.service",
         "scripts/llm/pk-devices/deploy-to-devices.sh",
+        "scripts/llm/pk-devices/k3-messung.sh",
         "scripts/llm/pk-devices/pk-host-portproxy-setup.ps1",
         "scripts/llm/pk-devices/pk-l-1-startup.ps1",
         "scripts/llm/pk-devices/pk-ssh-bootstrap.ps1",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 31879342035).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
