### PR TITLE
fix(ci): cosign sign per Digest statt oci://-Präfix (Host-Auflösung oci) [T007035]

### DIFF
--- a/.github/workflows/render-fleet-artifact.yml
+++ b/.github/workflows/render-fleet-artifact.yml
@@ -105,13 +105,17 @@ jobs:
         run: task flux:render
 
       - name: Push OCI artifact
+        id: push-artifact
         run: |
           set -euo pipefail
-          flux push artifact \
+          OUT="$(flux push artifact \
             oci://ghcr.io/paddione/fleet-manifests:latest \
             --path=./out \
             --source="$(git config --get remote.origin.url)" \
-            --revision="${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}"
+            --revision="${GITHUB_REF_NAME}@sha1:${GITHUB_SHA}" \
+            --output json)"
+          echo "$OUT"
+          echo "digest=$(printf '%s' "$OUT" | python3 -c 'import json,sys; print(json.load(sys.stdin)["digest"])')" >> "$GITHUB_OUTPUT"
           flux tag artifact \
             oci://ghcr.io/paddione/fleet-manifests:latest \
             --tag "sha-${GITHUB_SHA}"
@@ -120,6 +124,8 @@ jobs:
       # digest, so both `latest` and `sha-<GITSHA>` resolve to a verified
       # artifact. The cluster verifies via OCIRepository spec.verify
       # (flux/clusters/fleet/oci-source.yaml) with the same OIDC identity.
+      # NOTE: sign by DIGEST — cosign's `oci://` prefix is for local OCI
+      # layouts and would resolve host "oci" (observed failure on 2026-08-15).
       - name: Sign OCI artifact (cosign keyless)
         run: |
           set -euo pipefail
@@ -128,7 +134,8 @@ jobs:
               -o /usr/local/bin/cosign
             chmod +x /usr/local/bin/cosign
           fi
-          cosign sign --yes "oci://ghcr.io/paddione/fleet-manifests:latest"
+          cosign sign --yes \
+            "ghcr.io/paddione/fleet-manifests@${{ steps.push-artifact.outputs.digest }}"
 
       - name: Ping Flux receiver (immediate reconcile)
         if: success()


### PR DESCRIPTION
Der post-merge-Run 31879501394 nach dem Squash-Merge von #4633 schlug im cosign-Schritt fehl:

`Error: signing [oci://ghcr.io/paddione/fleet-manifests:latest]: accessing entity: Get "https://oci/v2/"`

Ursache: `oci://` ist in cosign der Präfix für **lokale OCI-Layout-Verzeichnisse** (hostbasierte Referenz "oci"), nicht für Registry-Referenzen. Folge: Der beim Merge gepushte (neue, unsignierte) Artifact unter `latest` blieb ohne Signatur — sobald die `spec.verify`-Policy aus #4633 im Cluster greift (Git-Sync, ≤10 min), friert source-controller die Fleet auf der alten Revision ein.

Fix:
1. Push-Step gibt die Digest aus (`flux push artifact --output json` → `steps.push-artifact.outputs.digest`).
2. `cosign sign` referenziert **per Digest** (`ghcr.io/paddione/fleet-manifests@sha256:...`) — keine Tag-Race, kein oci://-Fehlerbild. Signatur hängt am Digest, damit verifizieren `latest` UND `sha-<GITSHA>` gleichermaßen (wie in oci-source.yaml konfiguriert).

## Test Plan
- CI (BATS T002118 deckt Caller-Permissions) muss grün bleiben — keine Permissions-Änderung.
- Nach Merge: post-merge-Run signiert den neuen Artifact; Cluster-OCIRepository rekonziliert mit verify=cosign (Status-Check `kubectl get ocirepository -n flux-system ks-fleet-source`).

## Rollout-Hinweis
Der aktuelle `latest`-Artifact ist unsigniert → Fleet bleibt eingefroren, bis dieser Fix gemergt und der Folge-Run signiert hat (erwartetes, kurzes Fenster — laufende Workloads unberührt).
