### PR TITLE
docs(infra): loki-rendered.yaml pin caveat dokumentieren (kein Blind-Regen) [T007035]

### DIFF
--- a/k3d/monitoring/values/loki-values.yaml
+++ b/k3d/monitoring/values/loki-values.yaml
@@ -1,6 +1,13 @@
 # Single-binary Loki for unified log aggregation across both brands.
 # Dev baseline: local-path storage, 5Gi PVC. Prod: longhorn via overlay patch.
 # No MinIO/S3 — plain filesystem TSDB, 14d retention.
+#
+# NOTE (T007035, audit 2026-08-15): the committed loki-rendered.yaml is
+# INTENTIONALLY out of sync with `helm template` output — it pins
+# grafana/loki:3.7.4@sha256:87f0... and quay.io/kiwigrid/k8s-sidecar:2.8.1,
+# while a fresh `task loki:render` would fall back to the chart defaults
+# (3.6.7 / docker.io:2.5.0). Do NOT regenerate the rendered file blindly;
+# patch it minimally instead (see the cpu: 1000m fix below).
 
 deploymentMode: SingleBinary
 

--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -3909,6 +3909,12 @@
       "status": "archived"
     }
   ],
+  "T007056": [
+    {
+      "slug": "mishap-rollup-direct-dispatch",
+      "status": "plan_staged"
+    }
+  ],
   "TBD": [
     {
       "slug": "2026-06-21-secrets-deploy-automation",

--- a/website/src/data/openspec-status.json
+++ b/website/src/data/openspec-status.json
@@ -3909,12 +3909,6 @@
       "status": "archived"
     }
   ],
-  "T007056": [
-    {
-      "slug": "mishap-rollup-direct-dispatch",
-      "status": "plan_staged"
-    }
-  ],
   "TBD": [
     {
       "slug": "2026-06-21-secrets-deploy-automation",


### PR DESCRIPTION
Dokumentiert den absichtlichen Drift zwischen `k3d/monitoring/loki-rendered.yaml` (gepinnt: grafana/loki:3.7.4, quay.io/kiwigrid/k8s-sidecar:2.8.1) und frischem `helm template`-Output (Chart-Defaults 3.6.7 / docker.io:2.5.0). `task loki:render` wuerde die Pins stillschweigend zurueckstufen — Comment als Schutzschild, kein Manifest-Schema-Verhalten.

## Test Plan
- BATS CI-Gates (u.a. T002118) gruen.
- Kommentar-only: helm template-Output aendert sich nicht (identischer Digest).
