### PR TITLE
test: T002407-M6b auf T007056-Collect-Mode umgestellt (NOT IN-Form war T004898-Altlast) [T007215]

### DIFF
--- a/tests/spec/mcp-skill-integration.bats
+++ b/tests/spec/mcp-skill-integration.bats
@@ -248,12 +248,18 @@ setup() {
   printf '%s' "$status_flag" | grep -q 'triage' \
     || { echo "rollup-container muss den Container als triage anlegen, gefunden: $status_flag"; false; }
 
-  # [T004898] Der Wiederfinde-Pfad fuehrt seit dem ephemeren Lifecycle
-  # NOT IN ('done','archived') statt der expliziten Statusliste: plan_staged ist
-  # darin als offener Status enthalten — sonst legte jeder Lauf neben dem bereits
-  # gestagten Container einen neuen an.
-  printf '%s\n' "$block" | grep -q "status NOT IN.*done.*archived" \
-    || { echo "SELECT im Wiederfinde-Pfad schliesst nur done/archived aus — plan_staged bleibt offen"; false; }
+  # [T004898 → T007056] Der Wiederfinde-Pfad nutzt seit dem Staged-Lane-Muster
+  # (T007056, Teil-Ruecknahme von T004898) einen EXPLIZITEN Collect-Mode statt
+  # NOT IN ('done','archived'): Dispatchete Container (plan_staged) muessen vom
+  # Finder ausgeschlossen bleiben, damit neue Flushes einen frischen Container
+  # anlegen — sonst sammelte jeder Lauf weiter in den bereits gestagten
+  # Container. Collect-Mode = triage/backlog/planning (+ blocked ohne
+  # FACTORY-PLAN-REF); der Anlage-Pfad (triage) bleibt davon unberuehrt.
+  printf '%s\n' "$block" | grep -qE "status IN \('triage','backlog','planning'\)" \
+    || { echo "SELECT im Wiederfinde-Pfad fehlt der Collect-Mode (triage/backlog/planning) — T007056"; false; }
+  # Negativ-Anker: plan_staged darf nicht in der Collect-Mode-Statusliste stehen.
+  printf '%s\n' "$block" | grep -qE "status IN \([^)]*plan_staged" \
+    && { echo "plan_staged darf NICHT im Collect-Mode-Wiederfinde stehen (T007056: dispatched ausschliessen)"; false; }
 }
 
 @test "T002407-M6c: ROLLUP_TICKET_TITLE ist definiert" {

--- a/tests/spec/mcp-skill-integration.bats
+++ b/tests/spec/mcp-skill-integration.bats
@@ -258,8 +258,10 @@ setup() {
   printf '%s\n' "$block" | grep -qE "status IN \('triage','backlog','planning'\)" \
     || { echo "SELECT im Wiederfinde-Pfad fehlt der Collect-Mode (triage/backlog/planning) — T007056"; false; }
   # Negativ-Anker: plan_staged darf nicht in der Collect-Mode-Statusliste stehen.
-  printf '%s\n' "$block" | grep -qE "status IN \([^)]*plan_staged" \
-    && { echo "plan_staged darf NICHT im Collect-Mode-Wiederfinde stehen (T007056: dispatched ausschliessen)"; false; }
+  if printf '%s\n' "$block" | grep -qE "status IN \([^)]*plan_staged"; then
+    echo "plan_staged darf NICHT im Collect-Mode-Wiederfinde stehen (T007056: dispatched ausschliessen)"
+    false
+  fi
 }
 
 @test "T002407-M6c: ROLLUP_TICKET_TITLE ist definiert" {


### PR DESCRIPTION
**Blocker:** Factory spec shard 3 faellt seit dem T007056-Merge (#4644, 11:25) auf JEDEM PR — auch auf reinen CI/Manifest-PRs. Ursache: `cmd_rollup_container()` nutzt seit dem Staged-Lane-Muster bewusst den Collect-Mode (`status IN ('triage','backlog','planning')` + blocked ohne FACTORY-PLAN-REF, dispatched/plan_staged ausgeschlossen — Teil-Ruecknahme T004898, siehe T007056-Beschreibung), aber der Spec-Test T002407-M6b assertete noch die alte `NOT IN ('done','archived')`-Form.

Kein Code-Change: `scripts/ticket.sh` ist wie von T007056 spezifiziert. Der Test wird auf den neuen Collect-Mode umgestellt:
- Positiv: `status IN ('triage','backlog','planning')` im Wiederfinde-Pfad
- Negativ: `plan_staged` darf nicht in der IN-Liste stehen (dispatched ausschliessen)
- Anlage-Pfad (`--status triage`) unveraendert geprueft

## Test Plan
- Assertions lokal gegen aktuelles `scripts/ticket.sh` verifiziert (Positiv/Negativ PASS).
- Factory spec shard 3 muss gruen werden (deckt alle bisher blockierten PRs frei).
