### PR TITLE
chore(scripts): tablet startup on gemma-4-e2b ctx 16384 + parallel 1 in both device scripts [T007055]

### DIFF
--- a/scripts/llm/pk-devices/pk-l-1-startup.ps1
+++ b/scripts/llm/pk-devices/pk-l-1-startup.ps1
@@ -33,7 +33,7 @@ Write-Host "[PK-L-1] Starte LM-Studio-Server auf Port 1234 (bind 0.0.0.0 fuer LM
 if ($LASTEXITCODE -ne 0) { Write-Warning "server start lieferte Exit $LASTEXITCODE (Server laeuft evtl. bereits)." }
 
 Write-Host "[PK-L-1] Lade Qwen3.5-4B Q6_K (ctx 32768, GPU max) ..."
-& $lms load $ModelId --gpu max --context-length 32768 -y
+& $lms load $ModelId --gpu max --parallel 1 --context-length 32768 -y
 if ($LASTEXITCODE -ne 0) {
     Write-Warning "load lieferte Exit $LASTEXITCODE - Modell-ID pruefen: lms ls"
     exit 1

--- a/scripts/llm/pk-devices/pk-tablet-startup.ps1
+++ b/scripts/llm/pk-devices/pk-tablet-startup.ps1
@@ -20,7 +20,7 @@ $ErrorActionPreference = "Stop"
 
 # An den tatsaechlichen Modell-Verzeichnisnamen in LM Studio anpassen
 # (mit `lms ls` pruefen; -y bestaetigt Teilnamen-Matches automatisch).
-$ModelId = "gemma-4-12b-it"
+$ModelId = "gemma-4-e2b-it"
 
 $lms = Join-Path $env:USERPROFILE ".lmstudio\bin\lms.exe"
 if (-not (Test-Path $lms)) { $lms = "lms" }
@@ -30,7 +30,7 @@ Write-Host "[PK-Tablet] Starte LM-Studio-Server auf Port 1234 (bind 0.0.0.0 fuer
 if ($LASTEXITCODE -ne 0) { Write-Warning "server start lieferte Exit $LASTEXITCODE (Server laeuft evtl. bereits)." }
 
 Write-Host "[PK-Tablet] Lade Gemma 4 12B UD-IQ3_XXS (ctx 32768, GPU max) ..."
-& $lms load $ModelId --gpu max --context-length 32768 -y
+& $lms load $ModelId --gpu max --parallel 1 --context-length 16384 -y
 if ($LASTEXITCODE -ne 0) {
     Write-Warning "load lieferte Exit $LASTEXITCODE - Modell-ID pruefen: lms ls"
     exit 1


### PR DESCRIPTION
## Summary

- pk-tablet-startup.ps1: ModelId auf gemma-4-e2b-it, Kontext 16384, parallel 1 (E2B-Slot-Wechsel T007055; Tablet-Hardware 8 GB RAM)
- pk-l-1-startup.ps1: parallel 1 nachgetragen (der urspruengliche Fix ging nach dem Merge von PR #4622 auf dem Branch verloren — gleiches Muster wie k3-messung.sh/#4637)

## Test Plan

- ASCII+CRLF verifiziert; Load-Zeilen geprueft (grep)