### PR TITLE
ci: Kommentar aus multiline tags:-String entfernt (wurde als Literal-Tag geparst) [T007035]

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -81,6 +81,10 @@ jobs:
       # runtime stage (T002202). Historically this Dockerfile had no ARG line
       # at all, which silently turned build-args into no-ops — keep the ARG
       # declarations and these values in sync.
+      # dev-stack alias: k3d/dev-stack/website-dev.yaml pins
+      # workspace-website:dev (fleet dev node, T007035) — same build,
+      # additional tag, no extra pipeline. NOTE: must stay OUTSIDE the
+      # multiline `tags:` string — build-push-action parses it as literal tags.
       - name: Build & push Docker image
         id: build-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
@@ -95,9 +99,6 @@ jobs:
           tags: |
             ${{ steps.compute-tags.outputs.image }}:${{ steps.compute-tags.outputs.sha_tag }}
             ${{ steps.compute-tags.outputs.image }}:latest
-            # dev-stack alias: k3d/dev-stack/website-dev.yaml pins
-            # workspace-website:dev (fleet dev node, T007035) — same build,
-            # additional tag, no extra pipeline.
             ghcr.io/paddione/workspace-website:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Der build-website-Run nach #4646 schlug mit `invalid tag "# dev-stack alias: ..."` fehl: docker/build-push-action liest `tags:` als Multiline-STRING, Kommentare werden NICHT gestrippt und landen als Literal-Tags. Kommentar aus dem tags:-Block entfernt (steht jetzt als YAML-Kommentar vor dem Step).

## Test Plan
- build-website.yml muss gruen laufen; `workspace-website:dev`-Tag auf GHCR erscheinen.
