### PR TITLE
ci: website-dev-Image auf bestehendes website-Package umgestellt (workspace-website nicht pushbar) [T007035]

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -81,10 +81,12 @@ jobs:
       # runtime stage (T002202). Historically this Dockerfile had no ARG line
       # at all, which silently turned build-args into no-ops — keep the ARG
       # declarations and these values in sync.
-      # dev-stack alias: k3d/dev-stack/website-dev.yaml pins
-      # workspace-website:dev (fleet dev node, T007035) — same build,
-      # additional tag, no extra pipeline. NOTE: must stay OUTSIDE the
-      # multiline `tags:` string — build-push-action parses it as literal tags.
+      # dev-stack tag: k3d/dev-stack/website-dev.yaml pins website:dev (fleet
+      # dev node, T007035). Same build, additional tag. NOTE: `workspace-website`
+      # als Alias-Name scheiterte am GHCR-Token (permission_denied: read_package
+      # auf dem nicht-repo-verknuepften Package) — deshalb direkt :dev auf dem
+      # bestehenden `website`-Package. Kommentare duerfen NICHT in die
+      # multiline `tags:`-Zeichenkette (build-push-action parst sie als Tags).
       - name: Build & push Docker image
         id: build-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
@@ -99,7 +101,7 @@ jobs:
           tags: |
             ${{ steps.compute-tags.outputs.image }}:${{ steps.compute-tags.outputs.sha_tag }}
             ${{ steps.compute-tags.outputs.image }}:latest
-            ghcr.io/paddione/workspace-website:dev
+            ${{ steps.compute-tags.outputs.image }}:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/k3d/dev-stack/website-dev.yaml
+++ b/k3d/dev-stack/website-dev.yaml
@@ -45,7 +45,7 @@ spec:
         - name: ghcr-pull-secret
       containers:
         - name: website
-          image: ghcr.io/paddione/workspace-website:dev
+          image: ghcr.io/paddione/website:dev
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 4321


### PR DESCRIPTION
Der build-website-Push von `ghcr.io/paddione/workspace-website:dev` schlug mit `permission_denied: read_package` fehl — das `workspace-website`-Package ist nicht mit dem Repo verknuepft (GITHUB_TOKEN kann es weder lesen noch schreiben); `workspace-brett` funktioniert, weil es repo-verknuepft ist.

Stattdessen `website:dev` direkt auf dem bestehenden, CI-schreibbaren `website`-Package:
- build-website.yml: `tags` um `${image}:dev` erweitert, Alias-Tag entfernt
- k3d/dev-stack/website-dev.yaml: Image-Referenz auf `ghcr.io/paddione/website:dev`

Hinweis: `taskfiles/Taskfile.dev-stack.yml` (k3d-Dev-Build) bleibt vorsaechst auf `workspace-website:dev` — Datei traegt skip-worktree (Repo-Structure-Reorg T006999 ist aktiv); k3d-Dev-Konsistenz ist Folge-Aufgabe.

## Test Plan
- Nach Merge: build-website pusht `website:dev`; Website-Dev-Pod (fleet) startet; flux-dev Ready.
