### PR TITLE
ci: dev-stack-Proxies auf pocket-id-FQDN umgestellt (bare Name loest aus workspace-dev nicht auf) [T007035]

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -81,10 +81,12 @@ jobs:
       # runtime stage (T002202). Historically this Dockerfile had no ARG line
       # at all, which silently turned build-args into no-ops — keep the ARG
       # declarations and these values in sync.
-      # dev-stack alias: k3d/dev-stack/website-dev.yaml pins
-      # workspace-website:dev (fleet dev node, T007035) — same build,
-      # additional tag, no extra pipeline. NOTE: must stay OUTSIDE the
-      # multiline `tags:` string — build-push-action parses it as literal tags.
+      # dev-stack tag: k3d/dev-stack/website-dev.yaml pins website:dev (fleet
+      # dev node, T007035). Same build, additional tag. NOTE: `workspace-website`
+      # als Alias-Name scheiterte am GHCR-Token (permission_denied: read_package
+      # auf dem nicht-repo-verknuepften Package) — deshalb direkt :dev auf dem
+      # bestehenden `website`-Package. Kommentare duerfen NICHT in die
+      # multiline `tags:`-Zeichenkette (build-push-action parst sie als Tags).
       - name: Build & push Docker image
         id: build-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
@@ -99,7 +101,7 @@ jobs:
           tags: |
             ${{ steps.compute-tags.outputs.image }}:${{ steps.compute-tags.outputs.sha_tag }}
             ${{ steps.compute-tags.outputs.image }}:latest
-            ghcr.io/paddione/workspace-website:dev
+            ${{ steps.compute-tags.outputs.image }}:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/k3d/dev-stack/oauth2-proxy-brainstorm.yaml
+++ b/k3d/dev-stack/oauth2-proxy-brainstorm.yaml
@@ -88,13 +88,13 @@ spec:
             - --client-id=brainstorm
             - --client-secret=$(POCKET_ID_BRAINSTORM_SECRET)
             - --redirect-url=http://brainstorm.localhost/oauth2/callback
-            - --oidc-issuer-url=http://pocket-id:1411
+            - --oidc-issuer-url=http://pocket-id.workspace.svc.cluster.local:1411
             - --ssl-insecure-skip-verify=true
             - --skip-oidc-discovery=true
             - --login-url=http://auth.localhost/authorize
-            - --redeem-url=http://pocket-id:1411/api/oidc/token
-            - --oidc-jwks-url=http://pocket-id:1411/.well-known/jwks.json
-            - --profile-url=http://pocket-id:1411/api/oidc/userinfo
+            - --redeem-url=http://pocket-id.workspace.svc.cluster.local:1411/api/oidc/token
+            - --oidc-jwks-url=http://pocket-id.workspace.svc.cluster.local:1411/.well-known/jwks.json
+            - --profile-url=http://pocket-id.workspace.svc.cluster.local:1411/api/oidc/userinfo
             # ForwardAuth mode: return 202 on success; Traefik passes the real request to sish.
             - --upstream=static://202
             - --reverse-proxy=true

--- a/k3d/dev-stack/oauth2-proxy-dev.yaml
+++ b/k3d/dev-stack/oauth2-proxy-dev.yaml
@@ -83,7 +83,7 @@ spec:
             # Pocket ID loopback wie brainstorm/session-hub — die Keycloak-URL
             # (auth.${PROD_DOMAIN}/realms/workspace) existiert im Fleet nicht
             # mehr (OIDC-Discovery lieferte HTML → CrashLoop). [T007035]
-            - --oidc-issuer-url=http://pocket-id:1411
+            - --oidc-issuer-url=http://pocket-id.workspace.svc.cluster.local:1411
             - --redirect-url=https://${DEV_DOMAIN}/oauth2/callback
             # Loop back to the in-cluster Traefik web entrypoint; Host preserved
             # so Traefik routes by host to website-dev / brett-dev.

--- a/k3d/dev-stack/oauth2-proxy-sessions.yaml
+++ b/k3d/dev-stack/oauth2-proxy-sessions.yaml
@@ -86,13 +86,13 @@ spec:
             - --client-id=session-hub
             - --client-secret=$(POCKET_ID_SESSION_HUB_SECRET)
             - --redirect-url=http://session-hub.localhost/oauth2/callback
-            - --oidc-issuer-url=http://pocket-id:1411
+            - --oidc-issuer-url=http://pocket-id.workspace.svc.cluster.local:1411
             - --ssl-insecure-skip-verify=true
             - --skip-oidc-discovery=true
             - --login-url=http://auth.localhost/authorize
-            - --redeem-url=http://pocket-id:1411/api/oidc/token
-            - --oidc-jwks-url=http://pocket-id:1411/.well-known/jwks.json
-            - --profile-url=http://pocket-id:1411/api/oidc/userinfo
+            - --redeem-url=http://pocket-id.workspace.svc.cluster.local:1411/api/oidc/token
+            - --oidc-jwks-url=http://pocket-id.workspace.svc.cluster.local:1411/.well-known/jwks.json
+            - --profile-url=http://pocket-id.workspace.svc.cluster.local:1411/api/oidc/userinfo
             - --upstream=static://202
             - --reverse-proxy=true
             - --http-address=0.0.0.0:4180

--- a/k3d/dev-stack/website-dev.yaml
+++ b/k3d/dev-stack/website-dev.yaml
@@ -45,7 +45,7 @@ spec:
         - name: ghcr-pull-secret
       containers:
         - name: website
-          image: ghcr.io/paddione/workspace-website:dev
+          image: ghcr.io/paddione/website:dev
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 4321


### PR DESCRIPTION
Empirisch per DNS-Probe bestaetigt: `pocket-id` (bare Name) loest aus `workspace-dev` NICHT auf (NXDOMAIN) — der pocket-id-Service liegt in `workspace` (10.43.217.131:1411). Die 11d-alten brainstorm/session-hub-Pods laufen nur noch auf veralteter DNS-Aufloesung und wuerden beim naechsten Restart crashloopen; oauth2-proxy-dev crashloopte sofort nach dem Pocket-ID-Umstieg (#4656).

Fix: alle drei Dev-Proxies auf die Cross-Namespace-FQDN `http://pocket-id.workspace.svc.cluster.local:1411` (inkl. redeem/jwks/profile-URLs). Funktioniert im Fleet UND im k3d-Dev-Cluster (gleiche Service-Struktur).

## Test Plan
- Nach Merge + fleet-reconcile: oauth2-proxy-dev Pod Running ohne CrashLoop (setzt Pocket-ID-Client `workspace-dev` voraus); brainstorm/session-hub ueberleben Neustarts.
