### PR TITLE
docs(skills): opencode-Flow-Skills mit dev-flow-Skills synchronisieren [T007954]

### DIFF
--- a/.opencode/skills/opencode-flow-chore/SKILL.md
+++ b/.opencode/skills/opencode-flow-chore/SKILL.md
@@ -77,7 +77,11 @@ Delegate to **`opencode-git-workflow` Steps 2–6** (SSOT):
 
 ## Schritt 6: Worktree & Branch bereinigen
 
-Lock-Release, dann:
+**`opencode-git-workflow` Schritt 7** (SSOT): Im Haupt-Repo zuerst den Agent-Lock freigeben
+(`release ticket` + `release branch`, ohne stderr-Unterdrückung, T006290 — aus dem
+Lock-Worktree heraus verweigert `agent-lock.sh release branch` den Release, weil der
+nachfolgende Worktree-Remove die Shell-cwd zerstören würde), dann:
+
 ```bash
 git worktree remove .worktrees/<slug> --force && git branch -D chore/<slug>
 git push origin --delete chore/<slug>

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -172,6 +172,15 @@ Dann rebasen und alle Partials in Reihenfolge abarbeiten.
 - Lies den Plan aus `$PLAN_FILE` und — sofern vorhanden — das **Plan Intel Bundle** `openspec/changes/<slug>/intel.json` (Optional — der Implementer kann die Typen-Wahrheit selbst erheben, wenn die Datei fehlt)
 - Tasks in Reihenfolge; nach jedem Meilenstein Commit + Push
 - Vor PR: Freshness-Artefakte regenerieren
+- **SID-Propagation (PFLICHT, T006365):** Wird die Implementierung an einen
+  Subagenten delegiert, ermittle deine Session-SID mit `bash scripts/agent-lock.sh
+  mine` und weise den Implementer an, in jedem Bash-Call zuerst
+  `export AGENT_LOCK_SID=<deine-sid>` auszuführen — ohne diese Propagation
+  blockiert der Worktree-Write-Guard seine Edit/Write-Tools im geclaimten
+  Worktree (eigene Session-ID des Subagenten ≠ owner_sid).
+- **PR OHNE Auto-Merge-Anforderung (T005565):** Erstelle den PR, aber fordere
+  KEIN Auto-Merge an — das geschieht erst nach bestandenem Code-Review-Gate
+  (Schritt 4) durch den Orchestrator.
 - Phase-Telemetrie (best-effort):
   ```
   ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "implement", state: "entered", driver: "devflow" })
@@ -253,15 +262,38 @@ Falls neue Admin-Seiten hinzugefügt wurden:
 bash scripts/admin-menu-gate.sh
 ```
 
-## Schritt 4: Code Review Gate (Mandatory)
+## Schritt 4: Code-Review-Gate (PFLICHT vor Auto-Merge)
 
-Vor dem PR-Merge muss eine unabhängige Überprüfung stattfinden:
+**Unabhängige Prüfung, nicht Implementer-Selbst-Attestation** — die unabhängige Prüfung
+braucht einen anderen Kontext als den Implementer (Self-Attestation ist kein Review,
+T005307). Ohne bestandenes Gate gibt es keinen Auto-Merge: fail-closed im Prozess.
 
-```bash
-delegate(prompt: "Review this PR's changes for bugs, security issues, and style. PR: $(gh pr view --json url -q '.url')", agent: "explore")
-```
-
-Behebe alle gefundenen Probleme und stelle sicher, dass der Reviewer "Approved" gibt, bevor du fortfährst.
+1. Prüfe den Auto-Merge-Zustand des PRs (Regression T006282: extern aktiviertes Auto-Merge
+   ist für das Gate sonst unsichtbar):
+   ```bash
+   bash scripts/check-pr-automerge.sh
+   ```
+   Semantik:
+   - `rc=1`: Gate bricht fail-closed ab — die Meldung nennt die PR-Nummer; es wird KEIN
+     Review-Ergebnis erteilt und KEIN Auto-Merge deaktiviert (Design D2: der explizite
+     User-Akt wird sichtbar, der Operator entscheidet).
+   - `rc=2`: Abbruch als Umgebungsfehler.
+2. Reviewe die Änderungen unabhängig — delegiere an einen Review-Subagenten via
+   `delegate(prompt, agent="explore")`:
+   ```bash
+   delegate(prompt: "Review this PR's changes for bugs, security issues, and style. PR: $(gh pr view --json url -q '.url')", agent: "explore")
+   ```
+3. Findings gehen an den **bereits gespawnten** Implementer zurück (kein neuer Spawn,
+   Doppel-Push-Risiko aus T001408); nach dessen Push erneut reviewen.
+4. Erst wenn der Reviewer "Approved" gegeben hat, fordere den Auto-Merge an:
+   ```bash
+   PR_NUM=$(gh pr view --json number -q '.number')
+   # Auto-Merge sofort anfordern — GitHub merged selbstständig, sobald Required Checks grün sind.
+   # KEIN --delete-branch (T004612): Schritt 7 (Plan-/OpenSpec-Archiv) braucht den Branch noch —
+   # gelöscht wird er erst im Cleanup NACH der Archivierung. delete_branch_on_merge ist
+   # repo-seitig deaktiviert; verwaiste Branches räumt branch-reaper.sh ab.
+   (cd "$MAIN_REPO" && gh pr merge --auto --squash)
+   ```
 
 ## Schritt 5: PR erstellen
 
@@ -274,13 +306,14 @@ gh pr create --title "<type>(<scope>): <subject> [$TICKET_ID]" --body "..."
 
 > **⚠️ M1-Lesson (T001899):** Auto-Merge **nicht** vor dem ersten Implementierungs-Push aktivieren.
 > Proposal-Commits auf Feature-Branches triggern den Auto-Merge-Flow und können das Ticket
-> vorzeitig schließen (Merge = Abschluss, T001092). Auto-Merge erst enable, wenn mindestens ein
-> Implementierungs-Commit auf dem Branch liegt.
+> vorzeitig schließen (Merge = Abschluss, T001092). Der Auto-Merge wird erst im
+> Code-Review-Gate angefordert (Schritt 4) — zu dem Zeitpunkt liegt der
+> Implementierungs-Commit bereits auf dem Branch, die Voraussetzung ist also erfüllt.
 
 ## Schritt 5.5: CI/CD-Fix-Schleife
 
 Nachdem der PR gepusht ist, überwache CI und behebe Fehler — Auto-Merge ist bereits angefordert
-(Schritt 5) und greift, sobald die Required Checks grün sind.
+(Schritt 4, nach bestandenem Review-Gate) und greift, sobald die Required Checks grün sind.
 
 ```bash
 bash scripts/devflow-ci-watch.sh "$TICKET_ID" "$(gh pr view --json url -q '.url')"
@@ -295,81 +328,88 @@ Seit T001415 (Finding 2) beendet sich `devflow-ci-watch.sh` mit Exit-Code 4, wen
 `CONFLICTING` meldet — echte Merge-Konflikte. Auch hier löst der implementierende Subagent
 den Konflikt manuell (`git fetch origin main && git rebase origin/main`, lösen, push).
 
-## Schritt 6: Phase-Chain-Gate & Auto-Merge
+## Schritt 6: Phase-Chain-Gate & Merge-Wait
 
 > **Merge = Abschluss (T001092):** Das Ticket schließt beim grünen Merge nach `main`. Der
 > Prod-Deploy (Schritt 8) ist entkoppelt und ändert den Ticket-Status **nicht**.
 
-**Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge:**
-Prüft, dass `plan:done`, `implement:entered` und `verify:done` vorliegen:
+> **Schritt 6 läuft hier; die Finalisierung (Schritte 6.4–7.5) ist an den frischen
+> Finalizer delegiert (Schritt 6.2)** — der Implementer hat bereits zurückgemeldet.
+
+**Fail-closed Phase-Chain-Gate (T001444) — PFLICHT vor dem Merge, KEIN `|| true`:**
+Prüft, dass `plan:done`, `implement:entered` und `verify:done` vorliegen. Bei FAIL
+zuerst backfillen (insb. `verify done` nach grünem `task test:changed`), dann mergen.
+(Auto-Merge wurde bereits in Schritt 4 angefordert — hier läuft nur noch das Gate.)
 ```bash
 bash scripts/ticket.sh assert-phase-chain --id "$TICKET_ID"
 ```
 
-Dann Auto-Merge anfordern:
+## Schritt 6.2: Finalisierung delegieren (T006284)
+
+> **Härtung T006284:** Nach dem Auto-Merge-Request (Schritt 4) endet die Finalisierung im
+> eigenen, kontextbelasteten Kontext: Die Schritte 6.4–7.5 (Merge-Wait, Ticket-Abschluss,
+> Plan-/OpenSpec-Archiv, Worktree-/Branch-Cleanup, Lock-Release) laufen NICHT mehr in-context.
+> Beim Incident T006284/PR #4460 starb der Executor nach dem Merge an Kontext-Erschöpfung —
+> Closure, Archiv und Cleanup blieben liegen und mussten manuell nachgeholt werden. Die
+> Härtung entfernt die Gelegenheit, statt die Direktive zu verschärfen (Muster T002365/T001571).
+
+Spawne einen **frischen Finalizer-Subagenten** (write-capable Delegation via `task` — er braucht
+Bash/Git-Zugriff für das Skript; `delegate` ist read-only) mit kompaktem Lagebild — er hat
+KEINEN Kontext, gib ihm alles explizit: Ticket-ID `$TICKET_ID`,
+PR-Nummer `$PR_NUM`, Branch `$BRANCH`, Worktree-Pfad `$MAIN_REPO/.worktrees/<slug>`,
+Plan-Pfad `$PLAN_FILE`, Resolution (`shipped`/`fixed`).
+
+Auftrag an den Finalizer (wörtlich Teil des Prompts):
+- **Merge-Wait-Loop zuerst (T001149-M1):** `gh pr view "$PR_NUM" --json state,mergeStateStatus`
+  pollen, bis `state=MERGED` (Timeout: KEIN Ticket schließen — Drift Ticket=done bei PR=OPEN;
+  stattdessen strukturiert berichten).
+- **Abschluss über die idempotente Einheit,** keine freie Rekonstruktion der Einzelschritte:
+  ```bash
+  bash scripts/devflow-post-merge-finalize.sh "$TICKET_ID" --pr "$PR_NUM"
+  ```
+- **T001571-Standing-Direktive:** Bei Anzeichen von Kontext-Überlauf stoppen und einen
+  strukturierten Handoff-Report liefern (erledigte Schritte, Git-Zustand, offene Schritte in
+  Reihenfolge) — die offenen Schritte sind über das idempotente Skript von jeder Session
+  nachholbar.
+- **Rückmeldung an den Auftraggeber (Pflicht):** Endzustand strukturiert berichten — was
+  erledigt ist, was offen ist.
+
+**Die eigene Finalisierung endet hier:** die Schritte 6.4–7.5 NICHT im eigenen Kontext
+ausführen. Der eigene Kontext bleibt nur für die CI-Fix-Schleife (5.5) zuständig, solange
+sie läuft.
+
+## Schritte 6.4–7.5 — Merge-Wait, Ticket-Abschluss, Cleanup
+
+> **Zuständigkeit: ein frischer Finalizer-Subagent (Schritt 6.2), NICHT in-context.** Der
+> Abschluss läuft als **eine idempotente Skript-Einheit** — keine freie Rekonstruktion der
+> Einzelschritte:
+
 ```bash
-# KEIN --delete-branch (T004612): Schritt 7 (OpenSpec-Archiv) läuft nach dem Merge
-# und braucht den Branch noch; gelöscht wird er im Cleanup NACH der Archivierung.
-(cd "$MAIN_REPO" && gh pr merge --auto --squash)
+bash scripts/devflow-post-merge-finalize.sh "$TICKET_ID" --pr "$PR_NUM"
 ```
 
-## Schritt 6.4: Auf Merge warten
+Das Skript führt deterministisch und idempotent aus: PR verlinken, Ticket auf `done`
+(`shipped`/`fixed`), `verify:done`-Phase-Event, Plan nach `tickets.ticket_plans` archivieren,
+OpenSpec-Change ins Archiv (inkl. Archiv-PR), Claims freigeben, Worktree und Branch entfernen —
+jeder Schritt überspringt bereits erledigte Arbeit. Jede Session (Recovery, Eskalation,
+Factory-Poller) kann die offenen Schritte mit einem Aufruf nachholen.
 
-`gh pr merge --auto` kehrt sofort zurück — Merge passiert asynchron:
-
-```bash
-PR_NUM=$(gh pr view --json number -q '.number')
-MAX_MERGE_WAIT_MIN="${MAX_MERGE_WAIT_MIN:-15}"
-WAIT_START=$(date +%s)
-while true; do
-  MERGE_STATE=$(gh pr view "$PR_NUM" --json mergeStateStatus,state -q '.state + "|" + .mergeStateStatus' 2>/dev/null || echo "UNKNOWN|UNKNOWN")
-  STATE="${MERGE_STATE%%|*}"
-  case "$STATE" in
-    MERGED) break ;;
-    CLOSED) exit 2 ;;
-  esac
-  ELAPSED=$(( $(date +%s) - WAIT_START ))
-  (( ELAPSED > MAX_MERGE_WAIT_MIN * 60 )) && exit 3
-  sleep 15
-done
-```
-
-## Schritt 6.5: Ticket abschließen
-
-Der Abschluss selbst — `resolution` ist `shipped` (Feature) oder `fixed` (Fix):
+Die Closure im Skript — `resolution` ist `shipped` (Feature) oder `fixed` (Fix):
 
 ```bash
 ./scripts/vda.sh ticket update-status --id "$TICKET_ID" --status done --resolution "$RESOLUTION"
 ```
 
-```
-ticket-mcp: add_pr_link({ id: "$TICKET_ID", pr: "$PR_NUM" })
-ticket-mcp: record_phase_event({ id: "$TICKET_ID", phase: "deploy", state: "done", driver: "devflow" })
-```
+> **Merge = Abschluss (T001092):** Das Ticket schließt beim grünen Merge nach `main`. `qa_review`
+> und `awaiting_deploy` sind aus dem Happy-Path entfernt — nicht als Zwischenstatus setzen.
 
-> **Claims vor dem Worktree-Remove freigeben** — sonst bleibt ein Lock auf einen Pfad zurück,
-> den es nicht mehr gibt.
+> **Reihenfolge (T004612):** Archivierung läuft VOR der Branch-Löschung — der Fix-PR-Merge
+> löscht den Branch bewusst nicht mehr (`--delete-branch` entfernt,
+> `delete_branch_on_merge=false`), damit die Archivierung ihn noch vorfindet.
 
-## Schritt 7: Plan archivieren
-
-```bash
-sed -E -i 's/^status: (active|plan_staged|in_progress)$/status: completed/' "$PLAN_FILE"
-bash scripts/openspec.sh archive "$SLUG"
-# [T003136] openspec.sh archive regeneriert components/website/src/data/openspec-status.json
-# nach dem Move und staged sie bereits selbst (cmd_archive); der explizite
-# Eintrag hier ist Defense-in-Depth und haelt den Skill mit plan-archive-steps.md
-# konsistent. Ohne ihn traegt der Archiv-Commit die Datei nur, wenn der
-# pre-commit-Hook sie auto-staged (SKIP_FRESHNESS_REGEN/--no-verify umgehen das)
-# — PR #4083 fiel genau daran durch den Freshness-Gate.
-git add openspec/changes/ components/website/src/data/openspec-status.json
-git commit -m "chore(plans): archive $SLUG [$TICKET_ID]"
-```
-
-## Schritt 7.5: Worktree bereinigen
-
-```
-agent-lock.sh release branch "$(git branch --show-current)" && git worktree remove .worktrees/<slug> --force && git branch -D feature/<slug>
-```
+> **Claims vor dem Worktree-Remove freigeben (T006290)** — sonst bleibt ein Lock auf einen
+> Pfad zurück, den es nicht mehr gibt. Der Release läuft aus dem Haupt-Repo (cwd außerhalb
+> des Lock-Worktrees), ohne stderr-Unterdrückung.
 
 ## Schritt 8: Post-Merge Deploy
 
@@ -393,4 +433,6 @@ Melde alle aufgetretenen Fehler oder Prozess-Frictionen über `mishap-tracker`.
 | `opencode-git-workflow` | SSOT Commit/PR/Merge |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |
 | `background-agents.ts` | Subagent-Routing |
+| `scripts/devflow-post-merge-finalize.sh` | Schritte 6.4–7.5 (Finalizer, idempotent) |
 | `scripts/devflow-post-merge-deploy.sh` | Schritt 8 |
+| `scripts/check-pr-automerge.sh` | Schritt 4 (Auto-Merge-Preflight, T006366) |

--- a/.opencode/skills/opencode-flow-plan/SKILL.md
+++ b/.opencode/skills/opencode-flow-plan/SKILL.md
@@ -45,6 +45,12 @@ bash scripts/agent-lock.sh reap
 bash scripts/agent-lock.sh list
 bash scripts/agent-msg.sh read --unread
 git worktree list
+# Stale Worktrees ggf. löschen — aber NUR nach bestandenem Vorcheck [T005115]:
+#   bash scripts/worktree-clean-check.sh <path>
+# Das Skript lehnt dirty-Worktrees UND Worktrees mit aktivem fremden branch-Claim
+# ab (agent-lock.sh check branch <branch> — laufende Lauf/Rollup-Session!); schlägt
+# der Vorcheck an (rc 1), Worktree stehen lassen.
+#   git worktree remove <path> --force && git branch -D <branch>
 ```
 
 ## Schritt −0.5: Kollisions-Check vor der Planung ⚡ [T002444]
@@ -206,6 +212,11 @@ FOR each partial pX (p1, p2, ...):
   │     `bash scripts/plan-lint.sh --rules` als führende Instruktion („gleiche Karten"
   │     wie Factory und Claude). Schreibt `tasks.d/pX-<name>.md`.
   │
+  │     **SID-Propagation (PFLICHT, T006365):** Ermittle deine Session-SID mit
+  │     `bash scripts/agent-lock.sh mine` und weise den Plan-Subagenten an, in jedem
+  │     Bash-Call zuerst `export AGENT_LOCK_SID=<deine-sid>` auszuführen — sonst
+  │     blockiert der Worktree-Write-Guard seine Datei-Tools im Worktree.
+  │
   ├─► Schritt C.2b: tasks.md-Index aktualisieren
   │     Der Orchestrator updated `tasks.md` mit dem neuen Partial-Eintrag im Manifest
   │     und der aktualisierten File Structure.
@@ -336,7 +347,11 @@ hier harte Voraussetzung, nicht Stilfrage. Der Test gehört nach `tests/spec/<sp
 
 ### Pre-Commit Guard (PFLICHT vor Commit) [T001268]
 
-Bevor der plan-stage Commit läuft, MUSS der Operator `plan-preflight.sh` aufrufen. Das Skript bündelt alle drei Checks (nicht-main, clean tree, Lock-Match) und den branch-scoped Fallback [T003102] — ein Einzeiler statt drei Inline-Snippets:
+Bevor der plan-stage Commit läuft, MUSS der Operator `plan-preflight.sh` aufrufen. Das Skript bündelt alle drei Checks (nicht-main, Staged-Set, Lock-Match) und den branch-scoped Fallback [T003102] — ein Einzeiler statt drei Inline-Snippets:
+
+1. **Do not commit on main / Nicht auf main committen:** Plan-stage Commits auf `main` sind verboten — die Guards verweigern sie. Nur ein Worktree-Branch ist zulässig.
+2. **Staged-Set-Pflicht / Nur Plan-Artefakte stagen [T005114]:** der Guard wertet `git diff --cached --name-only` aus; erlaubt sind Pfade unter `tests/` und `openspec/changes/` sowie exakt `website/src/data/openspec-status.json` und `website/src/data/test-inventory.json`. Andere gestagte Dateien brechen den Guard ab (Abhilfe: `git restore --staged <pfad>` und nur Plan-Artefakte stagen). Unstaged/untracked wird nicht mehr geprüft — für den Commit zählt nur das Staged-Set.
+3. **Branch stimmt mit dem agent-lock-Claim überein (T003102 — akzeptiert ticket- UND branch-scoped Claims):** geprüft wird `agent-locks/ticket__${TICKET_EXT_ID}.json`, Fallback `agent-locks/branch__${BRANCH_SLUG}.json`; fehlt auch der, bricht der Guard ab.
 
 ```bash
 bash scripts/plan-preflight.sh pre-commit --ticket "$TICKET_EXT_ID"

--- a/.opencode/skills/opencode-git-workflow/SKILL.md
+++ b/.opencode/skills/opencode-git-workflow/SKILL.md
@@ -219,13 +219,17 @@ BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 MAIN_REPO=$(git worktree list --porcelain | awk '/^worktree/{print $2; exit}')
 
 cd "$MAIN_REPO"
+# Agent-Lock freigeben (T006290): NACH dem Wechsel ins Haupt-Repo — aus dem
+# Worktree heraus verweigert agent-lock.sh den Branch-Release, weil der
+# nachfolgende Worktree-Remove die Shell-cwd zerstören würde. Ohne
+# stderr-Unterdrückung, damit eine Verweigerung sichtbar bleibt.
+bash scripts/agent-lock.sh release ticket "<T00XXXX>"
+bash scripts/agent-lock.sh release branch "$BRANCH_NAME"
 git worktree remove "$WORKTREE_PATH"
 git worktree prune
 # Remote-Branch erst NACH der Archivierung löschen (T004612 — der Merge löscht nicht mehr):
 git push origin --delete "$BRANCH_NAME"
 ```
-
-Agent-Lock freigeben VOR dem Worktree-Remove.
 
 ---
 

--- a/tests/spec/active-sessions-hub/ticket-lock-closure-T003102.bats
+++ b/tests/spec/active-sessions-hub/ticket-lock-closure-T003102.bats
@@ -129,7 +129,12 @@ _section() {  # <file> <start-regex>
 @test "Claim-Verifikation + Release im opencode-flow-execute sind branch-scoped" {
   run grep -F 'check branch "$(git branch --show-current)"' "$EXEC_SKILL"
   [ "$status" -eq 0 ]
-  run grep -F 'release branch "$(git branch --show-current)"' "$EXEC_SKILL"
+  # T006284: Der Release liegt nicht mehr inline im Skill, sondern in der
+  # idempotenten Finalize-Einheit, die opencode-flow-execute Schritt 6.2
+  # dem Finalizer als Pflicht aufträgt (branch-scoped, T003102).
+  run grep -F 'release branch "$BRANCH"' "$REPO/scripts/devflow-post-merge-finalize.sh"
+  [ "$status" -eq 0 ]
+  run grep -F 'devflow-post-merge-finalize.sh' "$EXEC_SKILL"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary
Die opencode-nativen Skills lagen seit T004612 (2026-08-14) hinter den Claude-Code-dev-flow-Skills zurück. Nachgezogen (Ports der Änderungen aus 7 Tickets):

- **opencode-flow-plan**: T005114 (plan-preflight prüft Staged-Set statt clean tree), T005115 (worktree-clean-check-Vorcheck vor Stale-Removal), T006365 (SID-Propagation `AGENT_LOCK_SID` im Fan-out-Prompt)
- **opencode-flow-execute**: T005565 (Code-Review-Gate PFLICHT vor Auto-Merge — Implementer erstellt PR ohne Auto-Merge), T006366 (`check-pr-automerge.sh`-Preflight im Gate, fail-closed), T006284 (Finalisierung an frischen Finalizer-Subagenten via idempotentem `devflow-post-merge-finalize.sh` delegiert statt In-Context 6.4–7.5), T006365 (SID), T006290 (Release im Haupt-Repo)
- **opencode-flow-chore**: T006290 (Release `release ticket`+`release branch` im Haupt-Repo, ohne stderr-Unterdrückung)
- **opencode-git-workflow**: T006290 (Schritt 7 führt Release nach `cd "$MAIN_REPO"` aus)

Test-Anpassung: `ticket-lock-closure-T003102.bats` — Release-Assertion zeigte auf die (durch T006284) entfernte In-Skill-Zeile; retargetiert auf den branch-scoped Release in `devflow-post-merge-finalize.sh`, Skill-Pflicht (Skript-Aufruf in Schritt 6.2) bleibt geprüft.

## Test Plan
- [ ] ticket-lock-closure-T003102.bats (12 Tests grün)
- [ ] guard-parity.bats (grün)
- [ ] harness-workflow-split.bats (HWS-1 bis HWS-11 grün; HWS-12 roter Vorzustand: fehlendes `yaml`-npm-Paket im Environment, unabhängig)
- [ ] review-gate-before-auto-merge + automerge-preflight-check (grün)
- [ ] bats-no-live-branch-assertion (grün)

[T007954]