### PR TITLE
test: Drift-Guard auf Config-Klassen erweitern + stale Pfade nachziehen [T007909]

### DIFF
--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -25,7 +25,7 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -z "$REPO_ROOT" ]] && exit 0
 
-STATUS_MAP="$REPO_ROOT/website/src/data/openspec-status.json"
+STATUS_MAP="$REPO_ROOT/components/website/src/data/openspec-status.json"
 SCRIPT="$REPO_ROOT/scripts/openspec-status-map.sh"
 
 if [[ -x "$SCRIPT" && -f "$STATUS_MAP" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,8 +149,8 @@ Registry split: `mcp.yaml` owns *reachability* (transport, endpoint, credentials
 - `task test:changed` — smart selection, falls back to vitest if no domain detected.
 - `task freshness:check` — generated artifacts must be committed.
 - `task test:code-quality` — file-size caps, import-cycle detection, hardcoded-hostname scan.
-- Brett: `npm run typecheck --prefix brett && npm test --prefix brett && npm run build --prefix brett`
-- Website: `(cd website && pnpm test:unit)` (vitest)
+- Brett: `npm run typecheck --prefix components/brett && npm test --prefix components/brett && npm run build --prefix components/brett`
+- Website: `(cd components/website && pnpm test:unit)` (vitest)
 - PR titles: Conventional Commits with `[T000XXX]` tag (advisory only, not blocking).
 </details>
 

--- a/environments/dev.yaml
+++ b/environments/dev.yaml
@@ -32,7 +32,7 @@ env_vars:
   MEDIAVIEWER_HOST: mediaviewer.localhost
   VIDEOVAULT_DOMAIN: videovault.localhost
   POCKET_ID_FRONTEND_URL: "http://auth.localhost"
-  # FQDN statt Kurzname: brett/src/server/auth.ts akzeptiert http nur für
+  # FQDN statt Kurzname: components/brett/src/server/auth.ts akzeptiert http nur für
   # localhost/*.svc.cluster.local (T001933) — Kurzname 'pocket-id' wirft beim
   # OIDC-Client-Init.
   POCKET_ID_URL: "http://pocket-id.workspace.svc.cluster.local:1411"

--- a/environments/mentolder/README.md
+++ b/environments/mentolder/README.md
@@ -66,8 +66,7 @@ preview/                        Design System tab cards (registered assets)
   portrait.html                 portrait component
   process-step.html             process rail step
 
-ui_kits/
-  website/                      marketing site (homepage, leistungen, kontakt, etc.)
+ui_kits/website/              marketing site (homepage, leistungen, kontakt, etc.)
     index.html                  click-thru prototype
     README.md
     *.jsx                       extracted components

--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -357,7 +357,7 @@ env_vars:
   - name: POCKET_ID_URL
     required: false
     default_dev: "http://pocket-id.workspace.svc.cluster.local:1411"
-    description: "Cluster-internal URL of the Pocket ID service. MUST be an FQDN (T002154): the website runs in namespace `website`, pocket-id in `workspace` — the bare short name `pocket-id:1411` only resolves inside `workspace` and breaks the OIDC token exchange cross-namespace. Used by website/brett/nextcloud/grafana as the OIDC discovery base."
+    description: "Cluster-internal URL of the Pocket ID service. MUST be an FQDN (T002154): the website runs in namespace `website`, pocket-id in `workspace` — the bare short name `pocket-id:1411` only resolves inside `workspace` and breaks the OIDC token exchange cross-namespace. Used by the website, brett, nextcloud and grafana services as the OIDC discovery base."
 
   - name: WEBSITE_CONFIG_SHA
     required: false
@@ -972,8 +972,8 @@ secrets:
     generate: false
 
   # GITHUB_CONTENT_TOKEN (T001490 Task 9) — fine-grained token for the bot-PR
-  # content publish pipeline (website/src/lib/content-publish.ts). Scope: only
-  # `contents: write` + `pull-requests: write` on `website/content/**`. Prod
+  # content publish pipeline (components/website/src/lib/content-publish.ts). Scope: only
+  # `contents: write` + `pull-requests: write` on `components/website/content/**`. Prod
   # sealed per-env via `task env:seal`; dev placeholder lives in
   # k3d/website-content-token-secret.yaml.
   - name: GITHUB_CONTENT_TOKEN
@@ -981,7 +981,7 @@ secrets:
     dev_absent: true
     dev_absent_reason: "Externes GitHub-PAT; kein Dev-Aequivalent, ein Fake-Wert wuerde Konfigurationsfehler maskieren."
     generate: false
-    description: "Fine-grained GitHub token for the content publish bot. contents:write + pull-requests:write on website/content/**."
+    description: "Fine-grained GitHub token for the content publish bot. contents:write + pull-requests:write on components/website/content/**."
     extra_namespaces:
       - namespace: website
         secret: website-content-token

--- a/renovate.json5
+++ b/renovate.json5
@@ -41,7 +41,7 @@
     // The warning still fires after these entries (T002246). A full scan of all
     // tracked files found 15 hits, only 6 of which are listed here; the other 9
     // are Markdown/JSON/JSX/TS/Svelte files across docs/, openspec/changes/archive/,
-    // tests/e2e/ and website/src/. Every hit is U+00AD (soft hyphen, German
+    // tests/e2e/ and components/website/src/. Every hit is U+00AD (soft hyphen, German
     // hyphenation), U+200B (zero-width space) or U+200C/U+200D (ZWJ inside emoji
     // sequences) — no bidirectional overrides (U+202A–U+202E), so there is no
     // Trojan-Source exposure. Whether ignorePaths gates the Unicode scanner at all

--- a/tests/factory-eval/fixtures/T000725/expected.json
+++ b/tests/factory-eval/fixtures/T000725/expected.json
@@ -8,7 +8,7 @@
   "forbidden": [
     "k3d/configmap-domains.yaml",
     "environments/*.yaml",
-    "website/*"
+    "components/website/*"
   ],
   "tests": ["bash -n scripts/mishap-categorize.sh"],
   "min_recall": 0.5,

--- a/tests/spec/repo-structure/website-moved.bats
+++ b/tests/spec/repo-structure/website-moved.bats
@@ -41,3 +41,45 @@ setup() {
 
   [ "$stale" -eq 0 ] || return 1
 }
+
+@test "T007909: keine stale website/-Referenzen in Config-Klassen (Positiv-Anker)" {
+  # Positiv-Anker zuerst (T002356-M1): ohne den Move schlagen die Negativ-Aussagen
+  # ueber leere Listen vakuos fehl. Der Anker ist der T006999-Test oben
+  # (components/website existiert) — dieser Test ergaenzt die Klassen, die der
+  # urspruengliche Sweep (Taskfile.yml/taskfiles/.github/workflows) NICHT abdeckte:
+  # genau die Klassen, in denen T007855 nach dem Merge 17 Stale-Referenzen fand.
+  [ -f "$REPO_ROOT/components/website/package.json" ] \
+    || { echo "FEHLT: components/website/package.json — Move nicht ausgefuehrt"; return 1; }
+
+  # Config-Klassen aus T007855-Befund (der Sweep verfehlte sie):
+  #   .githooks/, .gitattributes, .dockerignore, renovate.json5,
+  #   docs/code-quality/subsystems.yaml, docs/agent-guide/registry/,
+  #   Root-MDs (bare Formen wie 'cd website' ohne Slash),
+  #   environments/-READMEs, factory-eval-Fixtures.
+  # Sweep-Muster no-slash-Formen (dokumentiert): `cd website`, `--prefix brett`,
+  # `brett/` in Tabellen — alle werden von den -F-Literalen unten erfasst
+  # (git grep -F findet Teilstrings; 'cd website' und 'website/' sind getrennte Muster).
+  local stale=0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      # neuer Praefix = erlaubt
+      *components/website/*|*components/brett/*) continue ;;
+      # Design-Kit-Ordner (ui_kits/website, ui_kits/brett in art-library/Uploads)
+      # sind KEINE Repo-Pfade — der Sweep ist auf die T007855-Klassen begrenzt.
+      *ui_kits/website/*|*ui_kits/brett/*) continue ;;
+      # k8s-Namespace-Name `website` (schema.yaml), kein Dateisystem-Pfad
+      *"namespace \`website\`"*) continue ;;
+    esac
+    echo "STALE: $line" >&2
+    stale=1
+  done < <(git -C "$REPO_ROOT" grep -F -n -e 'website/' -e 'brett/' \
+    -e 'cd website' -e 'cd brett' -e '--prefix brett' -- \
+    .githooks .gitattributes .dockerignore renovate.json5 \
+    docs/code-quality/subsystems.yaml docs/agent-guide/registry \
+    AGENTS.md README.md components/website/CLAUDE.md \
+    environments tests/factory-eval/fixtures || true)
+
+  [ "$stale" -eq 0 ] || return 1
+}
+


### PR DESCRIPTION
## T007909 — Drift-Guard-Scope erweitern

Review-Empfehlung aus T006999 (PR #4659). Der website-moved.bats-Guard deckte nur Taskfile.yml/taskfiles/.github/workflows ab — genau außerhalb dieses Scopes lagen alle 17 nach-Merge gefundenen Stale-Referenzen (T007855).

### Guard (tests/spec/repo-structure/website-moved.bats)
Neuer Test `T007909: keine stale website/-Referenzen in Config-Klassen (Positiv-Anker)`:
- Sweep über die T007855-Klassen: .githooks/, .gitattributes, .dockerignore, renovate.json5, docs/code-quality/subsystems.yaml, docs/agent-guide/registry/, Root-MDs, environments/, factory-eval-Fixtures
- Muster: `website/`, `brett/`, no-slash-Formen (`cd website`, `--prefix brett`)
- Positiv-Anker zuerst (T002356-M1): components/website/package.json muss existieren
- Allowlist: components/-Präfix, ui_kits/-Design-Kit-Ordner, k8s-Namespace `website`
- Negativ-Kontrolle verifiziert (eingepflanztes `cd website` wird gefangen)

### Stale Pfade nachgezogen (vom Sweep verfehlte Klassen, T007855-Folge)
- .githooks/post-rewrite: openspec-status.json-Pfad
- AGENTS.md: `--prefix brett`, `cd website` (no-slash-Formen)
- environments/dev.yaml, environments/schema.yaml: Pfade in Kommentaren/Descriptions (Service-Liste `website/brett/nextcloud/grafana` als Wortliste reworded — k8s-Service-Namen, keine Pfade)
- environments/mentolder/README.md: ui_kits/-Baum auf eine Zeile (Design-Kit-Ordner, kein Repo-Pfad)
- renovate.json5: website/src → components/website/src
- tests/factory-eval/fixtures/T000725/expected.json: `website/*` → `components/website/*`

### Hinweis
\texttt{task freshness:check} / \texttt{quality:check} laufen im Worktree nicht (13 broken node_modules-Symlinks im Haupt-Checkout → `repo-structure-reorg`-Worktree entfernt; ERR_MODULE_NOT_FOUND bei `yaml`). Change berührt keine generierten Artefakte.