### PR TITLE
fix(infra): allow-devstack-to-pocket-id NetworkPolicy — dev-stack OIDC nach T007035 [T007986]

### DIFF
--- a/k3d/network-policies.yaml
+++ b/k3d/network-policies.yaml
@@ -361,6 +361,28 @@ spec:
     - port: 1411
       protocol: TCP
 ---
+# dev-stack (workspace-dev ns): Fleet-Dev-Knoten (brett-dev, website-dev,
+# oauth2-proxy-dev/brainstorm/session-hub) brauchen Pocket-ID auf 1411 — ohne
+# diese Regel blockt workspace/default-deny-ingress sie (ECONNREFUSED, T007035).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-devstack-to-pocket-id-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app: pocket-id
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: workspace-dev
+    ports:
+    - port: 1411
+      protocol: TCP
+---
 # nextcloud: allow ingress from website namespace (CalDAV, Files, Talk integration)
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
## T007986 — Fleet-dev-stack: allow-devstack-to-pocket-id fehlt nach T007035

T007035 (pocktid-fqdn-devstack, done|shipped) wurde ohne dieses Policy-Stück gemergt: Der uncommittete Worktree-Stand des T007035-Branches enthielt die Regel bereits fertig — sie wurde nie committet/PR'd.

### Beleg (Fleet-Cluster, live 2026-08-15 ~19:15)
- `oauth2-proxy-dev-857c6888d8-z42zh` im **CrashLoopBackOff** (53 Restarts)
- `kubectl get networkpolicy -A`: nur `allow-website-to-pocket-id-ingress` (prod website-ns), **keine Regel für workspace-dev**
- default-deny-ingress im workspace-Namespace blockt den dev-stack (ECONNREFUSED auf pocket-id:1411)

### Änderung
`k3d/network-policies.yaml`: NetworkPolicy `allow-devstack-to-pocket-id-ingress` (podSelector app=pocket-id, from namespaceSelector workspace-dev, port 1411 TCP) — analog zur bestehenden website-Regel.

### Verifikation
- YAML-Parse + Struktur-Check (python yaml): OK
- `task workspace:validate`: ✓ Manifests are valid

Nach Merge: Fleet-Reconcile beobachten, CrashLoopBackOff von oauth2-proxy-dev prüfen.