### PR TITLE
test(test): add E2E tests for SDLC-Leitstand dev-only split [T007559]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -990,6 +990,12 @@
     "kind": "playwright"
   },
   {
+    "id": "FA-61",
+    "file": "tests/e2e/specs/fa-61-sdlc-leitstand-devonly-split.spec.ts",
+    "category": "FA",
+    "kind": "playwright"
+  },
+  {
     "id": "FA-AR-01",
     "file": "tests/local/FA-AR-01-filter-diff.bats",
     "category": "FA",

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
         '**/fa-50-*.spec.ts',                        // request correlation / X-Request-ID (T000964)
         '**/a11y-axe.spec.ts',                       // axe-core a11y-Scan der Kern-Routen (G-FE01, T001206)
         '**/coaching-studio-empty-customer.spec.ts', // coaching-studio Workspace-Crash bei leerem CUSTOMERS (T001656)
+        '**/fa-61-sdlc-leitstand-devonly-split.spec.ts', // FA-61: SDLC-Leitstand E1+E2 dev-only-Split (T007559)
       ],
       use: {
         ...devices['Desktop Chrome'],

--- a/tests/e2e/specs/fa-61-sdlc-leitstand-devonly-split.spec.ts
+++ b/tests/e2e/specs/fa-61-sdlc-leitstand-devonly-split.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+// FA-61: SDLC-Leitstand E1+E2 (T007559) — Development-only-Split bewachen.
+//
+// Kontext: Der Leitstand-Showcase (/sdlc/design-system, Astro-Route
+// components/website/src/pages/sdlc/design-system.astro) ist eine
+// SDLC-Oberfläche und damit Development-only — der Build-Target-Split
+// (T002624, PR #3762) hält SDLC-Oberflächen aus dem Produktions-Build
+// (BUILD_TARGET=prod) heraus. Ein 404 auf Prod ist der SOLL-Zustand,
+// kein Defekt. Dieser Test fällt genau dann, wenn jemand den Split
+// aufhebt oder die Route versehentlich in den Prod-Build aufnimmt.
+//
+// Positiv-Anker (T1): /api/health liegt in der Allowlist
+// (INFRA_ROUTE_SUBSTRINGS) und MUSS im Prod-Build erreichbar sein —
+// er belegt zugleich, dass der Test die Live-Site wirklich erreicht.
+//
+// WENN eine spätere Etappe den Leitstand prod-sichtbar macht, MUSS
+// dieser Test angepasst werden (dann 200 statt 404) — nicht umgekehrt
+// die Prod-Erreichbarkeit „reparieren".
+const BASE = process.env.WEBSITE_URL ?? 'https://web.mentolder.de';
+
+test.describe('FA-61: SDLC-Leitstand bleibt Development-only', { tag: ['@website'] }, () => {
+  test('T1: /api/health antwortet 200 — Live-Site erreichbar (Positiv-Anker)', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/health`);
+    expect(res.status()).toBe(200);
+  });
+
+  test('T2: /sdlc/design-system ist im Prod-Build nicht erreichbar (Build-Target-Split)', async ({ request }) => {
+    const res = await request.get(`${BASE}/sdlc/design-system`);
+    // SOLL: 404 — SDLC-Oberflächen fliegen aus BUILD_TARGET=prod.
+    expect(res.status()).toBe(404);
+  });
+});


### PR DESCRIPTION
FA-61: E2E-Spec für den SDLC-Leitstand E1+E2 (T007559, PR #4663).

Der Leitstand-Showcase (/sdlc/design-system) ist eine SDLC-Oberfläche und per Build-Target-Split (T002624/PR #3762) Development-only — ein 404 im Prod-Build ist der Sollzustand. Der Spec bewacht genau diese Eigenschaft gegen versehentliches Aufheben des Splits:

- T1 (Positiv-Anker): /api/health → 200 — belegt Live-Erreichbarkeit (Allowlist-Route, bleibt in BUILD_TARGET=prod)
- T2 (Split-Guard): /sdlc/design-system → 404 — SDLC-Oberflächen fliegen aus dem Prod-Build

Lokal gegen web.mentolder.de: 2 passed. Wird der Leitstand in einer späteren Etappe prod-sichtbar, MUSS dieser Test angepasst werden (im Spec-Header dokumentiert).

Closes T007559