### PR TITLE
fix(test): test:changed laeuft Website-Checks wieder — stale website/-Pfade + lokales ESLint-Gate [T008454]

### DIFF
--- a/.claude/skills/references/verification-block.md
+++ b/.claude/skills/references/verification-block.md
@@ -29,10 +29,16 @@ seine Datei-Universe aus `git ls-files` — untracked Dateien werden nicht erfas
 führt zu einem zweiten Durchlauf: erst `git add` der neuen Datei, dann `task
 freshness:regenerate` erneut, dann `freshness:check`. Planbar zwei Runden einplanen.
 
-Bei Änderungen unter `components/website/` zusätzlich: **`cd website && npx astro check`** [T002694].
+Bei Änderungen unter `components/website/` zusätzlich: **`cd components/website && npx astro check`** [T002694].
+
+> **ESLint läuft seit T008454 in `task test:changed` mit** (fail-closed, `eslint . --max-warnings 0`,
+> identisch zum CI-Gate im Job `Vitest (website)`). Erscheint stattdessen die Skip-Meldung
+> „vitest not available", ist damit auch **kein** Lint gelaufen — dann vor dem PR im
+> Haupt-Checkout `cd components/website && pnpm lint` ausführen. Genau diese Lücke ließ bei
+> T007957 (PR #4674) zwei unused-var-Fehler erst in CI auffallen.
 
 > **`tsc --noEmit` ist dafür kein Ersatz.** Der CI-Job heißt `Vitest (website)`, führt aber
-> `vitest + astro check + Knip` aus. `astro check` ist strenger als `tsc` und prüft zusätzlich
+> `vitest + astro check + Knip + ESLint` aus. `astro check` ist strenger als `tsc` und prüft zusätzlich
 > `.astro`-Dateien. Am 2026-08-08 fiel PR #3823 mit `ts(2322)` in `astro check`, während `tsc`
 > und die gezielt ausgeführte Testdatei lokal grün waren — der Jobname führte die Diagnose in
 > die Vitest-Ergebnisse, die grün waren.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1054,15 +1054,19 @@ tasks:
         echo "$CHANGED" | grep -qE "^(k3d/|environments/|components/VideoVault/)" && RUN_E2E_SERVICES=true || true
         echo "$CHANGED" | grep -qE "(korczewski)" && RUN_E2E_KORCZEWSKI=true || true
         if [ "$RUN_WEBSITE" = "true" ]; then
-          if command -v pnpm >/dev/null 2>&1 && (cd website && pnpm vitest --version >/dev/null 2>&1); then
+          if command -v pnpm >/dev/null 2>&1 && (cd components/website && pnpm vitest --version >/dev/null 2>&1); then
             echo "→ website changes: pnpm vitest run --changed"
-            (cd website && pnpm vitest run --changed --reporter verbose)
+            (cd components/website && pnpm vitest run --changed --reporter verbose)
+            # Spiegelt das fail-closed ESLint-Gate des CI-Jobs "Vitest (website)"
+            # (eslint . --max-warnings 0) — sonst erreichen Lint-Fehler erst CI [T008454].
+            echo "→ website changes: pnpm lint (eslint --max-warnings 0)"
+            (cd components/website && pnpm lint)
           else
-            echo "⚠ vitest not available (worktree symlink limitation) — skipping website JS tests"
+            echo "⚠ vitest not available (worktree symlink limitation) — skipping website JS tests + lint"
           fi
         fi
         if [ "$RUN_MENTOLDER_WEB" = "true" ]; then
-          if command -v pnpm >/dev/null 2>&1 && (cd website && pnpm vitest --version >/dev/null 2>&1); then
+          if command -v pnpm >/dev/null 2>&1 && (cd components/website && pnpm vitest --version >/dev/null 2>&1); then
             echo "→ mentolder-web changes: pnpm --filter mentolder-web test"
             pnpm --filter mentolder-web test
           else
@@ -1136,9 +1140,9 @@ tasks:
         if [ "$RUN_E2E_KORCZEWSKI" = "true" ] && command -v npx >/dev/null 2>&1; then echo "→ e2e korczewski changes: task test:e2e:korczewski"; task test:e2e:korczewski; fi
 
         if [ "$RUN_WEBSITE" = "false" ] && [ "$RUN_MENTOLDER_WEB" = "false" ] && [ "$RUN_K8S" = "false" ] && [ "$RUN_SCRIPTS" = "false" ] && [ "$RUN_FACTORY" = "false" ] && [ "$RUN_SPEC" = "false" ] && [ "$RUN_UNIT" = "false" ] && [ "$RUN_MCP" = "false" ] && [ "$RUN_AGENTS" = "false" ] && [ "$RUN_OPENSPEC" = "false" ] && [ "$RUN_WORKFLOWS" = "false" ] && [ "$RUN_E2E_WEBSITE" = "false" ] && [ "$RUN_E2E_SERVICES" = "false" ] && [ "$RUN_E2E_BRETT" = "false" ] && [ "$RUN_E2E_KORCZEWSKI" = "false" ]; then
-          if command -v pnpm >/dev/null 2>&1 && (cd website && pnpm vitest --version >/dev/null 2>&1); then
+          if command -v pnpm >/dev/null 2>&1 && (cd components/website && pnpm vitest --version >/dev/null 2>&1); then
             echo "→ no domain-specific changes: vitest --changed"
-            (cd website && pnpm vitest run --changed --reporter verbose)
+            (cd components/website && pnpm vitest run --changed --reporter verbose)
           else
             echo "⚠ vitest not available (worktree symlink limitation) — skipping JS fallback tests"
           fi
@@ -5084,7 +5088,7 @@ tasks:
   coaching:ingest:
     desc: "Ingest a coaching book (PDF/EPUB) into pgvector + coaching.books. Args: -- <file> <slug> [--title=...] [--author=...]"
     cmds:
-      - source scripts/env-resolve.sh "${ENV:-dev}" && cd website && npx tsx ../scripts/coaching/ingest-book.mts {{.CLI_ARGS}}
+      - source scripts/env-resolve.sh "${ENV:-dev}" && cd components/website && npx tsx ../../scripts/coaching/ingest-book.mts {{.CLI_ARGS}}
   coaching:ingest-json:
     desc: "Ingest a pre-chunked JSON file into a knowledge collection. Args: -- <file.json> <slug> [--brand=mentolder|korczewski]"
     cmds:
@@ -5115,10 +5119,10 @@ tasks:
           exit 1
         fi
 
-        cd website && PGHOST=localhost PGPORT=15499 PGDATABASE=website PGUSER=website \
+        cd components/website && PGHOST=localhost PGPORT=15499 PGDATABASE=website PGUSER=website \
           PGPASSWORD="$WEBSITE_DB_PASSWORD" \
           LLM_ENABLED=false \
-          npx tsx ../scripts/coaching/ingest-json.mts {{.CLI_ARGS}}
+          npx tsx ../../scripts/coaching/ingest-json.mts {{.CLI_ARGS}}
 
   coaching:batch-ingest:
     desc: "Batch-ingest a directory of coaching PDFs/DOCs — Usage: task coaching:batch-ingest -- <dir> <kurs-slug> [--dry-run] [--yes] [--classify]"
@@ -5129,7 +5133,7 @@ tasks:
   coaching:classify:
     desc: "Run AI classifier over UNCLASSIFIED chunks of a coaching book. Args: -- --slug=<slug> | --all"
     cmds:
-      - source scripts/env-resolve.sh "${ENV:-dev}" && cd website && npx tsx ../scripts/coaching/classify-book.mts {{.CLI_ARGS}}
+      - source scripts/env-resolve.sh "${ENV:-dev}" && cd components/website && npx tsx ../../scripts/coaching/classify-book.mts {{.CLI_ARGS}}
 
   scs:index:
     desc: "Build the semantic code search index (bge-m3 embeddings → pgvector). Requires cluster DB access."

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2700,6 +2700,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/taskfile-no-stale-website-root",
+    "file": "tests/spec/ci-cd/taskfile-no-stale-website-root.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/taskfiles-dir-convention",
     "file": "tests/spec/ci-cd/taskfiles-dir-convention.bats",
     "category": "ci-cd",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1054,
+      "file_count": 1055,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -480,6 +480,7 @@
         "tests/spec/ci-cd/spec-test-no-tracked-file-mutation.bats",
         "tests/spec/ci-cd/spec-tracked-file-guard-isolation.bats",
         "tests/spec/ci-cd/spec-tracked-file-guard.bats",
+        "tests/spec/ci-cd/taskfile-no-stale-website-root.bats",
         "tests/spec/ci-cd/taskfiles-dir-convention.bats",
         "tests/spec/ci-cd/test-inventory-coverage.bats",
         "tests/spec/ci-cd/unknown-scope-names-source.bats",

--- a/tests/spec/ci-cd/taskfile-no-stale-website-root.bats
+++ b/tests/spec/ci-cd/taskfile-no-stale-website-root.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# Prüfmodus: Source-Grep (Querschnitts-Konvention — der Defekt manifestiert sich
+# ausschließlich im Quelltext der Taskfiles; ein Laufzeit-Test müsste die volle
+# test:changed-Pipeline ausführen). [T002448-M4 Ausnahme]
+#
+# Hintergrund T008454: Die Repo-Reorg T006999 verschob website/ nach
+# components/website/. Taskfile.yml referenzierte danach weiter 8x `cd website`,
+# wodurch task test:changed lokal ALLE Website-JS-Checks still übersprang
+# (irreführende Meldung "worktree symlink limitation") — Lint-Fehler erreichten
+# erst CI (PR #4674). Dieser Guard verhindert die Wiederkehr toter
+# website/-Root-Pfade in Taskfiles.
+
+setup() {
+  cd "$BATS_TEST_DIRNAME/../../.."
+}
+
+@test "Taskfiles: kein cd auf totes website/-Root-Verzeichnis (T008454)" {
+  # Positiv-Anker [T002356-M1]: der korrekte Pfad muss vorkommen — sonst wäre
+  # die Negativ-Aussage vakuos (z.B. nach einer weiteren Verschiebung).
+  grep -qE 'cd components/website' Taskfile.yml
+
+  # Negativ-Aussage: `cd website` (ohne components/-Präfix) darf nicht mehr
+  # vorkommen — das Verzeichnis existiert seit T006999 nicht mehr im Repo-Root.
+  run bash -c "grep -nE '\bcd website\b' Taskfile.yml taskfiles/*.yml 2>/dev/null"
+  echo "Gefundene stale Pfade: $output"
+  [ "$status" -ne 0 ]
+}
+
+@test "test:changed: Website-Zweig enthält das ESLint-Gate (T008454)" {
+  # Positiv-Anker: der RUN_WEBSITE-Zweig existiert.
+  grep -q 'RUN_WEBSITE' Taskfile.yml
+  # Das lokale Gegenstück zum fail-closed CI-Gate (eslint . --max-warnings 0)
+  # muss im Taskfile verdrahtet sein.
+  grep -qE 'cd components/website && pnpm lint' Taskfile.yml
+}


### PR DESCRIPTION
## Zusammenfassung

**Problem (Bug T008454):** Seit der Repo-Reorg T006999 (#4659) referenzierte `Taskfile.yml` 8x das nicht mehr existierende Root-Verzeichnis `website/`. Folge: `task test:changed` übersprang lokal **alle** Website-JS-Checks still (irreführende Meldung „worktree symlink limitation"). Zusätzlich hatte das fail-closed ESLint-Gate des CI-Jobs `Vitest (website)` kein lokales Gegenstück — so erreichten bei T007957 (PR #4674) zwei unused-var-Fehler erst CI.

**Fix:**
- `Taskfile.yml`: `cd website` → `cd components/website` (test:changed 3 Blöcke, Coaching-Tasks 3x inkl. Relativpfad-Korrektur `../scripts` → `../../scripts`)
- `test:changed` RUN_WEBSITE-Zweig: `pnpm lint` (eslint `--max-warnings 0`) als lokales Spiegel-Gate
- `verification-block.md`: ESLint im CI-Job dokumentiert, Skip-Fallback beschrieben
- Guard: `tests/spec/ci-cd/taskfile-no-stale-website-root.bats` — RED-Check gegen origin/main belegt: 8 stale Treffer, 0 Lint-Gate

## Verifikation
- Neuer Guard grün; RED auf altem Stand bestätigt (`git show origin/main:Taskfile.yml | grep -cE '\bcd website\b'` → 8)
- `task --list` parst; `task test:code-quality` grün (52/52)
- Spec-Suite: 4014 ok; 10 Failures ausschließlich umgebungsabhängig (LM-Studio, mcp-postgres, Sandbox-Egress, Factory-DB, flux CLI) — unabhängig von diesem Diff
- Nebenbefund als eigenes Ticket erfasst: T008635 (Spec-Suite leakt leeres Top-Level `website/`, macht `website-moved.bats` lokal flaky)
- `task freshness:check` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECS68KX1WNcj7KNnt7ER4A
