### PR TITLE
fix(website): Review-Gate #4688 — Anker-Kontrakt komplett, Print-Light-Showcase, station-Link [T009137]

### DIFF
--- a/components/website/src/components/leitstand/ApiKatalog.svelte
+++ b/components/website/src/components/leitstand/ApiKatalog.svelte
@@ -118,7 +118,7 @@
   };
 </script>
 
-<section class="ls-api-katalog" data-testid="leitstand-api-katalog" aria-label="API-Katalog">
+<section class="ls-api-katalog" data-purpose-id="api-katalog" data-testid="leitstand-api-katalog" aria-label="API-Katalog">
   <header class="ls-api-katalog__head">
     <h2 class="ls-api-katalog__heading">API-Katalog</h2>
     <p class="ls-api-katalog__count">{shownCount} / {totalCount} Routen</p>

--- a/components/website/src/components/leitstand/KpiGrid.svelte
+++ b/components/website/src/components/leitstand/KpiGrid.svelte
@@ -64,7 +64,7 @@
   });
 </script>
 
-<section class="ls-kpi-grid" data-testid="leitstand-kpi-grid" aria-label="DORA- und Factory-KPIs">
+<section class="ls-kpi-grid" data-purpose-id="kpi-grid" data-testid="leitstand-kpi-grid" aria-label="DORA- und Factory-KPIs">
   <h2 class="ls-kpi-grid__heading">Delivery-KPIs</h2>
 
   {#if error}

--- a/components/website/src/components/sdlc/FactoryFloor.svelte
+++ b/components/website/src/components/sdlc/FactoryFloor.svelte
@@ -177,7 +177,7 @@
       <div class="rounded-xl bg-white/5 p-3"><p class="text-muted text-xs">Durchsatz heute</p><p class="text-xl font-bold">{data.metrics.shippedToday}</p></div>
       <div class="rounded-xl bg-white/5 p-3"><p class="text-muted text-xs">Ø Zyklus</p><p class="text-xl font-bold">{data.metrics.avgCycleH ?? '–'}h</p></div>
       <div class="rounded-xl bg-white/5 p-3"><p class="text-muted text-xs">Watchdog-Stale</p><p class="text-xl font-bold">{data.control.watchdogStale}</p></div>
-      <a href="/sdlc/cockpit?tab=planung" class="rounded-xl bg-white/5 p-3 hover:bg-white/10 transition-colors" data-testid="floor-office" title="Im Planungsbüro"><p class="text-muted text-xs">Büro</p><p class="text-xl font-bold">{data.officeWaiting ?? 0}</p></a>
+      <a href="/sdlc/cockpit?station=planung" class="rounded-xl bg-white/5 p-3 hover:bg-white/10 transition-colors" data-testid="floor-office" title="Im Planungsbüro"><p class="text-muted text-xs">Büro</p><p class="text-xl font-bold">{data.officeWaiting ?? 0}</p></a>
       <a href="#floor-kommissionierung" class="rounded-xl bg-white/5 p-3 hover:bg-white/10 transition-colors" data-testid="floor-komm-count" title="Zur Kommissionierung"><p class="text-muted text-xs">Kommissionierung</p><p class="text-xl font-bold">{data.stagedWaiting ?? 0}</p></a>
     </div>
 

--- a/components/website/src/pages/sdlc/design-system.astro
+++ b/components/website/src/pages/sdlc/design-system.astro
@@ -138,12 +138,14 @@ import '../../styles/sdlc-leitstand.css';
 
     <section class="ls-showcase__section">
       <h2>Print-Light (Report-Ansicht)</h2>
-      <div class="ls-report ls-showcase__report-demo">
+      <div class="ls-shell report ls-showcase__report-demo">
         <p class="ls-showcase__eyebrow">Report-Ansicht</p>
-        <p>Dieser Block nutzt <code>.ls-report</code> — ausschließlich unter
-          <code>@media print</code> wirksam. Kein zweites interaktives Theme: auf dem
-          Bildschirm hat die Klasse keine Wirkung, öffnen Sie die Druckvorschau des Browsers
-          (Strg/Cmd+P), um die Farben zu sehen.</p>
+        <p>Dieser Block nutzt die Modifier-Klasse <code>.report</code> auf dem
+          Shell-Root (<code>.ls-shell.report</code>) — dieselbe Regelmenge gilt
+          unter <code>@media print</code> für jeden Druck. Kein zweites
+          interaktives Theme: auf dem Bildschirm hat die Klasse nur mit
+          <code>?report=1</code> Wirkung, öffnen Sie die Druckvorschau des
+          Browsers (Strg/Cmd+P), um die Farben zu sehen.</p>
       </div>
     </section>
 


### PR DESCRIPTION
Nach-Merge-Fixes aus dem Review von PR #4688 (der Merge ging vor dem Review-Fix durch den „Enable Auto-Merge"-Workflow raus).

- **Anker-Kontrakt komplett:** `data-purpose-id="kpi-grid"` auf KpiGrid.svelte-Wurzel, `data-purpose-id="api-katalog"` auf ApiKatalog.svelte-Wurzel (rein additiv, E4-Logik unangetastet) — der help-overlay-anchors-Guard fordert für jeden Registry-Key einen Anker
- **Print-Light-Showcase:** design-system.astro demonstriert die tote `.ls-report`-Klasse nicht mehr; umgeschrieben auf `.ls-shell.report`
- **Toter Link:** FactoryFloor.svelte `/sdlc/cockpit?tab=planung` → `?station=planung`

Verifikation: BATS 8/8 (purpose-registry, help-overlay, livedaten), Anker-Vitest 4/4, astro check 0 errors, ESLint auf geänderten Dateien Exit 0, freshness grün.

Hinweis: Der Vitest-CI-Job läuft mit „No test files found, exiting with code 0" (shallow --changed) — die BATS-Guards sind das tatsächliche Sicherheitsnetz.

Closes T009137