### PR TITLE
fix(factory): wakeup-Pull-Fehler laut melden + Pre-Run-Orphan-Kurzschluss im opencode-Executor [T011581]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -4818,6 +4818,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/opencode-exec-prerun-shortcircuit",
+    "file": "tests/spec/software-factory/opencode-exec-prerun-shortcircuit.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/opencode-exec-result-check",
     "file": "tests/spec/software-factory/opencode-exec-result-check.bats",
     "category": "software-factory",
@@ -4916,6 +4922,12 @@
   {
     "id": "software-factory/update-status-id-allowlist-T002906",
     "file": "tests/spec/software-factory/update-status-id-allowlist-T002906.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
+    "id": "software-factory/wakeup-pull-loud-failure",
+    "file": "tests/spec/software-factory/wakeup-pull-loud-failure.bats",
     "category": "software-factory",
     "kind": "shell"
   },

--- a/scripts/factory/opencode-exec.sh
+++ b/scripts/factory/opencode-exec.sh
@@ -105,6 +105,28 @@ fi
 # shellcheck source=scripts/factory/pr-ready.sh
 source "$HERE/pr-ready.sh"
 
+# --- Pre-Run-Orphan-Kurzschluss [T011581] -------------------------------------------
+# Die Orphan-Rettung aus T011543 sitzt im Ergebnis-Check HINTER dem opencode-
+# Aufruf: ein bereits fertig gepushtes Ticket verbrannte erst einen kompletten
+# serialisierten Orchestrator-Lauf (max_inflight=1 — drei parallele Runs teilen
+# sich einen GPU-Slot), bevor die fertige Arbeit erkannt wurde. Beobachtet
+# 2026-08-17 an T008014: Commit [T008014] seit 20:34 auf origin, danach zwei
+# volle Re-Implement-Laeufe (einer starb an einer opencode-Kompaktierung, die
+# anderen am systemd-Kill). Deshalb VOR dem Lauf: sauberer Worktree + vorhandener
+# Implementierungs-Commit => direkt zum PR-Schritt, kein LLM-Lauf.
+if [[ -z "$(git -C "$LAUNCH_DIR" status --porcelain 2>/dev/null)" ]] \
+   && has_implementation "$LAUNCH_DIR" "$EXT_ID"; then
+  echo "opencode-exec: $EXT_ID — Implementierungs-Commit [$EXT_ID] liegt bereits auf ${BRANCH}; kein erneuter Orchestrator-Lauf, direkt zum PR-Schritt [T011581]" >&2
+  phase_event done orchestrator all 0 0 already_implemented
+  if ensure_pr "$LAUNCH_DIR" "$BRANCH" "$EXT_ID"; then
+    phase_event done orchestrator pr-ready 0 0
+  else
+    phase_event blocked orchestrator pr-ready 0 0 pr_step_failed
+  fi
+  bash "$REPO/scripts/ticket.sh" retry-count reset --id "$EXT_ID" >/dev/null 2>&1 || true
+  exit 0
+fi
+
 phase_event entered orchestrator all 0 0
 
 # --- build the orchestrator prompt (manifest as a data arg — NO shell expansion) -----

--- a/scripts/factory/wakeup.sh
+++ b/scripts/factory/wakeup.sh
@@ -72,7 +72,21 @@ cd "${REPO}"
 # [T002381-M3] Vor jedem Tick den lokalen main-Ref aktualisieren, damit die
 # Factory nicht mit stale Code tickt. Fail-open: bei Fehler (z.B. kein Netz)
 # laeuft mit dem aktuellen Stand weiter — besser stale als ausgefallen.
-git pull --ff-only origin main 2>/dev/null || true
+#
+# [T011581] Aber nicht mehr STUMM fail-open: `2>/dev/null || true` verschluckte
+# jeden Fehlgrund. Beobachtet 2026-08-17: eine lokal modifizierte, upstream
+# geloeschte Datei blockierte den ff-Pull; der Checkout blieb 7 Commits hinter
+# origin/main, und zwei Ticks fuhren einen Executor OHNE die eine Stunde zuvor
+# gemergten Factory-Fixes (PR #4700). Der Fehler und der Rueckstand gehoeren
+# ins Journal — beheben muss ihn weiterhin ein Mensch (lokale Aenderungen im
+# geteilten Haupt-Checkout raeumt die Factory bewusst nicht selbst weg).
+if ! pull_err="$(git pull --ff-only origin main 2>&1)"; then
+  echo "wakeup.sh: git pull --ff-only origin main fehlgeschlagen — Tick laeuft mit dem aktuellen (moeglicherweise stale) Stand weiter [T011581]" >&2
+  printf '%s\n' "$pull_err" | tail -n 3 | sed 's/^/wakeup.sh:   /' >&2
+  behind="$(git rev-list --count HEAD..origin/main 2>/dev/null || echo '?')"
+  echo "wakeup.sh:   HEAD ist ${behind} Commit(s) hinter origin/main" >&2
+fi
+unset pull_err
 
 # ── single-flight: acquire the tick lock non-blocking; bail if a tick is live ──
 exec 9>"${LOCKFILE}"

--- a/tests/spec/software-factory/opencode-exec-prerun-shortcircuit.bats
+++ b/tests/spec/software-factory/opencode-exec-prerun-shortcircuit.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/opencode-exec-prerun-shortcircuit.bats
+# SSOT: openspec/specs/software-factory.md
+# T011581 — Pre-Run-Orphan-Kurzschluss: liegt der Implementierungs-Commit [EXT_ID]
+# bereits gepusht auf dem Branch und ist der Worktree sauber, darf opencode-exec.sh
+# KEINEN Orchestrator-Lauf mehr starten, sondern geht direkt zum PR-Schritt.
+#
+# Hintergrund: Die Orphan-Rettung aus T011543 sitzt im Ergebnis-Check HINTER dem
+# opencode-Aufruf — ein fertig gepushtes Ticket verbrannte erst einen kompletten
+# serialisierten Orchestrator-Lauf (max_inflight=1), bevor die fertige Arbeit
+# erkannt wurde. Beobachtet 2026-08-17 an T008014: Commit seit 20:34 auf origin,
+# danach zwei volle Re-Implement-Läufe.
+#
+# Prüfmodus: Output-Verifikation (T002448-M4). Die Tests FÜHREN
+# scripts/factory/opencode-exec.sh AUS und prüfen Exit-Code, das
+# Orchestrator-Stub-Log (wurde das LLM aufgerufen?) und das gh-Stub-Log —
+# sie greppen nicht die Quelldatei. Negativfälle tragen einen Positiv-Anker
+# (T002356-M1): ohne vorliegende Implementierung WIRD der Orchestrator gestartet.
+#
+# Orchestrator (opencode) und gh sind gestubbt — kein Modell, kein Netz.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  EXEC="$REPO_ROOT/scripts/factory/opencode-exec.sh"
+
+  # Bare-Origin + Arbeits-Klon: origin/main existiert, Feature-Branch ist gepusht.
+  ORIGIN="$BATS_TEST_TMPDIR/origin.git"
+  git init -q --bare "$ORIGIN"
+  LAUNCH="$BATS_TEST_TMPDIR/launch"
+  git init -q -b main "$LAUNCH"
+  git -C "$LAUNCH" config user.email t@example.invalid
+  git -C "$LAUNCH" config user.name Test
+  echo base > "$LAUNCH/file.txt"
+  git -C "$LAUNCH" add -A
+  git -C "$LAUNCH" commit -qm "base"
+  git -C "$LAUNCH" remote add origin "$ORIGIN"
+  git -C "$LAUNCH" push -q origin main
+
+  BRANCH="fix/stub-T011581"
+  git -C "$LAUNCH" checkout -qb "$BRANCH"
+  mkdir -p "$LAUNCH/openspec/changes/stub"
+  echo "- [ ] Task" > "$LAUNCH/openspec/changes/stub/tasks.md"
+  git -C "$LAUNCH" add -A
+  git -C "$LAUNCH" commit -qm "chore(plans): stub plan [T011581]"
+  git -C "$LAUNCH" push -q -u origin "$BRANCH"
+
+  # Stubs vor den PATH: weder echter Orchestrator noch echtes gh dürfen laufen.
+  STUB_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+  export PATH="$STUB_BIN:$PATH"
+  GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+  export GH_LOG
+  OC_LOG="$BATS_TEST_TMPDIR/opencode.log"
+  export OC_LOG
+  _stub_gh
+  _stub_opencode
+
+  # Ticket-DB offline halten; agent-lock in tmp isolieren.
+  export TICKET_OFFLINE=1
+  export AGENT_LOCK_DIR="$BATS_TEST_TMPDIR/agent-locks"
+}
+
+# gh-Stub: loggt jeden Aufruf; `pr list … length` meldet 0 offene PRs.
+_stub_gh() {
+  cat > "$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "gh $*" >> "$GH_LOG"
+case "$1 $2" in
+  "pr list") echo "0" ;;
+  "pr create") echo "https://github.invalid/pr/1" ;;
+esac
+exit 0
+EOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+# Orchestrator-Stub: loggt den Aufruf (DAS ist die Messgröße dieses Tests) und
+# erzeugt einen Implementierungs-Commit, damit der Positiv-Anker-Lauf als done endet.
+_stub_opencode() {
+  cat > "$STUB_BIN/opencode" <<'EOF'
+#!/usr/bin/env bash
+echo "opencode $*" >> "$OC_LOG"
+echo implemented >> file.txt
+git add -A
+git commit -qm "fix(scripts): implementiert [T011581]"
+exit 0
+EOF
+  chmod +x "$STUB_BIN/opencode"
+}
+
+@test "T011581: gepushte Implementierung + sauberer Worktree => kein Orchestrator-Lauf, PR-Schritt läuft" {
+  # Implementierung liegt schon gepusht auf dem Branch (wie nach einem Lauf,
+  # dessen Nachlauf durch systemd-Kill verloren ging).
+  echo implemented >> "$LAUNCH/file.txt"
+  git -C "$LAUNCH" add -A
+  git -C "$LAUNCH" commit -qm "fix(scripts): implementiert [T011581]"
+  git -C "$LAUNCH" push -q origin "$BRANCH"
+
+  run env OPENCODE_BIN="$STUB_BIN/opencode" bash "$EXEC" T011581 "$LAUNCH" "$BRANCH" openspec/changes/stub/tasks.md
+  [ "$status" -eq 0 ]
+  # Kernaussage: der Orchestrator wurde NICHT gestartet …
+  [ ! -s "$OC_LOG" ]
+  # … der PR-Schritt aber sehr wohl ausgeführt.
+  run cat "$GH_LOG"
+  [[ "$output" == *"pr create"* ]]
+}
+
+@test "T011581: Positiv-Anker — ohne vorliegende Implementierung WIRD der Orchestrator gestartet" {
+  run env OPENCODE_BIN="$STUB_BIN/opencode" bash "$EXEC" T011581 "$LAUNCH" "$BRANCH" openspec/changes/stub/tasks.md
+  [ "$status" -eq 0 ]
+  run cat "$OC_LOG"
+  [[ "$output" == *"opencode"* ]]
+}
+
+@test "T011581: schmutziger Worktree verhindert den Kurzschluss — Orchestrator läuft" {
+  # Implementierung gepusht, aber der Worktree trägt uncommittete Reste eines
+  # abgebrochenen Laufs: der Kurzschluss darf NICHT greifen (der Orchestrator
+  # muss die Reste bewerten/zu Ende bringen).
+  echo implemented >> "$LAUNCH/file.txt"
+  git -C "$LAUNCH" add -A
+  git -C "$LAUNCH" commit -qm "fix(scripts): implementiert [T011581]"
+  git -C "$LAUNCH" push -q origin "$BRANCH"
+  echo halbfertig > "$LAUNCH/rest.txt"
+
+  run env OPENCODE_BIN="$STUB_BIN/opencode" bash "$EXEC" T011581 "$LAUNCH" "$BRANCH" openspec/changes/stub/tasks.md
+  [ "$status" -eq 0 ]
+  run cat "$OC_LOG"
+  [[ "$output" == *"opencode"* ]]
+}

--- a/tests/spec/software-factory/wakeup-pull-loud-failure.bats
+++ b/tests/spec/software-factory/wakeup-pull-loud-failure.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/wakeup-pull-loud-failure.bats
+# SSOT: openspec/specs/software-factory.md
+# T011581 — der Pre-Tick-Pull in wakeup.sh darf nicht mehr STUMM scheitern.
+#
+# Hintergrund: `git pull --ff-only origin main 2>/dev/null || true` verschluckte
+# jeden Fehlgrund. Beobachtet 2026-08-17: eine lokal modifizierte, upstream
+# gelöschte Datei blockierte den ff-Pull; der Checkout blieb 7 Commits hinter
+# origin/main und zwei Ticks fuhren einen Executor OHNE die eine Stunde zuvor
+# gemergten Factory-Fixes (PR #4700). Fail-open bleibt (Tick läuft weiter),
+# aber Fehlgrund + Rückstand gehören ins Journal.
+#
+# Prüfmodus: Output-Verifikation (T002448-M4). Die Tests FÜHREN wakeup.sh gegen
+# ein Fixture-Repo AUS. Der Tick selbst wird über den vorab gehaltenen
+# flock-Lock abgefangen: der Pull liegt VOR dem single-flight-Lock, das
+# "skipping"-Bail danach ist der Positiv-Anker, dass der Pull-Block durchlaufen
+# wurde — kein echter Tick, kein Netz, keine DB. Semantik statt Darstellung
+# (T002716): geprüft werden Exit-Code, das Vorhandensein der Fehlermeldung und
+# (im Erfolgsfall) der tatsächlich vorgerückte HEAD — keine Zeilenanker.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  WAKEUP="$REPO_ROOT/scripts/factory/wakeup.sh"
+
+  # Fixture: Bare-Origin + Factory-Checkout.
+  ORIGIN="$BATS_TEST_TMPDIR/origin.git"
+  git init -q --bare "$ORIGIN"
+  # Bare-Default-HEAD zeigt auf master; ohne Umbiegen klont der Zweit-Klon
+  # unten einen nicht existierenden Ref und landet branchlos.
+  git -C "$ORIGIN" symbolic-ref HEAD refs/heads/main
+  CHECKOUT="$BATS_TEST_TMPDIR/checkout"
+  git init -q -b main "$CHECKOUT"
+  git -C "$CHECKOUT" config user.email t@example.invalid
+  git -C "$CHECKOUT" config user.name Test
+  echo base > "$CHECKOUT/file.txt"
+  git -C "$CHECKOUT" add -A
+  git -C "$CHECKOUT" commit -qm "base"
+  git -C "$CHECKOUT" remote add origin "$ORIGIN"
+  git -C "$CHECKOUT" push -q -u origin main
+
+  # Upstream-Fortschritt über einen zweiten Klon einspielen.
+  OTHER="$BATS_TEST_TMPDIR/other"
+  git clone -q "$ORIGIN" "$OTHER"
+  git -C "$OTHER" config user.email t@example.invalid
+  git -C "$OTHER" config user.name Test
+  echo upstream > "$OTHER/upstream.txt"
+  git -C "$OTHER" add -A
+  git -C "$OTHER" commit -qm "upstream: neuer Stand"
+  git -C "$OTHER" push -q origin main
+
+  # Tick-Abfang: Lock VOR dem Lauf halten → wakeup.sh bail't direkt nach dem
+  # Pull-Block ("a factory tick is already running … skipping", Exit 0).
+  LOCKFILE="$BATS_TEST_TMPDIR/tick.lock"
+  exec 8>"$LOCKFILE"
+  flock -n 8
+}
+
+teardown() {
+  exec 8>&- || true
+}
+
+_run_wakeup() {
+  run env FACTORY_REPO="$CHECKOUT" \
+    FACTORY_ENV_FILE="$BATS_TEST_TMPDIR/no-such-env" \
+    FACTORY_TICK_LOCK="$LOCKFILE" \
+    bash "$WAKEUP"
+}
+
+@test "T011581: scheiternder ff-Pull wird laut gemeldet (Fehlgrund + Rückstand), Tick bleibt fail-open" {
+  # Divergenz: lokaler Commit im Checkout, anderer Commit upstream → ff-only scheitert.
+  echo local > "$CHECKOUT/local.txt"
+  git -C "$CHECKOUT" add -A
+  git -C "$CHECKOUT" commit -qm "lokal: divergiert"
+
+  _run_wakeup
+  [ "$status" -eq 0 ]
+  # Positiv-Anker: der Pull-Block wurde durchlaufen, der Lock-Bail kam danach.
+  [[ "$output" == *"skipping"* ]]
+  # Kernaussage: der Fehlschlag ist sichtbar, samt Rückstands-Zähler.
+  [[ "$output" == *"fehlgeschlagen"* ]]
+  [[ "$output" == *"hinter origin/main"* ]]
+}
+
+@test "T011581: erfolgreicher Pull bleibt still und rückt HEAD tatsächlich vor" {
+  _run_wakeup
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping"* ]]
+  [[ "$output" != *"fehlgeschlagen"* ]]
+  # Semantischer Beweis statt Log-Anker: HEAD steht jetzt auf origin/main.
+  [ "$(git -C "$CHECKOUT" rev-parse HEAD)" = "$(git -C "$CHECKOUT" rev-parse origin/main)" ]
+}


### PR DESCRIPTION
## Kontext (Live-Beobachtung 2026-08-17, gemma26-Factory)

Beim Beobachten der drei parallelen Orchestrator-Runs (T008014/T007968/T008635) zeigten sich zwei strukturelle Lücken:

**1. Stummer Pull-Fehler (`wakeup.sh:75`):** `git pull --ff-only origin main 2>/dev/null || true` verschluckte jeden Fehlgrund. Konkret blockierte eine lokal modifizierte, upstream gelöschte Datei (archivierter Change) den ff-Pull — der Haupt-Checkout blieb 7 Commits hinter origin/main, und die Ticks 21:31/22:11 fuhren den Executor **ohne** die um 21:11 gemergten Fixes aus #4700 (Orphan-Rettung, PR-Schritt, Doppel-Dispatch-Guard). Folge: T008014 (Commit `b361a9d4e` seit 20:34 gepusht) wurde zweimal komplett neu implementiert; ein Lauf starb an einer opencode-Kompaktierung, drei weitere am systemd-Kill (RuntimeMaxSec=3600, Exit 143).

**Fix:** Pull bleibt fail-open (besser stale als ausgefallen), meldet aber Fehlgrund (letzte 3 Zeilen) + Commit-Rückstand ins Journal.

**2. Orphan-Rettung erst nach vollem LLM-Lauf:** Die T011543-Rettung sitzt im Ergebnis-Check *hinter* dem opencode-Aufruf — ein fertig gepushtes Ticket verbrennt erst einen kompletten serialisierten Orchestrator-Lauf (max_inflight=1, drei Runs teilen sich einen GPU-Slot), bevor die Arbeit erkannt wird.

**Fix:** Pre-Run-Kurzschluss vor `phase_event entered`: sauberer Worktree + vorhandener `[EXT_ID]`-Commit ⇒ `done (already_implemented)` + direkt `ensure_pr`, kein LLM-Lauf.

## Tests
- `tests/spec/software-factory/opencode-exec-prerun-shortcircuit.bats` (3 Tests, inkl. Positiv-Anker + Dirty-Worktree-Guard)
- `tests/spec/software-factory/wakeup-pull-loud-failure.bats` (2 Tests; Tick per vorab gehaltenem flock abgefangen — kein echter Tick)
- RED gegen ungefixten Stand nachgewiesen (Kern-Assertions fielen), GREEN 5/5; Nachbar-Suiten (pr-step, already-running, result-check, binary-resolution) 12/12 grün.
- Test-Inventory regeneriert.

Ticket: T011581

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M88b494RnYCBw9sdk7eqhi