### PR TITLE
chore(infra): declare missing env vars in schema and fix toolset ESM imports [T011623] (#4691)

### DIFF
--- a/environments/schema.yaml
+++ b/environments/schema.yaml
@@ -518,6 +518,46 @@ env_vars:
     required: false
     default_dev: "info"
 
+  - name: WEBSITE_PRIMARY_SERVICE
+    required: false
+    default_dev: "website"
+    description: "Primary website service name (derived from PRIMARY_FRONTEND in workspace:deploy: 'website' for astro, 'mentolder-web' for react)."
+
+  - name: COLLABORA_INGRESS_MIDDLEWARES
+    required: false
+    default_dev: ""
+    description: "Traefik ingress middleware chain for Collabora office stack on primary brand."
+
+  - name: COLLABORA_INGRESS_MIDDLEWARES_2
+    required: false
+    default_dev: ""
+    description: "Traefik ingress middleware chain for Collabora office stack on Korczewski brand."
+
+  - name: COLLABORA_INGRESS_MIDDLEWARES_KORCZEWSKI
+    required: false
+    default_dev: ""
+    description: "Alias for COLLABORA_INGRESS_MIDDLEWARES_2."
+
+  - name: COLLABORA_TLS_SECRET_2
+    required: false
+    default_dev: "korczewski-tls"
+    description: "TLS secret name for Collabora ingress on Korczewski brand."
+
+  - name: POCKET_ID_SMTP_TLS
+    required: false
+    default_dev: "none"
+    description: "SMTP TLS mode for Pocket ID ('tls', 'starttls', or 'none', derived from SMTP_SECURE + SMTP_PORT)."
+
+  - name: POCKET_ID_FALLBACK_FRONTEND_URL
+    required: false
+    default_dev: "https://auth.mentolder.de"
+    description: "Optional fallback Pocket ID frontend URL for SDLC stack."
+
+  - name: POCKET_ID_FALLBACK_URL
+    required: false
+    default_dev: "https://auth.mentolder.de"
+    description: "Optional fallback Pocket ID internal URL for SDLC stack."
+
 secrets:
   - name: STUDIO_DB_URL
     required: false

--- a/scripts/agentic-lookup.mjs
+++ b/scripts/agentic-lookup.mjs
@@ -3,7 +3,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { execSync } from 'node:child_process';
-import yaml from 'js-yaml';
+import * as yamlPkg from 'js-yaml';
+const yaml = yamlPkg.default ?? yamlPkg;
 
 const argv = process.argv.slice(2);
 const verb = argv[0];

--- a/scripts/knowledge/lib-context-pinned.mjs
+++ b/scripts/knowledge/lib-context-pinned.mjs
@@ -27,7 +27,8 @@
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import yaml from 'js-yaml';
+import * as yamlPkg from 'js-yaml';
+const yaml = yamlPkg.default ?? yamlPkg;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REGISTRY_DIR = join(__dirname, '..', '..', 'docs', 'agent-guide', 'registry');

--- a/scripts/llm/ui-config-seed.mjs
+++ b/scripts/llm/ui-config-seed.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import yaml from 'js-yaml';
+import * as yamlPkg from 'js-yaml';
+const yaml = yamlPkg.default ?? yamlPkg;
 
 /**
  * Baut den Systemprompt aus der Registry (T002550).

--- a/scripts/toolset-context.sh
+++ b/scripts/toolset-context.sh
@@ -76,7 +76,8 @@ fi
 TOOLSET_REGISTRY="$REGISTRY" TOOLSET_ROLE="$ROLE" TOOLSET_JSON="$AS_JSON" \
 node --input-type=module -e '
 import fs from "node:fs";
-import yaml from "js-yaml";
+import * as yamlPkg from "js-yaml";
+const yaml = yamlPkg.default ?? yamlPkg;
 
 const registryPath = process.env.TOOLSET_REGISTRY;
 const role = process.env.TOOLSET_ROLE;

--- a/scripts/toolset/collect.mjs
+++ b/scripts/toolset/collect.mjs
@@ -16,7 +16,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import yaml from 'js-yaml';
+import * as yamlPkg from 'js-yaml';
+const yaml = yamlPkg.default ?? yamlPkg;
 import { readClaudeCodeConfig, readOpencodeConfig, readAgyConfig } from './lib/harness.mjs';
 import { loadRegistry } from './lib/registry.mjs';
 

--- a/scripts/toolset/lib/registry.mjs
+++ b/scripts/toolset/lib/registry.mjs
@@ -1,6 +1,7 @@
 // scripts/toolset/lib/registry.mjs
 import fs from 'node:fs';
-import yaml from 'js-yaml';
+import * as yamlPkg from 'js-yaml';
+const yaml = yamlPkg.default ?? yamlPkg;
 
 export const KNOWN_PREFIXES = ['cli:', 'mcp:', 'skill:', 'agent:', 'plugin:'];
 

--- a/scripts/toolset/probe.mjs
+++ b/scripts/toolset/probe.mjs
@@ -1,7 +1,8 @@
 // scripts/toolset/probe.mjs
 import fs from 'node:fs';
 import path from 'node:path';
-import yaml from 'js-yaml';
+import * as yamlPkg from 'js-yaml';
+const yaml = yamlPkg.default ?? yamlPkg;
 
 const lockfilePath = path.join(process.cwd(), 'docs', 'agent-guide', 'registry', 'toolset.lock.yaml');
 


### PR DESCRIPTION
Resolves #4691.

### Changes
- Declared missing deploy/manifest environment variables in `environments/schema.yaml` (`WEBSITE_PRIMARY_SERVICE`, `COLLABORA_INGRESS_MIDDLEWARES`, `COLLABORA_INGRESS_MIDDLEWARES_2`, `COLLABORA_INGRESS_MIDDLEWARES_KORCZEWSKI`, `COLLABORA_TLS_SECRET_2`, `POCKET_ID_SMTP_TLS`, `POCKET_ID_FALLBACK_FRONTEND_URL`, `POCKET_ID_FALLBACK_URL`).
- Fixed ESM imports for `js-yaml` (`import * as yaml from 'js-yaml'`) across `scripts/toolset/` and related scripts.
- Verified `task agents:toolset:check`, all 37 toolset-registry tests, `task freshness:check`, and `task workspace:validate`.