### PR TITLE
chore(deps): opencode-Plugin 1.18.18 + Archiv-Status-Drift completed [T011624]

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.16",
+        "@opencode-ai/plugin": "1.18.18",
         "jsonc-parser": "^3.3.1",
         "unique-names-generator": "^4.7.1"
       }
@@ -101,13 +101,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.16",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.16.tgz",
-      "integrity": "sha512-XvlZ9CFAXqrNrmpTe+EhhRYnDhca6db1ebcB10v5JO8kSm1iFbVbPP982Qzc4MRSrfpPjD8W1fg13Ubnff377g==",
+      "version": "1.18.18",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.18.tgz",
+      "integrity": "sha512-vqQeqJtn9c+J+tIQDzYk88xip/NVNN1hym1ATmckxo6zINHAoXoul4Sw/jgnvL00rLsfAvhja28qax4h3g/5Jg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.16",
+        "@opencode-ai/sdk": "1.18.18",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.16",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.16.tgz",
-      "integrity": "sha512-UvaHyL93spLm7MttoprWTOBSYQN3aYWd7/3Ie5WNnG2pRAPq/U/d51qt0smYBTrkjxqlQmg+AJoGw8MEH6lGUg==",
+      "version": "1.18.18",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.18.tgz",
+      "integrity": "sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.18.16",
+    "@opencode-ai/plugin": "1.18.18",
     "jsonc-parser": "^3.3.1",
     "unique-names-generator": "^4.7.1"
   }

--- a/openspec/changes/archive/2026-08-17-sdlc-deck-leiste-overflow/tasks.md
+++ b/openspec/changes/archive/2026-08-17-sdlc-deck-leiste-overflow/tasks.md
@@ -2,7 +2,7 @@
 title: "sdlc-deck-leiste-overflow — Implementation Plan"
 ticket_id: T011498
 domains: [website]
-status: active
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/archive/2026-08-17-sdlc-deck-leiste-resize/tasks.md
+++ b/openspec/changes/archive/2026-08-17-sdlc-deck-leiste-resize/tasks.md
@@ -2,7 +2,7 @@
 title: "sdlc-deck-leiste-resize — Implementation Plan"
 ticket_id: T011499
 domains: [website]
-status: active
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/archive/2026-08-17-sdlc-deck-resize-freeze-fix/tasks.md
+++ b/openspec/changes/archive/2026-08-17-sdlc-deck-resize-freeze-fix/tasks.md
@@ -2,7 +2,7 @@
 title: "sdlc-deck-resize-freeze-fix — Implementation Plan"
 ticket_id: T011501
 domains: [website]
-status: active
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/openspec/changes/archive/2026-08-17-sdlc-deck-resize-handle-fix/tasks.md
+++ b/openspec/changes/archive/2026-08-17-sdlc-deck-resize-handle-fix/tasks.md
@@ -2,7 +2,7 @@
 title: "sdlc-deck-resize-handle-fix — Implementation Plan"
 ticket_id: T011500
 domains: [website]
-status: active
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null


### PR DESCRIPTION
## Was

- `.opencode`: `@opencode-ai/plugin` 1.18.16 → 1.18.18 (aktuelle npm-Version). Der Bump lag als viermal identischer Stash-Inhalt vor (stash@{1..4}) und wird hiermit übernommen; die Stashes werden danach gedroppt.
- Vier Change-Archive vom 2026-08-17 trugen `status: active` statt `completed`: `sdlc-deck-leiste-overflow`, `sdlc-deck-leiste-resize`, `sdlc-deck-resize-freeze-fix`, `sdlc-deck-resize-handle-fix` — auf `completed` gesetzt (Konvention wie bei den 08-16-Archiven). Deckt den Mishap-Buffer-Eintrag zu diesem Drift ab.

## Verify

- `task test:changed`: 52/52 grün
- `task freshness:check`: grün
- `preflight-pr-scope`: ✓