### PR TITLE
chore(agents): align gemma and devstral subagents to gemma26-throughput loadout [T011657]

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -336,9 +336,9 @@
     // gemma26-factory (177.920 ctx). Zum beibehaltenen Namen siehe den Hinweis
     // bei "gptoss" oben.
     "devstral": {
-      "description": "Local subagent, now on the gemma26-factory loadout (Gemma 4 26B A4B UD-IQ4_XS, 177920 ctx, Port 8091, via llm-proxy :18235) — the devstral-quality loadout was disabled in T003204 because gemma26-factory dominates it in every dimension; the agent name is kept because it is the orchestrator's dispatch handle. Write-capable delegation; shares exclusiveGroup chat-gpu with the other local loadouts (only one runs at a time).",
+      "description": "Local subagent, now on the gemma26-throughput loadout (Gemma 4 26B A4B QAT UD-Q4_K_XL, 118016 ctx, Port 8092, via llm-proxy :18235) — the devstral-quality loadout was disabled in T003204 because gemma26-factory dominates it in every dimension; updated to gemma26-throughput to share the live loadout with orchestrator and gptoss without GPU swapping. Write-capable delegation; executes one at a time because the proxy serializes (max_inflight=1).",
       "mode": "subagent",
-      "model": "llamacpp-local/gemma26-factory",
+      "model": "llamacpp-local/gemma26-throughput",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#60A5FA",
       "temperature": 0.4,
@@ -346,9 +346,9 @@
       "permission": { "edit": "allow", "write": "deny", "bash": "allow", "task": "deny" }
     },
     "gemma": {
-      "description": "Local subagent for the gemma family (Gemma 4 26B A4B IQ4_XS, Loadout gemma26-factory auf Port 8091, via llm-proxy :18235). Write-capable delegation; shares exclusiveGroup chat-gpu.",
+      "description": "Local subagent for the gemma family (Gemma 4 26B A4B QAT UD-Q4_K_XL, Loadout gemma26-throughput auf Port 8092, via llm-proxy :18235). Write-capable delegation; shares the live GPU loadout with orchestrator/gptoss without swapping.",
       "mode": "subagent",
-      "model": "llamacpp-local/gemma26-factory",
+      "model": "llamacpp-local/gemma26-throughput",
       "prompt": "{file:./prompts/local-subagent.md}",
       "color": "#F59E0B",
       "temperature": 0.4,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ opencode reads its agents from `.opencode/agent-models.jsonc` — NOT `.agents/a
 |-------|-------|----------|
 | `orchestrator` | DeepSeek V4 Flash (OpenCode Go, 1M ctx), `mode: primary`, write-capable | Primary orchestrator — dispatches the local family subagents (`gptoss`/`devstral`/`gemma`/`gemma12`) sequentially (llm-proxy serializes at max_inflight=1) |
 | `gptoss` | `llamacpp-local/gemma26-throughput` (Gemma 4 26B A4B QAT, :8092) | Local bulk work. **Der Name lügt über das Modell seit T003204** — `gptoss-context` ist abgeschaltet, der Name bleibt als Dispatch-Schnittstelle. `write=deny`, `edit=allow` |
-| `devstral` | `llamacpp-local/gemma26-factory` (Gemma 4 26B A4B IQ4_XS, :8091) | Local work. **Name lügt über das Modell seit T003204** — `devstral-quality` war in allen Dimensionen dominiert und ist abgeschaltet |
-| `gemma` | `llamacpp-local/gemma26-factory` (Gemma 4 26B A4B IQ4_XS, :8091) | Local work, gemma family |
+| `devstral` | `llamacpp-local/gemma26-throughput` (Gemma 4 26B A4B QAT, :8092) | Local work. **Name lügt über das Modell seit T003204** — `devstral-quality` war in allen Dimensionen dominiert und ist abgeschaltet |
+| `gemma` | `llamacpp-local/gemma26-throughput` (Gemma 4 26B A4B QAT, :8092) | Local work, gemma family |
 | `gemma12` | `llamacpp-local/gemma12-vision` (Gemma 4 12B QAT + mmproj-F16, :8089) | Local work, 262144 ctx — größter lokaler Kontext und einziges vision-fähiges Loadout. Seit T003204 per `task` dispatchbar |
 | `gemma26-primary` | `llamacpp-local/gemma26-factory`, `mode: primary` | Fully-local tab-selectable agent; NOT summonable via `task` |
 | `gemma26-vision` | `llamacpp-local/gemma26-factory`, `mode: primary` | Max local context (161024, measured), no subagent dispatch. **No vision** — gemma26-factory loads no mmproj (loadouts.json); vision is on `gemma12-vision` only |

--- a/docs/agent-guide/maps/agents-map.md
+++ b/docs/agent-guide/maps/agents-map.md
@@ -27,9 +27,9 @@ Die Registry ist die SSOT: `docs/agent-guide/registry/agents.yaml`.
 | deepseek-helper | subagent | deepseek/deepseek-v4-flash | ja | Escalation: DeepSeek-V4 Flash (1M ctx) via direct DeepSeek API [T002632] |
 | deepseek-pro | all | opencode-go/deepseek-v4-pro | ja | DeepSeek-V4 Pro (1M ctx, max reasoning effort) for deep analysis and hard refactors; tab-selectable + task-dispatchable [T002632] |
 | deepseek-pro-direct | all | deepseek/deepseek-v4-pro | ja | Same model as deepseek-pro, but over the direct DeepSeek API instead of opencode-go — fallback when the gateway is unavailable; tab-selectable + task-dispatchable [T002633] |
-| devstral | subagent | llamacpp-local/gemma26-factory | nein | NAME luegt ueber das Modell: faehrt seit T003204 gemma26-factory (177920 ctx, Port 8091), weil devstral-quality in allen Dimensionen dominiert war. Name bleibt als Dispatch-Schnittstelle [T003204] |
+| devstral | subagent | llamacpp-local/gemma26-throughput | nein | NAME luegt ueber das Modell: faehrt gemma26-throughput (118016 ctx, Port 8092) — Name bleibt als Dispatch-Schnittstelle [T003204] |
 | devstral-primary | primary | llamacpp-local/gemma26-factory | nein | Tab-selectable primary, seit T003204 auf gemma26-factory (Port 8091), 177920 ctx, code-quality review — devstral-quality ist abgeschaltet [T003065/T003204] |
-| gemma | subagent | llamacpp-local/gemma26-factory | nein | gemma family: Gemma 4 26B A4B IQ4_XS, Loadout gemma26-factory auf Port 8091 (exclusiveGroup chat-gpu) [2026-08-09 T002753] |
+| gemma | subagent | llamacpp-local/gemma26-throughput | nein | gemma family: Gemma 4 26B A4B QAT UD-Q4_K_XL, Loadout gemma26-throughput auf Port 8092 (live GPU-Loadout) |
 | gemma12 | subagent | llamacpp-local/gemma12-vision | nein | gemma12 family: Gemma 4 12B QAT + mmproj-F16, Loadout gemma12-vision auf Port 8089, 262144 ctx — groesster lokaler Kontext und einziges vision-faehiges Loadout. Seit T003204 als Subagent dispatchbar (vorher nur Tab-waehlbar via gemma12-primary) |
 | gemma12-primary | primary | llamacpp-local/gemma12-vision | nein | Tab-selectable primary on gemma12-vision (Port 8089), 262144 ctx measured, vision-capable via mmproj-F16 [T003065] |
 | gemma26-primary | primary | llamacpp-local/gemma26-factory | nein | Tab-selectable primary local agent, 161024 ctx measured (np=3 -kvu q4_0 fitt 128) [T002753] |

--- a/docs/agent-guide/registry/agents.yaml
+++ b/docs/agent-guide/registry/agents.yaml
@@ -57,14 +57,14 @@ runtimes:
     note: "NAME luegt ueber das Modell: faehrt seit T003204 gemma26-throughput (118016 ctx, Port 8092), weil gptoss-context abgeschaltet wurde. Der Name bleibt, weil er die Dispatch-Schnittstelle des Orchestrators ist — Umbenennen ist ein eigener Vorgang [T003204]"
   devstral:
     mode: subagent
-    model: llamacpp-local/gemma26-factory
+    model: llamacpp-local/gemma26-throughput
     write_capable: false
-    note: "NAME luegt ueber das Modell: faehrt seit T003204 gemma26-factory (177920 ctx, Port 8091), weil devstral-quality in allen Dimensionen dominiert war. Name bleibt als Dispatch-Schnittstelle [T003204]"
+    note: "NAME luegt ueber das Modell: faehrt gemma26-throughput (118016 ctx, Port 8092) — Name bleibt als Dispatch-Schnittstelle [T003204]"
   gemma:
     mode: subagent
-    model: llamacpp-local/gemma26-factory
+    model: llamacpp-local/gemma26-throughput
     write_capable: false
-    note: "gemma family: Gemma 4 26B A4B IQ4_XS, Loadout gemma26-factory auf Port 8091 (exclusiveGroup chat-gpu) [2026-08-09 T002753]"
+    note: "gemma family: Gemma 4 26B A4B QAT UD-Q4_K_XL, Loadout gemma26-throughput auf Port 8092 (live GPU-Loadout)"
   gemma12:
     mode: subagent
     model: llamacpp-local/gemma12-vision


### PR DESCRIPTION
Aligns subagents gemma and devstral in .opencode/agent-models.jsonc and docs/agent-guide/registry/agents.yaml to llamacpp-local/gemma26-throughput (:8092), matching orchestrator and gptoss.