### PR TITLE
chore(plans): use teardown() instead of EXIT trap in gitleaks test [T011580]

### DIFF
--- a/openspec/changes/fix-alibaba-token-key-guard-tmpdir/design.md
+++ b/openspec/changes/fix-alibaba-token-key-guard-tmpdir/design.md
@@ -36,7 +36,7 @@ Der Test kopiert die Fixture künftig in ein Verzeichnis **ohne** `tmp`-Segment:
 ## Edge-Cases
 
 - `/dev/shm` fehlt (z. B. macOS): Guard `[ -d /dev/shm ] || skip …` — der Test skippt sauber statt zu brechen (Muster T002820).
-- tmpfs-Aufräumen: `trap 'rm -rf "$SCAN_DIR"' EXIT` — kein Müll in `/dev/shm`.
+- tmpfs-Aufräumen: `teardown()` entfernt `$SCAN_DIR` — kein Müll in `/dev/shm`. Bewusst kein `trap ... EXIT` im Testkörper: bats-core überschreibt den EXIT-trap (bats-exec-test), der trap würde nie feuern (Review-Befund 2026-08-18); teardown() läuft bei Pass UND Fail.
 - gitleaks fehlt: bestehender Guard (`command -v gitleaks || skip`) bleibt.
 - Die Fixture bleibt im Repo-Pfad allowlisted (`(?i)tests/.*fixtures/.*`) — der CI-Repo-Scan sieht sie weiterhin nicht; keine CI-Auswirkung.
 

--- a/openspec/changes/fix-alibaba-token-key-guard-tmpdir/tasks.md
+++ b/openspec/changes/fix-alibaba-token-key-guard-tmpdir/tasks.md
@@ -67,7 +67,6 @@ Die Änderung in `tests/spec/security/alibaba-token-key-guard.bats` (Test 1, Fix
 ```bash
 [ -d /dev/shm ] || skip "kein /dev/shm vorhanden — Test braucht einen Scan-Pfad ohne 'tmp'-Segment"
 SCAN_DIR="$(mktemp -d /dev/shm/alk.XXXXXX)"
-trap 'rm -rf "$SCAN_DIR"' EXIT
 cp "$REPO_ROOT/tests/spec/security/fixtures/alibaba-token-key-leak.txt" "$SCAN_DIR/"
 run gitleaks detect --config "$GITLEAKS_CONFIG" --no-git \
   --source "$SCAN_DIR/alibaba-token-key-leak.txt" 2>&1
@@ -75,13 +74,24 @@ run gitleaks detect --config "$GITLEAKS_CONFIG" --no-git \
 [[ "$output" == *"leaks found"* ]]
 ```
 
+Cleanup über eine `teardown()`-Funktion statt `trap ... EXIT` im Testkörper (Review-Befund 2026-08-18): bats-core überschreibt den EXIT-trap des Tests (bats-exec-test) — der trap feuert nie und jeder Lauf leakte ein `alk.*`-Verzeichnis nach /dev/shm. `teardown()` läuft bei Pass UND Fail. Der if-Block (statt `&&`-Einzeiler) ist Pflicht: eine false-Bedingung als letzte Zeile endet mit Exit 1 und bats färbt den Test als teardown-Fehler, obwohl die Testlogik grün war:
+
+```bash
+teardown() {
+  if [ -n "${SCAN_DIR:-}" ]; then
+    rm -rf "$SCAN_DIR"
+  fi
+}
+```
+
 Prüfschritte:
 
 1. Diff gegen den Basis-Stand prüfen: `git diff tests/spec/security/alibaba-token-key-guard.bats` — geändert ist nur der Fixture-Scan-Pfad in Test 1 (plus Kommentar), die gitleaks-Allowlist-Datei ist nicht berührt.
-2. Testlauf (muss grün sein — beide Tests ok, Exit 0):
+2. Testlauf (muss grün sein — beide Tests ok, Exit 0) plus Cleanup-Check (teardown() darf keinen `alk.*`-Rest in /dev/shm hinterlassen):
 
 ```bash
 tests/unit/lib/bats-core/bin/bats tests/spec/security/alibaba-token-key-guard.bats
+ls -d /dev/shm/alk.* 2>/dev/null | wc -l   # erwartet 0 — teardown() räumt auf
 ```
 
 3. Committen (Change-Set inkl. Delta-Spec) — der Stage-Commit trägt `chore(plans):`, weil sein Diff nur Test-/Plan-Artefakte enthält (commit-vs-diff-Guard blockiert `fix(…)`-Präfixe für reine Test/Plan-Diffs; T001434). Der Implementer führt diesen Commit nur aus, falls der Stage-Commit ihn nicht bereits enthält:

--- a/tests/spec/security/alibaba-token-key-guard.bats
+++ b/tests/spec/security/alibaba-token-key-guard.bats
@@ -18,6 +18,19 @@ setup() {
   GITLEAKS_CONFIG="$REPO_ROOT/.gitleaks.toml"
 }
 
+teardown() {
+  # Cleanup der Fixture-Kopie in /dev/shm. Bewusst teardown() statt
+  # 'trap ... EXIT' im Testkoerper: bats-core ueberschreibt den EXIT-trap
+  # (bats-exec-test) — der trap wuerde nie feuern und jeder Lauf leakte ein
+  # alk.*-Verzeichnis nach /dev/shm. teardown() laeuft bei Pass UND Fail.
+  # if-Block statt '&&'-Einzeiler: eine false-Bedingung als letzte Zeile der
+  # Funktion endet mit Exit 1 und bats faerbt den Test als teardown-Fehler,
+  # obwohl die Testlogik gruen war (beobachtet am 2026-08-18).
+  if [ -n "${SCAN_DIR:-}" ]; then
+    rm -rf "$SCAN_DIR"
+  fi
+}
+
 @test "gitleaks-Config erfasst das Alibaba-Token-Format (sk-separated-api-key)" {
   command -v gitleaks >/dev/null || skip "gitleaks nicht installiert (CI: security-scan-Job deckt den Scan ab)"
 
@@ -31,7 +44,6 @@ setup() {
   # taucht nie im --no-git-Arbeitsbaum-Scan des Pre-Commit-Hooks auf.
   [ -d /dev/shm ] || skip "kein /dev/shm vorhanden — Test braucht einen Scan-Pfad ohne 'tmp'-Segment"
   SCAN_DIR="$(mktemp -d /dev/shm/alk.XXXXXX)"
-  trap 'rm -rf "$SCAN_DIR"' EXIT
   cp "$REPO_ROOT/tests/spec/security/fixtures/alibaba-token-key-leak.txt" "$SCAN_DIR/"
   run gitleaks detect --config "$GITLEAKS_CONFIG" --no-git \
     --source "$SCAN_DIR/alibaba-token-key-leak.txt" 2>&1


### PR DESCRIPTION
## Follow-up auf PR #4710 (Review-Gate: With fixes)

PR #4710 wurde durch den user-aktivierten Auto-Merge bereits auf main gemergt (896c13e33), BEVOR der Review-Fix gepusht war — der gemergte Stand enthält den Trap-Cleanup-Fehler. Dieser PR liefert den Review-Fund nach (Commit fcb0daacc).

## Review-Fund (Important, empirisch verifiziert)

`trap 'rm -rf "$SCAN_DIR"' EXIT` im Testkörper funktioniert unter bats-core nicht:

- **Erfolgspfad:** bats-core klobbert den Test-trap nach dem Body (bats-exec-test:365) — der trap feuert nie; jeder grüne Lauf leakte ein `alk.*`-Verzeichnis (mit Fixture-Kopie) nach /dev/shm.
- **Fehlerpfad:** der Test-trap überschreibt bats' eigenen EXIT-trap und verschluckt die `not ok`-Zeile — genau die Diagnosequalität des Guards ginge verloren.

## Änderung

- **Testdatei:** `teardown()` räumt `$SCAN_DIR` (bats führt teardown bei Pass UND Fail aus); kein trap im Testkörper.
- **Verfeinerung gegenüber dem Review-Vorschlag:** if-Block statt `[ -n ... ] && rm -rf`-Einzeiler — eine false-Bedingung als letzte Zeile endet mit Exit 1, und bats färbt den Test als teardown-Fehler, obwohl die Testlogik grün war (beim ersten Verifikationslauf beobachtet: Test 2 'not ok' nur wegen des Guards).
- **tasks.md:** Snippet auf teardown() umgestellt, Cleanup-Check (`ls -d /dev/shm/alk.* | wc -l`, erwartet 0) in die Prüfschritte aufgenommen, if-Block-Begründung dokumentiert.
- **design.md:** Edge-Cases-Zeile auf teardown-Cleanup umformuliert.

## Verifikation

- BATS: beide Tests ok, Exit 0 — `alk.*`-Reste nach Lauf: 0
- `task test:spec:changed`: grün (1 von 571 selektiert)
- `bash scripts/plan-lint.sh` auf tasks.md: PASS (0 hard, 0 warn)
- Diff bleibt Test/Plan-only — kein fix()-Präfix im Commit (T001434)

Referenziert T011580 (Ticket wurde durch den Merge von #4710 geschlossen — kein Closes auf diesem PR).