### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/components/website/src/data/openspec-status.json
+++ b/components/website/src/data/openspec-status.json
@@ -3981,6 +3981,12 @@
       "status": "archived"
     }
   ],
+  "T009369": [
+    {
+      "slug": "mishap-incident-rollup-2026-08-17-T009369",
+      "status": "plan_staged"
+    }
+  ],
   "T011498": [
     {
       "slug": "2026-08-17-sdlc-deck-leiste-overflow",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32075911138).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
