### PR TITLE
chore(ci): GitLab-Runner-Runbook um reale Betriebsfallen ergaenzen [T012048]

### DIFF
--- a/docs/runbooks/gitlab-runner.md
+++ b/docs/runbooks/gitlab-runner.md
@@ -28,7 +28,43 @@ die fehlende Variable), statt still ohne Spiegelung zu enden.
   brechen den Push still: eine falsch zusammengesetzte URL ist kein `git`-Syntaxfehler,
   sondern schlaegt erst beim tatsaechlichen Netzwerkzugriff fehl.
 
-## 2. Ersteinrichtung des Runners
+## 2. Installation des Runner-Binaries
+
+Auf dem Host, der den Runner betreiben soll (Ubuntu/Debian). Der offizielle
+apt-Weg mit manuell hinterlegtem GPG-Key — kein `curl | sudo bash`:
+
+```bash
+curl -fsSL https://packages.gitlab.com/runner/gitlab-runner/gpgkey \
+  | sudo gpg --dearmor -o /usr/share/keyrings/gitlab-runner.gpg
+echo "deb [signed-by=/usr/share/keyrings/gitlab-runner.gpg] https://packages.gitlab.com/runner/gitlab-runner/ubuntu/ $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/gitlab-runner.list
+sudo apt-get update && sudo apt-get install -y gitlab-runner
+```
+
+Das Paket legt den Dienst-User `gitlab-runner` an und aktiviert den
+systemd-Dienst.
+
+### 2.1 Docker-Gruppe — sonst scheitert erst der erste Job
+
+Der Docker-Executor braucht Zugriff auf den Docker-Socket. Der Dienst-User ist
+nach der Installation **nicht** in der `docker`-Gruppe:
+
+```bash
+sudo usermod -aG docker gitlab-runner
+sudo systemctl restart gitlab-runner
+sudo -u gitlab-runner docker version --format '{{.Server.Version}}'   # muss eine Version ausgeben
+```
+
+Ohne diesen Schritt laufen Installation, Registrierung und `gitlab-runner verify`
+alle sauber durch — der Fehler taucht erst beim **ersten Job** auf, als
+`permission denied while trying to connect to the Docker daemon socket`.
+
+> **Sicherheitshinweis:** Mitgliedschaft in der `docker`-Gruppe entspricht
+> faktisch Root-Rechten auf dem Host. CI-Jobs laufen damit mit erheblichen
+> Rechten. Für einen lokalen Entwicklungs-Runner ist das der vorgesehene Weg;
+> auf einem geteilten oder produktiven Host wäre es das nicht.
+
+## 3. Ersteinrichtung des Runners
 
 1. Im GitLab-Projekt einen neuen Runner anlegen (Project Settings → CI/CD →
    Runners → "New project runner"), Tag `bachelorprojekt-local` vergeben und den
@@ -52,7 +88,66 @@ die fehlende Variable), statt still ohne Spiegelung zu enden.
    das Skript mit Exit-Code ≠ 0 ab und benennt die fehlende Voraussetzung — es
    endet nie wirkungslos-gruen.
 
-## 3. Fallback-Umschaltung — der eigentliche Zweck dieses Runbooks
+### 3.1 Registrierung braucht `sudo` — sonst läuft der Runner nie als Dienst
+
+`gitlab-runner register` **ohne** `sudo` schreibt nach
+`~/.gitlab-runner/config.toml`. Der systemd-Dienst liest aber
+`/etc/gitlab-runner/config.toml`. Das Ergebnis ist tückisch: Die Registrierung
+meldet Erfolg, der Runner erscheint in der GitLab-Oberfläche — und läuft
+trotzdem nicht, weil der Dienst eine leere Konfiguration vorfindet. Nach dem
+nächsten Neustart wäre er ganz verschwunden.
+
+Prüfen, in welcher Konfiguration der Runner gelandet ist:
+
+```bash
+sudo grep -c '\[\[runners\]\]' /etc/gitlab-runner/config.toml   # muss >= 1 sein
+sudo gitlab-runner verify                                        # muss "is valid" melden
+```
+
+Meldet `verify` keinen Runner, liegt die Registrierung im User-Modus. Die
+`[[runners]]`-Sektion nachträglich übernehmen (Token gerät dabei nicht ins Log):
+
+```bash
+sudo cp /etc/gitlab-runner/config.toml /etc/gitlab-runner/config.toml.bak
+awk '/^\[\[runners\]\]/{f=1} f' ~/.gitlab-runner/config.toml \
+  | sudo tee -a /etc/gitlab-runner/config.toml > /dev/null
+sudo systemctl restart gitlab-runner && sudo gitlab-runner verify
+```
+
+### 3.2 Tags werden beim `glrt-`-Fluss serverseitig verwaltet
+
+Beim Authentication-Token-Fluss gehören Tags und die Untagged-Einstellung zum
+Runner-Objekt **in GitLab**, nicht zur lokalen Konfiguration. Das
+`--tag-list`-Argument des Registrierungsbefehls bleibt dort **wirkungslos** —
+es steht im Skript, weil es beim älteren Fluss und bei self-managed Instanzen
+weiterhin greift, aber es setzt hier nichts.
+
+Nach der Registrierung deshalb in GitLab prüfen (Settings → CI/CD → Runners →
+Edit):
+
+- Tag `bachelorprojekt-local` ist gesetzt
+- "Run untagged jobs" ist **ausgeschaltet**
+
+Das zweite ist nicht kosmetisch: Nimmt der Runner auch ungetaggte Jobs an, zieht
+er Arbeit an, die eigentlich in die Cloud ausweichen soll — der Fallback aus
+Abschnitt 4 wäre damit ausgehebelt.
+
+### 3.3 Nebenläufigkeit an die Zahl der Jobs anpassen
+
+Der Default `concurrent = 1` lässt die drei Kern-Jobs seriell laufen. In
+`/etc/gitlab-runner/config.toml`:
+
+```toml
+concurrent = 3
+
+[[runners]]
+  request_concurrency = 2
+```
+
+`request_concurrency` mahnt der Runner sonst selbst als Long-Polling-Bottleneck
+im Journal an. Nach der Änderung `sudo systemctl restart gitlab-runner`.
+
+## 4. Fallback-Umschaltung — der eigentliche Zweck dieses Runbooks
 
 Der Compute-Fallback laeuft ausschliesslich ueber die Projekt-Variable
 `CI_RUNNER_TAG` (design.md D2). Kein Job in `.gitlab-ci.yml` traegt einen
@@ -73,7 +168,7 @@ hartkodierten Tag; jeder Job deklariert `tags: [$CI_RUNNER_TAG]`.
 Beide Richtungen (Umschalten und Zuruecksetzen) gehoeren zum selben Vorgang und
 sind im Ticket zu vermerken, wenn dieser Fallback real ausgeloest wurde.
 
-## 4. Diagnose — woran erkennt man einen Runner-Ausfall
+## 5. Diagnose — woran erkennt man einen Runner-Ausfall
 
 Ein ausgefallener self-hosted Runner sieht **nicht** wie ein Fehlschlag aus:
 Jobs bleiben `pending` statt zu scheitern, weil GitLab wartet, bis ein Runner mit
@@ -86,9 +181,33 @@ passendem Tag verfuegbar wird. Anzeichen:
 - Auf dem Runner-Host selbst: `sudo gitlab-runner status` bzw. `systemctl status
   gitlab-runner` meldet den Dienst als nicht laufend.
 
-Ein haengender Job ist deshalb der Trigger fuer Schritt 2, nicht ein rotes X.
+Ein haengender Job ist deshalb der Trigger fuer die Fallback-Umschaltung, nicht
+ein rotes X.
 
-## 5. Warum die Umschaltung manuell ist
+### 5.1 Jobs hängen, obwohl der Runner online ist
+
+`pending` hat zwei Ursachen, die von außen gleich aussehen. Die erste ist der
+Ausfall oben. Die zweite: Der Runner läuft einwandfrei, ihm fehlt nur der Tag,
+den die Jobs verlangen (Abschnitt 3.2). GitLab bietet ihm die Jobs dann gar
+nicht erst an — deshalb steht in seinem Journal **keine** Ablehnung, sondern
+überhaupt nichts. Genau dieses Schweigen führt in die Irre: Es liest sich wie
+ein Netzwerk- oder Authentifizierungsproblem, ist aber eine Konfigurationslücke.
+
+Die beiden Fälle unterscheidet man an einer Stelle:
+
+| Beobachtung | Ausfall (5) | Tag fehlt (3.2) |
+|---|---|---|
+| Runner-Status in GitLab | offline / stale | **online** |
+| `sudo gitlab-runner verify` | schlägt fehl oder findet nichts | `is valid` |
+| `systemctl is-active gitlab-runner` | inaktiv | `active` |
+| Journal des Runners | Verbindungsfehler | ruhig, nur Polling |
+
+Meldet `verify` einen gültigen Runner und ist der Dienst aktiv, liegt es nicht
+am Host — dann in GitLab die Tags des Runners prüfen. Denselben Weg nimmt man,
+wenn ein Job nach dem Fallback-Umschalten hängt: dann fehlt dem SaaS-Tag
+gegenüber der Variablenwert, nicht dem Runner der Tag.
+
+## 6. Warum die Umschaltung manuell ist
 
 Ein automatisches Ausweichen auf Shared Runner wuerde den Ausfall des
 self-hosted Runners verbergen — die Pipeline liefe unauffaellig weiter, nur auf
@@ -96,7 +215,7 @@ anderer Hardware. Ein Ausfall, den niemand bemerkt, wird nicht behoben. Der
 Rueckfall gehoert deshalb bewusst ins Runbook und nicht in eine Selbstheilung
 (design.md D2).
 
-## 6. Abgrenzung
+## 7. Abgrenzung
 
 Diese Etappe betreibt ausschliesslich den lokalen Docker-Executor auf einem
 einzelnen self-hosted Host. Ein Kubernetes-Executor auf `fleet` als zweiter


### PR DESCRIPTION
Ergänzt `docs/runbooks/gitlab-runner.md` um vier Betriebsfallen, die bei der Ersteinrichtung des self-hosted Runners (Etappe 1, T011790) real aufgetreten sind — keine theoretisch abgeleiteten Hinweise.

## Was neu ist

**Abschnitt 2 (neu) — Installation des Binaries.** Fehlte bisher ganz. Offizieller apt-Weg mit manuell hinterlegtem GPG-Key statt `curl | sudo bash`.

**2.1 — Docker-Gruppe.** Der Dienst-User ist nach der Installation nicht in der `docker`-Gruppe. Installation, Registrierung und `verify` laufen trotzdem sauber durch; der Fehler taucht erst beim *ersten Job* als `permission denied` auf. Mit Sicherheitshinweis, weil die Gruppe faktisch Root-Rechten entspricht.

**3.1 — `sudo`-Pflicht bei `register`.** Ohne `sudo` landet die Konfiguration in `~/.gitlab-runner/config.toml`, der systemd-Dienst liest aber `/etc/gitlab-runner/config.toml`. Die Registrierung meldet Erfolg, der Runner erscheint in der GitLab-Oberfläche — und läuft trotzdem nicht. Inklusive Prüfbefehl und Migrationsweg für den Fall, dass es schon passiert ist.

**3.2 — Tags sind beim `glrt-`-Fluss serverseitig.** Das `--tag-list`-Argument bleibt dort wirkungslos. Die Folge ist der verwirrendste der vier Fälle: Jobs bleiben `pending`, ohne Fehlermeldung und ohne Journal-Eintrag, weil GitLab einem Runner ohne passenden Tag die Jobs gar nicht erst anbietet.

**3.3 — Nebenläufigkeit.** `concurrent = 1` lässt die drei Kern-Jobs seriell laufen.

**5.1 — Diagnose-Ergänzung.** Bisher beschrieb der Abschnitt nur den Runner-*Ausfall*. „Runner online, aber Tag fehlt" sieht von außen identisch aus (`pending`), hat aber eine andere Ursache. Eine Tabelle trennt beide Fälle an vier Beobachtungen.

## Sonstiges

- Abschnitte umnummeriert (2–7), ein Querverweis nummernunabhängig formuliert, damit er beim nächsten Umbau nicht bricht.
- Reine Dokumentation, keine Verhaltensänderung. Kein Guard hängt an dieser Datei; `task freshness:regenerate` erzeugt keine Artefaktänderung.

Closes T012048