### PR TITLE
fix(test): Status-Guards gegen die SSOT statuses.json statt gegen SQL-Literale [T012241]

### DIFF
--- a/tests/unit/tickets-plan-staged-migration.bats
+++ b/tests/unit/tickets-plan-staged-migration.bats
@@ -12,11 +12,20 @@
 setup() {
   SRC="$BATS_TEST_DIRNAME/../../components/website/src/lib/tickets-schema.ts"
   TMIG="$BATS_TEST_DIRNAME/../../components/website/src/lib/tickets/migrations.ts"
+  STATUSES="$BATS_TEST_DIRNAME/../../components/website/src/lib/tickets/statuses.json"
 }
 
-@test "tickets: status CHECK enthält plan_staged" {
-  # The status CHECK lives in the legacy-migrations module since Batch 2.
-  run grep -F "'plan_staged'" "$TMIG"
+# Seit T007955 baut migrations.ts den Status-CHECK aus TICKET_STATUSES statt aus
+# einem SQL-Literal. Die Statusliste selbst ist damit die pruefbare Quelle — die
+# beiden folgenden Tests pruefen sie, nicht mehr den erzeugten SQL-Text.
+#
+# Die frueheren Fassungen greppten dafuer in migrations.ts. Das war doppelt
+# unbrauchbar: Der Reihenfolge-Test fiel, weil das Literal dort nicht mehr
+# existiert, und der Enthalten-Test BESTAND, weil 'plan_staged' in zwei
+# Kommentarzeilen vorkommt — er haette den Verlust des Status nie bemerkt.
+
+@test "tickets: plan_staged ist ein gueltiger Status (SSOT statuses.json)" {
+  run jq -e 'index("plan_staged") != null' "$STATUSES"
   [ "$status" -eq 0 ]
 }
 
@@ -33,6 +42,29 @@ setup() {
   STS="$BATS_TEST_DIRNAME/../../components/website/src/lib/tickets/status.ts"
   run awk -v p=0 -v s=0 -v b=0 \
     '/'"'"'planning'"'"'/{p=1} /'"'"'plan_staged'"'"'/{s=p} /'"'"'backlog'"'"'/{b=s} END{exit !(p && s && b)}' "$STS"
+  [ "$status" -eq 0 ]
+}
+
+@test "tickets: plan_staged steht zwischen planning und backlog (SSOT statuses.json)" {
+  # Zweite Ebene, absichtlich neben dem Test darueber: jener prueft das
+  # Tuple-Literal in status.ts (Compile-Time-Kontrakt), dieser die JSON-Datei, aus
+  # der status.ts zur Laufzeit liest. Driften die beiden auseinander, faellt das
+  # sonst niemandem auf — die Reihenfolge im Tuple ist reine Typ-Deklaration.
+  #
+  # Positiv-Anker: erst belegen, dass alle drei Status ueberhaupt vorhanden sind —
+  # sonst bestuende der Reihenfolge-Vergleich bei fehlenden Eintraegen vakuos.
+  run jq -e 'index("planning") != null and index("plan_staged") != null and index("backlog") != null' "$STATUSES"
+  [ "$status" -eq 0 ]
+
+  run jq -e 'index("planning") < index("plan_staged") and index("plan_staged") < index("backlog")' "$STATUSES"
+  [ "$status" -eq 0 ]
+}
+
+@test "tickets: der Status-CHECK wird aus TICKET_STATUSES gebaut, nicht aus einem Literal" {
+  # Die Zusicherung aus T007955: DB-Constraint und TypeScript-Union koennen nicht
+  # driften, weil beide aus derselben Liste stammen. Genau diese Umstellung hat den
+  # frueheren Literal-Test gebrochen — sie gehoert deshalb selbst unter einen Guard.
+  run grep -F "TICKET_STATUSES.map" "$TMIG"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
`tests/unit/tickets-plan-staged-migration.bats` prüfte den Status-CHECK, indem es SQL-Literale in `migrations.ts` greppte. Seit T007955 (`3fb3cbe93`) baut `migrations.ts` den CHECK aber **dynamisch aus `TICKET_STATUSES`** — das Literal existiert nicht mehr.

## Zwei Befunde, nicht einer

**Der sichtbare:** `plan_staged steht zwischen planning und backlog im CHECK` suchte `'planning','plan_staged','backlog'` und fiel, seit der String verschwunden ist. Das ist der rote Test in CI.

**Der unsichtbare — und der schlimmere:** `status CHECK enthält plan_staged` blieb **grün**, weil `grep -F "'plan_staged'"` in `migrations.ts` zwei Treffer findet — beide in **Kommentarzeilen** (Zeile 46 und 49). Der Test hätte den Verlust des Status nie bemerkt. Er prüfte Prosa.

## Der Fix

Beide Zusicherungen hängen jetzt an `components/website/src/lib/tickets/statuses.json` — der tatsächlichen SSOT, aus der sowohl der DB-Constraint als auch die TypeScript-Union entstehen. Geprüft wird per `jq` auf Indexpositionen statt per Substring auf generiertes SQL.

Dazu ein **Positiv-Anker** im Reihenfolge-Test (erst belegen, dass alle drei Status vorhanden sind — sonst bestünde der Vergleich bei fehlenden Einträgen vakuos) und ein **neuer vierter Guard**, der die Zusicherung aus T007955 selbst absichert: dass der CHECK aus `TICKET_STATUSES` gebaut wird und nicht wieder als Literal.

## Gegenprobe

`plan_staged` testweise aus `statuses.json` entfernt → Tests 1 und 3 werden **rot**. Der alte Test 1 wäre dabei grün geblieben. Datei danach bitidentisch wiederhergestellt.

Lokal: 8/8 grün.

## Kontext

Gefunden beim Implementieren von T012177 (GitLab-CI Etappe 2). Gehört zur selben Klasse wie T011899–T011906: veraltete Testerwartungen, die das Diff-Scoping der CI seit Monaten nicht ausführt. Kein Produktdefekt — `migrations.ts` verhält sich korrekt.

Closes T012241