### PR TITLE
chore(infra): ignore out/ (flux-render-artifact.sh default output dir) [T012308]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,6 @@ scripts/ticket-mcp/go/ticket-mcp
 # Audit-Log des Cockpit-Daemons — Laufzeitartefakt, entsteht bei jedem Start
 # und bei jedem Testlauf gegen die Write-Endpunkte [T002721].
 audit.jsonl
+
+# flux-render-artifact.sh rendert per Default nach out/ (Build-Artefakt)
+out/


### PR DESCRIPTION
`scripts/flux-render-artifact.sh` setzt `OUT_DIR="out"` (Zeile 10) und rendert die Flux-Manifeste per Default dorthin. Das Verzeichnis war nicht ignoriert und tauchte in jedem `git status` als untracked auf.

Verifiziert: `git check-ignore -v out/probe.yaml` → `.gitignore:232:out/`.

Ticket: T012308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K79tKVnbs8bhX2RTUuZQoD