### PR TITLE
fix(ci): yq, envsubst und PyYAML in den GitLab-bats-unit-Job aufnehmen [T012309]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,8 +44,24 @@ bats-unit:
   # dafuer existiert, dass test-bats OHNE kubectl auskommt).
   image: node:22
   tags: [$CI_RUNNER_TAG]
+  variables:
+    YQ_VERSION: "4.53.3"
   before_script:
-    - apt-get update -qq && apt-get install -y -qq --no-install-recommends git bash python3 jq ca-certificates curl >/dev/null
+    # python3-yaml und gettext-base (envsubst) gehoeren zur Toolchain-Paritaet, nicht
+    # zum Komfort: ubuntu-latest bringt beide vorinstalliert mit, das Debian-basierte
+    # node:22 keines. ci.yml installiert PyYAML sogar explizit nach (Zeile 312) mit
+    # genau dieser Begruendung. Ohne sie schlagen tests/unit/scripts.bats (4 Tests,
+    # ModuleNotFoundError: No module named 'yaml') und
+    # tests/unit/flux-render-runtime-vars.bats (envsubst) auf reine Umgebung fehl.
+    - apt-get update -qq && apt-get install -y -qq --no-install-recommends git bash python3 python3-yaml gettext-base jq ca-certificates curl >/dev/null
+    # yq: mikefarah v4, NICHT das gleichnamige apt-Paket (ein Python-jq-Wrapper mit
+    # anderer Syntax). tests/unit/plan-lint.bats ruft `yq -r` mit @tsv auf,
+    # scripts/hermes-mcp-provision.sh `yq eval` — beides v4-Syntax. Wie beim
+    # task-Binary ein eigener curl --fail-Schritt, damit ein toter Host den Job
+    # rot macht statt still ohne das Werkzeug weiterzulaufen.
+    - curl --fail -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
+    - chmod +x /usr/local/bin/yq
+    - yq --version
     # Separater Download-Schritt mit curl --fail (wie im manifests-Job): "-ssL" ist
     # zweimal --silent statt -sS, unterdrueckt also die Fehlermeldung, UND der
     # Exit-Code eines fehlschlagenden curl innerhalb von "$(...)" geht in der

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2640,6 +2640,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/gitlab-batsunit-toolchain",
+    "file": "tests/spec/ci-cd/gitlab-batsunit-toolchain.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/gitlab-mirror-workflow",
     "file": "tests/spec/ci-cd/gitlab-mirror-workflow.bats",
     "category": "ci-cd",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1089,
+      "file_count": 1090,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -469,6 +469,7 @@
         "tests/spec/ci-cd/generated-artifacts-registry.bats",
         "tests/spec/ci-cd/ghcr-digest-auth.bats",
         "tests/spec/ci-cd/git-flow-poll-and-branch-order.bats",
+        "tests/spec/ci-cd/gitlab-batsunit-toolchain.bats",
         "tests/spec/ci-cd/gitlab-mirror-workflow.bats",
         "tests/spec/ci-cd/gitlab-parallel-non-blocking.bats",
         "tests/spec/ci-cd/gitlab-pipeline-check.bats",

--- a/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
+++ b/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# T012309 — Der GitLab-Job bats-unit muss die Werkzeuge mitbringen, die
+# ubuntu-latest den GitHub-Jobs vorinstalliert liefert.
+#
+# PRUEFMODUS: Quelltext-Grep gegen .gitlab-ci.yml. Das ist hier das angemessene
+# Mittel und die dokumentierte Ausnahme der Test-Resultats-Konvention: die
+# Zusicherung ist eine CI-Konfigurationsaussage, ihr Resultat manifestiert sich
+# ausschliesslich im Quelltext. Den Laufzeitbeweis liefert die Pipeline selbst
+# (39 Fehlschlaege ohne, 1 mit den Werkzeugen, bei 875 Tests) — er ist in einem
+# Repo-Test nicht reproduzierbar, ohne den Job zu fahren.
+#
+# Bewusst NICHT festgeschrieben: Paketreihenfolge, Zeilenumbrueche, die exakte
+# apt-Aufrufform. Geprueft wird, DASS das Werkzeug beschafft wird (T002716:
+# Semantik statt Darstellung).
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  CI="$REPO_ROOT/.gitlab-ci.yml"
+  # Nur der bats-unit-Job, nicht die ganze Datei: ein Treffer im manifests-Job
+  # wuerde die Aussage sonst falsch erfuellen.
+  BATS_UNIT_BLOCK="$(awk '/^bats-unit:/{f=1} /^manifests:/{f=0} f' "$CI")"
+}
+
+@test "T012309: .gitlab-ci.yml existiert und enthaelt den bats-unit-Job" {
+  # Positiv-Anker vor den Werkzeug-Zusicherungen: ohne ihn wuerden die Tests
+  # unten bei leerem Block schweigend anders scheitern statt hier klar.
+  [ -f "$CI" ]
+  [ -n "$BATS_UNIT_BLOCK" ]
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'image: node:22'
+}
+
+@test "T012309: bats-unit installiert PyYAML (python3-yaml)" {
+  # tests/unit/scripts.bats laedt Taskfile.yml und kustomization.yaml per
+  # `python3 -c "import yaml"`. node:22 bringt das Modul nicht mit.
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'python3-yaml'
+}
+
+@test "T012309: bats-unit installiert envsubst (gettext-base)" {
+  # tests/unit/flux-render-runtime-vars.bats ruft envsubst direkt auf.
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'gettext-base'
+}
+
+@test "T012309: bats-unit beschafft yq als mikefarah-Binary, nicht per apt" {
+  # Das apt-Paket 'yq' ist ein Python-jq-Wrapper mit anderer Syntax;
+  # tests/unit/plan-lint.bats nutzt `yq -r ... @tsv` (mikefarah v4).
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'mikefarah/yq/releases'
+  # ... und der Download bricht bei totem Host ab, statt still ohne das
+  # Werkzeug weiterzulaufen (dieselbe Begruendung wie beim task-Binary).
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -F -e 'mikefarah/yq/releases' | grep -qF -e '--fail'
+}
+
+@test "T012309: yq wird NICHT ueber apt-get install bezogen" {
+  # Negativ-Aussage mit dem Positiv-Anker aus dem Test darueber: der
+  # mikefarah-Download ist dort bereits zugesichert, diese Zeile darf also
+  # nicht zusaetzlich das apt-Paket ziehen.
+  # Kein `run bash -c`: BATS_UNIT_BLOCK ist nicht exportiert, in einer Subshell
+  # waere es leer und die Zaehlung 0 — der Test bestuende vakuos.
+  apt_lines="$(printf '%s' "$BATS_UNIT_BLOCK" | grep -E '^[[:space:]]*- apt-get')"
+  [ -n "$apt_lines" ]                     # Positiv-Anker: es GIBT apt-get-Zeilen
+  printf '%s' "$apt_lines" | grep -qF -e 'python3-yaml'   # ... und sie sind die gemeinten
+  ! printf '%s' "$apt_lines" | grep -qE '(^| )yq( |$)' 
+}


### PR DESCRIPTION
## Summary

Der GitLab-Spiegel war seit Etappe 1 **nie grün**. Nach dem Merge von T011907 (#4752, 10 veraltete Testerwartungen behoben) blieben 39 Fehlschläge im Job `bats-unit`. Die dominante Ursache ist keine weitere veraltete Erwartung, sondern eine **unvollständige Toolchain**: `ubuntu-latest` bringt `yq`, `envsubst` und PyYAML vorinstalliert mit, das Debian-basierte `node:22` keines davon.

Der Job-Kommentar beansprucht Toolchain-Parität ("dieser Job muss dieselbe TOOLCHAIN mitbringen") — für diese drei war sie nicht hergestellt. `ci.yml` installiert PyYAML sogar explizit nach (Zeile 312) mit genau dieser Begründung.

## Messung

Der Job wurde im CI-Image nachgestellt (`before_script` + Dateiauswahl aus `.gitlab-ci.yml`), Repro-Skript im Job-Verzeichnis:

```bash
WORK=/tmp/ci-repro
git clone file:///home/patrick/Bachelorprojekt "$WORK"
cd "$WORK" && git checkout 8469783d9
docker run --rm -v "$WORK:/repo" -w /repo node:22 bash -c '
  apt-get update -qq && apt-get install -y -qq --no-install-recommends git bash python3 jq ca-certificates curl
  curl --fail -sSL https://taskfile.dev/install.sh -o /tmp/i.sh && sh /tmp/i.sh -b /usr/local/bin
  npm ci && bash scripts/ci-dummy-secrets.sh
  ./tests/unit/lib/bats-core/bin/bats $FILES --formatter tap > /repo/bats-tap.log'
grep -cE "^not ok" "$WORK/bats-tap.log"
```

| Stand | Fehlschläge | von |
|---|---|---|
| vor #4752 | 49 | 875 |
| nach #4752 (`8469783d9`) | 39 | 875 |
| **mit dieser Änderung** | **1** | **875** |

Ursachen-Cluster aus dem TAP-Log vor dem Fix:

- 4× `ModuleNotFoundError: No module named 'yaml'` — `tests/unit/scripts.bats`
- 5× `yq: command not found` — `tests/unit/plan-lint.bats`
- 1× `envsubst: command not found` — `tests/unit/flux-render-runtime-vars.bats`
- der Rest fällt als Folge weg (u. a. `wg-mesh-*.bats`, die ich zunächst für git-crypt-bedingt hielt — sie hingen an `yq`)

## Entscheidungen

- **`yq` als mikefarah-v4-Binary, nicht per apt.** Das gleichnamige Debian-Paket ist ein Python-jq-Wrapper mit anderer Syntax; `plan-lint.bats` nutzt `yq -r … @tsv`, `hermes-mcp-provision.sh` nutzt `yq eval` — beides v4. Ein Guard-Test hält das fest.
- **Eigener `curl --fail`-Schritt**, gleiche Begründung wie beim `task`-Binary im selben Job: ein toter Host macht den Job rot, statt ihn still ohne das Werkzeug weiterlaufen zu lassen.
- **Version gepinnt** (`YQ_VERSION: "4.53.3"`, die lokal verwendete).

## Guard

`tests/spec/ci-cd/gitlab-batsunit-toolchain.bats` (5 Zusicherungen). RED gegen die `.gitlab-ci.yml` vor dem Fix verifiziert: 4 von 5 fallen, der Positiv-Anker bleibt grün.

Der Guard greppt bewusst den Quelltext — die dokumentierte Ausnahme der Test-Resultats-Konvention für CI-Konfigurationsaussagen. Festgeschrieben wird nur, **dass** die Werkzeuge beschafft werden, nicht Paketreihenfolge oder Aufrufform (T002716: Semantik statt Darstellung).

## Verbleibend (eigene Vorgänge)

1 Fehlschlag bleibt: `tests/unit/ticket-grill.bats` — `grill --grilling-doc --dry-run-json splits answered vs unanswered`. Umgebungsbedingt, noch nicht triagiert.

Ein Befund meiner Nachstellung war **kein** CI-Befund: `detected dubious ownership in repository at '/repo'` entsteht nur durch den Docker-Bind-Mount eines fremd-eigenen Klons. Der GitLab-Runner klont selbst und sieht das nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3sHMZCA4ErKtRpr1yCshx
