### PR TITLE
fix(ci): envsubst und PyYAML in den GitLab-manifests-Job aufnehmen [T012313]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,7 +135,13 @@ manifests:
   variables:
     KUBECTL_VERSION: "v1.31.0"
   before_script:
-    - apt-get update -qq && apt-get install -y -qq --no-install-recommends curl bash ca-certificates python3 jq >/dev/null
+    # gettext-base und python3-yaml aus demselben Grund wie im bats-unit-Job
+    # (T012309): ubuntu-latest auf GitHub liefert beide vorinstalliert, das nackte
+    # ubuntu:24.04-Image nicht. Ohne envsubst bricht setup_file in
+    # tests/unit/manifests.bats mit Status 127 ab (die Office-Stack-Templates
+    # laufen dort durch envsubst) und reisst die ganze Datei mit; ohne PyYAML
+    # fallen zwei Tests in tests/unit/dead-node-affinity.bats.
+    - apt-get update -qq && apt-get install -y -qq --no-install-recommends curl bash ca-certificates python3 python3-yaml gettext-base jq >/dev/null
     - curl --fail -sSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
     - chmod +x /usr/local/bin/kubectl
   script:

--- a/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
+++ b/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
@@ -1,13 +1,20 @@
 #!/usr/bin/env bats
-# T012309 — Der GitLab-Job bats-unit muss die Werkzeuge mitbringen, die
+# T012309 / T012313 — Die GitLab-Jobs muessen die Werkzeuge mitbringen, die
 # ubuntu-latest den GitHub-Jobs vorinstalliert liefert.
 #
 # PRUEFMODUS: Quelltext-Grep gegen .gitlab-ci.yml. Das ist hier das angemessene
 # Mittel und die dokumentierte Ausnahme der Test-Resultats-Konvention: die
 # Zusicherung ist eine CI-Konfigurationsaussage, ihr Resultat manifestiert sich
 # ausschliesslich im Quelltext. Den Laufzeitbeweis liefert die Pipeline selbst
-# (39 Fehlschlaege ohne, 1 mit den Werkzeugen, bei 875 Tests) — er ist in einem
-# Repo-Test nicht reproduzierbar, ohne den Job zu fahren.
+# (bats-unit: 39 Fehlschlaege ohne, 1 mit den Werkzeugen, bei 875 Tests;
+# manifests: 3 ohne, 0 mit) — er ist in einem Repo-Test nicht reproduzierbar,
+# ohne den Job zu fahren.
+#
+# LEHRE AUS T012313: Die erste Fassung prueft nur den bats-unit-Block. Die
+# Eingrenzung auf einen Job war richtig (ein Treffer im anderen Job darf die
+# Aussage nicht falsch erfuellen) — der Fehler war, die Zusicherung nur fuer
+# EINEN der beiden Jobs aufzustellen, die das Werkzeug brauchen. Deshalb laufen
+# die Werkzeug-Tests hier ueber beide Bloecke.
 #
 # Bewusst NICHT festgeschrieben: Paketreihenfolge, Zeilenumbrueche, die exakte
 # apt-Aufrufform. Geprueft wird, DASS das Werkzeug beschafft wird (T002716:
@@ -16,17 +23,18 @@
 setup() {
   REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
   CI="$REPO_ROOT/.gitlab-ci.yml"
-  # Nur der bats-unit-Job, nicht die ganze Datei: ein Treffer im manifests-Job
-  # wuerde die Aussage sonst falsch erfuellen.
   BATS_UNIT_BLOCK="$(awk '/^bats-unit:/{f=1} /^manifests:/{f=0} f' "$CI")"
+  MANIFESTS_BLOCK="$(awk '/^manifests:/{f=1} /^gitleaks:/{f=0} f' "$CI")"
 }
 
-@test "T012309: .gitlab-ci.yml existiert und enthaelt den bats-unit-Job" {
+@test "T012309: .gitlab-ci.yml enthaelt die Jobs bats-unit und manifests" {
   # Positiv-Anker vor den Werkzeug-Zusicherungen: ohne ihn wuerden die Tests
   # unten bei leerem Block schweigend anders scheitern statt hier klar.
   [ -f "$CI" ]
   [ -n "$BATS_UNIT_BLOCK" ]
+  [ -n "$MANIFESTS_BLOCK" ]
   printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'image: node:22'
+  printf '%s' "$MANIFESTS_BLOCK" | grep -qF -e 'image: ubuntu:24.04'
 }
 
 @test "T012309: bats-unit installiert PyYAML (python3-yaml)" {
@@ -35,9 +43,22 @@ setup() {
   printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'python3-yaml'
 }
 
+@test "T012313: manifests installiert PyYAML (python3-yaml)" {
+  # tests/unit/dead-node-affinity.bats wertet gerenderte Manifeste per
+  # python3/yaml aus (zwei Tests).
+  printf '%s' "$MANIFESTS_BLOCK" | grep -qF -e 'python3-yaml'
+}
+
 @test "T012309: bats-unit installiert envsubst (gettext-base)" {
   # tests/unit/flux-render-runtime-vars.bats ruft envsubst direkt auf.
   printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'gettext-base'
+}
+
+@test "T012313: manifests installiert envsubst (gettext-base)" {
+  # setup_file in tests/unit/manifests.bats leitet das gerenderte Office-Stack-
+  # Kustomize durch envsubst. Fehlt es, bricht setup_file mit Status 127 ab und
+  # reisst die gesamte Datei mit — der teuerste Einzelfall der Serie.
+  printf '%s' "$MANIFESTS_BLOCK" | grep -qF -e 'gettext-base'
 }
 
 @test "T012309: bats-unit beschafft yq als mikefarah-Binary, nicht per apt" {
@@ -49,14 +70,11 @@ setup() {
   printf '%s' "$BATS_UNIT_BLOCK" | grep -F -e 'mikefarah/yq/releases' | grep -qF -e '--fail'
 }
 
-@test "T012309: yq wird NICHT ueber apt-get install bezogen" {
-  # Negativ-Aussage mit dem Positiv-Anker aus dem Test darueber: der
-  # mikefarah-Download ist dort bereits zugesichert, diese Zeile darf also
-  # nicht zusaetzlich das apt-Paket ziehen.
-  # Kein `run bash -c`: BATS_UNIT_BLOCK ist nicht exportiert, in einer Subshell
-  # waere es leer und die Zaehlung 0 — der Test bestuende vakuos.
-  apt_lines="$(printf '%s' "$BATS_UNIT_BLOCK" | grep -E '^[[:space:]]*- apt-get')"
-  [ -n "$apt_lines" ]                     # Positiv-Anker: es GIBT apt-get-Zeilen
-  printf '%s' "$apt_lines" | grep -qF -e 'python3-yaml'   # ... und sie sind die gemeinten
-  ! printf '%s' "$apt_lines" | grep -qE '(^| )yq( |$)' 
+@test "T012309: yq wird in keinem Job ueber apt-get install bezogen" {
+  # Kein `run bash -c`: die Block-Variablen sind nicht exportiert, in einer
+  # Subshell waeren sie leer und die Zaehlung 0 — der Test bestuende vakuos.
+  apt_lines="$(printf '%s\n%s' "$BATS_UNIT_BLOCK" "$MANIFESTS_BLOCK" | grep -E '^[[:space:]]*- apt-get')"
+  [ -n "$apt_lines" ]                                      # Positiv-Anker: es GIBT apt-get-Zeilen
+  printf '%s' "$apt_lines" | grep -qF -e 'python3-yaml'    # ... und sie sind die gemeinten
+  ! printf '%s' "$apt_lines" | grep -qE '(^| )yq( |$)'
 }


### PR DESCRIPTION
## Summary

T012309 (#4755) hat die Toolchain-Lücke im GitLab-Job `bats-unit` geschlossen — aber nur dort. Der Job `manifests` (`image: ubuntu:24.04`) hat dieselbe Lücke, und die Pipeline auf `7915f152c` (dem Merge von T012309) ist deshalb weiterhin rot.

## Zwei Ursachen, drei Fehlschläge

**1. `envsubst` fehlt → `setup_file` bricht mit Status 127 ab.**

`tests/unit/manifests.bats` leitet das gerenderte Office-Stack-Kustomize durch `envsubst`. Fehlt das Binary, scheitert `setup_file` — und reißt die **gesamte Datei** mit. Das ist der teuerste Einzelfall der Serie.

bats weist den Fehler dabei Zeile 48 zu (`printf '\n---\n' >> "$RENDERED"`). Das ist irreführend: ein `printf`-Builtin kann keinen Status 127 liefern. Der echte 127 stammt aus der Subshell darunter.

**2. PyYAML fehlt** → zwei Tests in `tests/unit/dead-node-affinity.bats` (`ModuleNotFoundError: No module named 'yaml'`).

## Messung

```bash
WORK=/tmp/ci-manifests
git clone file:///home/patrick/Bachelorprojekt "$WORK"
cd "$WORK" && git fetch origin main && git checkout origin/main
docker run --rm -v "$WORK:/repo" -w /repo ubuntu:24.04 bash -c '
  apt-get update -qq && apt-get install -y -qq --no-install-recommends curl bash ca-certificates python3 jq
  curl --fail -sSL "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
  chmod +x /usr/local/bin/kubectl
  ./tests/unit/lib/bats-core/bin/bats <die sieben Dateien des Jobs> --formatter tap > /repo/manifests-tap.log'
grep -cE "^not ok" "$WORK/manifests-tap.log"
```

| Stand | Fehlschläge |
|---|---|
| `origin/main` (`7915f152c`) | 3 |
| **mit dieser Änderung** | **0** |

## Der Guard hätte das nicht gefunden — und warum

`tests/spec/ci-cd/gitlab-batsunit-toolchain.bats` aus T012309 grenzt seine Suche bewusst auf den `bats-unit`-Block ein, damit ein Treffer im anderen Job die Aussage nicht falsch erfüllt. Diese Eingrenzung war richtig. Der Fehler lag daneben: die Zusicherung wurde nur für **einen** der beiden Jobs aufgestellt, die die Werkzeuge brauchen.

Der Guard läuft jetzt über beide Blöcke (5 → 7 Zusicherungen). RED gegen die `.gitlab-ci.yml` vor diesem Fix verifiziert: genau die zwei neuen Zusicherungen fallen, die fünf bestehenden bleiben grün.

Eine Werkzeug-Zusicherung gehört an jeden Job, der das Werkzeug braucht — nicht an den, in dem sie zuerst auffiel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3sHMZCA4ErKtRpr1yCshx
