### PR TITLE
fix(scripts): ticket-grill Ueberschriften-Regex mawk-tauglich machen [T012310]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2478,6 +2478,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/awk-interval-portability",
+    "file": "tests/spec/ci-cd/awk-interval-portability.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/bats-no-live-branch-assertion",
     "file": "tests/spec/ci-cd/bats-no-live-branch-assertion.bats",
     "category": "ci-cd",

--- a/scripts/lib/ticket-grill.sh
+++ b/scripts/lib/ticket-grill.sh
@@ -50,7 +50,13 @@ _grill_parse_doc() {
     }
     {
       line=$0
-      if (line ~ /^#{2,3}[ \t]+/) { flush(); p=line; sub(/^#{2,3}[ \t]+/,"",p); split_id(p); have=1; next }
+      # "###?" statt "#{2,3}": mawk (das awk in den CI-Images debian/ubuntu, via
+      # /etc/alternatives/awk) kennt KEINE Intervall-Ausdruecke und matcht {2,3}
+      # nie — die Ueberschriften-Form wurde dort still gar nicht erkannt, der
+      # Parser lieferte answers:{} questions:[]. gawk (lokal) matcht beides,
+      # deshalb war der Defekt nur in CI sichtbar. "###?" ist exakt {2,3} und
+      # portabel. Repo-weit das einzige Vorkommen (T012310).
+      if (line ~ /^###?[ \t]+/) { flush(); p=line; sub(/^###?[ \t]+/,"",p); split_id(p); have=1; next }
       if (line ~ /^[ \t]*(q?[0-9]+[.)])[ \t]+/) {
         flush(); m=line; eid=m; sub(/^[ \t]*/,"",eid);
         if (eid ~ /^q[0-9]+/) { num=eid; sub(/[.)].*/,"",num); sub(/^q/,"",num); curid_pre="q" num } else { curid_pre="" }

--- a/tests/spec/ci-cd/awk-interval-portability.bats
+++ b/tests/spec/ci-cd/awk-interval-portability.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+# T012310 — awk-Regexe im Repo duerfen keine Intervall-Ausdruecke ({n,m})
+# enthalten.
+#
+# WARUM: In den CI-Images (debian/ubuntu) zeigt /usr/bin/awk ueber
+# /etc/alternatives/awk auf **mawk**. mawk kennt keine Intervall-Ausdruecke und
+# matcht /^#{2,3}/ schlicht nie — ohne Fehlermeldung. Lokal laeuft gawk, das
+# beides beherrscht. Ein solcher Ausdruck ist deshalb lokal unsichtbar defekt
+# und faellt erst in CI auf — und dort als leeres Ergebnis, nicht als Fehler.
+#
+# Belegt (2026-08-18): scripts/lib/ticket-grill.sh nutzte /^#{2,3}[ \t]+/ fuer
+# Markdown-Ueberschriften. Unter mawk lieferte der Parser
+# {"answers":{},"questions":[]} — der zugehoerige Test war die letzte rote
+# Zusicherung im GitLab-Job bats-unit.
+#
+#   docker run --rm node:22 bash -c 'printf "## X\n" | awk "/^#{2,3}[ \t]+/{print \"MATCH\"}"'
+#   # -> keine Ausgabe (mawk 1.3.4)
+#   printf '## X\n' | awk '/^#{2,3}[ \t]+/{print "MATCH"}'
+#   # -> MATCH (gawk 5.2.1)
+#
+# PRUEFMODUS: Quelltext-Scan. Die Zusicherung ist eine Portabilitaetsaussage
+# ueber den Quelltext selbst; ein Laufzeitbeweis braeuchte mawk auf dem
+# pruefenden Rechner, was nicht vorausgesetzt werden kann.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+}
+
+@test "T012310: der Scan findet ueberhaupt awk-Regexe (Positiv-Anker)" {
+  # Ohne diesen Anker bestuende der Negativtest unten vakuos, sobald das
+  # Suchmuster oder die Verzeichnisse nicht mehr passen: eine leere
+  # Kandidatenmenge erfuellt "kein Treffer" trivial.
+  run bash -c "grep -rlE '(~ */|sub\\(/|gsub\\(/)' --include=*.sh '$REPO_ROOT/scripts' | wc -l"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "T012310: kein awk-Regex im Repo nutzt einen Intervall-Ausdruck" {
+  run bash -c "grep -rnE '(~ */|sub\\(/|gsub\\(/|match\\(.*/)[^/]*\\{[0-9]+,[0-9]*\\}' --include=*.sh '$REPO_ROOT/scripts' '$REPO_ROOT/tests' || true"
+  [ -z "$output" ] || {
+    echo "Intervall-Ausdruck in einem awk-Regex gefunden (mawk matcht ihn nie):"
+    echo "$output"
+    return 1
+  }
+}
+
+@test "T012310: ticket-grill erkennt ## -Ueberschriften mit einem mawk-tauglichen Muster" {
+  # Gezielter Anker auf den konkreten Fall: die Ueberschriften-Zeile muss die
+  # portable Form tragen, nicht die Intervall-Form.
+  run grep -cF -e '/^###?[' "$REPO_ROOT/scripts/lib/ticket-grill.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
## Summary

Der Markdown-Parser in `scripts/lib/ticket-grill.sh` erkannte `## Frage?`-Überschriften in CI **nie**. Das war die letzte rote Zusicherung im GitLab-Job `bats-unit`.

## Ursache

Die Überschriften-Erkennung nutzte einen Intervall-Ausdruck:

```awk
if (line ~ /^#{2,3}[ \t]+/) { … }
```

In den CI-Images (debian/ubuntu) zeigt `/usr/bin/awk` über `/etc/alternatives/awk` auf **mawk**. mawk kennt keine Intervall-Ausdrücke und matcht `{2,3}` schlicht nicht — **ohne Fehlermeldung**. Der Parser lieferte dort `{"answers":{},"questions":[]}`.

```console
$ docker run --rm node:22 bash -c 'ls -l /usr/bin/awk; awk -W version | head -1; printf "## X\n" | awk "/^#{2,3}[ \t]+/{print \"MATCH\"}"'
/usr/bin/awk -> /etc/alternatives/awk   (-> /usr/bin/mawk)
mawk 1.3.4 20200120
                                        # keine Ausgabe

$ printf '## X\n' | awk '/^#{2,3}[ \t]+/{print "MATCH"}'   # WSL-Host
MATCH                                   # GNU Awk 5.2.1
```

Lokal läuft gawk, das Intervalle beherrscht. Der Defekt war deshalb **nur in CI** sichtbar — und dort als leeres Ergebnis statt als Fehler, was ihn schwer zuzuordnen machte.

Das erklärt auch, warum der Nachbartest grün blieb: `grill --grilling-doc auto-assigns q1..qN` nutzt die nummerierte Form `1. Erste?`, deren Regex ohne Intervall auskommt.

## Fix

`###?` ist exakt `{2,3}` und portabel. Repo-weit war das die einzige Fundstelle:

```bash
grep -rnE '(~ */|sub\(/|gsub\(/|match\(.*/)[^/]*\{[0-9]+,[0-9]*\}' --include=*.sh scripts/ tests/
# -> nur scripts/lib/ticket-grill.sh:53
```

## Nachweis unter mawk

`tests/unit/ticket-grill.bats` im `node:22`-Container, einmal mit dem alten und einmal mit dem neuen Muster:

| Muster | Fehlschläge (von 14) |
|---|---|
| `#{2,3}` (vorher) | 1 |
| `###?` (dieser PR) | **0** |

## Guard

`tests/spec/ci-cd/awk-interval-portability.bats` (3 Zusicherungen): ein Positiv-Anker, dass der Scan überhaupt awk-Regexe findet, die repo-weite Negativ-Aussage, und ein gezielter Anker auf die konkrete Zeile.

Der Positiv-Anker ist hier nicht Formsache — ohne ihn bestünde die Negativ-Aussage vakuos, sobald Suchmuster oder Verzeichnisse nicht mehr passen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3sHMZCA4ErKtRpr1yCshx
