### PR TITLE
chore(agents): unify worktree paths to .worktrees/<slug> via bash script [T012407]

### DIFF
--- a/.opencode/skills/dev-flow/plugins/worktree/WORKTREE.SKILL.md
+++ b/.opencode/skills/dev-flow/plugins/worktree/WORKTREE.SKILL.md
@@ -2,10 +2,14 @@
 
 Worktree management for OpenCode git isolation and temporary workspace creation. Enables feature branching via native git worktrees with automatic cleanup.
 
+## Canonical path
+
+All harnesses (opencode, agy, factory) create worktrees at **`.worktrees/<slug>`** via `scripts/worktree-create.sh`. Config: `.opencode/worktree.jsonc` (`worktreePath: ".worktrees"`).
+
 ## Purpose
 
 - Create isolated worktrees for feature/fix branches
-- Automatic sync with main branch  
+- Automatic sync with main branch
 - Cleanup after task completion (via `worktree:cleanup`)
 
 ## Usage
@@ -14,24 +18,29 @@ Worktree management for OpenCode git isolation and temporary workspace creation.
 # Create a new worktree
 worktree:create {
   branch: "feature/my-feature"
-  path: ".worktrees/my-feature"
 }
 
 # ... do work in the worktree ...
 
-# Cleanup when done  
+# Cleanup when done
 worktree:cleanup {
-  worktreePath: ".worktrees/my-feature"
+  worktreePath: ".worktrees/feature-my-feature"
 }
 ```
 
 ## Architecture
 
+- `createWorktree()` delegates to `scripts/worktree-create.sh` (canonical bash harness)
 - `TerminalPlugin` — Manages shell sessions and worktree creation
 - State management via `state.ts` (14KB)
 - Launch context injection in `launch-context.ts`
 
 ---
 
-**Files:** `.opencode/plugins/worktree/*.ts` → SKILL documentation  
+**Files:**
+- `.opencode/skills/dev-flow/worktree.ts` → plugin entry, `createWorktree()` delegation
+- `.opencode/skills/dev-flow/plugins/worktree/*.ts` → state, terminal, launch-context
+- `.opencode/worktree.jsonc` → config
+- `scripts/worktree-create.sh` → canonical bash harness (guards, git-crypt, agent-lock)
+
 **Related:** [dev-flow-execute](file:///home/patrick/Bachelorprojekt/.claude/skills/dev-flow-execute/SKILL.md)

--- a/.opencode/skills/dev-flow/plugins/worktree/state.ts
+++ b/.opencode/skills/dev-flow/plugins/worktree/state.ts
@@ -83,6 +83,9 @@ const pendingDeleteSchema = z.object({
 /**
  * Get the default base directory for worktree storage.
  * Location: ~/.local/share/opencode/worktree/
+ * NOTE: This is the fallback. The canonical path is .worktrees/<slug>
+ * (set via .opencode/worktree.jsonc worktreePath), delegated to
+ * scripts/worktree-create.sh.
  */
 function getWorktreeBaseDirectory(): string {
 	return path.join(os.homedir(), ".local", "share", "opencode", "worktree")
@@ -94,6 +97,7 @@ function getWorktreeBaseDirectory(): string {
  * @param projectRoot - Absolute path to the project root
  * @param branch - Branch name for the worktree
  * @param basePath - Optional custom base path (absolute). Defaults to ~/.local/share/opencode/worktree
+ *   (legacy fallback — prefer .opencode/worktree.jsonc worktreePath = ".worktrees")
  * @returns Absolute path to the worktree directory
  */
 export async function getWorktreePath(

--- a/.opencode/skills/dev-flow/worktree.SKILL.md
+++ b/.opencode/skills/dev-flow/worktree.SKILL.md
@@ -2,10 +2,23 @@
 
 Worktree management for OpenCode git isolation and temporary workspace creation. Enables feature branching via native git worktrees with automatic cleanup.
 
+## Canonical path
+
+All harnesses create worktrees at **`.worktrees/<slug>`** (repo-relative), delegated to `scripts/worktree-create.sh`. This ensures consistent guards (branch-name validation, divergence check, git-crypt handling, agent-lock checks) across every harness.
+
+| Harness | Worktree path | Mechanism |
+|---------|--------------|-----------|
+| **opencode** | `.worktrees/<slug>` | `worktree_create` tool → `scripts/worktree-create.sh` |
+| **agy** | `.worktrees/<slug>` | Treats opencode path as authoritative — same script, same guards |
+| **Claude Code** | `.claude/worktrees/<branch>` | Built-in `worktree_create` tool (separate path, not delegated) |
+| **factory** | `.worktrees/<slug>` | `scripts/worktree-create.sh` directly |
+
+Config: `.opencode/worktree.jsonc` sets `worktreePath: ".worktrees"`.
+
 ## Purpose
 
 - Create isolated worktrees for feature/fix branches
-- Automatic sync with main branch  
+- Automatic sync with main branch
 - Cleanup after task completion (via `worktree:cleanup`)
 
 ## Usage
@@ -14,28 +27,30 @@ Worktree management for OpenCode git isolation and temporary workspace creation.
 # Create a new worktree
 worktree:create {
   branch: "feature/my-feature"
-  path: ".worktrees/my-feature"
 }
 
 # ... do work in the worktree ...
 
-# Cleanup when done  
+# Cleanup when done
 worktree:cleanup {
-  worktreePath: ".worktrees/my-feature"
+  worktreePath: ".worktrees/feature-my-feature"
 }
 ```
 
 ## Architecture
 
+- `createWorktree()` in `worktree.ts` delegates to `scripts/worktree-create.sh`
 - `TerminalPlugin` — Manages shell sessions and worktree creation
 - State management via `state.ts` (14KB)
 - Launch context injection in `launch-context.ts`
 
 ---
 
-**Files:** 
-- `.opencode/plugins/worktree/*.ts` → SKILL documentation  
-- **LOC reduction:** 2607 lines total → ~500 lines effective (docs replace code overhead)
+**Files:**
+- `.opencode/skills/dev-flow/worktree.ts` → plugin entry, `createWorktree()` delegation
+- `.opencode/skills/dev-flow/plugins/worktree/*.ts` → state, terminal, launch-context
+- `.opencode/worktree.jsonc` → config (`worktreePath: ".worktrees"`)
+- `scripts/worktree-create.sh` → canonical bash harness (all guards, git-crypt)
 
 
 ## Framework mapping
@@ -44,4 +59,4 @@ worktree:cleanup {
 |-----------|-------------|
 | **Claude Code** | Not available directly. Equivalent: native Claude Code `dev-flow-plan` / `dev-flow-execute` / `dev-flow-chore` skills |
 | **opencode** | Full — native skill for opencode |
-| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
+| **agy** | Full — treats the opencode path as authoritative. All CLI tools and MCP calls work identically; worktrees land in `.worktrees/<slug>` via the same `scripts/worktree-create.sh` |

--- a/.opencode/skills/dev-flow/worktree.ts
+++ b/.opencode/skills/dev-flow/worktree.ts
@@ -44,7 +44,6 @@ import {
 	clearPendingDelete,
 	getPendingDelete,
 	getSession,
-	getWorktreePath,
 	initStateDb,
 	removeSession,
 	setPendingDelete,
@@ -638,22 +637,46 @@ async function createWorktree(
 	baseBranch?: string,
 	basePath?: string,
 ): Promise<Result<string, string>> {
-	const worktreePath = await getWorktreePath(repoRoot, branch, basePath)
+	// Delegate to scripts/worktree-create.sh for consistent worktree creation
+	// across ALL harnesses (Claude Code, opencode, agy, factory).
+	// Path convention: .worktrees/<slug> — enforced by the bash script (T001936).
+	const slug = branch.replace(/\//g, "-")
+	const relativePath = path.join(basePath ?? ".worktrees", slug)
+	const scriptPath = path.join(repoRoot, "scripts", "worktree-create.sh")
 
-	// Ensure parent directory exists
-	await mkdir(path.dirname(worktreePath), { recursive: true })
+	const args = [branch, relativePath]
+	if (baseBranch) args.push(baseBranch)
 
-	const exists = await branchExists(repoRoot, branch)
+	try {
+		const result = await Bun.spawn(["bash", scriptPath, ...args], {
+			cwd: repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+		})
 
-	if (exists) {
-		// Checkout existing branch into worktree
-		const result = await git(["worktree", "add", worktreePath, branch], repoRoot)
-		return result.ok ? Result.ok(worktreePath) : result
-	} else {
-		// Create new branch from base
-		const base = baseBranch ?? "HEAD"
-		const result = await git(["worktree", "add", "-b", branch, worktreePath, base], repoRoot)
-		return result.ok ? Result.ok(worktreePath) : result
+		const exitCode = await result.exited
+		const stdout = await new Response(result.stdout).text()
+		const stderr = await new Response(result.stderr).text()
+
+		if (exitCode === 0) {
+			// Parse "ready on <path>" from stdout (worktree-create.sh contract)
+			const readyMatch = stdout.match(/ready on (.+)/)
+			if (readyMatch) {
+				const wtPath = readyMatch[1].trim()
+				return Result.ok(path.isAbsolute(wtPath) ? wtPath : path.resolve(repoRoot, wtPath))
+			}
+			// Fallback: construct the absolute path from the relative input
+			return Result.ok(path.resolve(repoRoot, relativePath))
+		}
+
+		if (exitCode === 3) {
+			// Branch is already checked out in another worktree — defer, not failure
+			return Result.err(`Branch "${branch}" is already checked out in another worktree`)
+		}
+
+		return Result.err(stderr.trim() || `worktree-create.sh failed (exit ${exitCode})`)
+	} catch (error) {
+		return Result.err(error instanceof Error ? error.message : String(error))
 	}
 }
 
@@ -924,9 +947,9 @@ async function loadWorktreeConfig(directory: string, log: Logger): Promise<Workt
   // Worktree plugin configuration
   // Documentation: https://github.com/kdcokenny/ocx
 
-  // Custom base path for worktree storage (supports ~)
-  // Default: ~/.local/share/opencode/worktree
-  // "worktreePath": "~/my-worktrees",
+  // Canonical worktree location — delegated to scripts/worktree-create.sh.
+  // All harnesses (opencode, agy, factory) use .worktrees/<slug>.
+  "worktreePath": ".worktrees",
 
   "sync": {
     // Files to copy from main worktree to new worktrees

--- a/.opencode/worktree.jsonc
+++ b/.opencode/worktree.jsonc
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://registry.kdco.dev/schemas/worktree.json",
+
+  // Canonical worktree location — matches scripts/worktree-create.sh convention.
+  // All harnesses (Claude Code, opencode, agy, factory) use .worktrees/<slug>.
+  "worktreePath": ".worktrees",
+
+  "sync": {
+    // Files to copy from main worktree to new worktrees
+    // Example: [".env", ".env.local", "dev.sqlite"]
+    "copyFiles": [],
+
+    // Directories to symlink (saves disk space)
+    // Example: ["node_modules"]
+    "symlinkDirs": [],
+
+    // Patterns to exclude from copying
+    "exclude": []
+  },
+
+  "hooks": {
+    // Commands to run after worktree creation
+    // Example: ["pnpm install", "docker compose up -d"]
+    "postCreate": [],
+
+    // Commands to run before worktree deletion
+    // Example: ["docker compose down"]
+    "preDelete": []
+  }
+}


### PR DESCRIPTION
## Summary

All harnesses (opencode, agy, factory) now create worktrees at `.worktrees/<slug>` delegated to `scripts/worktree-create.sh`. This ensures consistent guards (branch-name validation, divergence check, git-crypt handling, agent-lock checks) across every harness.

### Changes

- **`.opencode/worktree.jsonc`** (new) — sets `worktreePath: ".worktrees"`
- **`.opencode/skills/dev-flow/worktree.ts`** — `createWorktree()` now shells out to `scripts/worktree-create.sh` instead of native `git worktree add`. Slug = `branch.replace(/\//g, "-")`. Removed unused `getWorktreePath` import.
- **`worktree.SKILL.md`** (both locations) — added "Canonical path" section with harness comparison table documenting opencode/agy/factory all use `.worktrees/<slug>`
- **`state.ts`** — JSDoc updates noting the legacy fallback status

### agy inclusion

agy has no own worktree config — it "treats the opencode path as authoritative". Since agy delegates to the opencode worktree plugin, it automatically gets `.worktrees/<slug>` via `scripts/worktree-create.sh` with all guards.

## Test Plan

- [ ] Verify `worktree_create` tool creates worktree at `.worktrees/<branch-slug>`
- [ ] Verify the bash script guards (branch-name validation, divergence check) are applied
- [ ] Verify existing factory flow (which calls `scripts/worktree-create.sh` directly) is unaffected
- [ ] Check that agy sessions use the same path convention