### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -2987,7 +2987,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 518,
+      "file_count": 519,
       "files": [
         ".opencode/agent-models.jsonc",
         ".opencode/commands/opsx-apply.md",
@@ -3076,6 +3076,7 @@
         ".opencode/skills/openspec-archive-change",
         ".opencode/skills/openspec-explore",
         ".opencode/skills/openspec-propose",
+        ".opencode/worktree.jsonc",
         "claude-code/gekko-android-mcp-guide.md",
         "claude-code/settings.json",
         "claude-code/system-prompt.md",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32136593251).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
