### PR TITLE
fix(ci): release-please writes into components/, CLAUDE.md guards unpinned [T012406] [T012408]

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "brett": "0.41.2",
+  "components/brett": "0.41.2",
   "k3d/docs-content": "0.6.2",
-  "website": "1.284.2"
+  "components/website": "1.284.2"
 }

--- a/brett/CHANGELOG.md
+++ b/brett/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## [0.41.2](https://github.com/Paddione/Bachelorprojekt/compare/brett-v0.41.1...brett-v0.41.2) (2026-08-18)
-
-
-### Tests
-
-* **ci:** RED guards for gitlab k8s runner + registry cache [T012177] ([#4749](https://github.com/Paddione/Bachelorprojekt/issues/4749)) ([2730a35](https://github.com/Paddione/Bachelorprojekt/commit/2730a35cdf493b4dc924b3195a624d7ab984947b))

--- a/components/brett/CHANGELOG.md
+++ b/components/brett/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 <!-- dev-deploy smoke test 2 -->
 
+## [0.41.2](https://github.com/Paddione/Bachelorprojekt/compare/brett-v0.41.1...brett-v0.41.2) (2026-08-18)
+
+
+### Tests
+
+* **ci:** RED guards for gitlab k8s runner + registry cache [T012177] ([#4749](https://github.com/Paddione/Bachelorprojekt/issues/4749)) ([2730a35](https://github.com/Paddione/Bachelorprojekt/commit/2730a35cdf493b4dc924b3195a624d7ab984947b))
+
 ## [0.41.1](https://github.com/Paddione/Bachelorprojekt/compare/brett-v0.41.0...brett-v0.41.1) (2026-08-03)
 
 

--- a/components/brett/package.json
+++ b/components/brett/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=22.13.0"
   },
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": true,
   "main": "src/server/index.ts",
   "type": "commonjs",

--- a/components/website/CHANGELOG.md
+++ b/components/website/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.284.2](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.284.1...website-v1.284.2) (2026-08-18)
+
+
+### Tests
+
+* **ci:** RED guards for gitlab k8s runner + registry cache [T012177] ([#4749](https://github.com/Paddione/Bachelorprojekt/issues/4749)) ([2730a35](https://github.com/Paddione/Bachelorprojekt/commit/2730a35cdf493b4dc924b3195a624d7ab984947b))
+
 ## [1.284.1](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.284.0...website-v1.284.1) (2026-08-15)
 
 

--- a/components/website/package.json
+++ b/components/website/package.json
@@ -4,7 +4,7 @@
     "node": ">=22.13.0"
   },
   "type": "module",
-  "version": "1.284.1",
+  "version": "1.284.2",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -4380,6 +4380,12 @@
     "kind": "shell"
   },
   {
+    "id": "repo-structure/release-please-paths",
+    "file": "tests/spec/repo-structure/release-please-paths.bats",
+    "category": "repo-structure",
+    "kind": "shell"
+  },
+  {
     "id": "repo-structure/root-agent-md",
     "file": "tests/spec/repo-structure/root-agent-md.bats",
     "category": "repo-structure",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1094,
+      "file_count": 1095,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -765,6 +765,7 @@
         "tests/spec/repo-structure/components-group.bats",
         "tests/spec/repo-structure/inventory-registered.bats",
         "tests/spec/repo-structure/packages-assets.bats",
+        "tests/spec/repo-structure/release-please-paths.bats",
         "tests/spec/repo-structure/root-agent-md.bats",
         "tests/spec/repo-structure/spec-suite-website-leak.bats",
         "tests/spec/repo-structure/website-moved.bats",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,33 +1,113 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "changelog-sections": [
-    {"type": "feat", "section": "Features", "hidden": false},
-    {"type": "fix", "section": "Bug Fixes", "hidden": false},
-    {"type": "perf", "section": "Performance", "hidden": false},
-    {"type": "refactor", "section": "Code Refactoring", "hidden": false},
-    {"type": "docs", "section": "Documentation", "hidden": false},
-    {"type": "test", "section": "Tests", "hidden": false},
-    {"type": "build", "section": "Build System", "hidden": false},
-    {"type": "ci", "section": "CI/CD", "hidden": false},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true},
-    {"type": "revert", "section": "Reverts", "hidden": false}
+    {
+      "type": "feat",
+      "section": "Features",
+      "hidden": false
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes",
+      "hidden": false
+    },
+    {
+      "type": "perf",
+      "section": "Performance",
+      "hidden": false
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": false
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": false
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": false
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": false
+    },
+    {
+      "type": "ci",
+      "section": "CI/CD",
+      "hidden": false
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous",
+      "hidden": true
+    },
+    {
+      "type": "revert",
+      "section": "Reverts",
+      "hidden": false
+    }
   ],
   "packages": {
-    "brett": {
+    "components/brett": {
       "release-type": "node",
       "package-name": "brett",
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
-        {"type": "feat", "section": "Features", "hidden": false},
-        {"type": "fix", "section": "Bug Fixes", "hidden": false},
-        {"type": "perf", "section": "Performance", "hidden": false},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "test", "section": "Tests", "hidden": false},
-        {"type": "build", "section": "Build System", "hidden": false},
-        {"type": "ci", "section": "CI/CD", "hidden": false},
-        {"type": "chore", "section": "Miscellaneous", "hidden": true},
-        {"type": "revert", "section": "Reverts", "hidden": false}
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "Performance",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring",
+          "hidden": false
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": false
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": false
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": false
+        },
+        {
+          "type": "ci",
+          "section": "CI/CD",
+          "hidden": false
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous",
+          "hidden": true
+        },
+        {
+          "type": "revert",
+          "section": "Reverts",
+          "hidden": false
+        }
       ]
     },
     "k3d/docs-content": {
@@ -35,33 +115,113 @@
       "package-name": "docs",
       "changelog-path": "k3d/docs-content-built/CHANGELOG.html",
       "changelog-sections": [
-        {"type": "feat", "section": "Features", "hidden": false},
-        {"type": "fix", "section": "Bug Fixes", "hidden": false},
-        {"type": "perf", "section": "Performance", "hidden": false},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "test", "section": "Tests", "hidden": false},
-        {"type": "build", "section": "Build System", "hidden": false},
-        {"type": "ci", "section": "CI/CD", "hidden": false},
-        {"type": "chore", "section": "Miscellaneous", "hidden": true},
-        {"type": "revert", "section": "Reverts", "hidden": false}
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "Performance",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring",
+          "hidden": false
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": false
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": false
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": false
+        },
+        {
+          "type": "ci",
+          "section": "CI/CD",
+          "hidden": false
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous",
+          "hidden": true
+        },
+        {
+          "type": "revert",
+          "section": "Reverts",
+          "hidden": false
+        }
       ]
     },
-    "website": {
+    "components/website": {
       "release-type": "node",
       "package-name": "website",
       "changelog-path": "CHANGELOG.md",
       "changelog-sections": [
-        {"type": "feat", "section": "Features", "hidden": false},
-        {"type": "fix", "section": "Bug Fixes", "hidden": false},
-        {"type": "perf", "section": "Performance", "hidden": false},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "test", "section": "Tests", "hidden": false},
-        {"type": "build", "section": "Build System", "hidden": false},
-        {"type": "ci", "section": "CI/CD", "hidden": false},
-        {"type": "chore", "section": "Miscellaneous", "hidden": true},
-        {"type": "revert", "section": "Reverts", "hidden": false}
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "Performance",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring",
+          "hidden": false
+        },
+        {
+          "type": "docs",
+          "section": "Documentation",
+          "hidden": false
+        },
+        {
+          "type": "test",
+          "section": "Tests",
+          "hidden": false
+        },
+        {
+          "type": "build",
+          "section": "Build System",
+          "hidden": false
+        },
+        {
+          "type": "ci",
+          "section": "CI/CD",
+          "hidden": false
+        },
+        {
+          "type": "chore",
+          "section": "Miscellaneous",
+          "hidden": true
+        },
+        {
+          "type": "revert",
+          "section": "Reverts",
+          "hidden": false
+        }
       ]
     }
   }

--- a/tests/spec/agent-skills/guard-semantics-konvention.bats
+++ b/tests/spec/agent-skills/guard-semantics-konvention.bats
@@ -20,7 +20,28 @@
 
 setup() {
   REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  # [T012408] Die Konventionsdoku ist bereichsgebunden aufgeteilt: die Wurzel-
+  # CLAUDE.md gilt repo-weit, tests/CLAUDE.md laedt automatisch bei Arbeit unter
+  # tests/ und traegt seit der Auslagerung die Test- und Guard-Konventionen.
+  #
+  # Geprueft wird deshalb der DOKUMENTSATZ, nicht eine feste Datei. Die
+  # Zusicherung lautet "ein Agent, der an Tests arbeitet, bekommt diese
+  # Konvention zu lesen" — und die bleibt wahr, egal in welcher der beiden
+  # Dateien der Block steht. Ein Guard, der die Fundstelle festnagelt, wird beim
+  # naechsten Verschieben rot, ohne dass an der Konvention etwas fehlt: genau das
+  # ist hier passiert, und es blockierte jeden PR mit echtem Diff.
   CLAUDE_MD="$REPO/CLAUDE.md"
+  CONVENTION_DOCS=("$REPO/CLAUDE.md" "$REPO/tests/CLAUDE.md")
+}
+
+# Exit 0, sobald einer der Konventionsdokumente den Begriff traegt.
+_convention_docs_contain() {
+  local term="$1" doc
+  for doc in "${CONVENTION_DOCS[@]}"; do
+    [ -f "$doc" ] || continue
+    grep -qF -- "$term" "$doc" && return 0
+  done
+  return 1
 }
 
 @test "T003796: grep -qF '--flag' endet mit Exit 2 (Options-Parsing), mit -e mit 0 (Positiv-Anker)" {
@@ -62,15 +83,26 @@ FIX
   [ "${output%%:*}" != "4" ]
 }
 
-@test "T003796: CLAUDE.md nennt alle vier Spielarten der Konvention (Drift-Schutz)" {
+@test "T003796: die Konventionsdoku nennt alle vier Spielarten (Drift-Schutz)" {
   # Textabgleich — bewusste Ausnahme (T002448-M4): die Konvention existiert
   # nur als Text. Formatfrei geprueft (T002716): inhaltstragende Begriffe
   # statt exaktem Wortlaut, keine Zeilenanker. Keiner der Begriffe beginnt
   # mit '-', Fall 1 (Options-Parsing) greift hier also nicht.
+  # Positiv-Anker [T002356-M1]: Mindestens ein Konventionsdokument ist ueberhaupt
+  # vorhanden und lesbar. Ohne ihn wuerde die Schleife unten bei zwei fehlenden
+  # Dateien nicht "Konvention fehlt" melden, sondern "Datei fehlt" — zwei sehr
+  # verschiedene Befunde mit derselben roten Zeile.
+  present=0
+  for doc in "${CONVENTION_DOCS[@]}"; do
+    [ -f "$doc" ] && present=$((present + 1))
+  done
+  echo "Anker: vorhandene Konventionsdokumente=${present} von ${#CONVENTION_DOCS[@]}"
+  [ "$present" -gt 0 ]
+
   for term in 'Dokumentposition' 'Options-Parsing' 'Konfiguration statt Laufzeit' 'Prozesslisten-Format'; do
-    run bash -c "grep -qF -- '$term' '$CLAUDE_MD'"
-    [ "$status" -eq 0 ] || {
-      echo "CLAUDE.md nennt die Spielart '$term' nicht (T002716-Erweiterung fehlt)"
+    _convention_docs_contain "$term" || {
+      echo "Keines der Konventionsdokumente nennt die Spielart '$term' (T002716-Erweiterung fehlt)"
+      echo "Gesucht in: ${CONVENTION_DOCS[*]}"
       return 1
     }
   done

--- a/tests/spec/ci-cd/spec-dir-convention.bats
+++ b/tests/spec/ci-cd/spec-dir-convention.bats
@@ -114,14 +114,43 @@ setup() {
   [ "$output" -eq 0 ]
 }
 
-@test "spec-dir: CLAUDE.md dokumentiert die Verzeichniskonvention" {
-  # Positiv-Anker: der BATS-Konventionsblock existiert ...
-  run grep -c 'BATS convention' "${REPO_ROOT}/CLAUDE.md"
-  [ "$status" -eq 0 ]
-  [ "$output" -ge 1 ]
-  # ... und nennt die Verzeichnisform. Ohne Doku wandern neue Tests weiter in die
-  # Sammeldateien und die Konflikte kommen zurueck.
-  block="$(sed -n '/BATS convention/,/^- \*\*BATS .output/p' "${REPO_ROOT}/CLAUDE.md")"
-  [ -n "$block" ]
-  printf '%s\n' "$block" | grep -q 'tests/spec/<spec-slug>/'
+@test "spec-dir: die Konventionsdoku beschreibt die Verzeichnisform" {
+  # [T012408] Geprueft wird der DOKUMENTSATZ statt einer festen Datei: die
+  # Wurzel-CLAUDE.md gilt repo-weit, tests/CLAUDE.md laedt bereichsgebunden bei
+  # Arbeit unter tests/ und traegt seit der Auslagerung den BATS-Block.
+  #
+  # Die Zusicherung ist "die Verzeichnisform ist dokumentiert, wo ein Agent an
+  # Tests sie zu lesen bekommt" — nicht "sie steht in Datei X". Der frueher hier
+  # festgenagelte Pfad machte den Guard beim Verschieben rot, obwohl die
+  # Konvention vollstaendig im Repo stand; rot wurde dadurch jeder PR mit echtem
+  # Diff, waehrend main gruen blieb (dort selektiert der diff-skopierte Lauf
+  # diesen Test gar nicht).
+  docs=("${REPO_ROOT}/CLAUDE.md" "${REPO_ROOT}/tests/CLAUDE.md")
+
+  # Positiv-Anker [T002356-M1]: mindestens ein Dokument existiert.
+  present=0
+  for d in "${docs[@]}"; do
+    [ -f "$d" ] && present=$((present + 1))
+  done
+  echo "Anker: vorhandene Konventionsdokumente=${present} von ${#docs[@]}"
+  [ "$present" -gt 0 ]
+
+  # Irgendeines nennt den BATS-Konventionsblock UND die Verzeichnisform. Beides
+  # muss in DERSELBEN Datei stehen — sonst bestuende der Test auch, wenn eine
+  # Datei die Ueberschrift traegt und eine andere zufaellig den Pfad erwaehnt.
+  found=0
+  for d in "${docs[@]}"; do
+    [ -f "$d" ] || continue
+    grep -qF 'BATS convention' "$d" || continue
+    grep -qF 'tests/spec/<spec-slug>/' "$d" || continue
+    found=1
+    echo "Konvention gefunden in: $d"
+    break
+  done
+
+  if [ "$found" -ne 1 ]; then
+    echo "Kein Konventionsdokument nennt 'BATS convention' zusammen mit 'tests/spec/<spec-slug>/'" >&2
+    echo "Gesucht in: ${docs[*]}" >&2
+    false
+  fi
 }

--- a/tests/spec/repo-structure/release-please-paths.bats
+++ b/tests/spec/repo-structure/release-please-paths.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# tests/spec/repo-structure/release-please-paths.bats — release-please schreibt nur
+# in existierende Paketpfade [T012406]
+#
+# PRUEFMODUS: Quelltext-Inspektion der beiden JSON-Konfigurationen (T002448-M4-Ausnahme
+# fuer CI-/Release-Konfiguration). Ein Laufzeit-Beleg gaebe es erst beim naechsten
+# Release — also genau dann, wenn der Schaden schon im Repo steht.
+#
+# BELEGTER VORFALL: T006999 (Commit de4c5be7c, 2026-08-15) verschob brett/ und website/
+# nach components/. release-please-config.json behielt die alten Pfade. Beim naechsten
+# Release (Commit 14939835c, "chore: release main" #4751, 2026-08-18) legte
+# release-please brett/CHANGELOG.md und website/CHANGELOG.md auf Top-Level NEU an und
+# brach damit die Guards aus T006999 und components-group.bats.
+#
+# Zwei Eigenschaften machten das teuer:
+#   1. Es faellt nicht beim Verschieben auf, sondern erst beim naechsten Release —
+#      Tage spaeter, in einem Commit, der mit dem Verschieben nichts zu tun hat.
+#   2. main blieb GRUEN. Der Shard-Job waehlt auf push-to-main diff-skopiert aus;
+#      gegen main selbst ist der Diff leer, die Guards liefen dort also gar nicht.
+#      Rot wurde jeder PR mit echtem Diff — und dort sah es nach einem Fehler des
+#      PRs aus.
+#
+# Dieser Guard prueft die Ursache statt des Symptoms: die Pfade in der Konfiguration.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  CFG="${REPO_ROOT}/release-please-config.json"
+  MAN="${REPO_ROOT}/.release-please-manifest.json"
+}
+
+_cfg_paths() {
+  python3 -c "
+import json,sys
+print('\n'.join(json.load(open(sys.argv[1]))['packages'].keys()))" "$CFG"
+}
+
+_man_paths() {
+  python3 -c "
+import json,sys
+print('\n'.join(json.load(open(sys.argv[1])).keys()))" "$MAN"
+}
+
+@test "release-please: beide Konfigurationen sind lesbar und nennen Pakete" {
+  # Positiv-Anker [T002356-M1]: Ohne ihn bestuenden alle Aussagen unten ueber der
+  # leeren Menge — eine kaputte oder umbenannte Konfiguration waere "fehlerfrei".
+  [ -f "$CFG" ]
+  [ -f "$MAN" ]
+
+  cfg_count="$(_cfg_paths | grep -c .)"
+  man_count="$(_man_paths | grep -c .)"
+  echo "Anker: config-Pakete=${cfg_count} manifest-Eintraege=${man_count}"
+  [ "$cfg_count" -gt 0 ]
+  [ "$man_count" -gt 0 ]
+}
+
+@test "release-please: jeder konfigurierte Paketpfad existiert im Repo" {
+  # Das ist der Kern. Ein Pfad, den es nicht gibt, ist fuer release-please kein
+  # Fehler — es LEGT IHN AN. Deshalb kann diese Fehlklasse nicht durch einen
+  # fehlgeschlagenen Release auffallen, sondern nur durch einen Guard wie diesen.
+  missing=""
+  checked=0
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    checked=$((checked + 1))
+    [ -d "${REPO_ROOT}/${p}" ] || missing="${missing} ${p}"
+  done < <(_cfg_paths)
+
+  echo "Anker: gepruefte Paketpfade=${checked}"
+  [ "$checked" -gt 0 ]
+
+  if [ -n "$missing" ]; then
+    echo "release-please-config.json nennt nicht existierende Paketpfade:${missing}" >&2
+    echo "release-please wuerde sie beim naechsten Release ANLEGEN statt zu scheitern." >&2
+    false
+  fi
+}
+
+@test "release-please: Manifest und Konfiguration nennen dieselben Pfade" {
+  # Beide Dateien tragen die Pfade getrennt. Wird nur eine umgehaengt, sucht
+  # release-please die letzte Version unter einem Schluessel, den es nicht kennt,
+  # und faengt bei 1.0.0 an — ein stiller Versionssprung statt eines Fehlers.
+  cfg_sorted="$(_cfg_paths | sort)"
+  man_sorted="$(_man_paths | sort)"
+
+  echo "config:   $(printf '%s' "$cfg_sorted" | tr '\n' ' ')"
+  echo "manifest: $(printf '%s' "$man_sorted" | tr '\n' ' ')"
+  [ -n "$cfg_sorted" ]
+  [ -n "$man_sorted" ]
+
+  if [ "$cfg_sorted" != "$man_sorted" ]; then
+    echo "Pfade von release-please-config.json und .release-please-manifest.json weichen ab" >&2
+    false
+  fi
+}
+
+@test "release-please: kein Paketpfad zeigt auf eine verschobene Top-Level-Wurzel" {
+  # Namensgleiche Alt-Wurzeln sind der konkrete Rueckfall: 'brett' und 'website'
+  # liegen seit T006999 unter components/. Ein Pfad ohne Praefix ist deshalb kein
+  # Tippfehler, sondern der alte Zustand.
+  bad=""
+  while IFS= read -r p; do
+    case "$p" in
+      brett|website|brett/*|website/*) bad="${bad} ${p}" ;;
+    esac
+  done < <(_cfg_paths; _man_paths)
+
+  if [ -n "$bad" ]; then
+    echo "Paketpfad(e) zeigen auf die vor T006999 gueltige Top-Level-Wurzel:${bad}" >&2
+    echo "Richtig sind components/brett bzw. components/website." >&2
+    false
+  fi
+}
+
+@test "release-please: die Paket-Version steht auf dem Manifest-Wert" {
+  # Nach dem Vorfall standen Manifest (0.41.2/1.284.2, Tags existierten) und
+  # package.json (0.41.1/1.284.1) auseinander: release-please hatte die Version am
+  # falschen Pfad gesucht und deshalb nicht gehoben. Das faellt sonst erst auf,
+  # wenn jemand die Version einer gebauten Komponente liest.
+  checked=0
+  drift=""
+  for pkg in components/brett components/website; do
+    pj="${REPO_ROOT}/${pkg}/package.json"
+    [ -f "$pj" ] || continue
+    checked=$((checked + 1))
+    want="$(python3 -c "
+import json,sys
+print(json.load(open(sys.argv[1])).get(sys.argv[2], ''))" "$MAN" "$pkg")"
+    have="$(python3 -c "
+import json,sys
+print(json.load(open(sys.argv[1])).get('version',''))" "$pj")"
+    [ -n "$want" ] || continue
+    [ "$want" = "$have" ] || drift="${drift} ${pkg}(manifest=${want} package.json=${have})"
+  done
+
+  echo "Anker: gepruefte Pakete=${checked}"
+  [ "$checked" -gt 0 ]
+
+  if [ -n "$drift" ]; then
+    echo "Versions-Drift zwischen Manifest und package.json:${drift}" >&2
+    false
+  fi
+}

--- a/website/CHANGELOG.md
+++ b/website/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## [1.284.2](https://github.com/Paddione/Bachelorprojekt/compare/website-v1.284.1...website-v1.284.2) (2026-08-18)
-
-
-### Tests
-
-* **ci:** RED guards for gitlab k8s runner + registry cache [T012177] ([#4749](https://github.com/Paddione/Bachelorprojekt/issues/4749)) ([2730a35](https://github.com/Paddione/Bachelorprojekt/commit/2730a35cdf493b4dc924b3195a624d7ab984947b))


### PR DESCRIPTION
Behebt die beiden Defekte, die jeden PR mit echtem Diff rot machen — und die auf `main`
unsichtbar bleiben.

## Warum das auf main nie auffiel

Der Shard-Job wählt auf push-to-main diff-skopiert aus. Gegen `main` selbst ist der Diff leer,
die betroffenen Guards werden dort also **gar nicht selektiert**. `main` meldet grün, während
jeder PR an denselben vier Tests scheitert — und dort sieht es nach einem Fehler des PRs aus.
Gefunden bei der Arbeit an #4766 (GitLab-CI Etappe 3), die davon blockiert war.

## T012406 — release-please schrieb in die vor T006999 gültigen Wurzeln

`release-please-config.json` und `.release-please-manifest.json` nannten die Pakete noch als
`brett` und `website`. T006999 (`de4c5be7c`, 2026-08-15) hatte beide nach `components/`
verschoben. Beim nächsten Release (`14939835c`, „chore: release main" #4751, 2026-08-18) legte
release-please `brett/CHANGELOG.md` und `website/CHANGELOG.md` auf Top-Level **neu an**.

Die Eigenschaft, die das teuer macht: Ein nicht existierender Paketpfad ist für release-please
kein Fehler — **es legt ihn an**. Die Fehlklasse kann deshalb nicht durch einen fehlgeschlagenen
Release auffallen, sondern nur durch einen Guard.

Behoben:
- Paketpfade in beiden JSON-Dateien auf `components/brett` und `components/website`.
- Die zwei verirrten CHANGELOGs trugen je einen **echten** Release-Eintrag (`1.284.2` / `0.41.2`,
  Tags existieren). Die Einträge sind in die richtigen `components/*/CHANGELOG.md` übernommen,
  nicht gelöscht.
- `package.json`-Versionen auf die getaggten Werte gezogen: release-please hatte sie am falschen
  Pfad gesucht und deshalb nicht gehoben (Manifest stand auf `0.41.2`/`1.284.2`, die
  `package.json` auf `0.41.1`/`1.284.1`).
- Neuer Guard `tests/spec/repo-structure/release-please-paths.bats` (5 Tests): jeder
  konfigurierte Pfad existiert, Manifest und Konfiguration nennen dieselben Pfade, kein Pfad
  zeigt auf eine verschobene Alt-Wurzel, und die `package.json`-Version deckt sich mit dem
  Manifest. Gegenprobe gefahren — mit zurückgedrehter Konfiguration werden 2 der 5 rot.

## T012408 — die Guards zeigten auf die alte Fundstelle der Konvention

`spec-dir-convention.bats` und `guard-semantics-konvention.bats` grepten die Wurzel-`CLAUDE.md`.
Die Test- und Guard-Konventionen liegen seit der Auslagerung in `tests/CLAUDE.md` (lädt
bereichsgebunden bei Arbeit unter `tests/`). Die Konvention fehlte also nie — nur der Guard
zeigte woanders hin. Das ist die Drift-Klasse, gegen die diese Guards gebaut sind, eine Ebene
höher.

Beide prüfen jetzt den **Dokumentsatz** `{CLAUDE.md, tests/CLAUDE.md}` statt einer festen Datei.
Die Zusicherung lautet damit „die Konvention steht dort, wo ein Agent an Tests sie zu lesen
bekommt" — und überlebt eine erneute Verschiebung in beide Richtungen. `spec-dir` verlangt
zusätzlich, dass Überschrift und Verzeichnisform in **derselben** Datei stehen, sonst bestünde
der Test auch bei über zwei Dateien verstreuten Bruchstücken. Beide bekommen einen Positiv-Anker
auf die Existenz mindestens eines Dokuments — sonst wäre „Datei fehlt" von „Konvention fehlt"
nicht zu unterscheiden.

## Verifikation

- Die vier zuvor roten Tests sind grün; `tests/spec/repo-structure/`, `spec-dir-convention.bats`
  und `guard-semantics-konvention.bats` zusammen: **28 von 28**.
- `task freshness:check` Exit 0 (`ERRORS=0`), `task test:code-quality` Exit 0.
- Rotphase vorab im frischen Worktree gegen `origin/main` belegt.

Closes T012406
Closes T012408
