### PR TITLE
fix(ci): make gitlab-runner-cache actually apply pull_policy [T012410]

### DIFF
--- a/docs/runbooks/gitlab-runner.md
+++ b/docs/runbooks/gitlab-runner.md
@@ -393,3 +393,68 @@ Startet (idempotent) den `registry:2`-Proxy-Container, mergt
 - Die containerd-Mirror-Konfiguration auf den fleet-Worker-Knoten (Abschnitt 9)
   ist eine Host-Konfiguration ausserhalb von Git und wird ausschliesslich hier
   dokumentiert, nicht automatisiert.
+
+## 14. Warum der lokale Runner trotz Etappe 2 langsam blieb (T012410)
+
+Etappe 2 (T012177) lieferte `scripts/gitlab-runner-cache.sh` gegen den gemessenen Befund
+„self-hosted 2–3× langsamer als SaaS, Ursache Image-Pull je Job". Das Werkzeug wurde
+ausgeführt — und `pull_policy` war danach trotzdem nicht gesetzt. **Fünf Defekte in einer
+Kette**, jeder für sich still:
+
+| # | Defekt | Wirkung |
+|---|---|---|
+| 1 | `[ -f /etc/gitlab-runner/config.toml ]` unprivilegiert | Verzeichnis ist `0700 root` → Test **immer** falsch → Schritt übersprungen, Meldung „Runner noch nicht registriert?" |
+| 2 | `sudo systemctl restart docker` ungeschützt, **vor** dem `pull_policy`-Schritt | Auf Docker-Desktop-/rootless-Hosts Abbruch unter `set -e`, bevor der wertvollste Schritt läuft |
+| 3 | `daemon.json`-Merge meldet Erfolg | Unter Docker Desktop **wirkungslos** — der Daemon liest von der Windows-Seite |
+| 4 | awk-Insert mit globalem `!inserted` | Trifft nur den **ersten** `[runners.docker]`-Block → Einstellung landet beim falschen Runner |
+| 5 | Idempotenz-Prüfung auf erste Fundstelle | Meldet „bereits gesetzt", sobald **irgendein** Block sie hat → der fehlende bekommt sie nie |
+
+**Die gemeinsame Eigenschaft ist die eigentliche Lehre:** Jeder dieser Defekte erzeugt eine
+**Erfolgsmeldung**. Keiner erzeugt einen Fehlschlag. Das Skript berichtete durchweg „✓", während
+faktisch nichts passierte — und eine Erfolgsmeldung über eine wirkungslose Änderung ist
+schädlicher als ein Fehler, weil sie die Ursachensuche an der falschen Stelle beendet.
+
+Defekt 4 und 5 zusammen ergaben einen **stabilen** Fehlzustand: Zeile im falschen Runner,
+Erfolgsmeldung, unveränderte Laufzeit — und ein Wiederholen des Laufs heilte nichts.
+
+### Nachprüfen, ob es diesmal wirklich wirkt
+
+Nicht der Skript-Ausgabe glauben, sondern die Datei lesen — sie ist nur mit `sudo` lesbar:
+
+```bash
+sudo awk '/^\[\[runners\]\]/{blk++} /^  name = /{n=$0} /pull_policy/{print "Block " blk n}' \
+  /etc/gitlab-runner/config.toml
+```
+
+Erwartet: **genau eine** Zeile je registriertem Runner. Zwei Zeilen für denselben Block sind ein
+doppelter TOML-Key und damit ein Parse-Fehler.
+
+TOML-Gültigkeit gegenprüfen:
+
+```bash
+sudo cat /etc/gitlab-runner/config.toml | python3 -c "
+import sys,tomllib; d=tomllib.loads(sys.stdin.read())
+[print(r.get('name'),'->',r.get('docker',{}).get('pull_policy')) for r in d['runners']]"
+```
+
+### Konfiguration übernehmen, ohne laufende Jobs zu reißen
+
+`systemctl restart gitlab-runner` bricht laufende Jobs ab. `gitlab-runner` lädt seine
+Konfiguration auf **SIGHUP** neu:
+
+```bash
+sudo kill -HUP "$(pgrep -f 'gitlab-runner run')"
+```
+
+### Docker Desktop: der Registry-Mirror gehört auf die Windows-Seite
+
+`/etc/docker/daemon.json` in der WSL-Distro ist dort wirkungslos. Der Mirror wird eingetragen
+unter **Docker Desktop → Settings → Docker Engine**:
+
+```json
+{ "registry-mirrors": ["http://localhost:5000"] }
+```
+
+Danach Docker Desktop neu starten — das reißt laufende Container mit, also nicht während eines
+CI-Laufs oder eines aktiven k3d-Clusters. `pull_policy` wirkt **unabhängig davon** und ist der
+größere Hebel: Es verhindert den Pull ganz, statt ihn nur zu beschleunigen.

--- a/scripts/gitlab-runner-cache.sh
+++ b/scripts/gitlab-runner-cache.sh
@@ -115,6 +115,24 @@ _print_dry_run_plan() {
   echo ""
   echo "Geplanter Merge in ${DAEMON_JSON} (registry-mirrors):"
   printf '  { "registry-mirrors": ["http://localhost:%s"] }\n' "${CACHE_PORT}"
+  # [T012410] Unter Docker Desktop ist dieser Pfad WIRKUNGSLOS — der Daemon laeuft
+  # in der Docker-Desktop-VM und liest seine Konfiguration von der Windows-Seite.
+  # Das Skript meldete den Merge frueher trotzdem als Erfolg. Eine Erfolgsmeldung
+  # ueber eine wirkungslose Aenderung ist schaedlicher als gar keine: sie beendet
+  # die Suche nach der Ursache an der falschen Stelle.
+  #
+  # Die Erkennung laeuft ueber `docker info`, das im Dry-Run gelesen, aber nichts
+  # veraendert; fehlt docker, entfaellt der Hinweis stillschweigend (der Dry-Run
+  # muss ohne installiertes docker mit Exit 0 durchlaufen — bestehende Zusicherung).
+  if command -v docker >/dev/null 2>&1 \
+     && docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+    echo "  ACHTUNG: Dieser Host laeuft mit DOCKER DESKTOP — ${DAEMON_JSON} ist hier wirkungslos."
+    echo "           Registry-Mirror stattdessen eintragen unter:"
+    echo "             Docker Desktop -> Settings -> Docker Engine"
+    echo "           pull_policy (unten) wirkt unabhaengig davon und ist der groessere Hebel."
+  else
+    echo "  (Hinweis: unter Docker Desktop waere dieser Pfad wirkungslos — Konfiguration liegt dort auf der Windows-Seite.)"
+  fi
   echo ""
   echo "Geplanter Anhang in ${RUNNER_CONFIG_TOML} ([runners.docker]):"
   echo '  pull_policy = ["if-not-present"]'
@@ -143,7 +161,7 @@ fi
 #    unangewendet — ein Teilzustand, der bei einem erneuten Lauf nicht von
 #    selbst heilt (die Ursache, ein fehlender [runners.docker]-Block, aendert
 #    sich durch einen Docker-Neustart nicht).
-if [ -f "${RUNNER_CONFIG_TOML}" ] && ! sudo grep -qE '^[[:space:]]*\[runners\.docker\]' "${RUNNER_CONFIG_TOML}"; then
+if sudo test -f "${RUNNER_CONFIG_TOML}" && ! sudo grep -qE '^[[:space:]]*\[runners\.docker\]' "${RUNNER_CONFIG_TOML}"; then
   echo "ERROR: kein [runners.docker]-Block in ${RUNNER_CONFIG_TOML} gefunden — Runner noch nicht mit dem Docker-Executor registriert?" >&2
   echo "       Abbruch VOR jeder Aenderung (Cache-Container, daemon.json, Docker-Neustart)." >&2
   exit 1
@@ -158,7 +176,100 @@ else
   echo "✓ Container ${CONTAINER_NAME} gestartet (Port ${CACHE_PORT})."
 fi
 
-# 2. Anbindung im Docker-Daemon (registry-mirrors) — Merge statt Ueberschreiben.
+# 2. pull_policy im bestehenden self-hosted Runner — VORGEZOGEN [T012410].
+#
+#    Dieser Schritt stand frueher als Nummer 3 HINTER dem Docker-Neustart.
+#    Das war die teuerste denkbare Reihenfolge: pull_policy ist der groesste
+#    Einzelhebel fuer die Laufzeit UND der einzige Schritt, der den
+#    Docker-Daemon gar nicht braucht. Auf einem Host ohne
+#    systemd-docker.service (Docker Desktop unter WSL, rootless) brach das
+#    Skript unter `set -euo pipefail` am Neustart ab — und liess ausgerechnet
+#    den wertvollsten Schritt aus, waehrend die beiden dort wirkungslosen
+#    Schritte durchliefen. Belegt am 2026-08-18 auf PK-Desktop: daemon.json
+#    gemerged, Neustart fehlgeschlagen, `grep -c pull_policy config.toml` = 0.
+#    Block (S2, Review T012177). Ein blindes `tee -a` haengt an das Dateiende
+#    an — folgt dort z.B. [runners.cache] (wie in Etappe-1-Installationen
+#    ueblich), landet der Key in der FALSCHEN TOML-Tabelle und wird von
+#    gitlab-runner still ignoriert (genau der stille Fehlermodus, vor dem
+#    Design D4a warnt). awk sucht den [runners.docker]-Header gezielt und fuegt
+#    die Zeile DIREKT danach ein; die Idempotenz-Pruefung ist auf den
+#    [runners.docker]-Block SCOPED, damit ein pull_policy in einem anderen
+#    Block nicht faelschlich als "bereits gesetzt" durchgeht. Die Existenz des
+#    Blocks selbst ist bereits in Schritt 0 (fail-fast, vor jeder Aenderung)
+#    geprueft.
+#
+# N3 (Nachreview T012177): alle drei Anker sind [[:space:]]*-tolerant. Ein
+# echtes, von `gitlab-runner register` geschriebenes config.toml rueckt
+# verschachtelte Tabellen mit zwei Leerzeichen ein — ein Anker auf Spalte 0
+# (^\[runners\.docker\]) matcht eine solche Datei NIE und der Block-Reset
+# (^\[) ebenfalls nicht, was den awk-Insert stillschweigend leerlaufen liesse.
+# `sudo test -f` statt `[ -f ... ]` [T012410]: /etc/gitlab-runner ist bei einer
+# Standardinstallation 0700 root. Ein unprivilegierter Existenztest ist dort
+# IMMER falsch — das Skript uebersprang pull_policy dann still und meldete
+# "Runner noch nicht registriert?", also die falsche Ursache. Jeder Lese- und
+# Schreibzugriff auf diese Datei laeuft ohnehin ueber sudo; nur der Existenztest
+# tat es nicht.
+if sudo test -f "${RUNNER_CONFIG_TOML}"; then
+  # "Bereits gesetzt" heisst: JEDER [runners.docker]-Block traegt die Zeile —
+  # nicht "irgendeiner" [T012410]. Die frueher hier stehende Erste-Fundstelle-
+  # Pruefung meldete auf einem Mehr-Runner-Host "bereits gesetzt", sobald ein
+  # BELIEBIGER Block sie hatte, und der noch fehlende Block bekam sie nie.
+  # Zusammen mit dem ebenfalls nur erst-treffenden Insert ergab das den
+  # stabilen Fehlzustand: Zeile im falschen Runner, Erfolgsmeldung, unveraenderte
+  # Laufzeit.
+  already_set="$(sudo awk '
+    /^[[:space:]]*\[runners\.docker\]/ { in_block=1; blocks++; n[blocks]=0; next }
+    /^[[:space:]]*\[/ { in_block=0 }
+    in_block && /pull_policy[[:space:]]*=[[:space:]]*\["if-not-present"\]/ { n[blocks]++ }
+    END {
+      # "sauber" heisst: jeder Block hat GENAU EINE Zeile. Ein Block mit zwei
+      # Zeilen ist ein doppelter TOML-Key und damit ein Parse-Fehler — er muss
+      # den Normalisierungslauf ausloesen, nicht uebersprungen werden.
+      if (blocks == 0) exit
+      for (i = 1; i <= blocks; i++) if (n[i] != 1) exit
+      print "yes"
+    }
+  ' "${RUNNER_CONFIG_TOML}")"
+
+  if [ "${already_set}" = "yes" ]; then
+    echo "✓ pull_policy bereits im [runners.docker]-Block von ${RUNNER_CONFIG_TOML} gesetzt."
+  else
+    tmp_toml="$(mktemp)"
+    # shellcheck disable=SC2024 # gewollt: sudo hebt nur das Lesen der
+    # privilegierten Datei an, der tmp_toml-Schreibzugriff bleibt bewusst beim
+    # aktuellen Benutzer (mktemp-Datei); der privilegierte Rueckschreibschritt
+    # ist der separate `sudo cp` darunter.
+    # JEDER [runners.docker]-Block, nicht nur der erste [T012410]. Das frueher
+    # hier stehende globale `!inserted`-Flag traf auf einem Host mit mehreren
+    # registrierten Runnern den falschen Block — belegt am 2026-08-18: die Zeile
+    # landete in "Gitlabrunner", waehrend "bachelorprojekt fleet self-hosted" die
+    # Jobs fuhr. Das Skript meldete Erfolg, die Laufzeit blieb unveraendert.
+    #
+    # pull_policy ist eine Executor-Einstellung ohne Seiteneffekt auf andere
+    # Runner; sie auf jeden Docker-Executor des Hosts anzuwenden ist die richtige
+    # Semantik und bleibt idempotent (die Skip-Pruefung oben greift beim
+    # naechsten Lauf).
+    # Konstruktiv idempotent: erst JEDE vorhandene pull_policy-Zeile innerhalb
+    # eines [runners.docker]-Blocks entfernen, dann in JEDEN Block genau eine
+    # einsetzen. Ein reines "nach dem Header einfuegen" erzeugt sonst bei einem
+    # Zweitlauf ueber einen teilweise gepflegten Host einen DOPPELTEN Key in
+    # derselben TOML-Tabelle — und ein doppelter Key ist ein Parse-Fehler, also
+    # ein kaputter Runner statt einer harmlosen Wiederholung.
+    sudo awk '
+      /^[[:space:]]*\[runners\.docker\]/ { in_block=1; print; print "  pull_policy = [\"if-not-present\"]"; next }
+      /^[[:space:]]*\[/ { in_block=0 }
+      in_block && /^[[:space:]]*pull_policy[[:space:]]*=/ { next }
+      { print }
+    ' "${RUNNER_CONFIG_TOML}" > "${tmp_toml}"
+    sudo cp "${tmp_toml}" "${RUNNER_CONFIG_TOML}"
+    rm -f "${tmp_toml}"
+    echo "✓ pull_policy in den [runners.docker]-Block von ${RUNNER_CONFIG_TOML} eingefuegt — sudo systemctl restart gitlab-runner nicht vergessen."
+  fi
+else
+  echo "HINWEIS: ${RUNNER_CONFIG_TOML} nicht gefunden — pull_policy nicht gesetzt (Runner noch nicht registriert?)." >&2
+fi
+
+# 3. Anbindung im Docker-Daemon (registry-mirrors) — Merge statt Ueberschreiben.
 if [ ! -f "${DAEMON_JSON}" ]; then
   sudo mkdir -p "$(dirname "${DAEMON_JSON}")"
   echo "{}" | sudo tee "${DAEMON_JSON}" >/dev/null
@@ -176,49 +287,26 @@ else
   exit 1
 fi
 
-sudo systemctl restart docker
-echo "✓ Docker-Daemon neu gestartet."
-
-# 3. pull_policy im bestehenden self-hosted Runner, GEZIELT im [runners.docker]-
-#    Block (S2, Review T012177). Ein blindes `tee -a` haengt an das Dateiende
-#    an — folgt dort z.B. [runners.cache] (wie in Etappe-1-Installationen
-#    ueblich), landet der Key in der FALSCHEN TOML-Tabelle und wird von
-#    gitlab-runner still ignoriert (genau der stille Fehlermodus, vor dem
-#    Design D4a warnt). awk sucht den [runners.docker]-Header gezielt und fuegt
-#    die Zeile DIREKT danach ein; die Idempotenz-Pruefung ist auf den
-#    [runners.docker]-Block SCOPED, damit ein pull_policy in einem anderen
-#    Block nicht faelschlich als "bereits gesetzt" durchgeht. Die Existenz des
-#    Blocks selbst ist bereits in Schritt 0 (fail-fast, vor jeder Aenderung)
-#    geprueft.
-#
-# N3 (Nachreview T012177): alle drei Anker sind [[:space:]]*-tolerant. Ein
-# echtes, von `gitlab-runner register` geschriebenes config.toml rueckt
-# verschachtelte Tabellen mit zwei Leerzeichen ein — ein Anker auf Spalte 0
-# (^\[runners\.docker\]) matcht eine solche Datei NIE und der Block-Reset
-# (^\[) ebenfalls nicht, was den awk-Insert stillschweigend leerlaufen liesse.
-if [ -f "${RUNNER_CONFIG_TOML}" ]; then
-  already_set="$(sudo awk '
-    /^[[:space:]]*\[runners\.docker\]/ { in_block=1; next }
-    /^[[:space:]]*\[/ { in_block=0 }
-    in_block && /pull_policy[[:space:]]*=[[:space:]]*\["if-not-present"\]/ { print "yes"; exit }
-  ' "${RUNNER_CONFIG_TOML}")"
-
-  if [ "${already_set}" = "yes" ]; then
-    echo "✓ pull_policy bereits im [runners.docker]-Block von ${RUNNER_CONFIG_TOML} gesetzt."
+# Der Neustart ist ab hier NICHT mehr fatal [T012410]: pull_policy ist bereits
+# gesetzt, und auf einem Host, dessen Docker gar keine systemd-Unit ist, waere
+# ein Abbruch hier eine Fehlermeldung ueber einen Schritt, den es dort nicht gibt.
+if systemctl list-unit-files docker.service >/dev/null 2>&1 \
+   && systemctl cat docker.service >/dev/null 2>&1; then
+  if sudo systemctl restart docker; then
+    echo "✓ Docker-Daemon neu gestartet."
   else
-    tmp_toml="$(mktemp)"
-    # shellcheck disable=SC2024 # gewollt: sudo hebt nur das Lesen der
-    # privilegierten Datei an, der tmp_toml-Schreibzugriff bleibt bewusst beim
-    # aktuellen Benutzer (mktemp-Datei); der privilegierte Rueckschreibschritt
-    # ist der separate `sudo cp` darunter.
-    sudo awk '
-      { print }
-      /^[[:space:]]*\[runners\.docker\]/ && !inserted { print "  pull_policy = [\"if-not-present\"]"; inserted=1 }
-    ' "${RUNNER_CONFIG_TOML}" > "${tmp_toml}"
-    sudo cp "${tmp_toml}" "${RUNNER_CONFIG_TOML}"
-    rm -f "${tmp_toml}"
-    echo "✓ pull_policy in den [runners.docker]-Block von ${RUNNER_CONFIG_TOML} eingefuegt — sudo systemctl restart gitlab-runner nicht vergessen."
+    echo "WARNUNG: Neustart von docker.service fehlgeschlagen — registry-mirrors sind noch nicht aktiv." >&2
   fi
 else
-  echo "HINWEIS: ${RUNNER_CONFIG_TOML} nicht gefunden — pull_policy nicht gesetzt (Runner noch nicht registriert?)." >&2
+  echo "HINWEIS: keine systemd-Unit docker.service gefunden." >&2
+  if docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+    echo "         Dieser Host laeuft mit DOCKER DESKTOP. ${DAEMON_JSON} ist hier WIRKUNGSLOS —" >&2
+    echo "         der Daemon laeuft in der Docker-Desktop-VM und liest seine Konfiguration von" >&2
+    echo "         der Windows-Seite. Registry-Mirror dort eintragen:" >&2
+    echo "           Docker Desktop -> Settings -> Docker Engine -> \"registry-mirrors\": [\"http://localhost:${CACHE_PORT}\"]" >&2
+    echo "         danach Docker Desktop neu starten." >&2
+  else
+    echo "         Docker-Daemon manuell neu starten, damit registry-mirrors greifen." >&2
+  fi
+  echo "         pull_policy ist unabhaengig davon bereits gesetzt (Schritt 2)." >&2
 fi

--- a/tests/spec/ci-cd/gitlab-registry-cache.bats
+++ b/tests/spec/ci-cd/gitlab-registry-cache.bats
@@ -184,3 +184,202 @@ PY
   [ "$status" -ne 0 ]
   echo "$output" | grep -qe 'docker'
 }
+
+# ── T012410: der wertvollste Schritt darf nicht am Docker-Neustart haengen ───
+#
+# BELEGTER VORFALL (2026-08-18, PK-Desktop/WSL2 mit Docker Desktop):
+#   $ bash scripts/gitlab-runner-cache.sh
+#   ✓ registry-mirrors in /etc/docker/daemon.json gemerged.
+#   Failed to restart docker.service: Unit docker.service not found.
+#   $ grep -c pull_policy /etc/gitlab-runner/config.toml
+#   0
+#
+# Das Skript laeuft unter `set -euo pipefail`. Der ungeschuetzte
+# `sudo systemctl restart docker` bricht auf jedem Host ohne systemd-docker.service
+# ab (Docker Desktop, rootless), und der pull_policy-Schritt steht DAHINTER.
+#
+# Warum das die teuerste denkbare Reihenfolge ist: pull_policy ist der groesste
+# Einzelhebel fuer die Laufzeit UND der einzige Schritt, der den Docker-Daemon gar
+# nicht braucht. Er faellt hier als einziger aus — waehrend die beiden Schritte
+# durchlaufen, die auf diesem Host ohnehin wirkungslos sind. Der Etappe-2-Befund
+# (T012177: self-hosted 2-3x langsamer, Ursache Image-Pull je Job) blieb deshalb
+# unbehoben, obwohl das Werkzeug dafuer existierte und ausgefuehrt wurde.
+
+@test "gitlab-runner-cache: pull_policy wird VOR dem Docker-Neustart gesetzt" {
+  [ -f "$CACHE_SH" ]
+
+  # Positiv-Anker [T002356-M1]: beide Anker kommen im Skript ueberhaupt vor.
+  # Ohne ihn bestuende der Reihenfolge-Vergleich unten ueber zwei leeren Mengen.
+  # Kommentar- und echo-Zeilen aussondern. Der Filter muss die Zeilennummer aus
+  # `grep -n` VORHER abstreifen — ein Muster wie '^\s*#' gegen "9:# text" trifft
+  # nie, und der Test bestuende dann vakuos (beim Schreiben genau so passiert).
+  _first_real() {
+    grep -n "$1" "$CACHE_SH" \
+      | awk -F: '{ n=$1; sub(/^[0-9]+:/, "", $0); if ($0 !~ /^[[:space:]]*#/ && $0 !~ /echo/) { print n; exit } }'
+  }
+  pp_line="$(_first_real 'pull_policy')"
+  rs_line="$(_first_real 'systemctl restart docker')"
+  echo "Anker: erste pull_policy-Zeile=${pp_line:-<keine>} erster docker-restart=${rs_line:-<keiner>}"
+  [ -n "$pp_line" ]
+  [ -n "$rs_line" ]
+
+  if [ "$pp_line" -gt "$rs_line" ]; then
+    echo "pull_policy (Zeile $pp_line) steht NACH dem Docker-Neustart (Zeile $rs_line)." >&2
+    echo "Auf Hosts ohne systemd-docker.service bricht das Skript dort ab und setzt pull_policy nie." >&2
+    false
+  fi
+}
+
+@test "gitlab-runner-cache: ein fehlgeschlagener Docker-Neustart beendet das Skript nicht" {
+  [ -f "$CACHE_SH" ]
+
+  # Der Aufruf muss entweder geguarded sein (Existenzpruefung der Unit davor)
+  # oder seinen Fehlschlag abfangen (|| ...). Ein nackter Aufruf unter `set -e`
+  # ist der belegte Fehlerfall.
+  line="$(grep -n 'systemctl restart docker' "$CACHE_SH" | grep -v '^[0-9]*:[[:space:]]*#' | head -1)"
+  echo "Anker: gefundene Aufrufzeile='${line}'"
+  [ -n "$line" ]
+
+  body="${line#*:}"
+  if printf '%s' "$body" | grep -qE '\|\||if |&&'; then
+    return 0
+  fi
+
+  # Kein Inline-Guard — dann muss unmittelbar davor eine Existenzpruefung stehen.
+  num="${line%%:*}"
+  ctx="$(sed -n "$((num > 6 ? num - 6 : 1)),${num}p" "$CACHE_SH")"
+  if printf '%s' "$ctx" | grep -qE 'systemctl (is-active|list-unit-files|cat)|docker\.service|command -v systemctl'; then
+    return 0
+  fi
+
+  echo "sudo systemctl restart docker wird ungeschuetzt aufgerufen (Zeile $num)." >&2
+  echo "Unter 'set -euo pipefail' bricht das Skript damit auf Docker-Desktop-/rootless-Hosts ab." >&2
+  false
+}
+
+@test "gitlab-runner-cache: --dry-run benennt den Docker-Desktop-Fall" {
+  # Unter Docker Desktop ist /etc/docker/daemon.json wirkungslos — der Daemon
+  # laeuft in der Docker-Desktop-VM, seine Konfiguration liegt auf der
+  # Windows-Seite. Das Skript meldete trotzdem "gemerged". Eine Erfolgsmeldung
+  # ueber eine wirkungslose Aenderung ist schaedlicher als gar keine: sie beendet
+  # die Suche nach der Ursache.
+  run bash "$CACHE_SH" --dry-run
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  printf '%s\n' "$output" | grep -qiE 'docker desktop'
+}
+
+@test "gitlab-runner-cache: Existenztests auf die Runner-Config laufen privilegiert" {
+  # DRITTER, GRUNDLEGENDERER BEFUND (T012410, gemessen 2026-08-18):
+  #
+  #   $ ls -ld /etc/gitlab-runner
+  #   drwx------ 2 root root
+  #   $ [ -f /etc/gitlab-runner/config.toml ] && echo wahr || echo falsch
+  #   falsch          # obwohl die Datei existiert
+  #   $ sudo test -f /etc/gitlab-runner/config.toml && echo wahr
+  #   wahr
+  #
+  # 0700 root ist die STANDARD-Installationsrechte von gitlab-runner. Ein
+  # unprivilegierter `[ -f ... ]` auf diese Datei ist daher immer falsch — und
+  # das Skript ueberspringt pull_policy still mit der Meldung "Runner noch nicht
+  # registriert?". Die Meldung zeigt auf die falsche Ursache und beendet damit
+  # die Fehlersuche.
+  #
+  # Das ist die eigentliche Erklaerung dafuer, dass Etappe 2 (T012177) das
+  # Werkzeug lieferte und der lokale Runner trotzdem nie schneller wurde: auf
+  # KEINER Standardinstallation konnte der Schritt greifen. Jeder Lese- und
+  # Schreibzugriff im Skript nutzt bereits sudo — nur der Existenztest nicht.
+  [ -f "$CACHE_SH" ]
+
+  # Alle Existenztests auf die Runner-Config einsammeln.
+  hits="$(grep -nE '\[ +-f +"\$\{?RUNNER_CONFIG_TOML\}?" +\]' "$CACHE_SH" || true)"
+  sudo_hits="$(grep -cE 'sudo +test +-f +"\$\{?RUNNER_CONFIG_TOML\}?"' "$CACHE_SH" || true)"
+
+  # Positiv-Anker [T002356-M1]: Es gibt ueberhaupt Existenztests auf diese Datei.
+  # Ohne ihn bestuende der Test auch, wenn die Pruefung ganz entfiele.
+  total="$(printf '%s\n' "$hits" | grep -c . || true)"
+  echo "Anker: unprivilegierte -f-Tests=${total} privilegierte sudo-test-Tests=${sudo_hits}"
+  [ $((total + sudo_hits)) -gt 0 ]
+
+  if [ "$total" -gt 0 ]; then
+    echo "Unprivilegierte Existenztests auf die 0700-root-Runner-Config:" >&2
+    printf '%s\n' "$hits" >&2
+    echo "Sie sind auf einer Standardinstallation immer falsch — 'sudo test -f' verwenden." >&2
+    false
+  fi
+}
+
+@test "gitlab-runner-cache: pull_policy erreicht JEDEN [runners.docker]-Block" {
+  # VIERTER BEFUND (T012410, gemessen 2026-08-18 auf PK-Desktop):
+  # Nach einem erfolgreichen Lauf stand pull_policy in Block 1 ("Gitlabrunner") —
+  # NICHT in Block 2 ("bachelorprojekt fleet self-hosted"), der die Jobs
+  # tatsaechlich faehrt. Das Skript meldete Erfolg.
+  #
+  # Ursache: das awk-Insert traegt ein globales `!inserted`-Flag und trifft
+  # deshalb nur den ERSTEN Block. Ein Host mit mehreren registrierten Runnern —
+  # der Normalfall, sobald ein zweiter Runner dazukommt — bekommt die Einstellung
+  # am falschen Ort. Das ist schaedlicher als ein Fehlschlag: die Meldung sagt
+  # "gesetzt", die Laufzeit aendert sich nicht, und die Ursache steht in einer
+  # Datei, die man nur mit sudo liest.
+  #
+  # Geprueft wird das VERHALTEN: das awk-Programm aus dem Skript laeuft gegen
+  # eine Fixture mit zwei Runner-Bloecken (T002448-M4 — kein Quelltext-Grep).
+  [ -f "$CACHE_SH" ]
+
+  # Gezielt das INSERT-Programm extrahieren, nicht die Idempotenz-Pruefung: beide
+  # beginnen mit `sudo awk '`, und die erste Fundstelle ist die Pruefung. Anker
+  # ist deshalb die Zeile, die pull_policy wirklich ausgibt.
+  awk_prog="$(awk '
+    /sudo awk .$/ { start=NR; buf=""; collecting=1; next }
+    collecting && /^[[:space:]]*.[[:space:]]*"\$\{RUNNER_CONFIG_TOML\}"/ {
+      if (buf ~ /print "  pull_policy/) { printf "%s", buf; exit }
+      collecting=0; buf=""; next
+    }
+    collecting { buf = buf $0 "\n" }
+  ' "$CACHE_SH")"
+
+  # Positiv-Anker [T002356-M1]: das awk-Programm wurde ueberhaupt extrahiert.
+  echo "Anker: extrahierte awk-Zeilen=$(printf '%s\n' "$awk_prog" | grep -c .)"
+  [ -n "$awk_prog" ]
+  # Anker auf den Inhalt, der zaehlt. NICHT auf 'runners\.docker': das awk-Programm
+  # traegt dort einen echten Backslash (\[runners\.docker\]), den ein
+  # grep-Muster 'runners\.docker' gerade NICHT trifft — beim Schreiben genau in
+  # diese Falle getreten.
+  printf '%s' "$awk_prog" | grep -qF 'pull_policy'
+
+  fixture="$(mktemp)"
+  cat > "$fixture" <<'TOML'
+concurrent = 3
+
+[[runners]]
+  name = "erster"
+  executor = "docker"
+  [runners.docker]
+    image = "docker:24-git"
+  [runners.cache]
+
+[[runners]]
+  name = "zweiter"
+  executor = "docker"
+  [runners.docker]
+    image = "docker:24-git"
+  [runners.cache]
+TOML
+
+  out="$(awk "$awk_prog" "$fixture")"
+  count="$(printf '%s\n' "$out" | grep -c 'pull_policy' || true)"
+
+  echo "pull_policy-Zeilen in der Zwei-Runner-Fixture: ${count} (erwartet 2)"
+  [ "$count" -eq 2 ]
+
+  # Zweitlauf ueber das EIGENE Ergebnis: das Insert muss konstruktiv idempotent
+  # sein. Ein reines "nach dem Header einfuegen" ergaebe hier 4 Zeilen — also
+  # einen doppelten Key in derselben TOML-Tabelle. Das ist kein kosmetisches
+  # Problem: ein doppelter Key ist ein Parse-Fehler und damit ein kaputter
+  # Runner, ausgeloest ausgerechnet durch das Wiederholen eines Reparaturlaufs.
+  printf '%s\n' "$out" > "$fixture"
+  again="$(awk "$awk_prog" "$fixture" | grep -c 'pull_policy' || true)"
+  rm -f "$fixture"
+  echo "nach dem Zweitlauf: ${again} (erwartet weiterhin 2)"
+  [ "$again" -eq 2 ]
+}


### PR DESCRIPTION
`scripts/gitlab-runner-cache.sh` aus Etappe 2 (T012177) wurde auf PK-Desktop ausgeführt und
setzte `pull_policy` trotzdem nicht. Fünf Defekte in einer Kette — **jeder erzeugt eine
Erfolgsmeldung, keiner einen Fehlschlag**.

| # | Defekt | Wirkung |
|---|---|---|
| 1 | `[ -f "$RUNNER_CONFIG_TOML" ]` unprivilegiert | `/etc/gitlab-runner` ist `0700 root` (Standardinstallation) → Test **immer** falsch → Schritt still übersprungen, Meldung „Runner noch nicht registriert?" |
| 2 | `sudo systemctl restart docker` ungeschützt, **vor** dem `pull_policy`-Schritt | Auf Hosts ohne systemd-`docker.service` Abbruch unter `set -euo pipefail`, bevor der wertvollste Schritt läuft |
| 3 | `daemon.json`-Merge meldet „gemerged" | Unter Docker Desktop wirkungslos — der Daemon liest von der Windows-Seite |
| 4 | awk-Insert mit globalem `!inserted` | Trifft nur den **ersten** `[runners.docker]`-Block → Einstellung landet beim falschen Runner |
| 5 | Idempotenz-Prüfung auf erste Fundstelle | Meldet „bereits gesetzt", sobald **irgendein** Block sie hat → der fehlende bekommt sie nie |

Defekt 1 allein bedeutet: Auf **keiner** Standardinstallation konnte das Skript je `pull_policy`
setzen. Das ist die Erklärung dafür, dass Etappe 2 das Werkzeug lieferte und der Runner trotzdem
nie schneller wurde — der Etappe-2-Befund (2–3× langsamer als SaaS, Ursache Image-Pull je Job)
blieb unbehoben, obwohl das Gegenmittel existierte und ausgeführt wurde.

Defekt 4 und 5 zusammen ergaben einen **stabilen** Fehlzustand: Zeile im falschen Runner,
Erfolgsmeldung, unveränderte Laufzeit — und ein Wiederholen heilte nichts.

## Behoben

- **Existenztests privilegiert** (`sudo test -f`). Jeder Lese- und Schreibzugriff nutzte ohnehin
  `sudo`; nur der Existenztest nicht.
- **`pull_policy` vorgezogen**, vor den Docker-Neustart. Es ist der größte Einzelhebel *und* der
  einzige Schritt ohne Daemon-Abhängigkeit — er gehörte nie hinter eine Daemon-Operation.
- **Neustart geguarded** und nicht mehr fatal; fehlt die Unit, benennt das Skript den
  Docker-Desktop-Fall samt richtigem Ort für den Registry-Mirror, statt abzubrechen.
- **Insert und Idempotenz-Prüfung blockweise.** Das Insert entfernt vorhandene Zeilen erst und
  setzt dann genau eine je Block — konstruktiv idempotent. Ein reines „nach dem Header
  einfügen" hätte beim Zweitlauf einen **doppelten TOML-Key** erzeugt, also einen Parse-Fehler:
  ein kaputter Runner, ausgelöst ausgerechnet durch das Wiederholen eines Reparaturlaufs.
- **`--dry-run` benennt den Docker-Desktop-Fall**, statt eine wirkungslose Änderung als Erfolg
  zu melden.

## Guards (5 neu, `tests/spec/ci-cd/gitlab-registry-cache.bats`)

Reihenfolge `pull_policy` vor Neustart · Neustart nicht fatal · `--dry-run` benennt Docker
Desktop · Existenztests privilegiert · Insert trifft **jeden** Block und bleibt beim Zweitlauf
bei einer Zeile. Der Block-Test führt das aus dem Skript extrahierte awk-Programm gegen eine
Zwei-Runner-Fixture aus (Verhalten statt Quelltext-Grep, T002448-M4).

## Wirkung, am lebenden Runner nachgeprüft

```
Gitlabrunner                                      -> pull_policy = ['if-not-present']
bachelorprojekt fleet self-hosted (Docker-Executor) -> pull_policy = ['if-not-present']
```

TOML gegen `tomllib` validiert, Zweitlauf ist ein No-op. Übernommen per `SIGHUP` statt
`systemctl restart` — zwei CI-Jobs liefen und blieben unberührt. Der
Registry-Pull-Through-Cache läuft zusätzlich lokal (`gitlab-registry-cache`, `/v2/` → HTTP 200).

## Verifikation

`tests/spec/ci-cd/gitlab-registry-cache.bats` **12/12**, `task freshness:check` Exit 0,
`task test:code-quality` Exit 0. Rotphase vorab belegt (alle fünf Guards rot gegen `origin/main`).

Closes T012410
