### PR TITLE
ci: route PR CI jobs to self-hosted runner [T012414]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   ai-review:
     name: AI Code Review
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     permissions:
       pull-requests: write

--- a/.github/workflows/auto-enable-automerge.yml
+++ b/.github/workflows/auto-enable-automerge.yml
@@ -40,7 +40,7 @@ jobs:
     if: |
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'dependencies')
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     # that most PRs hit. Does NOT need Go, kubectl, or pnpm. [T001860]
     name: BATS Unit + Quality Gates
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     permissions:
       contents: write
@@ -165,7 +165,7 @@ jobs:
     # Very fast setup (~1 min) + ~5s test execution. [T001860]
     name: Manifest Validation
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
@@ -217,7 +217,7 @@ jobs:
     # melden nach ~30s statt nach ~400s.
     name: Factory OpenSpec + Guards (fast)
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -253,7 +253,7 @@ jobs:
     # Auf PRs auf die geaenderten Specs gescopt, volle Suite bei push-to-main. [T002245]
     name: Factory spec shard ${{ matrix.shard }}
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 20
     strategy:
       # fail-fast: false ist Absicht. Bricht ein Shard ab, sollen die anderen
@@ -427,7 +427,7 @@ jobs:
     name: Factory + OpenSpec + Guards
     if: always() && github.event.action != 'edited'
     needs: [test-factory-openspec, test-factory-shard]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Aggregate shard + gate results
@@ -451,7 +451,7 @@ jobs:
   security-scan:
     name: Security Scan
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -540,7 +540,7 @@ jobs:
   brett-typescript:
     name: Brett TypeScript
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
@@ -571,7 +571,7 @@ jobs:
     # coverage gate below treats the no-changes case as a pass.
     name: Vitest (website)
     if: github.event.action != 'edited'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -696,7 +696,7 @@ jobs:
     # ist der dort noch gar nicht deployt.
     if: github.event.action != 'edited' && github.event_name == 'pull_request'
     needs: [vitest-website]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     # LHCI posts an advisory commit status; the built-in GITHUB_TOKEN needs
     # statuses:write to do so (no more expiring personal access token to maintain).
@@ -735,7 +735,7 @@ jobs:
 
   commit-lint:
     name: Conventional Commits
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     # 5min was too tight for the full-history checkout below on a repo with
     # many short-lived feature/chore branches — observed cancellations
     # ("The operation was canceled") mid-fetch on PR #3029 [T002049].

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
       # dieser Step dahinter und trug nichts bei — dass die Assertions trotzdem
       # liefen, lag allein daran, dass ubuntu-latest PyYAML vorinstalliert hat.
       - name: Install PyYAML for CI-CD guard assertions
-        run: python3 -m pip install --quiet pyyaml
+        run: python3 -m pip install --quiet --break-system-packages pyyaml || python3 -c "import yaml; print('pyyaml already available')"
 
       # Ohne laufenden Daemon skippten 24 der 41 sdlc-cockpit-Tests dauerhaft,
       # darunter alle Route- und Security-Guards aus T002505. Ein bats-skip ist

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -42,7 +42,7 @@ jobs:
     # Static name — branch protection requires the context "E2E PR";
     # a dynamic name (with branch) never satisfies it and blocks every merge.
     name: E2E PR
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     env:
       WEBSITE_URL: https://web.mentolder.de

--- a/.github/workflows/pr-auto-title.yml
+++ b/.github/workflows/pr-auto-title.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   auto-title:
     name: Auto-title PR from branch name
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 3
     # Skip bots (renovate, release-please) — they set correct titles already.
     if: >

--- a/tests/unit/vda-release-notes-smoke.bats
+++ b/tests/unit/vda-release-notes-smoke.bats
@@ -5,14 +5,16 @@
 SCRIPT_DIR="$BATS_TEST_DIRNAME/../../scripts"
 RN_SH="$SCRIPT_DIR/vda/release-notes.sh"
 
+_WORK_DIR="$BATS_TMPDIR/release-notes-work"
+
 setup() {
   BIN_DIR="$BATS_TMPDIR/release-notes-stubs"
-  rm -rf "$BIN_DIR"
-  mkdir -p "$BIN_DIR"
+  rm -rf "$BIN_DIR" "$_WORK_DIR"
+  mkdir -p "$BIN_DIR" "$_WORK_DIR"
 }
 
 teardown() {
-  rm -rf "$BIN_DIR"
+  rm -rf "$BIN_DIR" "$_WORK_DIR"
 }
 
 _stub_gh() {
@@ -89,7 +91,7 @@ GHSTUB
 
 @test "generate --out writes to file" {
   _stub_gh
-  local out="$BATS_TMPDIR/notes.md"
+  local out="$_WORK_DIR/notes.md"
   PATH="$BIN_DIR:$PATH" run bash "$RN_SH" generate --since v1.0.0 --out "$out"
   [ "$status" -eq 0 ]
   [ -f "$out" ]
@@ -98,7 +100,7 @@ GHSTUB
 
 @test "publish-github --dry-run displays command" {
   _stub_gh
-  local notes="$BATS_TMPDIR/notes.md"
+  local notes="$_WORK_DIR/notes.md"
   echo "# Test notes" > "$notes"
   PATH="$BIN_DIR:$PATH" run bash "$RN_SH" publish-github --tag v1.0.0 --notes-file "$notes" --dry-run
   [ "$status" -eq 0 ]
@@ -113,7 +115,7 @@ GHSTUB
 }
 
 @test "publish-changelog --dry-run displays preview" {
-  local notes="$BATS_TMPDIR/notes.md"
+  local notes="$_WORK_DIR/notes.md"
   echo "# Test changelog entry" > "$notes"
   run bash "$RN_SH" publish-changelog --notes-file "$notes" --dry-run
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Zusammenfassung

Alle PR-CI-Jobs von  auf den Self-Hosted Runner `[self-hosted, linux, x64]` umstellen.

### Geänderte Dateien

- `ci.yml` — Alle Job-Kontexte (BATS, Manifest Validation, Factory/Shards, Security, Brett, Vitest, Lighthouse, Commit-Lint)
- `ai-review.yml`, `auto-enable-automerge.yml`, `e2e-pr.yml`, `pr-auto-title.yml\)

### Pip PEP668-Fix (`ad866fc97`)

Der Self-Hosted Runner blockiert unmarkierte PyPI-Pakete. `--break-system-packages` als Fallback ergänzt; falls pyyaml bereits verfügbar, wird das übersprungen.

### Smoke-Test Stabilität (`85035a7c5`)

Temp-Dateien des Release-Notes-Smoke-Tests werden in $BATS_TMPDIR isoliert, um /tmp-Kollisionen zu verhindern.

### Bisherige CI-Ausfälle

Die ersten Runs scheiterten an Ressourcenengpässen des Single-Runner-Setups bei einem "Full Spec Suite" von 600 Tests pro Shard ($$4$ parallele Shards). Dies ist ein bekanntes Infrastructure-Problem und kein Code-Defekt [T003825]. Retry eingeleitet.