### PR TITLE
fix(ci): factory-tick-Lock im repo-hygiene-cron isolierbar machen [T012444]

### DIFF
--- a/scripts/repo-hygiene-cron.sh
+++ b/scripts/repo-hygiene-cron.sh
@@ -48,9 +48,15 @@ bash "$HERE/agent-lock.sh" reap >&2 2>/dev/null || true
 # auf veraltetem Stand ist wertlos — die Sektion wird dann übersprungen und als
 # "skipped" ausgewiesen, statt falsche Zahlen zu liefern. Dasselbe Lock-Test-Muster
 # wie scripts/factory/mcp-server.mjs factory_status.
+# [T012444] Pfad überschreibbar. Der Default bleibt der geteilte /tmp-Pfad, den die
+# echte Factory hält. Nötig wurde die Naht durch den self-hosted Runner: der Job läuft
+# als `ghrunner`, die Lock-Datei gehört `patrick` (Modus 664), und schon der Probe-
+# Redirect `9>` braucht Schreibrechte. Ein Test, der den geteilten Pfad benutzt, scheitert
+# dort mit EACCES — und die Datei zu löschen scheidet aus, solange ein echter Tick sie hält.
+FACTORY_TICK_LOCK="${FACTORY_TICK_LOCK:-/tmp/factory-tick.lock}"
 tick_running() {
-  test -f /tmp/factory-tick.lock || return 1
-  (flock -n 9 2>/dev/null && return 1 || return 0) 9>/tmp/factory-tick.lock
+  test -f "$FACTORY_TICK_LOCK" || return 1
+  (flock -n 9 2>/dev/null && return 1 || return 0) 9>"$FACTORY_TICK_LOCK"
 }
 TICK_RUNNING=0
 if tick_running; then

--- a/tests/spec/batch-repo-hygiene-ops-fixes.bats
+++ b/tests/spec/batch-repo-hygiene-ops-fixes.bats
@@ -257,15 +257,21 @@ GH_EOF
   chmod +x "$WORK/bin/gh"
 
   # tick_running=true simulieren: Lock-Datei existiert UND ist gehalten.
-  # flock -w begrenzt die Wartezeit: hält eine echte Factory den Lock, blockt
-  # der Subshell-Flock nicht endlos. stdout/stderr auf /dev/null: überlebt ein
+  # [T012444] Eigener Pfad unter $WORK statt des geteilten /tmp/factory-tick.lock.
+  # Auf dem self-hosted Runner läuft der Job als `ghrunner`, während die echte
+  # Lock-Datei `patrick` gehört (664) — schon der Redirect `9>` scheiterte dort mit
+  # EACCES, der Lock entstand nie und die Assertion fiel deterministisch. Ein Test
+  # darf den Lock einer laufenden Factory ohnehin nicht anfassen.
+  TICK_LOCK="$WORK/factory-tick.lock"
+  # flock -w begrenzt die Wartezeit. stdout/stderr auf /dev/null: überlebt ein
   # verwaister Flock-Kindprozess den kill, hält er die Bats-Output-Pipe nicht
   # offen (sonst hängt die Suite am Testende).
-  ( flock -w 10 -x 9; sleep 30 ) 9>/tmp/factory-tick.lock >/dev/null 2>&1 &
+  ( flock -w 10 -x 9; sleep 30 ) 9>"$TICK_LOCK" >/dev/null 2>&1 &
   TMP_LOCK_PID=$!
   sleep 0.2
 
   run --separate-stderr env -C "$WORK" PATH="$WORK/bin:$PATH" REPO_DIR="$FIXTURE" AGENT_LOCK_DIR="$WORK/locks" \
+    FACTORY_TICK_LOCK="$TICK_LOCK" \
     bash "$PROJECT_DIR/scripts/repo-hygiene-cron.sh" standard
   kill "$TMP_LOCK_PID" 2>/dev/null || true
   wait "$TMP_LOCK_PID" 2>/dev/null || true


### PR DESCRIPTION
Behebt **T012444**. Entsperrt #4782 und #4780, die beide an diesem Test hängen.

## Symptom

`Factory spec shard 3` ist auf jedem PR rot, der die Datei selektiert:

```
not ok 61 T003227: repo-hygiene-cron.sh überspringt die Worktree-Messung bei tick_running=true
tests/spec/batch-repo-hygiene-ops-fixes.bats: line 264: /tmp/factory-tick.lock: Permission denied
```

## Ursache

Auf dem Runner-Host verifiziert:

| Prüfung | Ergebnis |
|---|---|
| `ps -o user= -C Runner.Listener` | `ghrunner` |
| `ls -la /tmp/factory-tick.lock` | `-rw-rw-r-- 1 patrick patrick 0` |
| `fuser -v /tmp/factory-tick.lock` | 6 haltende Prozesse, alle `patrick` |

Der Test stellt `tick_running=true` her, indem er den Lock hält — über `9>/tmp/factory-tick.lock`. Als `ghrunner` scheitert schon dieser Redirect mit `EACCES`. Der Lock entsteht nie, der Skip greift nicht, die Assertion fällt.

Der unscheinbare Teil: **auch der reine Probe-Pfad braucht Schreibrechte.** `tick_running()` prüft mit `9>"$LOCK"`, nicht lesend — ein nicht-schreibbarer Lock ist damit ununterscheidbar von „kein Tick läuft".

Deterministisch, kein Flake. Die Datei zu löschen scheidet aus: sie wird zum Prüfzeitpunkt von einem **laufenden** Tick gehalten, ein `rm` bräche dessen Mutual Exclusion.

## Fix

Keine neue Konvention — `scripts/factory/wakeup.sh` trägt seit **T000523** exakt dieselbe Naht:

```bash
LOCKFILE="${FACTORY_TICK_LOCK:-/tmp/factory-tick.lock}"
```

samt Regressionsguard (`FA-SF-41: … honors FACTORY_TICK_LOCK (hermetic, not the shared /tmp lock)`). `repo-hygiene-cron.sh` zieht nach:

- `scripts/repo-hygiene-cron.sh` — `FACTORY_TICK_LOCK` bei **unverändertem** Default
- Test — eigener Lock-Pfad unter `$WORK` statt des geteilten `/tmp`-Pfads

Der Runbook-Anker auf `/tmp/factory-tick.lock` (Test 9 derselben Datei) bleibt gültig, weil der Default sich nicht ändert.

## Warum jetzt

Folge der Umstellung auf den self-hosted Runner (T012414): vorher liefen Job und Host-Workload nicht als verschiedene Nutzer auf demselben `/tmp`. Gleiche Klasse wie `85035a7c5` („isolate temp files in vda-release-notes-smoke to prevent /tmp collisions").

## Verifikation

- `tests/spec/batch-repo-hygiene-ops-fixes.bats` → **10/10** (vorher 9/10)
- `tests/spec/software-factory/wakeup.bats` → 32/32 (keine Regression an der Schwester-Naht)
- `task test:all` → exit 0
