### PR TITLE
feat(ops): gemma12 als Factory-Modell mit drei parallelen Sessions [T012414]

### DIFF
--- a/scripts/llm/bench-concurrent.sh
+++ b/scripts/llm/bench-concurrent.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# bench-concurrent.sh — Misst den Durchsatz eines llama-server unter N
+# gleichzeitigen Anfragen und trennt dabei zwei Groessen, die bei mehreren
+# Slots auseinanderlaufen:
+#
+#   Einzelstrom  — was EIN Client sieht (predicted_per_second seiner Antwort)
+#   Gesamtdurchsatz — was die GPU insgesamt liefert (Summe der erzeugten Token
+#                     geteilt durch die Wanduhrzeit des gesamten Fensters)
+#
+# Bei -np 1 sind beide fast gleich. Bei -np 3 sinkt der Einzelstrom, waehrend
+# der Gesamtdurchsatz steigt — welcher der beiden zaehlt, haengt an der
+# Nutzung. Ein Mittelwert ueber die Einzelstroeme waere hier die falsche Zahl:
+# er verschweigt genau den Effekt, den man messen wollte.
+#
+# Die Wanduhr ist fuer den Gesamtdurchsatz NOETIG (nicht die timings-Summe):
+# die Anfragen ueberlappen, ihre Einzelzeiten addieren sich also zu mehr als
+# der real vergangenen Zeit.
+#
+# Aufruf:
+#     scripts/llm/bench-concurrent.sh <port> <nebenlaeufigkeit> [label]
+#
+# Beispiel:
+#     scripts/llm/bench-concurrent.sh 8089 3 "np3-kvu-mtp"
+set -euo pipefail
+
+PORT="${1:?port}"
+CONC="${2:?nebenlaeufigkeit}"
+LABEL="${3:-unbenannt}"
+BASE="http://127.0.0.1:${PORT}"
+N_PREDICT="${N_PREDICT:-512}"
+
+command -v jq >/dev/null || { echo "jq fehlt" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Unterschiedliche Prompts je Client: identische Prompts wuerden sich den
+# Prompt-Cache teilen und den Prefill kuenstlich verbilligen.
+_prompt_for() {
+  case "$(( $1 % 3 ))" in
+    0) printf 'Erklaere ausfuehrlich die Funktionsweise von Kuehlkreislaeufen in Rechenzentren, Variante %s.' "$1" ;;
+    1) printf 'Schreibe eine vollstaendige Python-Klasse fuer einen LRU-Cache mit Typannotationen, Variante %s.' "$1" ;;
+    *) printf 'Beschreibe den Aufbau eines verteilten Logsystems mit Backpressure, Variante %s.' "$1" ;;
+  esac
+}
+
+echo "== $LABEL (nebenlaeufigkeit=$CONC, n_predict=$N_PREDICT) =="
+
+# Aufwaermen: der erste Lauf traegt Kernel-Kompilierung und Allokationen.
+curl -s --max-time 300 -H 'content-type: application/json' \
+  -d '{"prompt":"Hallo","n_predict":16,"stream":false}' "${BASE}/completion" >/dev/null
+
+start_ns="$(date +%s%N)"
+for i in $(seq 1 "$CONC"); do
+  (
+    body="$(jq -n --arg p "$(_prompt_for "$i")" --argjson n "$N_PREDICT" \
+      '{prompt:$p, n_predict:$n, temperature:0, cache_prompt:false, stream:false}')"
+    curl -s --max-time 900 -H 'content-type: application/json' \
+      -d "$body" "${BASE}/completion" > "${WORK}/resp-${i}.json"
+  ) &
+done
+wait
+end_ns="$(date +%s%N)"
+
+wall_ms=$(( (end_ns - start_ns) / 1000000 ))
+
+jq -s --argjson wall "$wall_ms" --arg label "$LABEL" --argjson conc "$CONC" '
+  [ .[] | .timings ] as $t
+  | ($t | map(.predicted_n) | add) as $tok
+  | ($t | map(.predicted_per_second) | add / length) as $single
+  | ($t | map(.draft_n // 0) | add) as $dn
+  | ($t | map(.draft_n_accepted // 0) | add) as $da
+  | [
+      "  wanduhr        : \($wall) ms fuer \($conc) gleichzeitige Anfragen",
+      "  erzeugte token : \($tok)",
+      "  GESAMT         : \(($tok / ($wall / 1000)) | floor) tok/s (alle Slots zusammen)",
+      "  einzelstrom    : \($single | floor) tok/s (Mittel je Anfrage)",
+      (if $dn > 0
+       then "  draft          : \($da)/\($dn) angenommen = \((($da / $dn) * 100) | floor)%"
+       else "  draft          : kein spekulatives Dekodieren aktiv"
+       end)
+    ] | .[]' "${WORK}"/resp-*.json

--- a/scripts/llm/measurements/2026-08-19-gemma12-slots.md
+++ b/scripts/llm/measurements/2026-08-19-gemma12-slots.md
@@ -1,0 +1,135 @@
+# gemma12: Slots und geteilter KV — Messprotokoll 2026-08-19 [T012414]
+
+Vollständiges Protokoll der Slot-Messung, nach der Mess-Konvention aus
+`CLAUDE.md`: **jede Zahl mit dem ausführbaren Befehl, der sie erzeugt hat**, plus
+dem Repo-Stand, gegen den gemessen wurde.
+
+Angelegt, weil die Kernzahl (489 tok/s) sich als **nicht auf Zuruf
+reproduzierbar** erwies und ohne die exakte Vorgeschichte niemand nachstellen
+kann, unter welchen Bedingungen sie zustande kam.
+
+## Randbedingungen
+
+| | |
+|---|---|
+| Datum | 2026-08-19, 00:56–01:20 CEST |
+| Host | PK-Desktop (WSL2), NVIDIA GeForce RTX 5070 Ti, 16303 MiB |
+| Treiber | 610.88 |
+| llama.cpp | `version: 10241 (a55e77223)`, Unsloth-Build |
+| Repo-Stand | `f05603591820834060c7a2f50b4d9b11356ed431` (= `origin/main` zum Messzeitpunkt) plus `scripts/llm/bench-concurrent.sh` (damals unversioniert, in diesem Change ergänzt) |
+| Modell | `~/models/gguf/gemma4-12qat/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf` |
+| Drafter | `~/models/gguf/gemma4-12qat/mtp-gemma-4-12B-it.gguf` (`gemma4-assistant`, 423M, `nextn_predict_layers: 4`) |
+| Sonstiges | Factory-Timer und `factory.service` waren gestoppt, GPU exklusiv |
+
+## Die Kommandozeile, die zu 489 tok/s führte
+
+Server (aus `loadouts.json` gerendert, `-np 1` durch `-np 3` ersetzt):
+
+```bash
+/home/patrick/opt/llama-current/bin/llama-server \
+  -m /home/patrick/models/gguf/gemma4-12qat/gemma-4-12B-it-qat-UD-Q4_K_XL.gguf \
+  --host 0.0.0.0 --port 8089 \
+  -fit off -c 262144 -ngl 999 -np 3 \
+  -ctk f16 -ctv f16 -lm mmap -fa on \
+  --jinja --metrics -rea auto \
+  --temp 1 --top-p 0.95 --top-k 64 \
+  --mmproj /home/patrick/models/gguf/gemma4-12qat/mmproj-F16.gguf \
+  --spec-type draft-mtp \
+  --spec-draft-model /home/patrick/models/gguf/gemma4-12qat/mtp-gemma-4-12B-it.gguf \
+  --spec-draft-n-max 4 \
+  --alias gemma12-vision \
+  -kvu -b 4096 -ub 2048
+```
+
+Startlog dazu: `srv load_model: initializing, n_slots = 3, n_ctx_slot = 262144,
+kv_unified = 'true'`; VRAM 15909 von 16303 MiB.
+
+Messbefehl:
+
+```bash
+scripts/llm/bench-concurrent.sh 8089 3 "np=3 -kvu, 3 gleichzeitige Anfragen"
+# N_PREDICT unbelegt -> Default 512
+```
+
+**Und — das ist der Teil, der ohne dieses Protokoll verloren geht — die
+Vorgeschichte der Instanz:** der 489er-Lauf war **nicht** die erste Messung auf
+diesem Server. Davor lief auf derselben Instanz genau einmal:
+
+```bash
+scripts/llm/bench-concurrent.sh 8089 1 "np=3 -kvu, 1 Anfrage"   # 254 gesamt / 281 einzeln
+```
+
+## Vollständige Abfolge
+
+Chronologisch, mit Instanz-Vorgeschichte. „frisch" = erste Messung nach
+Serverstart.
+
+| # | Server | Messung | Vorgeschichte der Instanz | Gesamt | Einzelstrom | MTP |
+|---|---|---|---|---|---|---|
+| 1 | `-np 1` | `bench 8089 1` | frisch | 245 | 278 | 96 % |
+| 2 | `-np 1` | `bench 8089 3` | nach #1 | 199 | 288 | 92 % |
+| 3 | `-np 3` | `bench 8089 1` | frisch | 254 | 281 | 96 % |
+| 4 | `-np 3` | `bench 8089 3` | **nach #3 (leichter Lauf, conc=1)** | **489** | 183 | 92 % |
+| 5 | `-np 3` | `bench 8089 6` | nach #3, #4 | 337 | 180 | 96 % |
+| 6 | `-np 6` | — | — | startet nicht | | |
+| 7 | `-np 4` | `bench 8089 4` | frisch | 319 | 88 | 93 % |
+| 8 | `-np 3` | `bench 8089 3` | frisch | 307 | 106 | 95 % |
+| 9 | `-np 3` | `bench 8089 3` | nach #8 (schwerer Lauf, conc=3) | 205 | 70 | — |
+| 10 | `-np 3` | `bench 8089 3` | frisch | 439 | 154 | 95 % |
+| 11 | `-np 1` | `bench 8089 3` | frisch | 255 | 289 | 92 % |
+
+## Was die Zahlen tragen — und was nicht
+
+**Belastbar:**
+
+- Der Kontext wird mit `-kvu` **nicht** auf die Slots aufgeteilt: `n_ctx_slot =
+  262144` bei `n_slots = 3`, VRAM praktisch unverändert gegenüber einem Slot
+  (15909 vs. 15869 MiB).
+- MTP greift auch mit mehreren Slots — Annahmequote durchgehend 92–96 %.
+- Drei Slots schlagen einen Slot beim Gesamtdurchsatz deutlich (#4, #8, #10 gegen
+  #2, #11), und kosten Einzelstrom.
+- Vier Slots sind schlechter als drei (#7 gegen #8/#10), nicht besser.
+- `-np 6` scheitert **nicht** am VRAM, sondern hart beim Laden des Drafters:
+  `vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)`.
+  Die Grenze liegt zwischen 4 und 6.
+
+**Nicht belastbar — hier war meine erste Darstellung zu eng:**
+
+Ich hatte für `np=3` die Spanne „439–489" genannt und sie mit „jeweils erste
+Messung nach Serverstart" begründet. Das stimmt nicht: **#8 war ebenfalls eine
+erste Messung nach Serverstart und lieferte 307.** Unter identischer
+Konfiguration und identischer Vorgeschichte („frisch") liegen damit 307 (#8) und
+439 (#10) — eine Streuung von 43 %.
+
+Die Vermutung „Durchsatz sinkt monoton mit der Instanznutzung" trägt die Daten
+ebenfalls nicht vollständig: #4 (489) war ein *zweiter* Lauf und der höchste
+Wert überhaupt, #9 (205) ein zweiter Lauf und der niedrigste. Der Unterschied
+zwischen beiden ist die Art des vorangegangenen Laufs — leicht (conc=1) gegen
+schwer (conc=3).
+
+Daraus ergibt sich eine **Hypothese, keine Messung**: ein leichter Vorlauf wärmt
+auf und hilft, ein schwerer hinterlässt Zustand und schadet. Der 16-Token-Aufwärmlauf
+im Skript reicht dafür offenbar nicht.
+
+Ausgeschlossen ist thermisches Drosseln: unmittelbar nach der Serie meldete die
+GPU 40 °C, 37,61 W von 300 W, 0 % Auslastung und
+`clocks_throttle_reasons.active = 0x0`.
+
+## Was fehlt, um die 489 zu belegen
+
+Ein kontrollierter Lauf mit fester Vorgeschichte und Wiederholungen:
+
+```bash
+# je Durchgang: frischer Server, definierter Vorlauf, dann Messung
+for i in 1 2 3; do
+  NP=3 bash start-gemma12.sh                       # frische Instanz
+  bash wait-ready.sh 8089 600
+  scripts/llm/bench-concurrent.sh 8089 1 "vorlauf-$i"   # leichter Vorlauf
+  scripts/llm/bench-concurrent.sh 8089 3 "messung-$i"   # die eigentliche Zahl
+done
+```
+
+Erst wenn `messung-1..3` reproduzierbar bei ~489 liegen, ist die Zahl eine
+Eigenschaft der Konfiguration und nicht der Tagesform. Bis dahin gilt für
+`np=3 -kvu` bei drei gleichzeitigen Anfragen der belegte Bereich **307–489
+tok/s** gesamt, gegenüber **255 tok/s** bei einem Slot.


### PR DESCRIPTION
## Was

Drei zusammenhängende Schritte: Parallelität freischalten, messen, dann das Factory-Modell ablösen.

## 1 — Warum drei Slots bisher nichts brachten

Zwei unabhängige Stellen hoben sie auf, jede für sich unauffällig:

```
Factory-Tick → dispatcher-bridge (3 Pipelines je Brand, parallel)
   → opencode-Orchestrator → Subagenten
      → llm-proxy :18235   ← max_inflight = 1   ⟵ Engstelle 1
         → llama-server -np 3   ⟵ zwei Slots lagen brach
```

**Engstelle 1** — der Proxy serialisiert pro Backend in einem Semaphor. Auf `:8091` lief längst `-np 3`, es ging aber nie mehr als eine Anfrage hin. Der Default stammte aus 2026-07-23 und war ausdrücklich als „byte-identisch zur bisherigen Promise-Kette" eingezogen worden — Vorsicht, keine Kapazitätsaussage.

**Engstelle 2** — für `gemma12-vision` (`:8089`) gab es **gar keine Backend-Zeile**, obwohl `.opencode/agent-models.jsonc` zwei Agenten darauf zeigen ließ. Beide liefen ins Leere.

Behoben: `max_inflight = 3` auf beiden Backends, `llamacpp-gemma12` neu registriert, Loadout auf `parallel: 3`. Der Kommentar in `server.mjs` nannte die „Bonsai-Gang" als Anwendungsfall — die gibt es nicht mehr.

**Ende zu Ende belegt:** drei gleichzeitige Anfragen in **2563 ms** statt ~6339 ms seriell, `inflight`-Spitze **3**, 3/3 vollständige Antworten.

## 2 — Warum genau 3 (gemessen, nicht gewählt)

| Konfiguration | Gesamt | Einzelstrom | MTP |
|---|---|---|---|
| `np=1`, 3 Anfragen | 255 tok/s | 289 tok/s | 92 % |
| `np=3 -kvu`, 3 Anfragen | **307–489** | 106–183 | 92–95 % |
| `np=4 -kvu`, 4 Anfragen | 319 | 88 | 93 % |
| `np=6` | startet nicht | | |

`-np 4` ist **schlechter**, `-np 6` lädt gar nicht erst (MTP-Drafter bricht mit `vector::_M_range_check` ab — kein VRAM-Problem). `-kvu` drittelt den Kontext **nicht**: `n_slots = 3, n_ctx_slot = 262144`, VRAM 15.909 statt 15.869 MiB. Drei passt zudem auf `FACTORY_SLOTS_PER_BRAND` (Default 3).

Vollständiges Protokoll inkl. Instanz-Vorgeschichte je Zahl: `scripts/llm/measurements/2026-08-19-gemma12-slots.md`.

## 3 — Ablösung des Factory-Modells

`gemma12-vision` ersetzt `gemma26-factory`: zehn lokale Zeilen in `tickets.provider_config`, dazu ein etwaiger Phase-Pin in `factory_model_slots` (in `route-provider.sh` Kandidat #0, hätte die Umstellung sonst ausgehebelt). Beide Brands.

`.opencode/agent-models.jsonc`: neun Agenten umgestellt — jetzt liegen **alle elf** lokalen Agenten auf demselben Loadout. Notwendig, weil `exclusiveGroup: chat-gpu` immer nur eines laufen lässt.

**Vorher geprüft statt angenommen — die Tool-Fähigkeit.** Das 26B fuhr ein eigenes Template (`gemma4-26b-tools.jinja`) plus `--tools`; für das 12B gibt es keines. Ohne Tool-Calls wäre die Ablösung wertlos. Der Loadout-Start des Proxy meldet:

```
{"unit":"llama-gemma12-vision.service","port":8089,"chosen":{"ctx":262144},"toolCallOk":true}
```

Den `--tools`-Schalter braucht es nicht — opencode bringt seine Werkzeuge über die API mit, und llama.cpp kennt für die eingebauten weder Sandbox noch Wurzelverzeichnis-Beschränkung.

## Belegt nach der Umstellung

- `routing-check: alle lokalen Modell-IDs haben ein Backend` — vorher `FEHLT`, weshalb die Factory ~52 min leer drehte
- Proxy serviert `['gemma12-vision']`, healthy, `max_inflight=3`
- Factory-Tick lief durch und beendete sich sauber
- `tests/spec/local-llm-proxy/`, `llm-local-dev.bats`, `node --test scripts/llm-proxy/*.test.mjs` (29/29) grün

**Nebeneffekt:** `gemma26-vision` kann jetzt tatsächlich Vision — `gemma26-factory` lud kein mmproj, `gemma12-vision` tut es. Agentennamen bleiben historisch.

## Grenzen und offene Punkte

- **Nicht gemessen: die Ausgabequalität 12B gegen 26B.** Bewusster Tausch, keine Messfolge. Rückweg ist dieselbe Migration mit vertauschten Werten.
- Die Spanne 307–489 ist echt: zwei Läufe unter identischer Konfiguration *und* Vorgeschichte lieferten 307 und 439. Der Höchstwert entstand nach genau einem leichten Vorlauf. Das Protokoll nennt den kontrollierten Lauf, der das klären würde. Thermisches Drosseln ist ausgeschlossen (40 °C, 37,61 W, `throttle_reasons 0x0`).
- Bei zwei Brands à drei Pipelines können sechs auf drei Slots treffen; der Semaphor stellt sie in die Warteschlange.
- Cloud-Agenten sind unberührt — sie laufen nicht über den lokalen Proxy.

Ref: T012414