### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3520,7 +3520,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 765,
+      "file_count": 767,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32198222059).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
