### PR TITLE
fix(ci): Prod-E2E-Projektauswahl positiv aufzählen statt scheinnegieren [T012489]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -158,8 +158,25 @@ jobs:
           PLAYWRIGHT_WORKERS: "4"
         # Exclude korczewski projects — brand is frozen (T002602), web.korczewski.de returns 503.
         # Without this filter, every nightly run fails on the korczewski health check before
-        # any mentolder test executes. Negation syntax: --project=!<name> excludes a project.
-        run: npx playwright test --project=!korczewski-setup --project=!korczewski
+        # any mentolder test executes.
+        #
+        # Die Auswahl steht positiv, weil Playwright KEINE Negation in --project kennt
+        # [T012489]: `--project=!korczewski` wird als Projektname gelesen, nicht als
+        # Ausschluss, und der Lauf bricht mit "Project(s) not found" ab, bevor ein
+        # einziger Test laeuft. Damit die Liste nicht still veraltet, prueft
+        # tests/spec/ci-cd/e2e-project-selection.bats, dass jedes Projekt aus
+        # playwright.config.ts hier entweder aufgezaehlt oder bewusst ausgeschlossen ist.
+        run: |
+          npx playwright test \
+            --project website \
+            --project mentolder-setup \
+            --project mentolder \
+            --project services \
+            --project brett-mentolder-setup \
+            --project brett-mentolder \
+            --project smoke \
+            --project ios \
+            --project android
 
       # G-E2E02 / T002096: defense-in-depth post-run purge (covers timeout kill)
       - name: Post-run test-data purge (defense-in-depth)

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2610,6 +2610,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/e2e-project-selection",
+    "file": "tests/spec/ci-cd/e2e-project-selection.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/fetch-refspec-forced",
     "file": "tests/spec/ci-cd/fetch-refspec-forced.bats",
     "category": "ci-cd",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1100,
+      "file_count": 1101,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -465,6 +465,7 @@
         "tests/spec/ci-cd/devflow-ciwatch-ticket-path.bats",
         "tests/spec/ci-cd/devflow-execute-hardening-t002365.bats",
         "tests/spec/ci-cd/docs-content-guards.bats",
+        "tests/spec/ci-cd/e2e-project-selection.bats",
         "tests/spec/ci-cd/fetch-refspec-forced.bats",
         "tests/spec/ci-cd/fix-ticket-commit-guard.bats",
         "tests/spec/ci-cd/freshness-check-base-mismatch.bats",
@@ -3520,7 +3521,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 765,
+      "file_count": 767,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",

--- a/tests/spec/ci-cd/e2e-project-selection.bats
+++ b/tests/spec/ci-cd/e2e-project-selection.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+#
+# T012489 — Die Projektauswahl des naechtlichen Prod-E2E muss von Playwright
+# tatsaechlich verstanden werden, und sie darf nicht still veralten.
+#
+# Pruefmodus: Querschnittstest ueber CI-Konfiguration — hier ist grep das
+# angemessene Mittel (tests/CLAUDE.md, Ausnahme zur Output-Verifikation): das
+# gepruefte Ergebnis manifestiert sich ausschliesslich im Workflow-Text und in
+# der Playwright-Config. Ein Laufzeit-Nachweis waere nur mit installiertem
+# Playwright und Netzzugriff auf Produktion moeglich und taugt nicht als Gate.
+#
+# Vorgeschichte: `--project=!korczewski` sah wie eine Negation aus, ist aber
+# keine. Playwright 1.61 nimmt bei --project nur Projektnamen; der Lauf brach
+# mit "Project(s) ... not found" ab, BEVOR ein einziger Test lief. Der
+# naechtliche Prod-E2E war dadurch rot aus dem falschen Grund — echte
+# Regressionen waeren nicht aufgefallen.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  WF="$REPO/.github/workflows/e2e.yml"
+  CONFIG="$REPO/tests/e2e/playwright.config.ts"
+}
+
+# Projektnamen, die der nightly-Job bewusst auslaesst.
+_excluded_projects() {
+  printf '%s\n' korczewski-setup korczewski
+}
+
+# Alle in der Playwright-Config definierten Projekte.
+_config_projects() {
+  grep -oE "^[[:space:]]*name:[[:space:]]*'[^']+'" "$CONFIG" \
+    | sed -E "s/.*'([^']+)'.*/\1/" | sort -u
+}
+
+# Der komplette run-Block des nightly-Schritts, der playwright aufruft. Bewusst der
+# ganze Block statt einer Zeile: die Auswahl steht mehrzeilig mit \-Fortsetzungen,
+# eine zeilenweise Extraktion faende keine --project-Argumente und liesse den
+# Mengenvergleich unten vakuos bestehen.
+_playwright_run_block() {
+  yq -r '.jobs.playwright.steps[] | select(.run != null) | select(.run | test("playwright test")) | .run' "$WF"
+}
+
+# Die vom nightly-Job (`playwright`) angeforderten Projekte.
+_workflow_projects() {
+  _playwright_run_block | grep -oE -- '--project[= ][^ \\]+' \
+    | sed -E 's/--project[= ]//' | sort -u
+}
+
+@test "T012489: die Projektauswahl verwendet keine Pseudo-Negation" {
+  # Positiv-Anker zuerst: der Job existiert und ruft playwright ueberhaupt auf.
+  # Ohne ihn bestuende die Negativ-Aussage vakuos, sobald der Job wegfaellt.
+  local cmd
+  cmd="$(_playwright_run_block)"
+  [ -n "$cmd" ]
+
+  # Playwright kennt kein '!' in --project. Ein solcher Wert bricht den Lauf ab,
+  # bevor irgendein Test laeuft.
+  if printf '%s\n' "$cmd" | grep -qE -- '--project[= ]!'; then
+    echo "Pseudo-Negation in e2e.yml: $cmd" >&2
+    return 1
+  fi
+}
+
+@test "T012489: jedes Projekt der Config ist entweder angefordert oder ausgeschlossen" {
+  # Positiv-Anker: beide Seiten sind nicht leer. Waere eine leer, verglichen die
+  # Mengen unten nichts und der Test bestuende trivial.
+  local n_config n_wf
+  n_config="$(_config_projects | wc -l)"
+  n_wf="$(_workflow_projects | wc -l)"
+  [ "$n_config" -gt 0 ]
+  [ "$n_wf" -gt 0 ]
+
+  # Ein neu hinzugefuegtes Projekt liefe sonst still nie mit — dieselbe
+  # Drift-Klasse wie die Allowlist aus T012446.
+  local missing
+  missing="$(comm -23 <(_config_projects) <(cat <(_workflow_projects) <(_excluded_projects) | sort -u))"
+  if [ -n "$missing" ]; then
+    echo "Projekt(e) in playwright.config.ts, die der nightly-Job weder anfordert" >&2
+    echo "noch bewusst ausschliesst:" >&2
+    echo "$missing" >&2
+    return 1
+  fi
+}
+
+@test "T012489: der Job fordert kein Projekt an, das die Config nicht kennt" {
+  local unknown
+  unknown="$(comm -13 <(_config_projects) <(_workflow_projects))"
+  if [ -n "$unknown" ]; then
+    echo "e2e.yml fordert Projekt(e) an, die playwright.config.ts nicht definiert:" >&2
+    echo "$unknown" >&2
+    return 1
+  fi
+}
+
+@test "T012489: die ausgeschlossenen Projekte existieren in der Config" {
+  # Sonst wuerde ein Tippfehler in der Ausschlussliste den Drift-Guard oben
+  # aushebeln: das echte Projekt gilt dann als weder angefordert noch
+  # ausgeschlossen — oder, schlimmer, ein umbenanntes korczewski-Projekt liefe
+  # unbemerkt gegen die eingefrorene Brand.
+  local e
+  while IFS= read -r e; do
+    _config_projects | grep -qx "$e" || {
+      echo "Ausgeschlossenes Projekt '$e' existiert in der Config nicht (mehr)." >&2
+      return 1
+    }
+  done < <(_excluded_projects)
+}


### PR DESCRIPTION
## Problem

Der nächtliche E2E-Lauf gegen Produktion (`e2e.yml`, Job `mentolder`) bricht sofort ab:

```
Error: Project(s) "!korczewski-setup", "!korczewski" not found.
Available projects: "website", "mentolder-setup", "mentolder", "services",
"brett-mentolder-setup", "brett-mentolder", "korczewski-setup", "korczewski",
"smoke", "ios", "android"
```

Fundstelle war `.github/workflows/e2e.yml:162`:

```yaml
# Negation syntax: --project=!<name> excludes a project.
run: npx playwright test --project=!korczewski-setup --project=!korczewski
```

Der Kommentar behauptet eine Negations-Syntax, die es nicht gibt. Playwright 1.61.1 (`tests/e2e/package.json`) liest den Wert von `--project` als Projektnamen — `!korczewski` ist schlicht kein Projekt. Der Lauf endet, **bevor ein einziger mentolder-Test läuft**; der Report-Schritt scheitert danach mit „Playwright JSON report not found", weil nie ein Report entstand.

Wirkung: der Prod-E2E ist rot aus dem falschen Grund. Eine echte Regression gegen Produktion wäre darin nicht aufgefallen — der Job scheitert ja ohnehin.

Beleg (Lauf `32191059361`):

```bash
gh run view 32191059361 --log-failed | grep -i 'not found'
```

## Änderung

Die Auswahl steht jetzt positiv — neun Projekte, die zwei korczewski-Projekte bleiben ausgelassen (Brand eingefroren, T002602, `web.korczewski.de` antwortet 503):

```yaml
run: |
  npx playwright test \
    --project website \
    --project mentolder-setup \
    --project mentolder \
    --project services \
    --project brett-mentolder-setup \
    --project brett-mentolder \
    --project smoke \
    --project ios \
    --project android
```

Die Semantik ist unverändert: kein eingeschlossenes Projekt hängt über `dependencies` an einem korczewski-Projekt (nur `korczewski` → `korczewski-setup`), es wird also nichts über die Abhängigkeitskette nachgezogen.

## Drift-Guard

Eine feste Liste hat dieselbe Fehlerklasse wie die Allowlist aus T012446: ein **neu hinzugefügtes** Projekt stünde in keiner Aufzählung und liefe still nie mit. `tests/spec/ci-cd/e2e-project-selection.bats` prüft deshalb als Mengenvergleich in beide Richtungen:

- jedes Projekt aus `playwright.config.ts` ist entweder angefordert oder in der Ausschlussliste,
- der Job fordert kein Projekt an, das die Config nicht kennt,
- die ausgeschlossenen Projekte existieren überhaupt noch (sonst hebelte ein Tippfehler den Vergleich aus),
- und der `run`-Block enthält keine Pseudo-Negation `--project=!…`.

## Verifikation

```
tests/spec/ci-cd/e2e-project-selection.bats     4/4 ok
tests/spec/ci-cd/runner-role-assignment.bats    7/7 ok
tests/spec/ci-cd/hybrid-runner-placement.bats   6/6 ok
tests/spec/ci-cd/actionlint-workflow-gate.bats  ok   (24 ok gesamt, 0 rot)
scripts/lint-workflows.sh (actionlint)          exit 0
scripts/ci/runner-placement-check.sh            53 Jobs, 0 Verstöße
task test:changed                               exit 0
task freshness:check                            exit 0
```

RED-Lauf vor dem Fix: 3 von 4 rot, mit Nennung aller neun fehlenden Projekte.

Ein Zwischenbefund am Test selbst ist mit eingeflossen: die erste Fassung extrahierte den `run`-Befehl zeilenweise und fand nach der Umstellung auf einen mehrzeiligen Block keine `--project`-Argumente mehr — der Mengenvergleich hätte dann vakuos bestanden. Gefangen hat das der Positiv-Anker („beide Seiten sind nicht leer"); die Extraktion liest jetzt den gesamten Block.

_Ticket: T012489_
