### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1114,7 +1114,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 62,
+      "file_count": 64,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -1177,7 +1177,9 @@
         "scripts/migrations/2026-08-10-disable-gptoss-devstral.sql",
         "scripts/migrations/2026-08-10-disable-qwen.sql",
         "scripts/migrations/2026-08-10-llm-proxy-request-log.sql",
-        "scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql"
+        "scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql",
+        "scripts/migrations/2026-08-19-factory-model-gemma12.sql",
+        "scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql"
       ]
     },
     {


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32200680305).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
