### PR TITLE
fix(factory): Konflikt-Guard prueft das Feld, das den Konflikt fuehrt [T012500]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -4890,6 +4890,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/babysit-prs-conflict-guard-T012500",
+    "file": "tests/spec/software-factory/babysit-prs-conflict-guard-T012500.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/babysit-prs-live-lock-guard-T003137",
     "file": "tests/spec/software-factory/babysit-prs-live-lock-guard-T003137.bats",
     "category": "software-factory",

--- a/scripts/factory/babysit-prs.sh
+++ b/scripts/factory/babysit-prs.sh
@@ -69,7 +69,7 @@ is_branch_locked() {
 }
 
 # ── Scan (D-scan): required json fields per plan Task 1 ─────────────────────
-PRS_JSON=$(gh pr list --state open --json number,headRefName,isDraft,mergeStateStatus,statusCheckRollup,author,labels 2>/dev/null || echo '[]')
+PRS_JSON=$(gh pr list --state open --json number,headRefName,isDraft,mergeStateStatus,mergeable,statusCheckRollup,author,labels 2>/dev/null || echo '[]')
 
 if [[ -z "$PRS_JSON" || "$PRS_JSON" == "[]" ]]; then
   echo "babysit-prs: no open PRs" >&2
@@ -79,7 +79,16 @@ fi
 RENOVATE_OK="${FACTORY_BABYSIT_RENOVATE:-false}"
 
 # ── Filter chain (Task 2): draft, gave-up label, Renovate opt-in, red/conflicting ──
+# [T012500] Konflikt-Erkennung an EINER Stelle definiert. Vorher stand hier
+# '.mergeStateStatus == "CONFLICTING"' — ein Vergleich, der nie zutreffen kann:
+# das Enum mergeStateStatus kennt BEHIND/BLOCKED/CLEAN/DIRTY/DRAFT/HAS_HOOKS/
+# UNKNOWN/UNSTABLE, der Konflikt heisst dort DIRTY. CONFLICTING ist der Wert des
+# SEPARATEN Feldes mergeable, das die Abfrage oben bis T012500 nicht einmal
+# anforderte. Beide Felder werden geprueft, weil mergeable waehrend der
+# GitHub-Berechnung UNKNOWN sein kann.
 CANDIDATES=$(echo "$PRS_JSON" | jq -c --arg renovate_ok "$RENOVATE_OK" '
+  def _is_conflicting:
+    (.mergeable == "CONFLICTING") or (.mergeStateStatus == "DIRTY");
   [ .[]
     | select(.isDraft == false)
     | select((.labels // []) | map(.name) | index("ci-babysitter-gave-up") | not)
@@ -88,7 +97,7 @@ CANDIDATES=$(echo "$PRS_JSON" | jq -c --arg renovate_ok "$RENOVATE_OK" '
         or ($renovate_ok == "true")
       )
     | select(
-        (.mergeStateStatus == "CONFLICTING")
+        _is_conflicting
         or ((.statusCheckRollup // []) | any(
               .conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "ERROR"
             ))
@@ -155,11 +164,19 @@ fi
 NUM=$(echo "$SELECTED" | jq -r '.number')
 BRANCH_NAME=$(echo "$SELECTED" | jq -r '.headRefName')
 MERGE_STATE=$(echo "$SELECTED" | jq -r '.mergeStateStatus')
+MERGEABLE=$(echo "$SELECTED" | jq -r '.mergeable // "UNKNOWN"')
 
 echo "babysit-prs: selected PR #${NUM} (branch=${BRANCH_NAME}, mergeState=${MERGE_STATE})" >&2
 
 # ── CONFLICTING branch (D7): label + notify, never fix ──────────────────────
-if [[ "$MERGE_STATE" == "CONFLICTING" ]]; then
+#
+# [T012500] Geprueft werden mergeable UND mergeStateStatus. Vorher stand hier
+# nur '$MERGE_STATE == "CONFLICTING"' — der Guard konnte damit nie feuern, weil
+# mergeStateStatus diesen Wert nicht kennt (dort heisst der Konflikt DIRTY).
+# Folge: ein Konflikt-PR fiel in den Fix-Pfad, den er laut D7 nie erreichen
+# soll. An PR #4780 arbeitete die Factory darauf ueber 25 Minuten und ~30.000
+# Token, ohne Commit oder Push — und begann bei jedem Tick von vorn.
+if [[ "$MERGEABLE" == "CONFLICTING" || "$MERGE_STATE" == "DIRTY" ]]; then
   HAS_LABEL=$(echo "$SELECTED" | jq -r '(.labels // []) | map(.name) | index("ci-babysitter-conflict") // empty')
   if [[ -z "$HAS_LABEL" ]]; then
     if [[ "$DRY_RUN" == "true" ]]; then

--- a/tests/spec/software-factory/babysit-prs-conflict-guard-T012500.bats
+++ b/tests/spec/software-factory/babysit-prs-conflict-guard-T012500.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/babysit-prs-conflict-guard-T012500.bats
+# SSOT: openspec/specs/software-factory.md
+# Ticket: T012500 — der D7-Guard ("CONFLICTING: label + notify, never fix")
+# verglich mergeStateStatus gegen "CONFLICTING". Diesen Wert kennt das Enum
+# nicht: es fuehrt BEHIND/BLOCKED/CLEAN/DIRTY/DRAFT/HAS_HOOKS/UNKNOWN/UNSTABLE,
+# der Konflikt heisst dort DIRTY. CONFLICTING ist der Wert des SEPARATEN Feldes
+# mergeable — das die gh-pr-list-Abfrage bis T012500 nicht einmal anforderte.
+#
+# Der Guard konnte damit nie feuern. Ein Konflikt-PR wurde stattdessen ueber den
+# Rot-Check-Zweig ausgewaehlt und fiel in den Fix-Pfad, den er laut D7 nie
+# erreichen soll.
+#
+# BELEGTER VORFALL (2026-08-19, T012414): an PR #4780 arbeitete die Factory
+# ueber 25 Minuten und rund 30.000 erzeugte Token, ohne Commit, Push oder
+# PR-Aenderung; der Branch stand seit 5,5 Stunden unveraendert. Bei jedem Tick
+# begann das von vorn. Am lebenden PR:
+#   gh pr view 4780 --json mergeStateStatus,mergeable
+#   -> mergeStateStatus=DIRTY  mergeable=CONFLICTING
+#   gh pr view 4780 --json labels -> leer (das Label haette gesetzt sein muessen)
+#
+# PRUEFMODUS: Output-Verifikation. babysit-prs.sh laeuft mit FACTORY_DRY_RUN=true
+# und gh-Stub als echter Kommandoaufruf; geprueft wird die Ausgabe, kein
+# Source-Grep. Muster uebernommen von babysit-prs-red-detection.bats.
+
+load '_sf_common'
+
+setup()    { _sf_setup; _t012500_setup; }
+teardown() { _sf_teardown; }
+
+_t012500_setup() {
+  BIN_DIR="${BATS_TEST_TMPDIR}/t012500-bin"
+  rm -rf "$BIN_DIR"; mkdir -p "$BIN_DIR"
+  export PATH="$BIN_DIR:$PATH"
+
+  GUARDS_REPO_DIR="${BATS_TEST_TMPDIR}/t012500-guards-repo"
+  rm -rf "$GUARDS_REPO_DIR"; mkdir -p "$GUARDS_REPO_DIR/scripts"
+  cat > "$GUARDS_REPO_DIR/scripts/ticket.sh" <<'TSTUB'
+#!/usr/bin/env bash
+echo "off"
+exit 0
+TSTUB
+  chmod +x "$GUARDS_REPO_DIR/scripts/ticket.sh"
+  export GUARDS_REPO="$GUARDS_REPO_DIR"
+
+  export AGENT_LOCK_DIR="${BATS_TEST_TMPDIR}/t012500-agent-locks"
+  rm -rf "$AGENT_LOCK_DIR"; mkdir -p "$AGENT_LOCK_DIR"
+  export TMPDIR="$BATS_TEST_TMPDIR"
+  export FACTORY_DRY_RUN=true
+  export CLAUDE_BIN="/bin/false"
+}
+
+# _stub_gh <mergeStateStatus> <mergeable> <rollup-conclusion>
+# Bildet die echte GitHub-Antwort nach: die beiden Felder sind unabhaengig.
+_stub_gh() {
+  local mss="$1" mergeable="$2" conclusion="$3"
+  cat > "$BIN_DIR/gh" <<GHSTUB
+#!/usr/bin/env bash
+case "\$*" in
+  "pr list"*)
+    echo '[{"number":123,"headRefName":"testbranch-1","isDraft":false,"mergeStateStatus":"$mss","mergeable":"$mergeable","statusCheckRollup":[{"name":"CI Job X","conclusion":"$conclusion"}],"author":{"login":"tester"},"labels":[]}]'
+    ;;
+  *"pr view"*"--json comments"*) echo '{"comments":[]}' ;;
+  *"run view"*) printf '%s\n' "generated artifact(s) are stale" "run 'task freshness:regenerate'" ;;
+  *) exit 0 ;;
+esac
+GHSTUB
+  chmod +x "$BIN_DIR/gh"
+}
+
+# ── Positiv-Anker zuerst [T002356-M1] ───────────────────────────────────────
+# Ohne ihn waeren die Aussagen unten vakuos: bliebe der Scan-Pfad ueberhaupt
+# unerreicht, sagte "kein Fix-Pfad" nichts ueber den Guard aus.
+
+@test "T012500: ein roter, konfliktfreier PR erreicht den Fix-Pfad (Positiv-Anker)" {
+  _stub_gh "BLOCKED" "MERGEABLE" "FAILURE"
+
+  run bash "$REPO/scripts/factory/babysit-prs.sh"
+
+  grep -q "selected PR #123" <<<"$output" \
+    || { echo "Positiv-Anker verletzt: roter PR wurde nicht selektiert — Testaufbau kaputt, nicht der Fix"; echo "$output"; false; }
+  grep -qi "merge conflicts" <<<"$output" \
+    && { echo "Positiv-Anker verletzt: konfliktfreier PR wurde als Konflikt behandelt"; echo "$output"; false; }
+  return 0
+}
+
+# ── Der eigentliche Gegenstand ──────────────────────────────────────────────
+
+@test "T012500: DIRTY + CONFLICTING wird als Konflikt behandelt, nicht repariert" {
+  # Der reale Fall aus PR #4780: mergeStateStatus DIRTY, mergeable CONFLICTING,
+  # dazu ein roter Check (deshalb wurde er ueberhaupt ausgewaehlt).
+  _stub_gh "DIRTY" "CONFLICTING" "FAILURE"
+
+  run bash "$REPO/scripts/factory/babysit-prs.sh"
+
+  grep -q "selected PR #123" <<<"$output" \
+    || { echo "PR wurde gar nicht selektiert — erwartet war Selektion PLUS Konflikt-Abbruch"; echo "$output"; false; }
+
+  # D7: melden statt reparieren. Vor dem Fix lief der PR in den Fix-Pfad weiter.
+  grep -qi "merge conflicts" <<<"$output" \
+    || { echo "❌ Bug reproduziert: Konflikt-PR wurde NICHT als Konflikt gemeldet — der D7-Guard hat nicht gefeuert"; echo "$output"; false; }
+}
+
+@test "T012500: mergeable=CONFLICTING allein genuegt, auch wenn mergeStateStatus etwas anderes sagt" {
+  # Robustheit gegen die andere Richtung: GitHub liefert die beiden Felder
+  # unabhaengig und zeitversetzt.
+  _stub_gh "BLOCKED" "CONFLICTING" "FAILURE"
+
+  run bash "$REPO/scripts/factory/babysit-prs.sh"
+
+  grep -qi "merge conflicts" <<<"$output" \
+    || { echo "❌ Konflikt ueber mergeable allein wurde nicht erkannt"; echo "$output"; false; }
+}
+
+@test "T012500: mergeable=UNKNOWN ist KEIN Konflikt" {
+  # Waehrend GitHub die Mergebarkeit berechnet, steht mergeable auf UNKNOWN.
+  # Das als Konflikt zu werten, wuerde jeden frischen PR faelschlich stilllegen —
+  # die Umkehrung des behobenen Fehlers.
+  _stub_gh "BLOCKED" "UNKNOWN" "FAILURE"
+
+  run bash "$REPO/scripts/factory/babysit-prs.sh"
+
+  grep -qi "merge conflicts" <<<"$output" \
+    && { echo "❌ UNKNOWN wurde als Konflikt gewertet — frische PRs wuerden stillgelegt"; echo "$output"; false; }
+  return 0
+}


### PR DESCRIPTION
## Der Fehler

`scripts/factory/babysit-prs.sh` verglich an zwei Stellen:

```bash
.mergeStateStatus == "CONFLICTING"   # jq-Auswahlfilter
$MERGE_STATE == "CONFLICTING"        # der D7-Guard
```

`CONFLICTING` ist **kein Wert von `mergeStateStatus`**. Das Enum führt `BEHIND`, `BLOCKED`, `CLEAN`, `DIRTY`, `DRAFT`, `HAS_HOOKS`, `UNKNOWN`, `UNSTABLE` — der Konflikt heißt dort `DIRTY`. `CONFLICTING` ist der Wert des **separaten** Feldes `mergeable`, das die `gh pr list`-Abfrage bis hierher nicht einmal anforderte.

Der D7-Guard („label + notify, **never fix**") konnte damit nie feuern. Ein Konflikt-PR wurde stattdessen über den Rot-Check-Zweig ausgewählt und fiel in genau den Fix-Pfad, den er laut Design nie erreichen soll.

## Beleg am lebenden System

Beobachtet am 2026-08-19 an PR #4780:

```
$ gh pr view 4780 --json mergeStateStatus,mergeable
mergeStateStatus=DIRTY  mergeable=CONFLICTING

$ gh pr view 4780 --json labels
(leer)
```

Das leere Label ist der direkte Beleg — hätte der Guard gefeuert, stünde dort `ci-babysitter-conflict`.

**Kosten des Leerlaufs:** die Factory arbeitete über 25 Minuten und rund 30.000 erzeugte Token an diesem PR, ohne Commit, Push oder PR-Änderung. Der Branch stand seit 5,5 Stunden unverändert, und bei jedem Tick begann es von vorn.

**Nicht modellbedingt:** dieselbe Logzeile steht schon um 01:43, als noch `gemma26-factory` lief — unabhängig von der Modell-Ablösung in T012414.

## Der Fix

- `mergeable` wird in der `gh pr list`-Abfrage angefordert.
- Geprüft wird `mergeable == "CONFLICTING"` **oder** `mergeStateStatus == "DIRTY"`. Beide, weil GitHub die Felder unabhängig und zeitversetzt füllt; `mergeable` steht während der Berechnung auf `UNKNOWN`.
- Die Definition steht als jq-Funktion `_is_conflicting` an **einer** Stelle, damit Auswahlfilter und Guard nicht wieder auseinanderlaufen — sie waren es ja schon.

## Prüfung

`tests/spec/software-factory/babysit-prs-conflict-guard-T012500.bats`, 4 Fälle, Output-Verifikation über den echten Kommandoaufruf mit `gh`-Stub (Muster aus `babysit-prs-red-detection.bats`).

**Gegenprobe gegen den alten Stand** — der Test misst den Fehler, nicht sich selbst:

| Fall | alt | neu |
|---|---|---|
| roter, konfliktfreier PR erreicht Fix-Pfad (Positiv-Anker) | ok | ok |
| `DIRTY` + `CONFLICTING` wird als Konflikt behandelt | **not ok** | ok |
| `mergeable=CONFLICTING` allein genügt | **not ok** | ok |
| `mergeable=UNKNOWN` ist **kein** Konflikt | ok | ok |

Der `UNKNOWN`-Fall sichert die Gegenrichtung: ihn als Konflikt zu werten würde jeden frischen PR stilllegen — die Umkehrung des behobenen Fehlers.

Die drei bestehenden babysit-Tests (`red-detection`, `ci-never-ran`, `live-lock-guard-T003137`) bleiben grün.

Ref: T012500