### PR TITLE
fix(infra): zwei rote Flux-Kustomizations auf fleet beheben [T012501]

### DIFF
--- a/k3d/dev-stack/brett-dev.yaml
+++ b/k3d/dev-stack/brett-dev.yaml
@@ -35,8 +35,11 @@ spec:
             - name: DATABASE_URL
               value: "postgresql://website:$(WEBSITE_DB_PASSWORD)@shared-db-dev.workspace-dev.svc.cluster.local:5432/website?sslmode=disable"
           readinessProbe:
+            # /healthz wie in k3d/brett.yaml: "/" laeuft in den OIDC-Flow und
+            # antwortet ohne konfigurierten Pocket-ID-Client mit 500 — der Pod
+            # wurde dadurch nie ready und hielt die flux-dev-Kustomization rot.
             httpGet:
-              path: /
+              path: /healthz
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/k3d/dev-stack/oauth2-proxy-dev.yaml
+++ b/k3d/dev-stack/oauth2-proxy-dev.yaml
@@ -84,6 +84,16 @@ spec:
             # (auth.${PROD_DOMAIN}/realms/workspace) existiert im Fleet nicht
             # mehr (OIDC-Discovery lieferte HTML → CrashLoop). [T007035]
             - --oidc-issuer-url=http://pocket-id.workspace.svc.cluster.local:1411
+            # Discovery uebersprungen wie bei brainstorm/session-hub: Pocket ID
+            # meldet in seinem Discovery-Dokument die oeffentliche APP_URL
+            # (https://auth.${PROD_DOMAIN}), nie die Cluster-interne — mit
+            # aktivierter Discovery bricht oauth2-proxy beim Start mit
+            # "issuer did not match" ab. Die Endpunkte deshalb explizit. [T012501]
+            - --skip-oidc-discovery=true
+            - --login-url=https://auth.${PROD_DOMAIN}/authorize
+            - --redeem-url=http://pocket-id.workspace.svc.cluster.local:1411/api/oidc/token
+            - --oidc-jwks-url=http://pocket-id.workspace.svc.cluster.local:1411/.well-known/jwks.json
+            - --profile-url=http://pocket-id.workspace.svc.cluster.local:1411/api/oidc/userinfo
             - --redirect-url=https://${DEV_DOMAIN}/oauth2/callback
             # Loop back to the in-cluster Traefik web entrypoint; Host preserved
             # so Traefik routes by host to website-dev / brett-dev.

--- a/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
+++ b/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
@@ -28,8 +28,8 @@ data:
     set -e
 
     export CONFIG_PATH_FOR_INIT="/home/gitlab-runner/.gitlab-runner/"
-    mkdir -p $${CONFIG_PATH_FOR_INIT}
-    cp /configmaps/config.toml $${CONFIG_PATH_FOR_INIT}
+    mkdir -p ${CONFIG_PATH_FOR_INIT}
+    cp /configmaps/config.toml ${CONFIG_PATH_FOR_INIT}
     # Set up environment variables for cache
     if [[ -f /secrets/accesskey && -f /secrets/secretkey ]]; then
       export CACHE_S3_ACCESS_KEY=$(cat /secrets/accesskey)
@@ -166,21 +166,21 @@ data:
       unset RUNNER_TAG_LIST
     fi
 
-    for i in $$(seq 1 "$${MAX_REGISTER_ATTEMPTS}"); do
-      echo "Registration attempt $$i of $$MAX_REGISTER_ATTEMPTS"
+    for i in $(seq 1 "${MAX_REGISTER_ATTEMPTS}"); do
+      echo "Registration attempt ${i} of ${MAX_REGISTER_ATTEMPTS}"
       /entrypoint register \
-        $$RUN_UNTAGGED \
-        $$ACCESS_LEVEL \
+        ${RUN_UNTAGGED} \
+        ${ACCESS_LEVEL} \
         --template-config /configmaps/config.template.toml \
         --non-interactive &
 
-      register_pid=$$!
-      wait $$register_pid
-      retval=$$?
+      register_pid=$!
+      wait $register_pid
+      retval=$?
 
-      if [ $$retval = 0 ]; then
+      if [ ${retval} = 0 ]; then
         break
-      elif [ $$i = $$MAX_REGISTER_ATTEMPTS ]; then
+      elif [ ${i} = ${MAX_REGISTER_ATTEMPTS} ]; then
         exit 1
       fi
 
@@ -192,7 +192,7 @@ data:
     set -eou pipefail
 
     # default timeout is 3 seconds, can be overriden
-    VERIFY_TIMEOUT=$${1:-$${VERIFY_TIMEOUT:-3}}
+    VERIFY_TIMEOUT=${1:-${VERIFY_TIMEOUT:-3}}
 
     if ! /usr/bin/pgrep -f ".*register-the-runner"  > /dev/null && ! /usr/bin/pgrep -f "gitlab.*runner"  > /dev/null ; then
       exit 1
@@ -200,17 +200,17 @@ data:
 
     status=0
     # empty --url= helps `gitlab-runner verify` select all configured runners (otherwise filters for $CI_SERVER_URL)
-    verify_output=$$(timeout "$$VERIFY_TIMEOUT" gitlab-runner verify --url= 2>&1) || status=$$?
+    verify_output=$(timeout "${VERIFY_TIMEOUT}" gitlab-runner verify --url= 2>&1) || status=$?
 
     # timeout exit code is 143 with busybox, and 124 with coreutils
     if (( status == 143 )) || (( status == 124 )) ; then
       echo "'gitlab-runner verify' terminated by timeout, not a conclusive failure" >&2
       exit 0
     elif (( status > 0 )) ; then
-      exit $$status
+      exit ${status}
     fi
 
-    grep -qE "is (alive|valid)" <<<"$$verify_output"
+    grep -qE "is (alive|valid)" <<<"${verify_output}"
 
   pre-entrypoint-script: |
 ---
@@ -280,7 +280,7 @@ spec:
         release: "gitlab-runner"
         heritage: "Helm"
       annotations:
-        checksum/configmap: b9d9d4127a6c0095cc7f38f8408ce3840d1f5ac5ef134a56157b56cbf64da19b
+        checksum/configmap: c5241837ca3ff4cc8df888dd21ae57e348bdba68cfcec34e6218b0ff1aaad8e0
         checksum/secrets: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       securityContext: 

--- a/k3d/gitlab-runner-stack/values/gitlab-runner.yaml
+++ b/k3d/gitlab-runner-stack/values/gitlab-runner.yaml
@@ -39,6 +39,12 @@ rbac:
       verbs: ["get", "list", "watch", "create", "delete"]
     - resources: ["pods/log"]
       verbs: ["get"]
+    # Der Kubernetes-Executor legt pro Job ein Secret mit den Registry-
+    # Credentials an (image_pull_secrets) und raeumt es danach wieder ab.
+    # Stand bis T012413 nur in der gerenderten Datei — dort geht die Regel bei
+    # jedem gitlab-runner:render verloren, deshalb gehoert sie hierher.
+    - resources: ["secrets"]
+      verbs: ["get", "list", "create", "delete"]
 
 # nodeAffinity statt nodeSelector (p1, Aufgabe 4): ein simples Label-Map kann kein
 # ODER ueber zwei Hostnamen ausdruecken. Gleiche Form wie


### PR DESCRIPTION
Behebt die beiden dauerhaft roten Flux-Kustomizations auf `fleet`, gefunden beim Cluster-Debug.

## F1 — `flux-gitlab-runner`: `$$` ohne envsubst

Pod-Log: `/configmaps/register-the-runner: line 23: syntax error: unexpected "("`.

`k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml` enthielt envsubst-Escaping (`$$(seq …)`, `$$!`, `$$?`, `$${VAR}`), aber `flux/clusters/fleet/ks-gitlab-runner.yaml` hat kein `postBuild`, das es auflöst. Unter `/bin/sh` ist `$$` die PID.

Eingeführt von bc80f246b (#4778) — derselbe Commit, der den CrashLoop beheben sollte, hat die gerenderte Datei von Hand editiert.

Gegenprobe mit unveränderter Chart-Version und unveränderten Values:

```
helm template gitlab-runner gitlab/gitlab-runner --version 0.91.2 --namespace gitlab-runner \
  -f k3d/gitlab-runner-stack/values/gitlab-runner.yaml | grep -c '\$\$'
# => 0
```

Der Fix ist `task gitlab-runner:render`. Damit dabei nichts verloren geht, wandert die im selben Commit von Hand ergänzte RBAC-Regel für `secrets` in die Values — dort ist sie reproduzierbar, in der gerenderten Datei überlebt sie den nächsten Render nicht.

## F2 — `flux-dev`: brett-dev Readiness

`Deployment/workspace-dev/brett` 0/1 seit 15 Tagen, Probe auf `/` mit HTTP 500 (32171 Fehlschläge). `/` läuft in den OIDC-Flow. `k3d/brett.yaml` (prod) probet korrekt `/healthz`; dev zieht nach.

Verifiziert gegen den laufenden Pod: `wget -qO- http://127.0.0.1:3000/healthz` → `HTTP/1.1 200 OK`, Body `ok`.

## F3 — `flux-dev`: oauth2-proxy-dev Issuer-Mismatch

972 Restarts mit `issuer did not match the issuer returned by provider, expected "http://pocket-id.workspace.svc.cluster.local:1411" got "https://auth.mentolder.de"`.

Die laufenden Nachbarn `oauth2-proxy-brainstorm` und `-sessions` setzen `--skip-oidc-discovery=true` plus explizite `redeem-`/`jwks-`/`profile-url`; `oauth2-proxy-dev` tat das nicht und lief deshalb in die Discovery-Prüfung. Pocket ID meldet dort immer die öffentliche `APP_URL`.

## Nicht enthalten

`brett-dev` hat weiterhin keinen OIDC-Client — in `workspace-dev` fehlt `POCKET_ID_BRETT_SECRET` (vorhanden sind nur die Cookie-Secrets sowie die Brainstorm- und Session-Hub-Clients). Das braucht ein SealedSecret plus Client-Seed und ist ein eigener Vorgang. Die Probe-Korrektur macht den Pod gesund, ersetzt den Seed aber nicht.

## Verifikation

- `task workspace:validate` → ✓ Manifests are valid
- `kubectl kustomize k3d/gitlab-runner-stack/` und `k3d/dev-stack/` → beide bauen
- `tests/spec/mcp-gateway.bats` (einziger Test, der die geänderten Dateien referenziert) → 40/40 ok
- Render-Diff enthält ausschließlich die `$$`-Korrektur plus Configmap-Checksum; Chart bleibt 0.91.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tmh4bCPjoDZgdKBYmS2h5k