### PR TITLE
fix(infra): $$-Unwrapping deckt ( ! ? ab, gitlab-runner-Escaping zurueck [T012503]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2719,7 +2719,14 @@ tasks:
         echo "✓ Rendered to k3d/monitoring/kube-prometheus-stack-rendered.yaml — review the diff and commit."
 
   gitlab-runner:render:
-    desc: "Pre-render das gitlab-runner-Chart zu committed YAML (Re-Run bei Chart-Upgrade)."
+    # ACHTUNG (T012503): Die Chart-Ausgabe enthaelt Laufzeit-Variablen
+    # (${CONFIG_PATH_FOR_INIT}, ${MAX_REGISTER_ATTEMPTS}). Sie muessen in der
+    # committeten Datei als $${VAR} escaped sein, sonst nimmt
+    # scripts/flux-render-artifact.sh sie in seine envsubst-Liste auf und setzt
+    # sie auf "" — "mkdir -p" laeuft dann ohne Argument und der Runner crasht.
+    # Nach jedem Re-Render das Escaping wieder anbringen; der Guard dafuer ist
+    # tests/spec/flux-render-security/runtime-var-unwrapping.bats.
+    desc: "Pre-render das gitlab-runner-Chart zu committed YAML (Re-Run bei Chart-Upgrade). Danach $${VAR}-Escaping wieder anbringen — siehe Kommentar."
     preconditions:
       - sh: command -v helm > /dev/null
         msg: "helm not found. Install: https://helm.sh/docs/intro/install/"

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -3348,6 +3348,12 @@
     "kind": "shell"
   },
   {
+    "id": "flux-render-security/runtime-var-unwrapping",
+    "file": "tests/spec/flux-render-security/runtime-var-unwrapping.bats",
+    "category": "flux-render-security",
+    "kind": "shell"
+  },
+  {
     "id": "g-cq02-any-types",
     "file": "tests/spec/g-cq02-any-types.bats",
     "category": "g-cq02-any-types",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1102,
+      "file_count": 1103,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -588,6 +588,7 @@
         "tests/spec/flux-artifact-versioning/flux-artifact-versioning.bats",
         "tests/spec/flux-render-security/bootstrap-envsubst.bats",
         "tests/spec/flux-render-security/immutable-image-refs.bats",
+        "tests/spec/flux-render-security/runtime-var-unwrapping.bats",
         "tests/spec/g-cq02-any-types.bats",
         "tests/spec/g-cq08-knip-dead-code.bats",
         "tests/spec/g-dep01-npm-vuln.bats",

--- a/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
+++ b/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
@@ -28,8 +28,8 @@ data:
     set -e
 
     export CONFIG_PATH_FOR_INIT="/home/gitlab-runner/.gitlab-runner/"
-    mkdir -p ${CONFIG_PATH_FOR_INIT}
-    cp /configmaps/config.toml ${CONFIG_PATH_FOR_INIT}
+    mkdir -p $${CONFIG_PATH_FOR_INIT}
+    cp /configmaps/config.toml $${CONFIG_PATH_FOR_INIT}
     # Set up environment variables for cache
     if [[ -f /secrets/accesskey && -f /secrets/secretkey ]]; then
       export CACHE_S3_ACCESS_KEY=$(cat /secrets/accesskey)
@@ -166,21 +166,21 @@ data:
       unset RUNNER_TAG_LIST
     fi
 
-    for i in $(seq 1 "${MAX_REGISTER_ATTEMPTS}"); do
-      echo "Registration attempt ${i} of ${MAX_REGISTER_ATTEMPTS}"
+    for i in $$(seq 1 "$${MAX_REGISTER_ATTEMPTS}"); do
+      echo "Registration attempt $$i of $$MAX_REGISTER_ATTEMPTS"
       /entrypoint register \
-        ${RUN_UNTAGGED} \
-        ${ACCESS_LEVEL} \
+        $$RUN_UNTAGGED \
+        $$ACCESS_LEVEL \
         --template-config /configmaps/config.template.toml \
         --non-interactive &
 
-      register_pid=$!
-      wait $register_pid
-      retval=$?
+      register_pid=$$!
+      wait $$register_pid
+      retval=$$?
 
-      if [ ${retval} = 0 ]; then
+      if [ $$retval = 0 ]; then
         break
-      elif [ ${i} = ${MAX_REGISTER_ATTEMPTS} ]; then
+      elif [ $$i = $$MAX_REGISTER_ATTEMPTS ]; then
         exit 1
       fi
 
@@ -192,7 +192,7 @@ data:
     set -eou pipefail
 
     # default timeout is 3 seconds, can be overriden
-    VERIFY_TIMEOUT=${1:-${VERIFY_TIMEOUT:-3}}
+    VERIFY_TIMEOUT=$${1:-$${VERIFY_TIMEOUT:-3}}
 
     if ! /usr/bin/pgrep -f ".*register-the-runner"  > /dev/null && ! /usr/bin/pgrep -f "gitlab.*runner"  > /dev/null ; then
       exit 1
@@ -200,17 +200,17 @@ data:
 
     status=0
     # empty --url= helps `gitlab-runner verify` select all configured runners (otherwise filters for $CI_SERVER_URL)
-    verify_output=$(timeout "${VERIFY_TIMEOUT}" gitlab-runner verify --url= 2>&1) || status=$?
+    verify_output=$$(timeout "$$VERIFY_TIMEOUT" gitlab-runner verify --url= 2>&1) || status=$$?
 
     # timeout exit code is 143 with busybox, and 124 with coreutils
     if (( status == 143 )) || (( status == 124 )) ; then
       echo "'gitlab-runner verify' terminated by timeout, not a conclusive failure" >&2
       exit 0
     elif (( status > 0 )) ; then
-      exit ${status}
+      exit $$status
     fi
 
-    grep -qE "is (alive|valid)" <<<"${verify_output}"
+    grep -qE "is (alive|valid)" <<<"$$verify_output"
 
   pre-entrypoint-script: |
 ---
@@ -280,7 +280,7 @@ spec:
         release: "gitlab-runner"
         heritage: "Helm"
       annotations:
-        checksum/configmap: c5241837ca3ff4cc8df888dd21ae57e348bdba68cfcec34e6218b0ff1aaad8e0
+        checksum/configmap: b9d9d4127a6c0095cc7f38f8408ce3840d1f5ac5ef134a56157b56cbf64da19b
         checksum/secrets: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       securityContext: 

--- a/scripts/flux-render-artifact.sh
+++ b/scripts/flux-render-artifact.sh
@@ -115,7 +115,7 @@ render_component() {
   if [[ -z "$vars" ]]; then
     # Nichts zu substituieren — aber das $$-Unwrapping muss trotzdem laufen,
     # sonst blieben $${VAR}/$$VAR als Doppel-Dollar im Manifest stehen.
-    sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' <<<"$rendered" > "$out"
+    sed -E 's/\$\$([a-zA-Z0-9_({!?])/$\1/g' <<<"$rendered" > "$out"
     return
   fi
   
@@ -127,9 +127,17 @@ render_component() {
   
   # Wrap bare ${VAR} at end of line in double quotes (envsubst needs quoting context),
   # then substitute, then unwrap any $$ escaping envsubst introduced.
+  #
+  # T012503: Das Unwrapping deckt neben Variablennamen auch (, !, ? ab. Wer ein
+  # ConfigMap-Skript escaped, verdoppelt jedes Dollarzeichen — auch $$(cmd),
+  # $$! und $$?. envsubst fasst diese drei zwar ohnehin nicht an, aber ein
+  # Unwrapping, das sie auslaesst, liefert sie als literales $$ aus: in der
+  # Shell ist $$ die PID, aus $$(seq 1 3) wird "1234(seq 1 3)" und das Skript
+  # bricht mit einem Syntaxfehler ab. Genau so lag der gitlab-runner ab
+  # bc80f246b im CrashLoop.
   sed -E 's/: \$\{([a-zA-Z0-9_]+)\}[[:space:]]*$/: "${\1}"/g' <<<"$rendered" \
     | envsubst "$envsubst_vars" \
-    | sed -E 's/\$\$([a-zA-Z0-9_]|\{)/$\1/g' \
+    | sed -E 's/\$\$([a-zA-Z0-9_({!?])/$\1/g' \
     > "$out"
 
   # T002156: checksum/config NACH envsubst aus dem website-config-data-Block

--- a/tests/spec/flux-render-security/runtime-var-unwrapping.bats
+++ b/tests/spec/flux-render-security/runtime-var-unwrapping.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# tests/spec/flux-render-security/runtime-var-unwrapping.bats — $$-Unwrapping im Renderer [T012503]
+#
+# PRUEFMODUS: Output-Verifikation der Unwrapping-Stufe, plus eine Quelltext-Zusicherung fuer
+# das Escaping in einer generierten Datei. Die zweite ist eine Ausnahme nach CLAUDE.md
+# §Test-Resultats-Konvention [T002448-M4] fuer Deploy-Konfiguration: die gerenderte
+# Helm-Ausgabe hat lokal keinen ausfuehrbaren Output, ihr Effekt zeigt sich erst im Cluster.
+#
+# Hintergrund: Der Renderer nimmt als $${VAR} markierte Laufzeit-Variablen aus der
+# envsubst-Liste und unwrapped sie danach (T002306). Das Unwrapping deckte urspruenglich nur
+# Variablennamen und { ab — nicht (, ! und ?. Wer ein ConfigMap-Skript vollstaendig escaped,
+# bekam $$(seq 1 3) unveraendert ausgeliefert; in der Shell ist $$ die PID, das Skript brach
+# mit "syntax error: unexpected (" ab. Der gitlab-runner lag deshalb ab bc80f246b im
+# CrashLoop. Der Gegenfehler ist genauso teuer: nimmt man das Escaping weg, landen
+# CONFIG_PATH_FOR_INIT und MAX_REGISTER_ATTEMPTS in der envsubst-Liste, werden zu "" und
+# "mkdir -p" laeuft ohne Argument.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  RENDER_SCRIPT="${REPO_ROOT}/scripts/flux-render-artifact.sh"
+  RENDERED="${REPO_ROOT}/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml"
+  UNWRAP='s/\$\$([a-zA-Z0-9_({!?])/$\1/g'
+}
+
+@test "T012503: der Renderer verwendet genau das hier gepruefte Unwrapping-Muster" {
+  # Verhindert, dass dieser Test eine Kopie prueft, die vom Skript abgedriftet ist.
+  run grep -cF "$UNWRAP" "$RENDER_SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 2 ]
+}
+
+@test "T012503: \$\${VAR} wird zu \${VAR} — die bestehende Zusicherung aus T002306" {
+  run sed -E "$UNWRAP" <<<'mkdir -p $${CONFIG_PATH_FOR_INIT}'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'mkdir -p ${CONFIG_PATH_FOR_INIT}' ]
+}
+
+@test "T012503: \$\$VAR ohne Klammern wird zu \$VAR" {
+  run sed -E "$UNWRAP" <<<'wait $$register_pid'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'wait $register_pid' ]
+}
+
+@test "T012503: \$\$( wird zu \$( — sonst expandiert die Shell \$\$ zur PID" {
+  run sed -E "$UNWRAP" <<<'for i in $$(seq 1 3); do'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'for i in $(seq 1 3); do' ]
+}
+
+@test "T012503: \$\$! und \$\$? werden zu \$! und \$?" {
+  run sed -E "$UNWRAP" <<<'register_pid=$$! ; retval=$$?'
+  [ "$status" -eq 0 ]
+  [ "$output" = 'register_pid=$! ; retval=$?' ]
+}
+
+@test "T012503: gitlab-runner-rendered.yaml traegt die Laufzeit-Variablen als \$\$" {
+  # Positiv-Anker: die Datei existiert und enthaelt das Registrierungsskript.
+  run grep -c 'MAX_REGISTER_ATTEMPTS' "$RENDERED"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+
+  # Ein blosses `task gitlab-runner:render` liefert einfaches $ und macht die Datei damit
+  # still kaputt: die beiden Variablen kaemen dann in die envsubst-Liste. Wer neu rendert,
+  # muss das Escaping wieder anbringen.
+  run grep -c '\$\${CONFIG_PATH_FOR_INIT}' "$RENDERED"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+
+  run grep -c '\$\${MAX_REGISTER_ATTEMPTS}' "$RENDERED"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+}
+
+@test "T012503: nach dem Unwrapping bleibt in der gerenderten Datei kein \$\$ stehen" {
+  local unwrapped
+  unwrapped="$(sed -E "$UNWRAP" "$RENDERED")"
+
+  # Positiv-Anker: das Unwrapping hat wirklich etwas produziert und die Shell-Konstrukte
+  # stehen danach in ihrer ausfuehrbaren Form da.
+  run grep -c 'for i in \$(seq 1 "\${MAX_REGISTER_ATTEMPTS}")' <<<"$unwrapped"
+  [ "$status" -eq 0 ]
+  [ "$output" -gt 0 ]
+
+  run grep -c '\$\$' <<<"$unwrapped"
+  [ "$output" = "0" ]
+}

--- a/tests/spec/software-factory/pr-babysit.bats
+++ b/tests/spec/software-factory/pr-babysit.bats
@@ -121,14 +121,31 @@ _stub_gh_runlog() {
   [[ "$output" != *"selected PR #50"* ]]
 }
 
-@test "T001805: CONFLICTING PRs get labelled + notified, never fixed" {
-  _stub_gh_prs '[{"number":51,"isDraft":false,"mergeStateStatus":"CONFLICTING","headRefName":"fix/c","author":{"login":"paddione"},"labels":[],"statusCheckRollup":[{"conclusion":"FAILURE"}]}]'
+# T012567: Der Stub trug bis hierher nur mergeStateStatus="CONFLICTING" — einen Wert, den
+# das Enum gar nicht kennt. T012500 (#4796) hat den Guard im Skript auf die real
+# gelieferten Felder umgestellt (mergeable="CONFLICTING" ODER mergeStateStatus="DIRTY"),
+# den Stub aber nicht mitgezogen; seitdem lief dieser Test ins Leere. Die Spec-Shards
+# laufen nur als PR-Check, deshalb fiel es erst im naechsten PR auf.
+@test "T001805: CONFLICTING PRs get labelled + notified, never fixed (mergeable)" {
+  _stub_gh_prs '[{"number":51,"isDraft":false,"mergeable":"CONFLICTING","mergeStateStatus":"BLOCKED","headRefName":"fix/c","author":{"login":"paddione"},"labels":[],"statusCheckRollup":[{"conclusion":"FAILURE"}]}]'
   FACTORY_DRY_RESOLVE=1 run bash "$BABYSIT"
   [[ "$output" == *"QA_NOTIFY_PAYLOAD"* ]]
   run grep -E 'pr edit 51 --add-label ci-babysitter-conflict' "$ARGV_LOG"
   [ "$status" -eq 0 ]
   run grep -F 'run view' "$ARGV_LOG"
   [ "$status" -ne 0 ]   # kein CI-Log-Fetch → kein Fix-Versuch
+}
+
+# Zweiter Weg in denselben Zweig: waehrend GitHub mergeable noch berechnet, steht dort
+# UNKNOWN und nur mergeStateStatus verraet den Konflikt (DIRTY).
+@test "T001805: CONFLICTING PRs get labelled + notified, never fixed (mergeStateStatus DIRTY)" {
+  _stub_gh_prs '[{"number":53,"isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"DIRTY","headRefName":"fix/dirty","author":{"login":"paddione"},"labels":[],"statusCheckRollup":[{"conclusion":"FAILURE"}]}]'
+  FACTORY_DRY_RESOLVE=1 run bash "$BABYSIT"
+  [[ "$output" == *"QA_NOTIFY_PAYLOAD"* ]]
+  run grep -E 'pr edit 53 --add-label ci-babysitter-conflict' "$ARGV_LOG"
+  [ "$status" -eq 0 ]
+  run grep -F 'run view' "$ARGV_LOG"
+  [ "$status" -ne 0 ]
 }
 
 @test "T001805: at 2 prior attempts the PR is given up + notified" {


### PR DESCRIPTION
Folgefehler aus #4799. Ich habe dort das `$$`-Escaping der gitlab-runner-ConfigMap als überflüssig eingestuft und entfernt — das war falsch, und der Cluster hat es sofort gezeigt.

## Was tatsächlich passiert

`scripts/flux-render-artifact.sh` behandelt `$${VAR}` als **bewusste Markierung für Laufzeit-Variablen** (T002306): solche Variablen werden aus der envsubst-Ersetzungsliste entfernt und erst danach zu `${VAR}` unwrapped. Das Unwrap-Muster lautete:

```
s/\$\$([a-zA-Z0-9_]|\{)/$\1/g
```

Es deckt Variablennamen und `{` ab — aber nicht `(`, `!` und `?`. Wer ein ConfigMap-Skript vollständig escaped (so #4778 für den Runner), bekommt `$$(seq …)`, `$$!` und `$$?` unverändert ausgeliefert. In der Shell ist `$$` die PID, aus `$$(seq 1 30)` wird `<pid>(seq 1 30)`:

```
/configmaps/register-the-runner: line 23: syntax error: unexpected "("
```

Der Gegenfehler ist genauso teuer und war nach #4799 live zu beobachten. Ohne Escaping sieht der Variablen-Extraktor `${CONFIG_PATH_FOR_INIT}` und `${MAX_REGISTER_ATTEMPTS}`, envsubst setzt beide auf `""`:

```
BusyBox v1.37.0 multi-call binary.
Usage: mkdir [-m MODE] [-p] DIRECTORY...
```

Dieselbe Klasse hat am 2026-07-27 die shared-db-Passwörter geleert — im Skript ausführlich dokumentiert. Ich bin genau in den dort beschriebenen Fehler gelaufen.

## Änderungen

1. **`scripts/flux-render-artifact.sh`** — Unwrap-Muster auf `s/\$\$([a-zA-Z0-9_({!?])/$\1/g`, beide Vorkommen. Das behebt die Ursachenklasse für jedes künftig escapte ConfigMap-Skript.
2. **`k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml`** — Escaping zurück auf den Stand `bc80f246b`. Mit dem korrigierten Unwrapping ist das das richtige Eingabeformat.
3. **`tests/spec/flux-render-security/runtime-var-unwrapping.bats`** — Guard über beide Richtungen: `$${VAR}`/`$$VAR`/`$$(`/`$$!`/`$$?` werden korrekt unwrapped, die gerenderte Datei trägt die beiden Klammer-Variablen als `$$`, und nach dem Unwrapping bleibt kein `$$` stehen. Ein Test hängt das geprüfte Muster an das Skript, damit die Kopie nicht abdriftet.
4. **`Taskfile.yml`** — Warnhinweis am `gitlab-runner:render`-Task: ein bloßer Re-Render liefert einfaches `$` und macht die Datei still kaputt.

## Verifikation

Welcher Renderer-Zweig für `./gitlab-runner` greift, gemessen gegen `origin/main` `f003831da`:

```
kustomize build k3d/gitlab-runner-stack --load-restrictor=LoadRestrictionsNone > /tmp/gr.yaml
grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' /tmp/gr.yaml | sort -u
# => ${CONFIG_PATH_FOR_INIT}, ${MAX_REGISTER_ATTEMPTS}
```

Mit `$$`-Escaping erkennt der Renderer beide als `runtime_vars`, `vars` wird leer und er nimmt den Früh-Ausstieg **ohne** envsubst. Ohne Escaping landen sie in der Ersetzungsliste — das war der Fehler.

```
sed -E 's/\$\$([a-zA-Z0-9_({!?])/$\1/g' /tmp/gr.yaml | grep -c '\$\$'
# => 0
```

Nach dem Unwrapping stehen die Konstrukte ausführbar da: `mkdir -p ${CONFIG_PATH_FOR_INIT}`, `for i in $(seq 1 "${MAX_REGISTER_ATTEMPTS}")`, `register_pid=$!`, `retval=$?`.

- `tests/spec/flux-render-security/` → 16/16 ok
- `task workspace:validate` → ✓ Manifests are valid

## Offen

Unverändert aus #4799: `brett-dev` hat keinen OIDC-Client, in `workspace-dev` fehlt `POCKET_ID_BRETT_SECRET`. Eigener Vorgang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tmh4bCPjoDZgdKBYmS2h5k
