### PR TITLE
fix(factory): Branch-Namen aus dem Ticket-Typ bilden, Ticket-ID gross [T012502]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -4920,6 +4920,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/branch-naming-T012502",
+    "file": "tests/spec/software-factory/branch-naming-T012502.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/brand-is-row-filter-not-namespace",
     "file": "tests/spec/software-factory/brand-is-row-filter-not-namespace.bats",
     "category": "software-factory",

--- a/scripts/factory/dispatcher-bridge.sh
+++ b/scripts/factory/dispatcher-bridge.sh
@@ -55,7 +55,10 @@ for row in "${launch_rows[@]}"; do
   branch="$(echo "$row" | jq -r '.branch // ""')"
   plan_path="$(echo "$row" | jq -r '.plan_path // ""')"
   wt_path="$(echo "$row" | jq -r '.worktree_path // ""')"
-  slug="$(echo "$row" | jq -r '.branch // ""' | sed -E 's#^(feature|fix|chore)/##')"
+  # [T012502] docs/ mitstrippen: pipeline.mjs leitet den Praefix seit T012502 aus
+  # dem Ticket-Typ ab. Bliebe docs/ stehen, landete es im slug — und damit im
+  # Worktree-Pfad (.worktrees/docs/<name>) und im OpenSpec-Verzeichnis.
+  slug="$(echo "$row" | jq -r '.branch // ""' | sed -E 's#^(feature|fix|chore|docs)/##')"
   [[ -z "$slug" ]] && slug="sf-$(echo "$ext_id" | tr '[:upper:]' '[:lower:]')"
   dry_run_val="$(echo "$row" | jq -r '.dry_run // false')"
   [[ "$DRY_RUN" == "true" ]] && dry_run_val=true

--- a/scripts/factory/pipeline-partials.cjs
+++ b/scripts/factory/pipeline-partials.cjs
@@ -122,8 +122,11 @@ function buildDeployPrompt(ctx) {
    Deploy to both brands. Operate from MAIN repo ${R} (NOT ${c.workWt}).
 
    HARD GUARDS — STOP on any failure:
-   a. Branch: WORK_BRANCH must match ^(feature|fix|chore)/ .
-      printf '%s' "${c.workBranch}" | grep -Eq '^(feature|fix|chore)/' || { echo "BLOCK: WORK_BRANCH ${c.workBranch} not feature/*|fix/*|chore/*"; exit 1; }
+   a. Branch: WORK_BRANCH must match ^(feature|fix|chore|docs)/ .
+      [T012502] docs/ ergaenzt: pipeline.mjs leitet den Praefix seit T012502 aus
+      dem Ticket-Typ ab und kann docs/ erzeugen — ohne diesen Eintrag blockte der
+      Guard einen Namen, den die Konvention ausdruecklich erlaubt.
+      printf '%s' "${c.workBranch}" | grep -Eq '^(feature|fix|chore|docs)/' || { echo "BLOCK: WORK_BRANCH ${c.workBranch} not feature/*|fix/*|chore/*|docs/*"; exit 1; }
    b. Diff-size cap: source ${R}/scripts/factory/guards.sh
       GUARDS_REPO=${R} guard_check_diff_size ${c.maxDiff || '800'} ${c.workBranch}
    c. CWD: every command MUST run from ${R}, never ${c.workWt} (T000342).

--- a/scripts/factory/pipeline.mjs
+++ b/scripts/factory/pipeline.mjs
@@ -175,10 +175,13 @@ let REUSE = !!(REUSE_BRANCH && REUSE_PLAN)
 // If dev-flow-plan staged a plan but the dispatcher didn't pass branch/plan_path,
 // the ticket still carries a FACTORY-PLAN-REF comment. Parse it to enable REUSE
 // and skip Scout/Design/Plan-creation — the human already did that work.
+let TICKET_TYPE = ''
 if (!REUSE && A.ticket_id) {
   try {
     const ticketJsonStr = await runRunner(agent, 'ticket-get', { ticket_id: A.ticket_id, brand })
-    const planRef = (JSON.parse(ticketJsonStr).plan_ref) || ''
+    const ticketObj = JSON.parse(ticketJsonStr)
+    TICKET_TYPE = String(ticketObj.type || '')
+    const planRef = ticketObj.plan_ref || ''
     const branchMatch = planRef.match(/branch=(\S+)/)
     const planMatch   = planRef.match(/plan=(\S+)/)
     if (branchMatch && planMatch) {
@@ -192,9 +195,44 @@ if (!REUSE && A.ticket_id) {
   }
 }
 
-// Ensure slug is never "null" — fall back to ticket-based slug
+// Ensure slug is never "null" — fall back to ticket-based slug.
+// Der slug benennt Pfade (.worktrees/<slug>, openspec/changes/<slug>) und bleibt
+// deshalb klein. Der BRANCH-Name folgt einer anderen Regel — siehe unten.
 const safeSlug = (!slug || slug === 'null') ? `sf-${(A.ticket_id || '').toLowerCase()}` : slug
-const WORK_BRANCH = REUSE ? REUSE_BRANCH : `feature/${safeSlug}`
+
+// [T012502] Branch-Namen nach Repo-Konvention: type/<slug>-T000XXX.
+// scripts/worktree-create.sh (~Z. 102) laesst genau vier Typ-Praefixe zu und
+// verlangt die Ticket-ID in GROSSschreibung. Zuvor stand hier fest `feature/`
+// mit dem unveraenderten safeSlug — zwei Defekte in einer Zeile:
+//
+//   1. Jeder Vorgang hiess feature/, auch ein type=bug- oder chore-Ticket.
+//   2. Der Fallback-slug `sf-t012415` traegt die ID KLEIN. Der Guard prueft
+//      /T[0-9]{6,}/ und ist case-sensitiv — er lehnte den Namen ab, den die
+//      Factory selbst gebildet hatte. worktree-create.sh haelt fuer genau
+//      diesen Fall sogar eine eigene Fehlermeldung bereit ("Muss GROSS sein").
+//
+// Der Typ kommt aus `ticket.sh get` (Feld `type`); faellt der Aufruf aus, bleibt
+// TICKET_TYPE leer und wir landen bewusst auf `feature` — dem bisherigen
+// Verhalten, nicht auf einem Abbruch.
+// >>> T012502-BRANCH-REGEL — Anfang (Testanker, nicht entfernen) >>>
+// pipeline.mjs laeuft im Workflow-Sandbox OHNE import/require. Die Regel kann
+// deshalb nicht in ein Modul ausgelagert werden, das der Test importiert.
+// Damit der Test trotzdem den laufenden Code prueft und keine Kopie, schneidet
+// tests/spec/software-factory/branch-naming-T012502.bats genau diesen Block aus
+// der Datei und fuehrt ihn aus. Die Marker sind Teil des Vertrags.
+const BRANCH_PREFIX_BY_TICKET_TYPE = { bug: 'fix', chore: 'chore', docs: 'docs' }
+const branchPrefix = BRANCH_PREFIX_BY_TICKET_TYPE[String(TICKET_TYPE || '').toLowerCase()] || 'feature'
+
+// Ticket-ID im Branch erzwingen: erst eine klein geschriebene ID hochziehen,
+// dann — falls gar keine drinsteht — die des Tickets anhaengen.
+const upcasedSlug = String(safeSlug || '').replace(/\bt([0-9]{6,})\b/g, (_m, digits) => `T${digits}`)
+const ticketIdUpper = String(A.ticket_id || '').toUpperCase()
+const branchSlug = /T[0-9]{6,}/.test(upcasedSlug)
+  ? upcasedSlug
+  : (ticketIdUpper ? (upcasedSlug ? `${upcasedSlug}-${ticketIdUpper}` : ticketIdUpper) : upcasedSlug)
+
+const WORK_BRANCH = REUSE ? REUSE_BRANCH : `${branchPrefix}/${branchSlug}`
+// <<< T012502-BRANCH-REGEL — Ende <<<
 // [T003270] Ein wiederverwendeter Worktree (factory-prep V1-Reuse) kann an
 // einem nicht-kanonischen Pfad liegen (.worktrees/mishap-incident-rollup statt
 // .worktrees/<slug>-reuse). A.worktree_path traegt den tatsaechlich verwendeten

--- a/scripts/factory/watchdog.sh
+++ b/scripts/factory/watchdog.sh
@@ -81,9 +81,18 @@ mapfile -t stale < <(_stale_query | factory_psql)
 _wd_cleanup_worktree() {
   local ext_id="$1" ext_lc stale_wt
   ext_lc="$(printf '%s' "$ext_id" | tr '[:upper:]' '[:lower:]')"
+  # [T012502] Alle vier Konventions-Praefixe und beide Schreibweisen der
+  # Ticket-ID erfassen. Vorher stand hier exakt feature/sf-<klein> bzw.
+  # chore/sf-<klein> — die Gegenstelle in pipeline.mjs bildet seit T012502 den
+  # Praefix aus dem Ticket-Typ (fix/, docs/ kamen hinzu) und schreibt die ID
+  # GROSS, weil worktree-create.sh sie klein ablehnt. Ohne diese Anpassung
+  # faende der Watchdog seine eigenen Zombie-Worktrees nicht mehr.
+  # Unveraendert eng bleibt der sf-Praefix: geraeumt wird weiterhin nur der
+  # Fallback-Slug, nicht jeder Branch mit dieser Ticket-ID.
   stale_wt="$(git worktree list --porcelain 2>/dev/null \
-    | awk -v p1="refs/heads/feature/sf-$ext_lc" -v p2="refs/heads/chore/sf-$ext_lc" '
-        /^worktree /{w=$2} $0=="branch "p1 || $0=="branch "p2{print w}')"
+    | awk -v pat="^branch refs/heads/(feature|fix|chore|docs)/sf-" -v id="$ext_lc" '
+        /^worktree /{w=$2}
+        /^branch /{ b=tolower($0); if (b ~ (pat id "$")) print w }')"
   [[ -z "$stale_wt" ]] && return 0
   if git -C "$stale_wt" status --short 2>/dev/null | grep -q .; then
     bash "$HERE/../ticket.sh" add-comment --id "$ext_id" \

--- a/tests/spec/software-factory/branch-naming-T012502.bats
+++ b/tests/spec/software-factory/branch-naming-T012502.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/branch-naming-T012502.bats
+# SSOT: openspec/specs/software-factory.md
+# Ticket: T012502 — die Factory bildete den Arbeitsbranch als `feature/${safeSlug}`.
+# Zwei Defekte in dieser einen Zeile:
+#   1. Der Typ-Praefix war hartkodiert. Ein type=bug- oder chore-Ticket bekam
+#      trotzdem feature/, obwohl scripts/worktree-create.sh vier Praefixe fuehrt
+#      und der Typ in `ticket.sh get` als Feld `type` bereitsteht.
+#   2. Der Fallback-Slug lautete `sf-${ticket_id.toLowerCase()}`. Der Guard
+#      prueft /T[0-9]{6,}/ case-sensitiv — die Factory bildete also einen Namen,
+#      den die eigene Konvention ablehnt.
+#
+# PRUEFMODUS: Output-Verifikation am LAUFENDEN Code. pipeline.mjs ist ein
+# Workflow-Skript und laeuft ohne import/require; die Regel kann deshalb nicht in
+# ein Modul, das dieser Test importiert. Stattdessen wird der markierte Block aus
+# pipeline.mjs ausgeschnitten und ausgefuehrt. Damit gibt es keine zweite Kopie
+# der Regel, die vom Original wegdriften koennte.
+#
+# Auch die Guard-Ausdruecke werden nicht nachgebaut, sondern aus
+# scripts/worktree-create.sh extrahiert und ausgefuehrt — sonst pruefte dieser
+# Test seine eigene Vorstellung des Guards statt den Guard.
+
+setup() {
+  REPO="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  export REPO
+  PIPELINE="${REPO}/scripts/factory/pipeline.mjs"
+  WTC="${REPO}/scripts/worktree-create.sh"
+
+  HARNESS="${BATS_TEST_TMPDIR}/harness.cjs"
+  cat > "$HARNESS" <<'JS'
+// Schneidet den markierten Block aus pipeline.mjs und fuehrt ihn aus.
+const fs = require('fs')
+const [, , file, slug, ticketId, ticketType, reuse, reuseBranch] = process.argv
+const src = fs.readFileSync(file, 'utf8')
+const m = src.match(/\/\/ >>> T012502-BRANCH-REGEL[\s\S]*?\/\/ <<< T012502-BRANCH-REGEL[^\n]*/)
+if (!m) { console.error('MARKER-BLOCK NICHT GEFUNDEN'); process.exit(2) }
+const fn = new Function(
+  'safeSlug', 'TICKET_TYPE', 'A', 'REUSE', 'REUSE_BRANCH',
+  m[0] + '\n; return WORK_BRANCH'
+)
+process.stdout.write(String(fn(
+  slug, ticketType, { ticket_id: ticketId }, reuse === 'true', reuseBranch || ''
+)) + '\n')
+JS
+
+  # Die beiden Guard-Bedingungen AUS worktree-create.sh holen, statt sie zu raten.
+  GUARD="${BATS_TEST_TMPDIR}/guard.sh"
+  {
+    echo 'bn="$1"; ht=0; hk=0'
+    grep -F '_has_type=1' "$WTC" | head -1 | sed 's/_bn/bn/g; s/_has_type/ht/g'
+    grep -F '_has_ticket=1' "$WTC" | head -1 | sed 's/_bn/bn/g; s/_has_ticket/hk/g'
+    echo 'if [ "$ht" -eq 1 ] && [ "$hk" -eq 1 ]; then echo OK; else echo ABGELEHNT; fi'
+  } > "$GUARD"
+  export HARNESS GUARD PIPELINE
+}
+
+# branch <slug> <ticketId> <ticketType> [reuse] [reuseBranch]
+branch() { node "$HARNESS" "$PIPELINE" "$1" "$2" "$3" "${4:-false}" "${5:-}"; }
+guard()  { bash "$GUARD" "$1"; }
+
+# ── Positiv-Anker zuerst [T002356-M1] ───────────────────────────────────────
+# Ohne ihn saemen alle Aussagen unten vakuos: schluege das Ausschneiden des
+# Blocks fehl, brauechen alle Faelle gleichermassen ab, und "ist nicht feature/"
+# gaelte trivial.
+
+@test "T012502: Positiv-Anker — der Block laesst sich ausfuehren und der Regelfall bleibt feature/" {
+  run branch "gitlab-registry-mirror-T012415" "T012415" "feature"
+  [ "$status" -eq 0 ] || { echo "Harness kaputt (Marker-Block nicht ausfuehrbar): $output"; false; }
+  [ "$output" = "feature/gitlab-registry-mirror-T012415" ] \
+    || { echo "Regelfall verletzt, erhalten: $output"; false; }
+
+  run guard "feature/gitlab-registry-mirror-T012415"
+  [ "$output" = "OK" ] || { echo "Guard-Extraktion kaputt — akzeptiert nicht einmal den Regelfall: $output"; false; }
+}
+
+@test "T012502: Positiv-Anker — der extrahierte Guard lehnt einen unkonventionellen Namen ab" {
+  # Belegt, dass `guard` ueberhaupt ablehnen KANN. Ohne diese Probe koennte die
+  # Extraktion stillschweigend immer OK liefern und jede Zusicherung unten waere
+  # wertlos.
+  run guard "wip/irgendwas-ohne-ticket"
+  [ "$output" = "ABGELEHNT" ] || { echo "Guard lehnt nichts ab — Extraktion kaputt: $output"; false; }
+}
+
+# ── Defekt 1: Typ-Praefix ───────────────────────────────────────────────────
+
+@test "T012502: type=bug ergibt fix/ statt feature/" {
+  run branch "babysit-conflict-guard-T012500" "T012500" "bug"
+  [ "${output%%/*}" = "fix" ] || { echo "erwartet fix/, erhalten: $output"; false; }
+}
+
+@test "T012502: type=chore ergibt chore/, type=docs ergibt docs/" {
+  run branch "deps-bump-T001500" "T001500" "chore"
+  [ "${output%%/*}" = "chore" ] || { echo "erwartet chore/, erhalten: $output"; false; }
+
+  run branch "readme-update-T001501" "T001501" "docs"
+  [ "${output%%/*}" = "docs" ] || { echo "erwartet docs/, erhalten: $output"; false; }
+}
+
+@test "T012502: unbekannter oder fehlender Typ faellt auf feature/ zurueck (kein Abbruch)" {
+  # Faellt ticket-get aus, ist TICKET_TYPE leer. Das darf die Pipeline nicht
+  # anhalten — es soll sich wie vorher verhalten.
+  run branch "spike-etwas-T001502" "T001502" ""
+  [ "${output%%/*}" = "feature" ] || { echo "leerer Typ: erwartet feature/, erhalten: $output"; false; }
+
+  run branch "spike-etwas-T001502" "T001502" "spike"
+  [ "${output%%/*}" = "feature" ] || { echo "unbekannter Typ: erwartet feature/, erhalten: $output"; false; }
+}
+
+# ── Defekt 2: Ticket-ID in GROSSschreibung ──────────────────────────────────
+
+@test "T012502: der Fallback-Slug sf-<klein> wird vom Guard akzeptiert" {
+  # Der reale Selbstblock: pipeline.mjs bildete `sf-t012415`, worktree-create.sh
+  # verlangt T[0-9]{6,} GROSS.
+  run branch "sf-t012415" "T012415" "bug"
+  [ "$output" = "fix/sf-T012415" ] || { echo "erwartet fix/sf-T012415, erhalten: $output"; false; }
+
+  run guard "fix/sf-T012415"
+  [ "$output" = "OK" ] || { echo "❌ Bug reproduziert: der Guard lehnt den erzeugten Namen ab"; false; }
+}
+
+@test "T012502: ein Slug ganz ohne Ticket-ID bekommt sie angehaengt" {
+  run branch "irgendein-slug" "T012415" "feature"
+  [ "$output" = "feature/irgendein-slug-T012415" ] || { echo "erhalten: $output"; false; }
+
+  run guard "feature/irgendein-slug-T012415"
+  [ "$output" = "OK" ] || { echo "Guard lehnt ab: $output"; false; }
+}
+
+@test "T012502: eine bereits GROSS geschriebene ID wird nicht verdoppelt" {
+  run branch "slug-T099999" "T012415" "feature"
+  [ "$output" = "feature/slug-T099999" ] || { echo "ID verdoppelt oder veraendert: $output"; false; }
+}
+
+# ── REUSE bleibt unberuehrt ─────────────────────────────────────────────────
+
+@test "T012502: bei REUSE bleibt der uebergebene Branch unveraendert" {
+  # Ein von dev-flow-plan gestagter Branch darf nicht umbenannt werden — sonst
+  # zeigt FACTORY-PLAN-REF ins Leere.
+  run branch "egal" "T012415" "bug" "true" "feature/vom-menschen-gestaged-T012415"
+  [ "$output" = "feature/vom-menschen-gestaged-T012415" ] \
+    || { echo "REUSE-Branch wurde veraendert: $output"; false; }
+}
+
+# ── Alle erzeugten Praefixe muessen den Downstream-Guard passieren ──────────
+
+@test "T012502: jeder erzeugbare Praefix passiert den Guard in pipeline-partials.cjs" {
+  # pipeline-partials.cjs blockt den Deploy-Schritt, wenn WORK_BRANCH nicht
+  # matcht. Vor T012502 kannte er docs/ nicht — die Pipeline haette sich beim
+  # ersten docs-Ticket selbst gestoppt.
+  local partials="${REPO}/scripts/factory/pipeline-partials.cjs"
+  local pattern
+  pattern="$(grep -o "grep -Eq '\^([a-z|]*)/'" "$partials" | head -1 | sed "s/grep -Eq '//; s/'$//")"
+  [ -n "$pattern" ] || { echo "Guard-Muster in pipeline-partials.cjs nicht gefunden"; false; }
+
+  local p
+  for p in feature fix chore docs; do
+    echo "${p}/x-T012415" | grep -Eq "$pattern" \
+      || { echo "❌ pipeline-partials.cjs blockt Praefix '${p}/' (Muster: $pattern)"; false; }
+  done
+}
+
+# -- Watchdog-Gegenstelle ----------------------------------------------------
+# Der Zombie-Worktree-Cleanup suchte exakt feature/sf-<klein> bzw.
+# chore/sf-<klein>. Beide Teile widersprachen sich damit: die Form, die der
+# Watchdog erwartete, lehnte worktree-create.sh ab. Nach T012502 muss er die
+# neue Form finden UND die alte weiter erkennen (Bestands-Worktrees).
+#
+# Extrahiert wird nur der Musterstring (pat="..."), nicht ueber Zeilennummern
+# oder Einrueckung, die sich beim naechsten Edit verschieben.
+
+_wd_match() {
+  printf '%s\n' "worktree $1" "branch $2" \
+    | awk -v pat="$3" -v id="t012415" '/^worktree /{w=$2} /^branch /{b=tolower($0); if (b ~ (pat id "$")) print w}'
+}
+
+@test "T012502: das Watchdog-Muster deckt alle vier Praefixe ab und ist case-tolerant" {
+  local wd="${REPO}/scripts/factory/watchdog.sh"
+  local pat
+  pat="$(grep -o 'pat="[^"]*"' "$wd" | head -1 | sed 's/^pat="//; s/"$//')"
+  [ -n "$pat" ] || { echo "Musterstring in watchdog.sh nicht gefunden"; false; }
+
+  # Positiv-Anker: das Muster trifft ueberhaupt etwas.
+  run _wd_match "/w/neu" "refs/heads/fix/sf-T012415" "$pat"
+  [ "$output" = "/w/neu" ] || { echo "Positiv-Anker verletzt - neue Form nicht getroffen: $output"; false; }
+
+  # Bestands-Worktrees der alten, klein geschriebenen Form.
+  run _wd_match "/w/alt" "refs/heads/feature/sf-t012415" "$pat"
+  [ "$output" = "/w/alt" ] || { echo "alte Form nicht mehr erkannt - Zombie-Worktrees blieben liegen: $output"; false; }
+
+  # Ein fremdes Ticket darf NICHT geraeumt werden.
+  run _wd_match "/w/fremd" "refs/heads/fix/sf-T099999" "$pat"
+  [ -z "$output" ] || { echo "fremdes Ticket T099999 wuerde geraeumt: $output"; false; }
+
+  # Und die neuen Praefixe muessen im Muster stehen.
+  local p
+  for p in feature fix chore docs; do
+    printf '%s' "$pat" | grep -q "$p" || { echo "Praefix $p fehlt im Watchdog-Muster: $pat"; false; }
+  done
+}

--- a/tests/spec/software-factory/pr-babysit.bats
+++ b/tests/spec/software-factory/pr-babysit.bats
@@ -122,7 +122,14 @@ _stub_gh_runlog() {
 }
 
 @test "T001805: CONFLICTING PRs get labelled + notified, never fixed" {
-  _stub_gh_prs '[{"number":51,"isDraft":false,"mergeStateStatus":"CONFLICTING","headRefName":"fix/c","author":{"login":"paddione"},"labels":[],"statusCheckRollup":[{"conclusion":"FAILURE"}]}]'
+  # [T012500] Der Stub trug bis hierher mergeStateStatus:"CONFLICTING" — einen
+  # Wert, den GitHub in diesem Feld nie liefert. Das Enum fuehrt BEHIND/BLOCKED/
+  # CLEAN/DIRTY/DRAFT/HAS_HOOKS/UNKNOWN/UNSTABLE; der Konflikt heisst dort DIRTY.
+  # CONFLICTING ist der Wert des SEPARATEN Feldes mergeable. Der Test bestaetigte
+  # damit eine Fiktion und deckte den realen Fall nicht ab — an PR #4780 lief die
+  # Factory deshalb 25 Minuten in den Fix-Pfad, den D7 verbietet.
+  # Stub jetzt so, wie GitHub tatsaechlich antwortet.
+  _stub_gh_prs '[{"number":51,"isDraft":false,"mergeStateStatus":"DIRTY","mergeable":"CONFLICTING","headRefName":"fix/c","author":{"login":"paddione"},"labels":[],"statusCheckRollup":[{"conclusion":"FAILURE"}]}]'
   FACTORY_DRY_RESOLVE=1 run bash "$BABYSIT"
   [[ "$output" == *"QA_NOTIFY_PAYLOAD"* ]]
   run grep -E 'pr edit 51 --add-label ci-babysitter-conflict' "$ARGV_LOG"

--- a/tests/spec/software-factory/ticket-lifecycle.bats
+++ b/tests/spec/software-factory/ticket-lifecycle.bats
@@ -40,17 +40,52 @@ teardown() { _sf_teardown; }
 }
 
 @test "FA-SF-52: dispatcher-bridge strips feature|fix|chore prefix from slug" {
-  run grep -Fq "s#^(feature|fix|chore)/#" scripts/factory/dispatcher-bridge.sh
-  [ "$status" -eq 0 ]
-  # old feature-only strip must be gone
-  run grep -Fq "sed 's/^feature\\///'" scripts/factory/dispatcher-bridge.sh
-  [ "$status" -ne 0 ]
+  # [T012502] Wieder Semantik statt Darstellung: geprueft wird, WAS der sed-
+  # Ausdruck aus einem Branch-Namen macht, nicht sein Wortlaut. Der frühere
+  # Literal-Vergleich auf "s#^(feature|fix|chore)/#" wurde rot, als docs/
+  # hinzukam — obwohl das Strippen danach mehr, nicht weniger konnte.
+  #
+  # Der Slug wird zum Pfad (.worktrees/<slug>). Bliebe ein Praefix stehen, ent-
+  # stuenden verschachtelte Verzeichnisse wie .worktrees/docs/<name>.
+  # Den sed-Ausdruck AUS dem Skript ziehen und ausfuehren — nicht nachbauen.
+  local sedexpr
+  sedexpr="$(grep -o "s#\^([a-z|()]*)/##" scripts/factory/dispatcher-bridge.sh | head -1)"
+  [ -n "$sedexpr" ] || { echo "sed-Ausdruck in dispatcher-bridge.sh nicht gefunden"; false; }
+
+  local p out
+  for p in feature fix chore docs; do
+    out="$(echo "${p}/mein-slug-T000730" | sed -E "$sedexpr")"
+    [ "$out" = "mein-slug-T000730" ] \
+      || { echo "Praefix '${p}/' wird nicht gestrippt (Ausdruck: $sedexpr): $out"; false; }
+  done
+
+  # Positiv-Anker in die Gegenrichtung: es wird nicht blind alles vor dem ersten
+  # / entfernt — ein Slug mit fremdem Praefix bliebe sonst verstuemmelt.
+  out="$(echo "wip/etwas" | sed -E "$sedexpr")"
+  [ "$out" = "wip/etwas" ] || { echo "fremder Praefix wurde gestrippt: $out"; false; }
 }
 
 @test "FA-SF-52: pipeline.js deploy guard admits chore branches" {
   # The branch-regex guard moved into buildDeployPrompt (pipeline-partials.cjs).
-  run grep -Fq '^(feature|fix|chore)/' scripts/factory/pipeline-partials.cjs
-  [ "$status" -eq 0 ]
+  #
+  # [T012502] Geprueft wird, WAS das Muster zulaesst — nicht, wie es geschrieben
+  # ist. Vorher stand hier `grep -Fq '^(feature|fix|chore)/'`, ein Literal-
+  # Vergleich: das Ergaenzen von docs/ (eines Praefixes, das die Konvention
+  # ausdruecklich erlaubt) faerbte den Test rot, obwohl die Zusicherung — chore/
+  # kommt durch — unveraendert erfuellt war. Semantik statt Darstellung.
+  local pattern
+  pattern="$(grep -o "grep -Eq '\^([a-z|]*)/'" scripts/factory/pipeline-partials.cjs \
+    | head -1 | sed "s/grep -Eq '//; s/'$//")"
+  [ -n "$pattern" ] || { echo "Guard-Muster in pipeline-partials.cjs nicht gefunden"; false; }
+
+  echo "chore/etwas-T000730" | grep -Eq "$pattern" \
+    || { echo "Deploy-Guard laesst chore/ NICHT durch (Muster: $pattern)"; false; }
+
+  # Positiv-Anker in die Gegenrichtung: das Muster lehnt ueberhaupt etwas ab.
+  # Ohne ihn bestuende der Test auch bei einem Muster, das alles zulaesst.
+  echo "wip/etwas" | grep -Eq "$pattern" \
+    && { echo "Muster laesst jeden Praefix durch — Guard wirkungslos: $pattern"; false; }
+  return 0
 }
 
 @test "FA-SF-52: pipeline.js PR title uses chore prefix for chore branches" {


### PR DESCRIPTION
## Was war kaputt

`scripts/factory/pipeline.mjs` bildete den Arbeitsbranch als `` `feature/${safeSlug}` `` — zwei Defekte in einer Zeile.

**1. Der Typ-Präfix war hartkodiert.** Jeder Vorgang hieß `feature/`, auch ein `type=bug`- oder `chore`-Ticket. `scripts/worktree-create.sh` führt vier Präfixe (`feature/ fix/ chore/ docs/`), und der Typ steht in `ticket.sh get` als Feld `type` bereit — er wurde nur nie gelesen.

**2. Der Fallback-Slug wurde vom eigenen Guard abgelehnt.** Fehlt der Slug, fällt die Pipeline auf `` `sf-${ticket_id.toLowerCase()}` `` zurück. Der Guard prüft `/T[0-9]{6,}/` und ist case-sensitiv — die Factory bildete also einen Namen, den die eigene Konvention zurückweist. `worktree-create.sh` hält für genau diesen Fall sogar eine eigene Fehlermeldung bereit („Muss GROSS sein").

### Messung (2026-08-19, Commit `f003831da`)

Guard-Bedingungen aus `scripts/worktree-create.sh:102-103`:

```bash
bn=feature/sf-t012415
[[ "$bn" =~ ^feature/|^fix/|^chore/|^docs/ ]]   # typ=1
[[ "$bn" =~ T[0-9]{6,} ]]                       # ticket=0  -> ABGELEHNT

bash scripts/ticket.sh get --id T012500 \
  | python3 -c "import sys,json;print(json.load(sys.stdin)['type'])"   # -> bug
```

## Zwei Gegenstellen mussten mit

Ohne sie hätte der Fix Bestehendes gebrochen:

| Datei | Vorher | Warum es bricht |
|---|---|---|
| `scripts/factory/watchdog.sh` | räumte Zombie-Worktrees nur bei exakt `feature/sf-<klein>` / `chore/sf-<klein>` | Genau die Form, die `worktree-create.sh` ablehnt — **zwei Teile desselben Systems widersprachen sich**. Muster deckt jetzt alle vier Präfixe ab und vergleicht case-tolerant, damit Bestands-Worktrees weiter gefunden werden. Der `sf-`Präfix bleibt bewusst eng: geräumt wird weiterhin nur der Fallback-Slug. |
| `scripts/factory/pipeline-partials.cjs` | ließ `^(feature\|fix\|chore)/` durch | Beim ersten `docs`-Ticket hätte der Deploy-Schritt einen Namen geblockt, den die Konvention erlaubt. |

## Test

`tests/spec/software-factory/branch-naming-T012502.bats`, 11 Tests.

`pipeline.mjs` läuft im Workflow-Sandbox **ohne** `import`/`require` — die Regel kann also nicht in ein Modul, das der Test importiert. Damit keine zweite Kopie entsteht, die wegdriften kann, schneidet der Test den mit `T012502-BRANCH-REGEL` markierten Block aus `pipeline.mjs` und führt ihn aus: geprüft wird der laufende Code. Ebenso werden die Guard-Ausdrücke aus `worktree-create.sh` und das Muster aus `watchdog.sh` extrahiert statt nachgebaut.

### RED-Lauf — Beleg, dass die Tests nicht vakuos bestehen

| Eingriff | Ergebnis |
|---|---|
| Regel auf `` `feature/${safeSlug}` `` zurückgesetzt | **4 von 11 rot** |
| Watchdog-Muster auf `^branch refs/heads/(feature)/sf-` verengt | **Test 11 rot** |
| beides wiederhergestellt | **11/11 grün** |

Ticket: T012502
