### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1104,
+      "file_count": 1105,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -859,6 +859,7 @@
         "tests/spec/software-factory/babysit-prs-live-lock-guard-T003137.bats",
         "tests/spec/software-factory/babysit-prs-red-detection.bats",
         "tests/spec/software-factory/batch-closure-title-children.bats",
+        "tests/spec/software-factory/branch-naming-T012502.bats",
         "tests/spec/software-factory/brand-is-row-filter-not-namespace.bats",
         "tests/spec/software-factory/canary-and-cleanup.bats",
         "tests/spec/software-factory/catalog-eval-telemetry.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32207255296).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
