### PR TITLE
fix(infra): non-root UID fuer die Job-Pods des Runners [T012644]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2730,6 +2730,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/gitlab-runner-nonroot-uid",
+    "file": "tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/gitlab-runner-setup-dryrun",
     "file": "tests/spec/ci-cd/gitlab-runner-setup-dryrun.bats",
     "category": "ci-cd",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1106,
+      "file_count": 1107,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -485,6 +485,7 @@
         "tests/spec/ci-cd/gitlab-runner-fleet-guardrails.bats",
         "tests/spec/ci-cd/gitlab-runner-fleet-rbac.bats",
         "tests/spec/ci-cd/gitlab-runner-job-pod-toml.bats",
+        "tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats",
         "tests/spec/ci-cd/gitlab-runner-setup-dryrun.bats",
         "tests/spec/ci-cd/gitlab-runner-tag-routing.bats",
         "tests/spec/ci-cd/gitlab-tool-parity.bats",

--- a/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
+++ b/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
@@ -116,16 +116,44 @@ data:
         # Namespace — also auch fuer die vom Manager erzeugten Job-Pods
         # (build+helper-Container, dazu init-permissions und service — siehe
         # T012634 weiter unten). Ohne diese Bloecke scheitert jeder CI-Job an
-        # der Admission, bevor er ueberhaupt startet. run_as_user wird
-        # bewusst NICHT gesetzt: Job-Images sind beliebig (Job-.gitlab-ci.yml
-        # entscheidet per eigenem image:), ein fest verdrahteter UID wuerde
-        # Images brechen, die eine andere non-root-UID mitbringen. runAsNonRoot
-        # verlangt nur, dass die tatsaechliche UID des Images != 0 ist — welche
-        # UID das ist, bleibt Sache des Job-Images (Konsequenz der Wahl von
-        # "restricted" als Namespace-Policy, dokumentiert in namespace.yaml und
-        # Runbook Abschnitt 8; nicht durch dieses Partial aufloesbar).
+        # der Admission, bevor er ueberhaupt startet.
+        #
+        # T012644 — run_as_user wird jetzt gesetzt, entgegen der frueheren
+        # Festlegung an dieser Stelle. Die lautete: "run_as_user wird bewusst
+        # NICHT gesetzt, ein fest verdrahteter UID wuerde Images brechen, die
+        # eine andere non-root-UID mitbringen; runAsNonRoot verlangt nur, dass
+        # die tatsaechliche UID des Images != 0 ist." Der zweite Satz stimmt —
+        # und genau daran scheiterte es: die tatsaechliche UID IST 0. Belegt an
+        # zwei Containern:
+        #   docker run --rm ubuntu:24.04 id -u        => 0   (Default-Job-Image)
+        #   Event am Job-Pod: "container has runAsNonRoot and image will run as
+        #   root ... container: init-permissions"     (Helper-Image)
+        # Ohne eigene UID startete kein Job-Pod; der Pod blieb Pending, bis der
+        # Executor mit "timed out waiting for pod to start" abbrach.
+        #
+        # Die Sorge der alten Festlegung bleibt berechtigt: ein Job-Image, das
+        # eine eigene non-root-UID mitbringt und auf sie angewiesen ist, laeuft
+        # jetzt trotzdem als 59417. Das ist der bewusst gewaehlte Preis dafuer,
+        # dass der Namespace restricted BLEIBT (Alternative waere baseline, also
+        # ein Sicherheitsabbau). Konkrete Folge fuer die .gitlab-ci.yml: was im
+        # Job root braucht — apt-get install, npm -g, Schreiben ausserhalb des
+        # Workspace — schlaegt fehl und muss anders geloest werden (fertiges
+        # Image statt Installation zur Laufzeit).
+        #
+        # 59417 ist die UID aus dem Doku-Beispiel des Runners. Sie ist frei
+        # gewaehlt; entscheidend ist nur != 0 und Konsistenz zwischen
+        # run_as_user, run_as_group und fs_group. fs_group sorgt dafuer, dass
+        # das Build-Volume der Gruppe gehoert — sonst koennte init-permissions
+        # als non-root nicht darauf schreiben und der Pod haenge weiter.
+        #
+        # build/helper/service erben run_as_user vom Pod: ihre Bloecke unten
+        # setzen es bewusst nicht erneut, damit es genau eine Stelle gibt, an
+        # der die UID steht.
         [runners.kubernetes.pod_security_context]
           run_as_non_root = true
+          run_as_user = 59417
+          run_as_group = 59417
+          fs_group = 59417
           [runners.kubernetes.pod_security_context.seccomp_profile]
             type = "RuntimeDefault"
         [runners.kubernetes.build_container_security_context]
@@ -168,6 +196,13 @@ data:
         #   => build_ / helper_ / init_permissions_ / service_container_security_context
         [runners.kubernetes.init_permissions_container_security_context]
           run_as_non_root = true
+          # T012644: hier steht die UID ein zweites Mal, obwohl der Pod sie
+          # bereits vorgibt. Die Runner-Doku fuehrt beide Stellen auf, und der
+          # Container ist derjenige, der ohne sie nachweislich nicht startete —
+          # bei einem Chart-Upgrade, das die Vererbung aendert, faellt der
+          # Ausfall sonst wieder auf die schwerste Art auf.
+          run_as_user = 59417
+          run_as_group = 59417
           allow_privilege_escalation = false
           [runners.kubernetes.init_permissions_container_security_context.capabilities]
             drop = ["ALL"]
@@ -334,7 +369,7 @@ spec:
         release: "gitlab-runner"
         heritage: "Helm"
       annotations:
-        checksum/configmap: 2b40986bb2ac0b567b9fb51cfcba84a1a7dfe342b46d5bc25907dac009cb84c9
+        checksum/configmap: 1cf23480ace938c773c37fcea39044715fd2e92fd0da8e1363d41d553c2fcb54
         checksum/secrets: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       securityContext: 

--- a/k3d/gitlab-runner-stack/values/gitlab-runner.yaml
+++ b/k3d/gitlab-runner-stack/values/gitlab-runner.yaml
@@ -179,16 +179,44 @@ runners:
         # Namespace — also auch fuer die vom Manager erzeugten Job-Pods
         # (build+helper-Container, dazu init-permissions und service — siehe
         # T012634 weiter unten). Ohne diese Bloecke scheitert jeder CI-Job an
-        # der Admission, bevor er ueberhaupt startet. run_as_user wird
-        # bewusst NICHT gesetzt: Job-Images sind beliebig (Job-.gitlab-ci.yml
-        # entscheidet per eigenem image:), ein fest verdrahteter UID wuerde
-        # Images brechen, die eine andere non-root-UID mitbringen. runAsNonRoot
-        # verlangt nur, dass die tatsaechliche UID des Images != 0 ist — welche
-        # UID das ist, bleibt Sache des Job-Images (Konsequenz der Wahl von
-        # "restricted" als Namespace-Policy, dokumentiert in namespace.yaml und
-        # Runbook Abschnitt 8; nicht durch dieses Partial aufloesbar).
+        # der Admission, bevor er ueberhaupt startet.
+        #
+        # T012644 — run_as_user wird jetzt gesetzt, entgegen der frueheren
+        # Festlegung an dieser Stelle. Die lautete: "run_as_user wird bewusst
+        # NICHT gesetzt, ein fest verdrahteter UID wuerde Images brechen, die
+        # eine andere non-root-UID mitbringen; runAsNonRoot verlangt nur, dass
+        # die tatsaechliche UID des Images != 0 ist." Der zweite Satz stimmt —
+        # und genau daran scheiterte es: die tatsaechliche UID IST 0. Belegt an
+        # zwei Containern:
+        #   docker run --rm ubuntu:24.04 id -u        => 0   (Default-Job-Image)
+        #   Event am Job-Pod: "container has runAsNonRoot and image will run as
+        #   root ... container: init-permissions"     (Helper-Image)
+        # Ohne eigene UID startete kein Job-Pod; der Pod blieb Pending, bis der
+        # Executor mit "timed out waiting for pod to start" abbrach.
+        #
+        # Die Sorge der alten Festlegung bleibt berechtigt: ein Job-Image, das
+        # eine eigene non-root-UID mitbringt und auf sie angewiesen ist, laeuft
+        # jetzt trotzdem als 59417. Das ist der bewusst gewaehlte Preis dafuer,
+        # dass der Namespace restricted BLEIBT (Alternative waere baseline, also
+        # ein Sicherheitsabbau). Konkrete Folge fuer die .gitlab-ci.yml: was im
+        # Job root braucht — apt-get install, npm -g, Schreiben ausserhalb des
+        # Workspace — schlaegt fehl und muss anders geloest werden (fertiges
+        # Image statt Installation zur Laufzeit).
+        #
+        # 59417 ist die UID aus dem Doku-Beispiel des Runners. Sie ist frei
+        # gewaehlt; entscheidend ist nur != 0 und Konsistenz zwischen
+        # run_as_user, run_as_group und fs_group. fs_group sorgt dafuer, dass
+        # das Build-Volume der Gruppe gehoert — sonst koennte init-permissions
+        # als non-root nicht darauf schreiben und der Pod haenge weiter.
+        #
+        # build/helper/service erben run_as_user vom Pod: ihre Bloecke unten
+        # setzen es bewusst nicht erneut, damit es genau eine Stelle gibt, an
+        # der die UID steht.
         [runners.kubernetes.pod_security_context]
           run_as_non_root = true
+          run_as_user = 59417
+          run_as_group = 59417
+          fs_group = 59417
           [runners.kubernetes.pod_security_context.seccomp_profile]
             type = "RuntimeDefault"
         [runners.kubernetes.build_container_security_context]
@@ -231,6 +259,13 @@ runners:
         #   => build_ / helper_ / init_permissions_ / service_container_security_context
         [runners.kubernetes.init_permissions_container_security_context]
           run_as_non_root = true
+          # T012644: hier steht die UID ein zweites Mal, obwohl der Pod sie
+          # bereits vorgibt. Die Runner-Doku fuehrt beide Stellen auf, und der
+          # Container ist derjenige, der ohne sie nachweislich nicht startete —
+          # bei einem Chart-Upgrade, das die Vererbung aendert, faellt der
+          # Ausfall sonst wieder auf die schwerste Art auf.
+          run_as_user = 59417
+          run_as_group = 59417
           allow_privilege_escalation = false
           [runners.kubernetes.init_permissions_container_security_context.capabilities]
             drop = ["ALL"]

--- a/tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats
+++ b/tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats — non-root-UID der Job-Pods [T012644]
+# SSOT: openspec/specs/ci-cd.md
+#
+# PRUEFMODUS: Quelltext-Inspektion des gerenderten Manifests. Ausnahme nach
+# CLAUDE.md §Test-Resultats-Konvention [T002448-M4] fuer Deploy-Konfiguration — die Wirkung
+# zeigt sich erst beim Start eines Job-Pods im Cluster.
+#
+# Hintergrund: Der Namespace erzwingt restricted, das verlangt runAsNonRoot fuer jeden
+# Container. Sowohl das Helper-Image (init-permissions) als auch das Default-Job-Image
+# ubuntu:24.04 starten als UID 0. Ohne eigene UID blieb jeder Job-Pod Pending, bis der
+# Executor mit "timed out waiting for pod to start" abbrach — das Kubelet meldete
+# "container has runAsNonRoot and image will run as root".
+#
+# Geprueft wird beides, was den Ausfall verhindert: eine UID ungleich 0, und dass
+# run_as_user, run_as_group und fs_group denselben Wert tragen. Weichen sie voneinander
+# ab, laeuft init-permissions unter einer UID, der das Build-Volume nicht gehoert, und der
+# Pod haengt aus einem anderen Grund genauso.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  RENDERED="${REPO_ROOT}/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml"
+}
+
+# Wert eines TOML-Schluessels im gerenderten config.template.toml-Block.
+_toml_val() {
+  grep -oE "^\s*$1 = [0-9]+" "$RENDERED" | grep -oE '[0-9]+$'
+}
+
+@test "T012644: pod_security_context traegt run_as_user, run_as_group und fs_group" {
+  [ -f "$RENDERED" ]
+  for key in run_as_user run_as_group fs_group; do
+    run _toml_val "$key"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+  done
+}
+
+@test "T012644: die gesetzte UID ist nicht 0 — sonst greift runAsNonRoot nicht" {
+  uid="$(_toml_val run_as_user | head -1)"
+  # Positiv-Anker: es gibt ueberhaupt einen Wert. Ohne ihn bestuende der Vergleich
+  # unten auch dann, wenn der Schluessel fehlte und $uid leer waere.
+  [ -n "$uid" ]
+  [ "$uid" -ne 0 ]
+}
+
+@test "T012644: run_as_user, run_as_group und fs_group stimmen ueberein" {
+  u="$(_toml_val run_as_user | head -1)"
+  g="$(_toml_val run_as_group | head -1)"
+  f="$(_toml_val fs_group | head -1)"
+  [ -n "$u" ]
+  [ "$u" = "$g" ]
+  [ "$u" = "$f" ]
+}
+
+@test "T012644: init-permissions traegt die UID selbst, nicht nur geerbt" {
+  # Der Container ist derjenige, der ohne eigene UID nachweislich nicht startete.
+  # Der Block wird bis zur naechsten [runners.…]-Sektion gelesen statt ueber eine
+  # feste Zeilenzahl: zwischen Header und Schluessel stehen Kommentarzeilen, deren
+  # Anzahl sich beim naechsten Redigieren aendert.
+  block="$(awk '/init_permissions_container_security_context\]/{f=1;next} /^\s*\[runners\.kubernetes\.[a-z_]+\]/{f=0} f' "$RENDERED")"
+
+  # Positiv-Anker: der Block wurde ueberhaupt gefunden.
+  [ -n "$block" ]
+  [[ "$block" == *"allow_privilege_escalation"* ]]
+
+  [[ "$block" == *"run_as_user"* ]]
+  [[ "$block" == *"run_as_group"* ]]
+}


### PR DESCRIPTION
Dritte und letzte Stufe derselben Kette: #4807 hat die PodSecurity-Blöcke ergänzt, #4810 die RBAC-Rechte — beide wirken. Die Job-Pods werden jetzt erzeugt und scheitern am Container-Start:

```
container has runAsNonRoot and image will run as root
(pod: "runner-r03er3ubf-project-85506856-concurrent-0-i2ypqv5c", container: init-permissions)
ERROR: Job failed (system failure): prepare environment: waiting for pod running:
timed out waiting for pod to start (last phase: Pending)
```

## Der Zielkonflikt

Der Namespace erzwingt `restricted`, das verlangt `runAsNonRoot` für **jeden** Container. Zwei laufen als UID 0:

```
docker run --rm ubuntu:24.04 id -u
# => 0      (Default-Job-Image, values/gitlab-runner.yaml)
```
und das Helper-Image, aus dem `init-permissions` gebaut wird — belegt durch das Kubelet-Event oben.

Das kollidierte mit einer ausdrücklichen Festlegung in den Values: *„run_as_user wird bewusst NICHT gesetzt: ein fest verdrahteter UID würde Images brechen, die eine andere non-root-UID mitbringen. runAsNonRoot verlangt nur, dass die tatsächliche UID des Images != 0 ist."* Der zweite Satz stimmt — und genau daran scheiterte es: die tatsächliche UID **ist** 0.

## Entscheidung

Nach Rückfrage: `restricted` bleibt, die UID wird gesetzt. Die Alternative wäre gewesen, den Namespace auf `baseline` zu senken — ein Sicherheitsabbau, der die Zusicherung aus `specs/ci-cd.md` und `namespace.yaml` aufgehoben hätte.

```toml
[runners.kubernetes.pod_security_context]
  run_as_non_root = true
  run_as_user  = 59417
  run_as_group = 59417
  fs_group     = 59417

[runners.kubernetes.init_permissions_container_security_context]
  run_as_user  = 59417
  run_as_group = 59417
```

`build`, `helper` und `service` erben die UID vom Pod — sie steht bewusst an genau einer Stelle. `init-permissions` trägt sie zusätzlich selbst, weil er der Container ist, der ohne sie nachweislich nicht startete; ein Chart-Upgrade, das die Vererbung ändert, soll den Ausfall nicht erneut auf die schwerste Art zeigen. `fs_group` sorgt dafür, dass das Build-Volume der Gruppe gehört — sonst könnte `init-permissions` als non-root nicht darauf schreiben und der Pod hinge aus einem anderen Grund genauso.

## Preis, ausdrücklich

Die Sorge der alten Festlegung bleibt berechtigt. Jobs laufen jetzt als 59417, unabhängig davon, was ihr Image vorsieht. Was im Job root braucht — `apt-get install`, `npm -g`, Schreiben außerhalb des Workspace — schlägt fehl und gehört ins Image statt in die Laufzeit. Das steht so im Values-Kommentar, damit der nächste Leser den Zusammenhang nicht rekonstruieren muss.

## Verifikation

- `tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats` (neu, 4 Tests) + `gitlab-runner-executor-rbac.bats` + `gitlab-runner-fleet-rbac.bats` → alle grün
- Rot-Proben gefahren: `fs_group` abweichend → Test 3 rot; `run_as_user = 0` → Tests 2 und 3 rot; danach wiederhergestellt und wieder grün
- Keine unescapte `${VAR}` in der gerenderten Datei (0 Treffer)
- `task workspace:validate` → ✓ Manifests are valid, `task freshness:check` → Exit 0

Der UID-Guard prüft bewusst nicht nur „ungleich 0", sondern auch die Übereinstimmung von `run_as_user`, `run_as_group` und `fs_group`: weichen sie ab, läuft `init-permissions` unter einer UID, der das Volume nicht gehört, und der Pod hängt genauso — nur mit anderer Meldung.

## Nach dem Merge

Pipeline auslösen und prüfen, ob ein Job auf dem Kubernetes-Runner durchläuft. Zur Vorsicht: in der letzten Pipeline waren `manifests` und `bats-unit` grün, sie liefen aber auf dem Runner **PK-Desktop** — grüne Jobs allein beweisen hier nichts, der Job muss auf `runner-r03er3ubf-…` gelaufen sein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tmh4bCPjoDZgdKBYmS2h5k
