### PR TITLE
chore(skills): restore update-dependencies metadata [T012646]

### DIFF
--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-dependencies
+description: 'Archived dependency-update routine retained for reference; invoke explicitly only when the scheduled biweekly workflow must be run manually.'
 archived: true
-# Kein description-Feld — dieser Skill läuft als biweekly Cloud-Routine (CronCreate).
 # Manuell: Skill explizit mit /update-dependencies aufrufen, falls sofortige Ausführung nötig.
 ---
 
@@ -79,4 +79,3 @@ cd website && pnpm install --frozen-lockfile
 | **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
 | **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
 | **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
-


### PR DESCRIPTION
## Summary
- add the required description field to the archived update-dependencies skill
- keep the skill explicit-invocation-only and remove the obsolete omission comment

## Test Plan
- [x] validate YAML frontmatter with the repository Node YAML parser
- [x] task test:changed
- [x] task workspace:validate
- [x] task freshness:regenerate
- [x] task freshness:check

🤖 [T012646]