### PR TITLE
fix(infra): concurrent auf 3 senken + description fuer update-dependencies SKILL [T012647]

### DIFF
--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-dependencies
+description: 'Archived dependency-update routine retained for reference; invoke explicitly only when the scheduled biweekly workflow must be run manually.'
 archived: true
-# Kein description-Feld — dieser Skill läuft als biweekly Cloud-Routine (CronCreate).
 # Manuell: Skill explizit mit /update-dependencies aufrufen, falls sofortige Ausführung nötig.
 ---
 
@@ -79,4 +79,3 @@ cd website && pnpm install --frozen-lockfile
 | **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
 | **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
 | **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |
-

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2736,6 +2736,12 @@
     "kind": "shell"
   },
   {
+    "id": "ci-cd/gitlab-runner-quota-fit",
+    "file": "tests/spec/ci-cd/gitlab-runner-quota-fit.bats",
+    "category": "ci-cd",
+    "kind": "shell"
+  },
+  {
     "id": "ci-cd/gitlab-runner-setup-dryrun",
     "file": "tests/spec/ci-cd/gitlab-runner-setup-dryrun.bats",
     "category": "ci-cd",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1107,
+      "file_count": 1108,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -486,6 +486,7 @@
         "tests/spec/ci-cd/gitlab-runner-fleet-rbac.bats",
         "tests/spec/ci-cd/gitlab-runner-job-pod-toml.bats",
         "tests/spec/ci-cd/gitlab-runner-nonroot-uid.bats",
+        "tests/spec/ci-cd/gitlab-runner-quota-fit.bats",
         "tests/spec/ci-cd/gitlab-runner-setup-dryrun.bats",
         "tests/spec/ci-cd/gitlab-runner-tag-routing.bats",
         "tests/spec/ci-cd/gitlab-tool-parity.bats",

--- a/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
+++ b/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
@@ -75,7 +75,7 @@ data:
       --working-directory=/home/gitlab-runner
   config.toml: |
     shutdown_timeout = 0
-    concurrent = 4
+    concurrent = 3
     check_interval = 3
     log_level = "info"
 
@@ -369,7 +369,7 @@ spec:
         release: "gitlab-runner"
         heritage: "Helm"
       annotations:
-        checksum/configmap: 1cf23480ace938c773c37fcea39044715fd2e92fd0da8e1363d41d553c2fcb54
+        checksum/configmap: 7b306129eb07488b5c2e1c94b53ed74ca0eb3b750a4deff7364fa10df3d1e360
         checksum/secrets: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     spec:
       securityContext: 

--- a/k3d/gitlab-runner-stack/namespace.yaml
+++ b/k3d/gitlab-runner-stack/namespace.yaml
@@ -44,6 +44,25 @@ spec:
   #     defaultRequest.cpu <= 3700m / 8 = 462m    -> gewaehlt: 400m (8*400=3200m, 500m Puffer)
   #     defaultRequest.memory <= 3840Mi / 8 = 480Mi -> gewaehlt: 400Mi (8*400=3200Mi, 640Mi Puffer)
   #
+  # T012647 — KORREKTUR der Zielgroesse: drei parallele Jobs, nicht vier.
+  # Der Fehler der Rechnung oben liegt nicht in den Zahlen, sondern in einer
+  # fehlenden Groesse: sie bemisst den Zustand, in dem vier Jobs LAUFEN, und
+  # laesst dafuer 500m Puffer. Beim Wechsel eines Jobs existieren aber kurz
+  # FUENF Pods — der alte im Zustand Terminating zaehlt weiter zur Quota,
+  # waehrend der naechste angefordert wird. Ein Pod belegt 800m requests
+  # (2 Container a 400m), der Puffer von 500m deckt das nicht.
+  # Die Ablehnung ist kein Warten: der Runner wertet sie als system failure und
+  # der Job scheitert sofort. In Pipeline 2771092581 traf das alle 10 Jobs.
+  #
+  #   3 Jobs = 6 Container a 400m = 2400m + 300m Basis = 2700m von 4000m
+  #   Rest 1300m, davon 800m fuer genau einen Terminating-Pod -> 500m echter Puffer
+  #
+  # Die defaultRequest-Werte bleiben unveraendert; korrigiert wurde
+  # `concurrent` in values/gitlab-runner.yaml (4 -> 3). Wer wieder auf vier
+  # will, hebt die Quota an — und muss dann die Worker-Kapazitaet pruefen:
+  # gekko-hetzner-3 lag am 2026-08-19 bei 1960m von 4 CPU requests (49 %) und
+  # 4950m limits (123 % overcommit).
+  #
   # Limits-Budget (ResourceQuota limits.cpu = 8000m, limits.memory = 8Gi):
   #   Basislast (Limits, nicht Requests):
   #     Runner-Manager   500m / 256Mi   (values/gitlab-runner.yaml resources.limits)
@@ -57,9 +76,9 @@ spec:
   # Worker-Kapazitaet (4,48 CPU * 2 Knoten = 8,96 / 2 = 4480m) — die Rechnung
   # senkt defaultRequest/ default statt die Quota weiter anzuheben (design.md D2).
   #
-  # `runners.concurrent: 4` (values/gitlab-runner.yaml) deckelt den Manager selbst
-  # auf "vier parallele Jobs" — ohne das waere der Chart-Default (10) versucht,
-  # mehr Job-Pods zu erzeugen, als die Quota je zulaesst.
+  # `concurrent: 3` (values/gitlab-runner.yaml, Top-Level) deckelt den Manager
+  # selbst auf "drei parallele Jobs" — ohne das wuerde der Chart-Default (10)
+  # versuchen, mehr Job-Pods zu erzeugen, als die Quota je zulaesst.
   limits:
     - type: Container
       defaultRequest:

--- a/k3d/gitlab-runner-stack/values/gitlab-runner.yaml
+++ b/k3d/gitlab-runner-stack/values/gitlab-runner.yaml
@@ -9,9 +9,24 @@ gitlabUrl: https://gitlab.com/
 # STILL VERWORFEN (dieselbe Fehlerklasse wie B1: unbekannter Chart-Value-Pfad,
 # kein Fehler, kein Hinweis) und der Chart-Default 10 bleibt bestehen —
 # beobachtet beim ersten Render-Versuch dieser Korrektur, deshalb hier explizit
-# festgehalten. Deckelt den Manager auf "zwei parallele Jobs" (design.md D2,
-# Rechnung in namespace.yaml).
-concurrent: 4
+# festgehalten. Deckelt den Manager auf parallele Jobs (design.md D2, Rechnung
+# in namespace.yaml).
+#
+# T012647: von 4 auf 3 gesenkt. Die Rechnung in namespace.yaml bemass die Quota
+# fuer VIER parallele Jobs und liess 500m requests.cpu Puffer — ein Job-Pod
+# belegt aber 800m (zwei Container a 400m). Beim Wechsel eines Jobs zaehlt der
+# alte Pod im Zustand Terminating noch zur Quota, waehrend der naechste schon
+# angefordert wird; der Puffer deckt diese Ueberlappung nicht. Folge war kein
+# Warten, sondern ein sofortiger Fehlschlag — der Runner wertet eine
+# Quota-Ablehnung als system failure:
+#   pods "runner-…-concurrent-3-…" is forbidden: exceeded quota,
+#   requested: requests.cpu=800m, used: 3500m, limited: 4
+# In Pipeline 2771092581 scheiterten daran ALLE 10 Jobs.
+#
+# Mit 3: 6 Container a 400m = 2400m + 300m Basis = 2700m von 4000m. Die
+# verbleibenden 800m sind exakt ein Terminating-Pod — der Puffer ist damit
+# bemessen, nicht geschaetzt.
+concurrent: 3
 
 # N1 (Nachreview T012177): KEIN Top-Level automountServiceAccountToken hier.
 # Der urspruengliche Kommentar an dieser Stelle behauptete, dieser Chart-Value

--- a/tests/spec/ci-cd/gitlab-runner-quota-fit.bats
+++ b/tests/spec/ci-cd/gitlab-runner-quota-fit.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# tests/spec/ci-cd/gitlab-runner-quota-fit.bats — concurrent passt in die Quota [T012647]
+# SSOT: openspec/specs/ci-cd.md
+#
+# PRUEFMODUS: Rechnung ueber Werte aus zwei Repo-Dateien. Ausnahme nach CLAUDE.md
+# §Test-Resultats-Konvention [T002448-M4] fuer Deploy-Konfiguration — die Wirkung zeigt
+# sich erst, wenn der Runner unter Vollast Jobs wechselt.
+#
+# Hintergrund: Die Herleitung in namespace.yaml bemass die Quota fuer den Zustand, in dem
+# N Jobs LAUFEN. Beim Wechsel existieren kurz N+1 Pods — der alte zaehlt im Zustand
+# Terminating weiter zur Quota, waehrend der naechste angefordert wird. Bei concurrent=4
+# fehlten dafuer 300m; die Ablehnung ist kein Warten, sondern ein sofortiger system
+# failure. In Pipeline 2771092581 scheiterten daran alle 10 Jobs.
+#
+# Der Test rechnet deshalb mit N+1, nicht mit N. Er prueft die Vertraeglichkeit zweier
+# Dateien, die niemand gemeinsam im Blick hat: wer concurrent in values/ erhoeht, sieht
+# die Quota in namespace.yaml nicht.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  VALUES="${REPO_ROOT}/k3d/gitlab-runner-stack/values/gitlab-runner.yaml"
+  NS="${REPO_ROOT}/k3d/gitlab-runner-stack/namespace.yaml"
+
+  CONCURRENT="$(grep -E '^concurrent: [0-9]+' "$VALUES" | grep -oE '[0-9]+$')"
+  QUOTA_CPU="$(grep -E '^\s*requests\.cpu: "[0-9]+"' "$NS" | grep -oE '[0-9]+' | head -1)"
+  # defaultRequest.cpu steht als erster cpu-Wert im LimitRange-Block.
+  DEFREQ="$(awk '/defaultRequest:/{f=1;next} f&&/cpu:/{print;exit}' "$NS" | grep -oE '[0-9]+')"
+}
+
+@test "T012647: die Rechengroessen sind in beiden Dateien auffindbar" {
+  # Positiv-Anker fuer alle folgenden Tests: ohne ihn wuerden leere Variablen
+  # die Vergleiche unten stillschweigend bestehen lassen.
+  [ -n "$CONCURRENT" ]
+  [ -n "$QUOTA_CPU" ]
+  [ -n "$DEFREQ" ]
+  [ "$CONCURRENT" -gt 0 ]
+  [ "$DEFREQ" -gt 0 ]
+}
+
+@test "T012647: concurrent+1 Job-Pods passen in requests.cpu der Quota" {
+  # Basislast im Namespace, aus der Herleitung in namespace.yaml:
+  # Runner-Manager 200m + registry-cache 100m.
+  local basis=300
+  local quota_m=$(( QUOTA_CPU * 1000 ))
+  # Ein Job-Pod = 2 Container (build + helper), je defaultRequest.
+  local pro_pod=$(( DEFREQ * 2 ))
+  # N+1: waehrend eines Wechsels haelt der terminierende Pod seine Requests noch.
+  local benoetigt=$(( (CONCURRENT + 1) * pro_pod + basis ))
+
+  [ "$benoetigt" -le "$quota_m" ]
+}
+
+@test "T012647: die Quota ist nicht unnoetig gross fuer concurrent" {
+  # Gegenrichtung: waere die Quota so gross, dass concurrent+3 Pods hineinpassen,
+  # koennte concurrent hoeher stehen — dann ist einer der beiden Werte veraltet.
+  # Der Test faengt damit den Fall ab, dass jemand die Quota anhebt und vergisst,
+  # concurrent nachzuziehen (der Durchsatz laege dann brach).
+  local basis=300
+  local quota_m=$(( QUOTA_CPU * 1000 ))
+  local pro_pod=$(( DEFREQ * 2 ))
+  local grosszuegig=$(( (CONCURRENT + 3) * pro_pod + basis ))
+
+  [ "$grosszuegig" -gt "$quota_m" ]
+}


### PR DESCRIPTION
## Änderungen
- **Runner concurrent 4→3** [T012647]: Beim Job-Wechsel existieren kurz 5 Pods (alter terminating + neuer startet). Mit 5×800m = 4000m quota-full. Mit 3: 6 Container = 2400m + 300m Basis = 2700m von 4000m.
- **namespace.yaml Guard**: Rechnung prüft jetzt N+1 statt N — erkennt das Quota-Problem künftig.
- **update-dependencies SKILL.md**: Fehlendes -Feld ergänzt (benötigt für Framework-Routing).

## Tests
- [x] `tests/spec/ci-cd/gitlab-runner-quota-fit.bats` (neu, 64 Zeilen)
- [x] `task quality:check` clean