### PR TITLE
fix(ci): raise mirror workflow timeout to 30 minutes [T012403]

### DIFF
--- a/.github/workflows/mirror-to-gitlab.yml
+++ b/.github/workflows/mirror-to-gitlab.yml
@@ -55,7 +55,7 @@ jobs:
   mirror:
     name: Push-Spiegel nach GitLab
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30 # Erhöht auf 30 Min, da fetch-depth:0 bei großen Repositories oft > 10 Min benötigt.
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Bumps the timeout for the mirror job from 10 to 30 minutes to accommodate full clone (fetch-depth:0) on large repositories.

This addresses the issue where the mirror workflow was being killed by the 10-minute limit before reaching the push step.

Closes T012403