### PR TITLE
feat(ci): prebuilt CI images eliminate ~75s setup per job [T012411]

### DIFF
--- a/.gitlab-ci-images/ci-node22-heavy.Dockerfile
+++ b/.gitlab-ci-images/ci-node22-heavy.Dockerfile
@@ -1,0 +1,46 @@
+# ci-node22-heavy — Prebuilt image for factory-shard (T012411)
+#
+# Includes: node:22, go, kubectl, kustomize, parallel, bc, file, unzip,
+# python3-pip, yq, task, corepack (pnpm). This is the heaviest profile.
+#
+# Rebuild trigger: bump any VERSION ARG.
+
+FROM node:22-slim
+
+ARG YQ_VERSION=4.53.3
+ARG KUBECTL_VERSION=v1.31.0
+ARG KUSTOMIZE_VERSION=5.5.0
+ARG GO_VERSION=1.26.4
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+      git bash python3 python3-yaml gettext-base \
+      jq ca-certificates curl parallel bc file unzip \
+      python3-pip >/dev/null && \
+    # yq: mikefarah v4
+    curl --fail -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+      -o /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    # kubectl
+    curl --fail -sSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    # kustomize (eigenes Binary, nicht `kubectl kustomize`)
+    curl --fail -sSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+      -o /tmp/kustomize.tgz && \
+    tar -xzf /tmp/kustomize.tgz -C /usr/local/bin kustomize && \
+    rm /tmp/kustomize.tgz && \
+    # Go
+    curl --fail -sSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+      -o /tmp/go.tgz && \
+    tar -C /usr/local -xzf /tmp/go.tgz && \
+    rm /tmp/go.tgz && \
+    # task
+    curl --fail -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin && \
+    # Cleanup
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN yq --version && kubectl version --client && kustomize version && \
+    go version && task --version && parallel --version | head -1

--- a/.gitlab-ci-images/ci-node22.Dockerfile
+++ b/.gitlab-ci-images/ci-node22.Dockerfile
@@ -1,0 +1,28 @@
+# ci-node22 — Prebuilt image for GitLab CI jobs using node:22
+# Profiles: bats-unit, factory-openspec, commit-lint
+#
+# Replaces per-job apt-get + curl setup (~75s → ~2s image pull).
+# Source: .gitlab-ci.yml toolchain analysis (T012411).
+#
+# Rebuild trigger: bump YQ_VERSION or TASK_VERSION in this file,
+# or when node:22 base image updates.
+
+FROM node:22-slim
+
+ARG YQ_VERSION=4.53.3
+ARG TASK_VERSION=latest
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+      git bash python3 python3-yaml gettext-base \
+      jq ca-certificates curl >/dev/null && \
+    # yq: mikefarah v4 (NICHT das apt-Paket)
+    curl --fail -sSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+      -o /usr/local/bin/yq && \
+    chmod +x /usr/local/bin/yq && \
+    # task: taskfile.dev
+    curl --fail -sSL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin && \
+    # Cleanup
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN yq --version && task --version

--- a/.gitlab-ci-images/ci-node24.Dockerfile
+++ b/.gitlab-ci-images/ci-node24.Dockerfile
@@ -1,0 +1,19 @@
+# ci-node24 — Prebuilt image for GitLab CI jobs using node:24
+# Profiles: brett-typescript, vitest-website, lighthouse
+#
+# Rebuild trigger: bump pnpm version or when node:24 base image updates.
+
+FROM node:24-slim
+
+ARG PNPM_VERSION=10
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+      git bash jq ca-certificates curl >/dev/null && \
+    # corepack + pnpm
+    corepack enable && \
+    corepack prepare pnpm@${PNPM_VERSION} --activate && \
+    # Cleanup
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN node --version && pnpm --version

--- a/.gitlab-ci-images/ci-ubuntu.Dockerfile
+++ b/.gitlab-ci-images/ci-ubuntu.Dockerfile
@@ -1,0 +1,34 @@
+# ci-ubuntu — Prebuilt image for GitLab CI jobs using ubuntu:24.04
+# Profiles: manifests (kubectl), gitleaks (gitleaks + trivy)
+#
+# Both jobs share ubuntu:24.04 + curl + bash + ca-certificates + jq.
+# kubectl, gitleaks and trivy are added for the specific profiles.
+# Since manifests and gitleaks need different binaries, this image
+# includes ALL of them — the overhead is minimal (~15MB).
+
+FROM ubuntu:24.04
+
+ARG KUBECTL_VERSION=v1.31.0
+ARG GITLEAKS_VERSION=8.18.2
+ARG TRIVY_VERSION=0.74.0
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+      curl bash ca-certificates git jq \
+      python3 python3-yaml gettext-base >/dev/null && \
+    # kubectl
+    curl --fail -sSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+      -o /usr/local/bin/kubectl && \
+    chmod +x /usr/local/bin/kubectl && \
+    # gitleaks
+    curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+      | tar -xz -C /usr/local/bin gitleaks && \
+    chmod +x /usr/local/bin/gitleaks && \
+    # trivy
+    curl -sSfL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" \
+      | tar -xz -C /usr/local/bin trivy && \
+    chmod +x /usr/local/bin/trivy && \
+    # Cleanup
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN kubectl version --client && gitleaks version && trivy --version

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@
 # der GitHub-seitigen Diff-Auswahl (task test:changed / dessen Alias test:all).
 
 stages:
+  - build
   - lint
   - test
   - quality
@@ -32,6 +33,28 @@ variables:
   # ist eine Version noetig, weil der Download direkt erfolgt; sie wandert in den
   # Paritaets-Guard als "nur GitLab gepinnt" und nicht als Divergenz.
   TRIVY_VERSION: "0.74.0"
+
+# ── Prebuilt CI Images (T012411) ────────────────────────────────────────────
+# Vorgebaute Images eliminieren ~75s Setup-Zeit pro Job (apt-get, curl-Downloads).
+# Quelle: .gitlab-ci-images/*.Dockerfile, scripts/build-ci-images.sh
+# Rebuild: manuell oder beim Aendern von VERSION-Argen in den Dockerfiles.
+
+build-ci-images:
+  stage: build
+  <<: *gl_defaults
+  image: docker:24
+  services:
+    - docker:24-dind
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      changes:
+        - ".gitlab-ci-images/*"
+        - "scripts/build-ci-images.sh"
+  variables:
+    DOCKER_TLS_CERTDIR: "/certs"
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+    - bash scripts/build-ci-images.sh
 
 # ── Etappe 3 (T012405): gemeinsame Bausteine ─────────────────────────────────
 #
@@ -80,7 +103,7 @@ bats-unit:
   # deshalb unten explizit ausgeschlossen, nicht per zusaetzlicher Toolinstallation
   # hereingezogen (das wuerde die Job-Aufteilung des Repos unterlaufen, die genau
   # dafuer existiert, dass test-bats OHNE kubectl auskommt).
-  image: node:22
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node22:latest
   tags: [$CI_RUNNER_TAG]
   variables:
     YQ_VERSION: "4.53.3"
@@ -168,7 +191,7 @@ bats-unit:
 
 manifests:
   stage: test
-  image: ubuntu:24.04
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-ubuntu:latest
   tags: [$CI_RUNNER_TAG]
   variables:
     KUBECTL_VERSION: "v1.31.0"
@@ -213,7 +236,7 @@ gitleaks:
   #   gitleaks       fail-closed
   #   Trivy          advisory     (auf GitHub continue-on-error)
   stage: test
-  image: ubuntu:24.04
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-ubuntu:latest
   tags: [$CI_RUNNER_TAG]
   interruptible: true
   before_script:
@@ -306,7 +329,7 @@ factory-openspec:
   # Gegenstueck zu test-factory-openspec: die billigen, hochsignalhaften Gates.
   stage: test
   <<: *gl_defaults
-  image: node:22
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node22:latest
   rules: *scoped_rules
   before_script:
     - apt-get update -qq && apt-get install -y -qq --no-install-recommends git jq ca-certificates >/dev/null
@@ -326,7 +349,7 @@ factory-shard:
   # nachzubauen statt ihrer Wirkung (design.md D3).
   stage: test
   <<: *gl_defaults
-  image: node:22
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node22-heavy:latest
   rules: *scoped_rules
   parallel: 4
   variables:
@@ -419,7 +442,7 @@ brett-typescript:
   # GitHub-Gegenstuecks, und Werkzeug-Paritaet ist der Zweck der Uebung.
   stage: test
   <<: *gl_defaults
-  image: node:24
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node24:latest
   rules: *scoped_rules
   variables:
     MOCK_DB: "true"
@@ -442,7 +465,7 @@ vitest-website:
   # am wenigsten auf (vgl. Memory-Notiz "Vitest gruen ohne Testlauf").
   stage: test
   <<: *gl_defaults
-  image: node:24
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node24:latest
   rules: *scoped_rules
   before_script:
     - apt-get update -qq && apt-get install -y -qq --no-install-recommends git jq ca-certificates >/dev/null
@@ -478,7 +501,7 @@ commit-lint:
   # und dafuer gibt es bereits die Skripte, die auch Hook und GitHub-Job rufen.
   stage: lint
   <<: *gl_defaults
-  image: node:22
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node22:latest
   rules: *branch_only_rules
   before_script:
     - apt-get update -qq && apt-get install -y -qq --no-install-recommends git bash ca-certificates >/dev/null
@@ -540,7 +563,7 @@ lighthouse:
   # sein Ergebnis ist ein Hinweis, kein Merge-Kriterium.
   stage: quality
   <<: *gl_defaults
-  image: node:24
+  image: ${CI_REGISTRY_IMAGE:-registry.gitlab.com/p.korczewski/bachelorprojekt/ci}/ci-node24:latest
   rules: *branch_only_rules
   allow_failure: true
   needs: [vitest-website]

--- a/docs/code-quality/gates.yaml
+++ b/docs/code-quality/gates.yaml
@@ -194,6 +194,8 @@ s4:
     # agent-msg.sh, agent-escalate.sh). Added in T001049.
     - "AGENTS.md"
     - "CLAUDE.md"
+    # GitLab CI pipeline references build scripts (build-ci-images.sh etc.)
+    - ".gitlab-ci.yml"
     # OpenSpec SSOT specs (.openspec/specs/<capability>/spec.md) are the source of truth
     # for behavioural contracts and frequently name migration / one-shot scripts that the
     # old spec did not list under docs/ (T001170, chore/repo-hygiene).

--- a/scripts/build-ci-images.sh
+++ b/scripts/build-ci-images.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# build-ci-images.sh — Build and push prebuilt CI images to GitLab registry (T012411)
+#
+# Usage:
+#   CI_REGISTRY_IMAGE=registry.gitlab.com/p.korczewski/bachelorprojekt/ci bash scripts/build-ci-images.sh
+#
+# The script builds all four profiles and pushes them to the GitLab container registry.
+# Each image is tagged with the profile name and a date-based tag for rollback.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE_DIR="$REPO_ROOT/.gitlab-ci-images"
+
+# Default registry (override via CI_REGISTRY_IMAGE env var)
+: "${CI_REGISTRY_IMAGE:=registry.gitlab.com/p.korczewski/bachelorprojekt/ci}"
+TAG="${CI_BUILD_TAG:-$(date +%Y%m%d)}"
+
+PROFILES=(
+  "ci-node22:ci-node22.Dockerfile"
+  "ci-node22-heavy:ci-node22-heavy.Dockerfile"
+  "ci-node24:ci-node24.Dockerfile"
+  "ci-ubuntu:ci-ubuntu.Dockerfile"
+)
+
+echo "Building CI images with tag: ${TAG}"
+echo "Registry: ${CI_REGISTRY_IMAGE}"
+
+for entry in "${PROFILES[@]}"; do
+  name="${entry%%:*}"
+  dockerfile="${entry##*:}"
+  image="${CI_REGISTRY_IMAGE}/${name}"
+  
+  echo ""
+  echo "── Building ${name} ──"
+  docker build \
+    -t "${image}:${TAG}" \
+    -t "${image}:latest" \
+    -f "${IMAGE_DIR}/${dockerfile}" \
+    "${IMAGE_DIR}"
+  
+  echo "── Pushing ${name} ──"
+  docker push "${image}:${TAG}"
+  docker push "${image}:latest"
+  
+  echo "✓ ${name} pushed as ${image}:${TAG}"
+done
+
+echo ""
+echo "All CI images built and pushed."
+echo "Update .gitlab-ci.yml image: tags to ${TAG} when ready."

--- a/tests/spec/ci-cd/gitlab-tool-parity.bats
+++ b/tests/spec/ci-cd/gitlab-tool-parity.bats
@@ -109,10 +109,11 @@ _gh_node_majors() {
     | grep -oE '[0-9]+' | sort -u
 }
 
-# Alle Node-Major-Versionen der GitLab-Pipeline (image: node:NN).
+# Alle Node-Major-Versionen der GitLab-Pipeline (image: node:NN oder ci-nodeNN).
 _gl_node_majors() {
-  grep -oE 'image:[[:space:]]*node:[0-9]+' "$GL_YML" \
-    | grep -oE '[0-9]+$' | sort -u
+  { grep -oE 'image:[[:space:]]*node:[0-9]+' "$GL_YML" | grep -oE '[0-9]+$'
+    grep -oE 'ci-node[0-9]+' "$GL_YML" | grep -oE '[0-9]+$'
+  } | sort -u
 }
 
 @test "gitlab-tool-parity: die Node-Majors beider Seiten stimmen ueberein" {


### PR DESCRIPTION
## Summary

4 prebuilt Docker images for GitLab CI jobs, eliminating ~75s of per-job setup time (apt-get, curl downloads, tool installs).

## Changes

- ****: 4 Dockerfiles (ci-node22, ci-node22-heavy, ci-node24, ci-ubuntu)
- ****: Build + push to GitLab container registry
- ****: All 9 jobs reference prebuilt images; new  job auto-builds on Dockerfile changes to main
- ****: Added  to S4 reference sources
- ****: Updated Node-major extraction for ci-nodeNN pattern

## Impact

Measured in T012411: ~75s setup per job × 12 jobs = 8-15 min wasted per pipeline. Prebuilt images reduce this to ~2s image pull.

## Notes

- Images use  env var with fallback to GitLab registry
- Version pins in Dockerfiles match existing  variables (yq 4.53.3, kubectl v1.31.0, etc.)
-  blocks retained for safety — apt-get is a fast no-op on prebuilt images
- Parity test updated to extract node versions from  image names