### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3530,7 +3530,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 768,
+      "file_count": 769,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3637,6 +3637,7 @@
         "scripts/brett-bot-setup.sh",
         "scripts/build-api-map.mjs",
         "scripts/build-blast-radius.mjs",
+        "scripts/build-ci-images.sh",
         "scripts/build-docs.mjs",
         "scripts/build-graph-docs.mjs",
         "scripts/build-graph-shared.mjs",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32220997002).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
