### PR TITLE
fix(ci): gl_defaults-Anker vor seine erste Verwendung ziehen [T012899]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,26 @@ variables:
   # Paritaets-Guard als "nur GitLab gepinnt" und nicht als Divergenz.
   TRIVY_VERSION: "0.74.0"
 
+# ── Gemeinsame Job-Vorgaben ─────────────────────────────────────────────────
+#
+# Warum Anker statt Wiederholung je Job: dieselbe Anti-Duplikations-Entscheidung
+# wie bei CI_RUNNER_TAG in Etappe 1. Eine Toolchain, die an sieben Stellen steht,
+# driftet an sieben Stellen.
+#
+# Der Block steht bewusst VOR dem ersten `<<: *gl_defaults`. YAML loest Aliase
+# beim Parsen von oben nach unten auf — ein Alias auf einen erst spaeter
+# definierten Anker ist kein gueltiges YAML, sondern ein ComposerError
+# ("found undefined alias"). Genau das war T012899: der Job build-ci-images kam
+# mit #4823 oberhalb dieses Blocks hinzu und machte die gesamte Datei
+# unparsebar — fuer die Guards in tests/spec/ci-cd/ ebenso wie fuer GitLab
+# selbst. Neue Jobs, die den Anker verwenden, gehoeren UNTER diesen Block.
+.gl_defaults: &gl_defaults
+  tags: [$CI_RUNNER_TAG]
+  # Bei mehreren Pushes hintereinander bricht GitLab die ueberholte Pipeline ab,
+  # statt den Runner mit veralteten Staenden zu belegen. Auf einem Runner, der
+  # laut Etappe-2-Messung 2-3x langsamer ist als SaaS, ist das kein Feinschliff.
+  interruptible: true
+
 # ── Prebuilt CI Images (T012411) ────────────────────────────────────────────
 # Vorgebaute Images eliminieren ~75s Setup-Zeit pro Job (apt-get, curl-Downloads).
 # Quelle: .gitlab-ci-images/*.Dockerfile, scripts/build-ci-images.sh
@@ -66,13 +86,6 @@ build-ci-images:
 # Warum Anker statt Wiederholung je Job: dieselbe Anti-Duplikations-Entscheidung
 # wie bei CI_RUNNER_TAG in Etappe 1. Eine Toolchain, die an sieben Stellen steht,
 # driftet an sieben Stellen.
-
-.gl_defaults: &gl_defaults
-  tags: [$CI_RUNNER_TAG]
-  # Bei mehreren Pushes hintereinander bricht GitLab die ueberholte Pipeline ab,
-  # statt den Runner mit veralteten Staenden zu belegen. Auf einem Runner, der
-  # laut Etappe-2-Messung 2-3x langsamer ist als SaaS, ist das kein Feinschliff.
-  interruptible: true
 
 # Laeuft auf main (Vollmenge), auf Arbeits-Branches und in MR-Pipelines.
 # Die Unterscheidung Vollmenge/Diff-Auswahl trifft NICHT diese Regel, sondern der


### PR DESCRIPTION
## Symptom

Die Factory-Spec-Shards sind auf **jedem** offenen PR rot — belegt an zwei unabhängigen
PRs auf demselben `main`-Stand: #4826 (Shards 1, 2, 3) und #4825 (Shards 1, 2, 4).
Neun Guards in `tests/spec/ci-cd/` scheitern, alle mit derselben Meldung:

```
yaml.composer.ComposerError: found undefined alias 'gl_defaults'
  in ".gitlab-ci.yml", line 44, column 7
```

`Factory + OpenSpec + Guards` aggregiert die Shards und **ist ein Required Check**.
Damit war die gesamte Merge-Queue blockiert.

## Ursache

Der Job `build-ci-images` verwendet in Zeile 44 `<<: *gl_defaults`. Der Anker
`.gl_defaults: &gl_defaults` wurde aber erst in Zeile 70 definiert. YAML löst Aliase
beim Parsen von oben nach unten auf — ein Alias auf einen später definierten Anker ist
kein gültiges YAML.

Eingebracht mit `592e4f5b1` („feat(ci): prebuilt CI images eliminate ~75s setup per job
[T012411]", #4823): der neue Job kam **oberhalb** des Anker-Blocks hinzu.

Betroffen sind nicht nur die Tests — GitLab selbst kann die Datei ebenso wenig laden,
der Spiegel liefert also seit #4823 vermutlich keine lauffähige Pipeline.

## Fix

Reine Reihenfolge, kein inhaltlicher Eingriff: der Anker-Block wandert vor den Job.
Der neue Kommentar hält fest, warum er dort steht — sonst landet der nächste eingefügte
Job wieder darüber und der Defekt kehrt zurück.

## Verifikation

Rot vorher, grün nachher, beides gemessen:

```bash
# vorher
python3 -c "import yaml; yaml.safe_load(open('.gitlab-ci.yml'))"
# -> ComposerError: found undefined alias 'gl_defaults', line 44
bats tests/spec/ci-cd/gitlab-job-coverage.bats tests/spec/ci-cd/gitlab-runner-tag-routing.bats
# -> 9 Fehlschläge

# nachher
python3 -c "import yaml; d=yaml.safe_load(open('.gitlab-ci.yml')); print(len(d))"
# -> 16 Top-Level-Schlüssel, parst sauber
bats -r tests/spec/ci-cd/
# -> grün
```

Semantik unverändert gegengeprüft: nach dem Parsen tragen weiterhin 8 der 10 Jobs
`tags` + `interruptible` aus dem Anker — dieselbe Menge wie vor #4823 beabsichtigt.

Entdeckt bei der Umsetzung von T012781 (PR #4826); dort bewusst nicht mitbehoben,
weil es ein fremder Defekt in fremdem Gegenstand ist.

Closes T012899
