### PR TITLE
fix(ci): Toolchain-Guard auf die vorgebauten CI-Images nachziehen [T012899]

### DIFF
--- a/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
+++ b/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
@@ -33,8 +33,18 @@ setup() {
   [ -f "$CI" ]
   [ -n "$BATS_UNIT_BLOCK" ]
   [ -n "$MANIFESTS_BLOCK" ]
-  printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'image: node:22'
-  printf '%s' "$MANIFESTS_BLOCK" | grep -qF -e 'image: ubuntu:24.04'
+  # [T012899] Geprueft wird die TOOLCHAIN-Familie, nicht der Image-Literal.
+  # Bis #4823 standen hier 'node:22' und 'ubuntu:24.04'. Dieser PR stellte auf
+  # vorgebaute CI-Images um (ci-node22 / ci-ubuntu, ~75s Setup-Ersparnis je Job),
+  # zog den Guard aber nicht nach. Aufgefallen ist das erst jetzt, weil der
+  # gleichzeitig eingebrachte Anker-Defekt die ganze Datei unparsebar machte und
+  # dieser Test schon vorher aus einem anderen Grund rot war.
+  #
+  # Auf die Familie zu pruefen statt auf den Literal haelt die Zusicherung am
+  # Zweck: der Job muss node22 bzw. ubuntu mitbringen. Ein erneuter Wechsel des
+  # Bezugswegs (Registry, Tag) bricht den Guard dann nicht wieder.
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -qE 'image:.*(node:22|ci-node22)'
+  printf '%s' "$MANIFESTS_BLOCK" | grep -qE 'image:.*(ubuntu:24\.04|ci-ubuntu)'
 }
 
 @test "T012309: bats-unit installiert PyYAML (python3-yaml)" {


### PR DESCRIPTION
## Nachtrag zu #4829

Dieser Fix war in #4829 bereits committet, kam aber zu spät: der Auto-Merge feuerte
auf dem grünen Stand des ersten Commits, der zweite Push landete nach dem Merge und
fiel damit aus dem Squash heraus. `main` trägt jetzt den behobenen Anker, aber den
alten Guard.

## Symptom

`tests/spec/ci-cd/gitlab-batsunit-toolchain.bats` ist auf `main` rot:

```
not ok 1 T012309: .gitlab-ci.yml enthaelt die Jobs bats-unit und manifests
  `printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'image: node:22'' failed
```

## Ursache

#4823 stellte `bats-unit` und `manifests` auf vorgebaute Images um:

| Job | vorher | seit #4823 |
|---|---|---|
| `bats-unit` | `node:22` | `…/ci-node22:latest` |
| `manifests` | `ubuntu:24.04` | `…/ci-ubuntu:latest` |

Der Guard blieb auf den alten Literalen stehen. Solange der Anker-Defekt aus demselben
PR die Datei unparsebar machte, scheiterte der Test aus einem *anderen* Grund — die
Altlast war dadurch verdeckt. Seit #4829 parst die Datei, und der eigentliche Grund
tritt hervor.

## Fix

Der Guard prüft die Toolchain-**Familie** statt des Image-Literals. Das hält die
Zusicherung an ihrem Zweck (der Job muss node22 bzw. ubuntu mitbringen) und überlebt
einen erneuten Wechsel des Bezugswegs — Registry, Tag, Pfad.

## Verifikation

```bash
# gegen den main-Stand: rot
bats tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
# -> not ok 1 ... `grep -qF -e 'image: node:22'' failed

# mit diesem Fix: grün
bats tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
# -> 7/7 ok
```

Gegengeprüft, dass der Guard nicht bloß weicher wurde: mit `image: alpine:3` im
`bats-unit`-Job fällt er weiterhin durch. Ein Guard, der nach dem Aufweichen alles
durchlässt, wäre schlimmer als der rote Test.

Refs T012899
