### PR TITLE
fix(ci): .gitlab-ci.yml wieder parsebar machen — blockiert derzeit jeden PR [T012901]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,23 @@ variables:
   # Paritaets-Guard als "nur GitLab gepinnt" und nicht als Divergenz.
   TRIVY_VERSION: "0.74.0"
 
+# ── Gemeinsame Job-Bausteine ─────────────────────────────────────────────────
+#
+# Diese Definition steht bewusst VOR dem ersten Job. YAML loest Anker beim
+# Parsen von oben nach unten auf: ein `<<: *gl_defaults` oberhalb der
+# Definition macht die ganze Datei ungueltig, nicht nur den einen Job. Genau
+# das passierte, als build-ci-images (T012411) oberhalb der damaligen
+# Definition eingefuegt wurde — GitLab konnte die Pipeline nicht mehr lesen
+# und der Paritaets-Guard fiel in jedem PR gegen main (T012901).
+#
+# Wer hier einen neuen Anker ergaenzt, setzt ihn ebenfalls in diesen Block.
+.gl_defaults: &gl_defaults
+  tags: [$CI_RUNNER_TAG]
+  # Bei mehreren Pushes hintereinander bricht GitLab die ueberholte Pipeline ab,
+  # statt den Runner mit veralteten Staenden zu belegen. Auf einem Runner, der
+  # laut Etappe-2-Messung 2-3x langsamer ist als SaaS, ist das kein Feinschliff.
+  interruptible: true
+
 # ── Prebuilt CI Images (T012411) ────────────────────────────────────────────
 # Vorgebaute Images eliminieren ~75s Setup-Zeit pro Job (apt-get, curl-Downloads).
 # Quelle: .gitlab-ci-images/*.Dockerfile, scripts/build-ci-images.sh
@@ -66,13 +83,9 @@ build-ci-images:
 # Warum Anker statt Wiederholung je Job: dieselbe Anti-Duplikations-Entscheidung
 # wie bei CI_RUNNER_TAG in Etappe 1. Eine Toolchain, die an sieben Stellen steht,
 # driftet an sieben Stellen.
-
-.gl_defaults: &gl_defaults
-  tags: [$CI_RUNNER_TAG]
-  # Bei mehreren Pushes hintereinander bricht GitLab die ueberholte Pipeline ab,
-  # statt den Runner mit veralteten Staenden zu belegen. Auf einem Runner, der
-  # laut Etappe-2-Messung 2-3x langsamer ist als SaaS, ist das kein Feinschliff.
-  interruptible: true
+#
+# Die Definition von .gl_defaults steht weiter oben, direkt hinter variables —
+# siehe die Begruendung dort.
 
 # Laeuft auf main (Vollmenge), auf Arbeits-Branches und in MR-Pipelines.
 # Die Unterscheidung Vollmenge/Diff-Auswahl trifft NICHT diese Regel, sondern der

--- a/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
+++ b/tests/spec/ci-cd/gitlab-batsunit-toolchain.bats
@@ -33,8 +33,14 @@ setup() {
   [ -f "$CI" ]
   [ -n "$BATS_UNIT_BLOCK" ]
   [ -n "$MANIFESTS_BLOCK" ]
-  printf '%s' "$BATS_UNIT_BLOCK" | grep -qF -e 'image: node:22'
-  printf '%s' "$MANIFESTS_BLOCK" | grep -qF -e 'image: ubuntu:24.04'
+  # Geprueft wird, DASS jeder Job an ein Image gebunden ist — nicht, welches.
+  # Bis T012411 stand hier der Bildname woertlich ('image: node:22',
+  # 'image: ubuntu:24.04'). Die Umstellung auf vorgebaute Registry-Images
+  # (ci-node22, ci-ubuntu) machte den Test rot, ohne dass ein Defekt vorlag:
+  # er mass die Darstellung statt der Zusicherung (T002716). Ob die noetige
+  # Toolchain wirklich da ist, pruefen die Tests darunter.
+  printf '%s' "$BATS_UNIT_BLOCK" | grep -qE '^[[:space:]]*image:[[:space:]]*\S'
+  printf '%s' "$MANIFESTS_BLOCK" | grep -qE '^[[:space:]]*image:[[:space:]]*\S'
 }
 
 @test "T012309: bats-unit installiert PyYAML (python3-yaml)" {


### PR DESCRIPTION
## Was kaputt war

`main` ist seit `592e4f5b1` (PR #4823, T012411) ungültiges YAML. Der neue Job `build-ci-images` steht oberhalb der Definition von `.gl_defaults` und benutzt dort `<<: *gl_defaults`:

```
$ python3 -c "import yaml; yaml.safe_load(open('.gitlab-ci.yml'))"
yaml.composer.ComposerError: found undefined alias 'gl_defaults'
  in ".gitlab-ci.yml", line 44, column 7
```

YAML löst Anker beim Parsen von oben nach unten auf. Eine Vorwärtsreferenz macht die **ganze Datei** unlesbar, nicht nur den einen Job.

**Wirkung:** GitLab kann die Pipeline nicht mehr lesen, und `tests/spec/ci-cd/gitlab-job-coverage.bats` fällt mit allen sechs Tests. Dadurch wurde **jeder PR gegen main rot** (`Factory spec shard 3`), unabhängig von seinem Inhalt. Aufgefallen an #4827.

## Der Fix

Die Anker-Definition steht jetzt vor dem ersten Job, mit einem Kommentar, der die Reihenfolge begründet. Den Job zu verschieben hätte dasselbe Problem beim nächsten Einschub oberhalb wieder erzeugt.

## Zweiter Defekt aus demselben PR, mitbehoben

Der Guard `T012309` erwartete wörtlich `image: node:22` bzw. `image: ubuntu:24.04`. Die Umstellung auf vorgebaute Registry-Images (`ci-node22`, `ci-ubuntu`) machte ihn rot, ohne dass ein Defekt vorlag — er maß die Darstellung statt der Zusicherung (die Fehlerklasse aus T002716).

Er prüft jetzt, **dass** jeder Job an ein Image gebunden ist. Ob die nötige Toolchain da ist, prüfen die Tests darunter (`python3-yaml`, `gettext-base`, `yq`) ohnehin — und die sind unverändert grün. Gegenprobe, dass der neue Anker nicht vakuos ist: ein Block ohne `image:` erzeugt keinen Treffer.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `.gitlab-ci.yml` mit PyYAML | parst, 16 Top-Level-Keys |
| `build-ci-images` erbt Defaults | `tags: [$CI_RUNNER_TAG]`, `interruptible: true` |
| Jobs mit `interruptible` | 9 |
| `tests/spec/ci-cd/` | 356 Tests, alle grün |
