### PR TITLE
fix(infra): preserve CronJob secrets through fleet render [T012907]

### DIFF
--- a/k3d/cronjob-scheduled-publish.yaml
+++ b/k3d/cronjob-scheduled-publish.yaml
@@ -35,7 +35,7 @@ spec:
                 - -c
                 - |
                   curl -sf -X GET \
-                    -H "Authorization: Bearer $CRON_SECRET" \
+                    -H "Authorization: Bearer $${CRON_SECRET}" \
                     http://website.${WEBSITE_NAMESPACE}.svc.cluster.local/api/cron/scheduled-publish
               resources:
                 requests:

--- a/k3d/error-log-retention-cronjob.yaml
+++ b/k3d/error-log-retention-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
                 - -c
                 - |
                   curl -sf -X POST \
-                    -H "Authorization: Bearer $CRON_SECRET" \
+                    -H "Authorization: Bearer $${CRON_SECRET}" \
                     http://website.${WEBSITE_NAMESPACE}.svc.cluster.local/api/cron/error-log-retention
               resources:
                 requests:

--- a/k3d/notify-unread-cronjob.yaml
+++ b/k3d/notify-unread-cronjob.yaml
@@ -32,7 +32,7 @@ spec:
                 - -c
                 - |
                   curl -sf -X POST \
-                    -H "Authorization: Bearer $CRON_SECRET" \
+                    -H "Authorization: Bearer $${CRON_SECRET}" \
                     -H "Content-Type: application/json" \
                     http://website.${WEBSITE_NAMESPACE}.svc.cluster.local/api/cron/notify-unread
               resources:

--- a/tests/spec/flux-render-security/runtime-var-unwrapping.bats
+++ b/tests/spec/flux-render-security/runtime-var-unwrapping.bats
@@ -103,3 +103,19 @@ setup() {
   run grep -c '\$\$' <<<"$unwrapped"
   [ "$output" = "0" ]
 }
+
+@test "T012907: CronJob auth secrets survive fleet envsubst for runtime expansion" {
+  local manifest
+  for manifest in \
+    k3d/cronjob-scheduled-publish.yaml \
+    k3d/notify-unread-cronjob.yaml \
+    k3d/error-log-retention-cronjob.yaml; do
+    run grep -cF 'Bearer $${CRON_SECRET}' "${REPO_ROOT}/${manifest}"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+
+    run bash -c "sed -E '$UNWRAP' '${REPO_ROOT}/${manifest}' | grep -cF 'Bearer \${CRON_SECRET}'"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+  done
+}


### PR DESCRIPTION
## Summary
- preserve runtime CRON_SECRET expansion in all three website CronJobs
- add a fleet-render regression guard for the escaped token
- restore scheduled publishing in both production brands after Flux reconciliation

## Test Plan
- [x] runtime-var-unwrapping.bats
- [x] task test:changed
- [x] task test:spec:changed
- [x] task workspace:validate
- [x] task freshness:check

🤖 [T012907]