### PR TITLE
fix(infra): bound overlapping backup jobs [T012908]

### DIFF
--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -13,10 +13,19 @@ metadata:
     graph.bachelorprojekt.de/depends-on: shared-db
 spec:
   schedule: "0 2 * * *"
+  # A second backup cannot usefully run while the first still owns backup-pvc.
+  # This also prevents a stuck upload sidecar from accumulating daily Pods and
+  # exhausting CPU requests on the PVC's node.
+  concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      # The completion marker lives on emptyDir. If the upload container
+      # restarts after backup completed, that marker can be lost; cap the Job
+      # so it releases its requests instead of waiting forever.
+      activeDeadlineSeconds: 7200
+      backoffLimit: 2
       template:
         metadata:
           labels:

--- a/tests/spec/backup-pipeline.bats
+++ b/tests/spec/backup-pipeline.bats
@@ -40,6 +40,16 @@ REPO_ROOT="${PROJECT_DIR}"
   [ "$output" -ge 1 ]
 }
 
+@test "db-backup cannot overlap and has a bounded runtime" {
+  run grep -cE '^  concurrencyPolicy: Forbid$' "${REPO_ROOT}/k3d/backup-cronjob.yaml"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+
+  run grep -cE '^      activeDeadlineSeconds: 7200$' "${REPO_ROOT}/k3d/backup-cronjob.yaml"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
 @test "backup-restore.sh exists and is runnable" {
   [ -f "${REPO_ROOT}/scripts/backup-restore.sh" ]
   # Script is currently not chmod +x in repo, so check it can be invoked via bash


### PR DESCRIPTION
## Summary
- prevent daily db-backup Jobs from overlapping
- bound each backup Job to two hours with limited retries
- add a regression test for both scheduling safeguards

The live incident was also recovered by removing 20 validated stale Jobs and correcting the controller-owned ntfy SealedSecret key casing.

## Test Plan
- [x] focused backup-pipeline BATS
- [x] task workspace:validate
- [x] task test:changed
- [x] task freshness:check
- [x] live ntfy rollout complete
- [x] current backup pod scheduled

🤖 [T012908]