### PR TITLE
fix(infra): --wipe-disks gegen Partitionierungs-Abbruch + Nachzuegler aus T012906 [T012910]

### DIFF
--- a/docs/runbooks/workstation-cluster-pxe.md
+++ b/docs/runbooks/workstation-cluster-pxe.md
@@ -86,16 +86,35 @@ sudo k3s-join.sh --role server --token "$T" --server https://<ip-node-1>:6443  #
 Netzwerkstack mit Windows, und dort hält der Hyper-V-eigene DHCP den Port. Von
 Linux aus ist daran nichts zu ändern — weder `bind-dynamic` noch ein Bind auf
 die konkrete Adresse helfen, weil ein DHCP-Server den Wildcard-Socket braucht.
-Zwei Auswege: Weg B (HTTP-Boot), oder in einer Windows-Shell mit
-Administratorrechten:
+Drei Auswege, in dieser Reihenfolge:
+
+**1. Weg B (HTTP-Boot).** Kein Eingriff nötig — setzt aber voraus, dass die
+Firmware der Workstation einen HTTP-Boot-Eintrag anbietet. Ältere Boards haben
+nur klassisches PXE.
+
+**2. Port von der Spiegelung ausnehmen.** In `%USERPROFILE%\.wslconfig` unter
+`[wsl2]`:
+
+```ini
+ignoredPorts = 67
+```
+
+Danach `wsl --shutdown`, WSL neu starten, Server neu starten. Das fasst keinen
+Windows-Dienst an. Ob `ignoredPorts` für UDP greift, ist nicht dokumentiert —
+`setup-pxe.sh` prüft den Port beim Start und sagt es.
+
+**3. Den Dienst stoppen.** In einer Windows-Shell mit Administratorrechten:
 
 ```powershell
 Stop-Service SharedAccess     # danach setup-pxe.sh neu starten
 Start-Service SharedAccess    # rückgängig
 ```
 
-Das schaltet die gemeinsame Internetverbindung ab und kann Docker Desktop und
-Hyper-V-VMs betreffen.
+Beobachtet: der Aufruf schlägt mit `StopServiceFailed` fehl, obwohl Windows den
+Dienst als stoppbar und ohne abhängige Dienste meldet — Hyper-V startet ihn per
+Trigger sofort neu. Dann bleibt `Set-Service SharedAccess -StartupType Disabled`
+plus Windows-Neustart. Das schaltet die gemeinsame Internetverbindung ab und
+kann Docker Desktop und Hyper-V-VMs betreffen.
 
 **GRUB landet in seiner Kommandozeile.** Dann wurde das falsche GRUB
 ausgeliefert. Das `grubx64.efi` aus dem ISO hat einen lokalen `$prefix`
@@ -103,6 +122,21 @@ einkompiliert und sucht seine Konfiguration auf einem Laufwerk statt im Netz —
 im Netzwerkmitschnitt fragt es nach dem eigenen Laden **keine weitere Datei**
 mehr an. Nötig ist `grubnetx64.efi.signed` aus dem Paket
 `grub-efi-amd64-signed`; `setup-pxe.sh` holt es automatisch.
+
+**„Failed to find matching device".** Der Installer bricht ab, bevor er
+partitioniert. Zwei Ursachen, in dieser Reihenfolge prüfen — der Installer
+bietet eine Root-Shell an, dort `lsblk -o NAME,SIZE,TYPE,MODEL,TRAN`:
+
+- **Keine Platte sichtbar:** die SATA/NVMe-Einstellung im UEFI steht auf
+  „RAID"/„Intel RST" statt „AHCI". Ubuntu sieht die Platte dann grundsätzlich
+  nicht. Im UEFI umstellen.
+- **Platte sichtbar:** dann lag es an einem `match`-Filter in der
+  Autoinstall-Konfiguration. Findet der keinen Kandidaten, bricht subiquity ab,
+  statt auf die Standardauswahl zurückzufallen. Deshalb steht dort kein
+  `match` mehr; eine bestimmte Platte erzwingt man mit `--disk /dev/nvme0n1`.
+
+Beobachtet auf echter Hardware: dieselbe Konfiguration lief auf der ersten
+Maschine durch und brach auf der zweiten ab.
 
 **Arbeitsspeicher.** casper lädt das komplette ISO (~3,2 GB) ins RAM. Unter
 etwa 6 GB wird es eng.

--- a/scripts/iso/autoinstall/user-data.tmpl
+++ b/scripts/iso/autoinstall/user-data.tmpl
@@ -31,8 +31,11 @@ autoinstall:
   storage:
     layout:
       name: direct
-      match:
-        size: largest
+      # KEIN match-Block. "match: {size: largest}" liess eine Installation mit
+      # "Failed to find matching device" abbrechen, waehrend dieselbe Konfiguration
+      # auf der Maschine davor durchlief: findet der Filter keinen Kandidaten,
+      # bricht subiquity ab, statt auf die Standardauswahl zurueckzufallen.
+      # Ohne match waehlt der direct-Layout-Algorithmus die Platte selbst.
     # Kein Swap. Der Schluessel gehoert unter storage — unter user-data
     # (cloud-init) wird er ignoriert, und der Installer legt dann doch eine
     # /swap.img an. Genau das passierte im ersten VM-Testlauf.

--- a/scripts/pxe/autoinstall/user-data-net.tmpl
+++ b/scripts/pxe/autoinstall/user-data-net.tmpl
@@ -8,7 +8,7 @@
 autoinstall:
   version: 1
   interactive-sections: []
-
+${PXE_EARLY_COMMANDS}
   locale: ${PXE_LOCALE}
   keyboard:
     layout: ${PXE_KEYBOARD_LAYOUT}

--- a/scripts/pxe/autoinstall/user-data-net.tmpl
+++ b/scripts/pxe/autoinstall/user-data-net.tmpl
@@ -29,8 +29,13 @@ autoinstall:
   storage:
     layout:
       name: direct
-      match:
-        size: largest
+      # KEIN match-Block. "match: {size: largest}" liess die Installation auf
+      # einer Maschine mit "Failed to find matching device" abbrechen, waehrend
+      # sie auf der Maschine davor durchlief: findet der Filter keinen
+      # Kandidaten, bricht subiquity ab, statt auf die Standardauswahl
+      # zurueckzufallen. Ohne match waehlt der direct-Layout-Algorithmus die
+      # Platte selbst — bei genau einer Platte ohnehin eindeutig.
+      # Eine bestimmte Platte erzwingt man mit --disk (setzt match.path).${PXE_DISK_MATCH}
     # Der Schluessel gehoert unter storage — unter user-data wird er
     # ignoriert und der Installer legt doch eine /swap.img an.
     swap:

--- a/scripts/pxe/setup-pxe.sh
+++ b/scripts/pxe/setup-pxe.sh
@@ -49,6 +49,7 @@ TIMEZONE="Europe/Berlin"
 HOSTNAME_FALLBACK="ws-node"
 PACKAGE_UPGRADE="false"
 SHUTDOWN_MODE="poweroff"
+DISK_PATH=""
 ACTION="start"
 FOREGROUND=0
 
@@ -67,6 +68,9 @@ Flags:
   --release <x.yy>         Ubuntu-Release (default: 24.04)
   --source-iso <datei>     vorhandenes ISO statt Download
   --locale / --keyboard / --timezone / --hostname-fallback
+  --disk </dev/pfad>       Zielplatte festnageln (z. B. /dev/nvme0n1). Ohne
+                           Angabe waehlt der Installer selbst — das ist der
+                           Normalfall und robuster.
   --shutdown <poweroff|reboot>  default: poweroff
                            poweroff ist Absicht: bootet die Maschine nach der
                            Installation neu und steht die Boot-Reihenfolge noch
@@ -98,6 +102,7 @@ while [[ $# -gt 0 ]]; do
     --hostname-fallback) HOSTNAME_FALLBACK="$2"; shift 2 ;;
     --package-upgrade)   PACKAGE_UPGRADE="true"; shift ;;
     --shutdown)          SHUTDOWN_MODE="$2";     shift 2 ;;
+    --disk)              DISK_PATH="$2";         shift 2 ;;
     --foreground)        FOREGROUND=1;           shift ;;
     --stop)              ACTION="stop";          shift ;;
     --status)            ACTION="status";        shift ;;
@@ -165,6 +170,9 @@ fi
 [[ "$SSH_PUBLIC_KEY" == *PRIVATE* ]] && die "--ssh-key zeigt auf einen PRIVATEN Schluessel."
 
 case "$SHUTDOWN_MODE" in poweroff|reboot) ;; *) die "--shutdown: poweroff oder reboot" ;; esac
+if [[ -n "$DISK_PATH" ]]; then
+  [[ "$DISK_PATH" == /dev/* ]] || die "--disk erwartet einen Geraetepfad wie /dev/nvme0n1, nicht: $DISK_PATH"
+fi
 [[ "$HTTP_PORT" =~ ^[0-9]+$ ]] || die "--http-port ist keine Zahl: $HTTP_PORT"
 if [[ -n "$NODE_MAP" ]]; then
   [[ -f "$NODE_MAP" ]] || die "--node-map nicht gefunden: $NODE_MAP"
@@ -353,7 +361,18 @@ export PXE_LOCALE="$LOCALE" \
        PXE_SHUTDOWN_MODE="$SHUTDOWN_MODE" \
        PXE_BASE_URL="$BASE_URL"
 
-envsubst '${PXE_LOCALE} ${PXE_KEYBOARD_LAYOUT} ${PXE_TIMEZONE} ${PXE_HOSTNAME_FALLBACK} ${PXE_ADMIN_USER} ${PXE_ADMIN_PASSWORD_HASH} ${PXE_SSH_ALLOW_PW} ${PXE_SSH_PUBLIC_KEY} ${PXE_PACKAGE_UPGRADE} ${PXE_SHUTDOWN_MODE} ${PXE_BASE_URL}' \
+# Der match-Block wird nur eingefuegt, wenn eine Platte ausdruecklich genannt
+# wurde. Ohne --disk bleibt die Stelle leer und subiquity waehlt selbst.
+if [[ -n "$DISK_PATH" ]]; then
+  export PXE_DISK_MATCH="
+      match:
+        path: ${DISK_PATH}"
+  info "Zielplatte festgelegt: ${DISK_PATH}"
+else
+  export PXE_DISK_MATCH=""
+fi
+
+envsubst '${PXE_LOCALE} ${PXE_KEYBOARD_LAYOUT} ${PXE_TIMEZONE} ${PXE_HOSTNAME_FALLBACK} ${PXE_ADMIN_USER} ${PXE_ADMIN_PASSWORD_HASH} ${PXE_SSH_ALLOW_PW} ${PXE_SSH_PUBLIC_KEY} ${PXE_PACKAGE_UPGRADE} ${PXE_SHUTDOWN_MODE} ${PXE_BASE_URL} ${PXE_DISK_MATCH}' \
   < "${SCRIPT_DIR}/autoinstall/user-data-net.tmpl" > "${HTTP_DIR}/nocloud/user-data"
 
 # instance-id muss vorhanden sein; ohne sie haelt cloud-init den Seed fuer

--- a/scripts/pxe/setup-pxe.sh
+++ b/scripts/pxe/setup-pxe.sh
@@ -50,6 +50,7 @@ HOSTNAME_FALLBACK="ws-node"
 PACKAGE_UPGRADE="false"
 SHUTDOWN_MODE="poweroff"
 DISK_PATH=""
+WIPE_DISKS=0
 ACTION="start"
 FOREGROUND=0
 
@@ -71,6 +72,12 @@ Flags:
   --disk </dev/pfad>       Zielplatte festnageln (z. B. /dev/nvme0n1). Ohne
                            Angabe waehlt der Installer selbst — das ist der
                            Normalfall und robuster.
+  --wipe-disks             LOESCHT vor der Installation alle Signaturen auf
+                           allen eingebauten Platten (LVM, mdadm, alte
+                           Partitionstabellen). Gegen "curtin bricht beim
+                           Partitionieren ab" auf Maschinen mit Vorleben.
+                           Betrifft JEDE nicht-wechselbare Platte der Zielmaschine,
+                           nicht nur die Installationsziel-Platte.
   --shutdown <poweroff|reboot>  default: poweroff
                            poweroff ist Absicht: bootet die Maschine nach der
                            Installation neu und steht die Boot-Reihenfolge noch
@@ -103,6 +110,7 @@ while [[ $# -gt 0 ]]; do
     --package-upgrade)   PACKAGE_UPGRADE="true"; shift ;;
     --shutdown)          SHUTDOWN_MODE="$2";     shift 2 ;;
     --disk)              DISK_PATH="$2";         shift 2 ;;
+    --wipe-disks)        WIPE_DISKS=1;           shift ;;
     --foreground)        FOREGROUND=1;           shift ;;
     --stop)              ACTION="stop";          shift ;;
     --status)            ACTION="status";        shift ;;
@@ -361,6 +369,38 @@ export PXE_LOCALE="$LOCALE" \
        PXE_SHUTDOWN_MODE="$SHUTDOWN_MODE" \
        PXE_BASE_URL="$BASE_URL"
 
+# early-commands laufen VOR der Storage-Erkennung. Genau dort muessen alte
+# Signaturen weg: curtin bricht beim Partitionieren ab, wenn ein LVM- oder
+# mdadm-Superblock die Platte noch belegt ("Device or resource busy"). Das
+# Symptom ist ein Abbruch in stage-partitioning, lange nach der Plattenwahl.
+#
+# Bewusst hinter einem Flag: das loescht die Platten der Zielmaschine
+# vollstaendig und ohne Rueckfrage.
+if [[ "$WIPE_DISKS" -eq 1 ]]; then
+  export PXE_EARLY_COMMANDS='
+  early-commands:
+    # Reihenfolge ist wesentlich: erst alles loesen, was die Geraete haelt,
+    # dann die Signaturen entfernen. Umgekehrt scheitert wipefs mit EBUSY.
+    - swapoff -a || true
+    - |
+      command -v vgchange >/dev/null 2>&1 && vgchange -an || true
+    - |
+      command -v mdadm >/dev/null 2>&1 && mdadm --stop --scan || true
+    - |
+      for d in /sys/block/*; do
+        n=$(basename "$d")
+        case "$n" in loop*|sr*|ram*|fd*|dm-*|md*) continue ;; esac
+        # Wechselmedien auslassen: der Installer selbst kann davon kommen.
+        [ "$(cat "$d/removable" 2>/dev/null)" = "1" ] && continue
+        echo "wipe: /dev/$n"
+        wipefs --all --force "/dev/$n" || true
+        command -v sgdisk >/dev/null 2>&1 && sgdisk --zap-all "/dev/$n" || true
+      done'
+  info "WARNUNG: --wipe-disks aktiv — alle eingebauten Platten der Zielmaschine werden geloescht"
+else
+  export PXE_EARLY_COMMANDS=""
+fi
+
 # Der match-Block wird nur eingefuegt, wenn eine Platte ausdruecklich genannt
 # wurde. Ohne --disk bleibt die Stelle leer und subiquity waehlt selbst.
 if [[ -n "$DISK_PATH" ]]; then
@@ -372,7 +412,7 @@ else
   export PXE_DISK_MATCH=""
 fi
 
-envsubst '${PXE_LOCALE} ${PXE_KEYBOARD_LAYOUT} ${PXE_TIMEZONE} ${PXE_HOSTNAME_FALLBACK} ${PXE_ADMIN_USER} ${PXE_ADMIN_PASSWORD_HASH} ${PXE_SSH_ALLOW_PW} ${PXE_SSH_PUBLIC_KEY} ${PXE_PACKAGE_UPGRADE} ${PXE_SHUTDOWN_MODE} ${PXE_BASE_URL} ${PXE_DISK_MATCH}' \
+envsubst '${PXE_LOCALE} ${PXE_KEYBOARD_LAYOUT} ${PXE_TIMEZONE} ${PXE_HOSTNAME_FALLBACK} ${PXE_ADMIN_USER} ${PXE_ADMIN_PASSWORD_HASH} ${PXE_SSH_ALLOW_PW} ${PXE_SSH_PUBLIC_KEY} ${PXE_PACKAGE_UPGRADE} ${PXE_SHUTDOWN_MODE} ${PXE_BASE_URL} ${PXE_DISK_MATCH} ${PXE_EARLY_COMMANDS}' \
   < "${SCRIPT_DIR}/autoinstall/user-data-net.tmpl" > "${HTTP_DIR}/nocloud/user-data"
 
 # instance-id muss vorhanden sein; ohne sie haelt cloud-init den Seed fuer


### PR DESCRIPTION
## Zwei Dinge in einem PR

### 1. Nachzügler aus T012906

Auto-Merge hat #4843 gemergt, **bevor** zwei Commits gepusht waren. Auf `main` fehlen deshalb:

- der Wegfall des `match: {size: largest}`-Filters (Ursache für `Failed to find matching device` auf echter Hardware)
- die Runbook-Ergänzungen zu Port 67 und dem Plattenfehler

Beide sind hier per Cherry-pick enthalten.

### 2. `--wipe-disks` (T012910)

Auf einer der Workstations bricht curtin in `stage-partitioning` ab — **nachdem** die Plattenwahl bereits erfolgreich war. Der vorherige Fix hat also gegriffen; der Lauf kommt weiter und scheitert erst beim Anlegen der Partitionen.

Typische Ursache sind Reste einer früheren Installation: ein LVM- oder mdadm-Superblock hält das Gerät, curtin scheitert mit `EBUSY`.

`--wipe-disks` legt `early-commands` an, die vor der Storage-Erkennung aufräumen:

```
swapoff -a
vgchange -an
mdadm --stop --scan
wipefs --all --force /dev/<disk>
sgdisk --zap-all /dev/<disk>
```

**Die Reihenfolge ist wesentlich**: erst alles lösen, was die Geräte hält, dann die Signaturen entfernen. Umgekehrt scheitert `wipefs` an genau dem Halter, den es beseitigen soll.

**Bewusst hinter einem Flag, nicht als Voreinstellung.** Die Befehle löschen jede nicht-wechselbare Platte der Zielmaschine ohne Rückfrage. Wechselmedien bleiben ausgenommen — bei einer USB-Installation käme der Installer sonst von einem Gerät, das er gerade löscht.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| mit `--wipe-disks` | gültiges YAML, 4 `early-commands` in korrekter Reihenfolge |
| ohne `--wipe-disks` | gültiges YAML, kein `early-commands`-Schlüssel |
| `storage` in beiden Fällen | `{layout: {name: direct}, swap: {size: 0}}` |
| BATS | 28 Tests grün (PXE + ISO) |

Der Nachweis, dass es den konkreten Abbruch behebt, steht noch aus — dafür braucht es die Ausgabe von der betroffenen Maschine (`lsblk`, `curtin/install.log`). Zeigt sie kein LVM/RAID, ist die Ursache eine andere und dieser PR behebt sie nicht; die Option bleibt trotzdem richtig für Maschinen mit Vorleben.
