### PR TITLE
fix: toolset valid roles big pickle T012912

### DIFF
--- a/scripts/toolset/check.mjs
+++ b/scripts/toolset/check.mjs
@@ -31,6 +31,10 @@ const VALID_ROLES = new Set([
   'bachelorprojekt-db',
   'bachelorprojekt-security',
   'orchestrator',
+  // [T012912] Rolle aus agents.yaml/AGENTS.md; PR #4839 trug sie in
+  // capabilities.yaml und toolset-context.sh ein, hier fehlte sie — das Gate
+  // stand danach auf jedem PR rot.
+  'big-pickle',
   'all',
 ]);
 


### PR DESCRIPTION
## Symptom

`task agents:toolset:check` endet auf `main` mit Exit 1:

```
Capability 'postgres-lesen' instance 'mcp:mcp-postgres': unknown role 'big-pickle'
(valid: bachelorprojekt-website, -ops, -infra, -test, -db, -security, orchestrator, all).
```

Dadurch fallen **auf jedem PR** zwei Tests um, unabhaengig vom Inhalt des PR:
`tests/spec/toolset-registry/schema-gate.bats` ("die echte Registry ist vollstaendig kuriert") und `tests/spec/toolset-registry/check-offline.bats`.

## Ursache

Commit `a0b93019d` (PR #4839, T012411) trug die Rolle `big-pickle` in `docs/agent-guide/registry/capabilities.yaml` und `scripts/toolset-context.sh` ein — nicht aber in `VALID_ROLES` in `scripts/toolset/check.mjs`. Die Rolle ist legitim: sie steht in `docs/agent-guide/registry/agents.yaml` und in `AGENTS.md`.

Die Liste ist laut Kommentar in `check.mjs` bewusst dreifach gefuehrt (check.mjs, toolset-context.sh, plan-context.sh), SSOT ist CONTRACT.md §2 des Change `toolset-usage-injection`. Genau diese Doppelung ist auseinandergelaufen.

## Nachweis

Gemessen 2026-08-19 gegen Repo-Stand `00157dc66` (= `origin/main`):

```bash
task agents:toolset:check; echo "rc=$?"    # vorher: 1 · nachher: 0
./tests/unit/lib/bats-core/bin/bats \
  tests/spec/toolset-registry/check-offline.bats \
  tests/spec/toolset-registry/schema-gate.bats   # vorher: 2 not ok · nachher: alle ok
```

Reproduziert auf einem Branch ohne inhaltliche Aenderung, also nicht PR-spezifisch.

## Nicht in diesem PR

`_role_allowlist()` in `scripts/plan-context.sh` kennt `big-pickle` ebenfalls nicht. Dort ist der Fallback fail-soft (WARN + `__ALL__`), es blockiert also nichts. Die Funktion bildet Rollen auf Plan-Domaenen ab — welche Domaenen `big-pickle` fuehren soll, ist eine Entscheidung und keine Reparatur. Im Ticket als Nebenbefund notiert.