### PR TITLE
fix(agents): address Brain lifecycle review findings [T012957]

### DIFF
--- a/docs/brain-expertise/approved/source-policy.md
+++ b/docs/brain-expertise/approved/source-policy.md
@@ -27,7 +27,9 @@ Credentials, Tokens, URL-Userinfo und Private Keys werden redigiert; Textfelder 
 
 Approval ist append-only und erfordert interaktiv oder per Datei exakt:
 `APPROVE <owner/repo>#<pr>@<sha> <slug>`. Nur danach entsteht ein Dokument unter
-`docs/brain-expertise/approved/`.
+`docs/brain-expertise/approved/`. Es hält die geprüfte GitHub-SHA als `upstream_revision` fest;
+der allgemeine Ingest berechnet davon getrennt `source_revision` aus den Bytes dieses lokalen
+approved-Artefakts.
 
 Verboten sind organisationsweite oder ambiente Suche, Autorenprofile und Leistungsbewertung,
 Persistenz roher API-Antworten, ungeprüfte Secrets oder PII, Ingest aus `fetched/` oder

--- a/openspec/changes/brain-knowledge-lifecycle/design.md
+++ b/openspec/changes/brain-knowledge-lifecycle/design.md
@@ -22,10 +22,15 @@ Seiten erhalten flache, YAML-parserfreundliche Felder:
 
 - `source_kind`: kontrollierter Ursprung wie `openspec`, `runbook`, `adr` oder
   `github-reviewed`;
-- `source_revision`: deterministischer Quellhash oder unveränderliche GitHub-Revision;
+- `source_revision`: deterministischer Hash der lokalen Quelldatei;
+- optional `upstream_revision`: validierte unveränderliche GitHub-Head-SHA für
+  `github-reviewed`-Artefakte;
 - `observed_at`: ISO-8601-Zeitpunkt der Quellenbeobachtung;
 - `valid_from`: ISO-Datum oder Zeitpunkt, ab dem der Inhalt gilt;
 - optional `valid_until` und `superseded_by`.
+
+Beim Kompilieren eines reviewed-Artefakts bleibt `upstream_revision` erhalten, während
+`source_revision` deterministisch die Bytes des lokalen approved-Artefakts bezeichnet.
 
 Alte Seiten ohne diese Felder bleiben lesbar. Zeitintervalle sind halboffen
 `valid_from <= as_of < valid_until`. Optionale Body-Kanten der Form

--- a/openspec/changes/brain-knowledge-lifecycle/specs/brain-foundation.md
+++ b/openspec/changes/brain-knowledge-lifecycle/specs/brain-foundation.md
@@ -4,7 +4,9 @@
 
 The Brain ingest pipeline SHALL add deterministic, flat provenance metadata to newly compiled
 pages: `source_kind`, `source_revision`, `observed_at`, and `valid_from`. It MAY add
-`valid_until` and `superseded_by`. Existing pages without these fields SHALL remain valid and
+`valid_until`, `superseded_by`, and `upstream_revision`. For `github-reviewed` sources,
+`source_revision` SHALL identify the approved local artifact bytes while `upstream_revision`
+SHALL retain the validated immutable GitHub head SHA. Existing pages without these fields SHALL remain valid and
 readable. When `valid_until` is present, the validity interval SHALL be interpreted as half-open:
 `valid_from <= as_of < valid_until`.
 
@@ -14,6 +16,13 @@ readable. When `valid_until` is present, the validity interval SHALL be interpre
 - **WHEN** the pipeline compiles it into a Brain page
 - **THEN** the page carries its source kind, source revision, observation time, and validity start
 - **AND** the source revision is derived from the source rather than invented by the LLM
+
+#### Scenario: Reviewed upstream revision survives compilation
+
+- **GIVEN** an approved GitHub expertise artifact with a validated immutable head SHA
+- **WHEN** the pipeline compiles it into a Brain page
+- **THEN** `source_revision` is the SHA-256 of the approved local artifact
+- **AND** `upstream_revision` remains the validated GitHub head SHA
 
 #### Scenario: Legacy pages remain compatible
 
@@ -61,5 +70,5 @@ organization-wide discovery and automatic ingestion of staged material SHALL be 
 
 - **GIVEN** a reviewer approves a redacted staged artifact
 - **WHEN** the approval command writes the allowlisted source document
-- **THEN** it records repository, PR or review identifiers, source URL, and revision
+- **THEN** it records repository, PR or review identifiers, source URL, and `upstream_revision`
 - **AND** the worklist includes it under source kind `github-reviewed`

--- a/openspec/changes/brain-knowledge-lifecycle/specs/brain-k4-brain-wiki.md
+++ b/openspec/changes/brain-knowledge-lifecycle/specs/brain-k4-brain-wiki.md
@@ -6,7 +6,8 @@ The Brain MCP server SHALL continue to advertise exactly `brain_search` and `bra
 `brain_search` SHALL accept its existing `query` and `top_k` parameters plus optional conjunctive
 filters for `type`, `tags`, `status`, `source_kind`, and `as_of`. Without optional filters its
 ranking and result-limit behavior SHALL remain backward compatible. Search results SHALL include
-available provenance and validity metadata plus a computed freshness state. `brain_read` SHALL
+available provenance (including `upstream_revision` when present) and validity metadata plus a
+computed freshness state. `brain_read` SHALL
 continue returning the complete frontmatter and body for a slug.
 
 #### Scenario: Existing unfiltered search remains compatible

--- a/scripts/brain-expertise.py
+++ b/scripts/brain-expertise.py
@@ -65,9 +65,34 @@ def residual_secret(text: str) -> bool:
                 or URL_USERINFO_RE.search(sanitized))
 
 
-def atomic_write(path: Path, content: bytes) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    os.chmod(path.parent, 0o700)
+def _require_under(root: Path, path: Path) -> Path:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"state path escapes canonical state root: {path}") from exc
+    return resolved
+
+
+def _secure_state_ancestors(root: Path, parent: Path) -> None:
+    root = root.resolve()
+    parent = _require_under(root, parent)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(root, 0o700)
+    relative = parent.relative_to(root)
+    current = root
+    for part in relative.parts:
+        current = current / part
+        current.mkdir(exist_ok=True, mode=0o700)
+        os.chmod(current, 0o700)
+
+
+def atomic_write(path: Path, content: bytes, *, state_root_path: Path | None = None) -> None:
+    if state_root_path is not None:
+        path = _require_under(state_root_path, path)
+        _secure_state_ancestors(state_root_path, path.parent)
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         if path.read_bytes() == content:
             return
@@ -95,6 +120,8 @@ def validate_scope(args: argparse.Namespace) -> tuple[str, str, int, str]:
     if not SHA_RE.fullmatch(args.revision or ""):
         raise ValueError("--revision must be a 40-character hexadecimal SHA")
     owner, repository = args.repo.split("/", 1)
+    if owner in {".", ".."} or repository in {".", ".."}:
+        raise ValueError("repository components must not be '.' or '..'")
     return owner, repository, args.pr, args.revision.lower()
 
 
@@ -118,15 +145,35 @@ def state_root(args: argparse.Namespace) -> Path:
 def state_paths(args: argparse.Namespace) -> tuple[Path, Path, Path]:
     owner, repository, pr, revision = validate_scope(args)
     root = state_root(args)
-    fetched = root / "fetched" / owner / repository / f"pr-{pr}" / f"{revision}.json"
-    staged = root / "staged" / owner / repository / f"pr-{pr}" / revision / "candidate.md"
+    fetched = _require_under(root, root / "fetched" / owner / repository / f"pr-{pr}" / f"{revision}.json")
+    staged = _require_under(root, root / "staged" / owner / repository / f"pr-{pr}" / revision / "candidate.md")
     return root, fetched, staged
+
+
+def _parse_json_stream(output: str) -> Any:
+    decoder = json.JSONDecoder()
+    values: list[Any] = []
+    offset = 0
+    while offset < len(output):
+        while offset < len(output) and output[offset].isspace():
+            offset += 1
+        if offset >= len(output):
+            break
+        value, offset = decoder.raw_decode(output, offset)
+        values.append(value)
+    if not values:
+        raise json.JSONDecodeError("empty JSON response", output, 0)
+    if len(values) == 1:
+        return values[0]
+    if all(isinstance(value, list) for value in values):
+        return [item for value in values for item in value]
+    raise json.JSONDecodeError("paginated response is not an array stream", output, 0)
 
 
 def gh_json(arguments: list[str]) -> Any:
     try:
         result = subprocess.run(["gh", *arguments], check=True, capture_output=True, text=True)
-        return json.loads(result.stdout)
+        return _parse_json_stream(result.stdout)
     except (subprocess.CalledProcessError, OSError, json.JSONDecodeError) as exc:
         raise ExpertiseError(f"GitHub request failed: {' '.join(arguments)}") from exc
 
@@ -159,7 +206,7 @@ def fetch(args: argparse.Namespace) -> None:
                          for item in comments if isinstance(item, dict) and isinstance(item.get("id"), int)]
     evidence = {
         "schema_version": 1, "repository": f"{owner}/{repository}", "pull_request": pr,
-        "source_url": str(pull.get("html_url", "")), "source_revision": revision,
+        "source_url": str(pull.get("html_url", "")), "upstream_revision": revision,
         "pull": {"role": "pr-author", "title": clean(pull.get("title")), "body": clean(pull.get("body"))},
         "files": selected_files, "reviews": selected_reviews, "comments": selected_comments,
         "redaction": {"version": 1, **counters},
@@ -177,7 +224,7 @@ def fetch(args: argparse.Namespace) -> None:
         else:
             raise ExpertiseError("redacted evidence exceeds the 2 MiB limit")
         raw = (json.dumps(evidence, ensure_ascii=False, sort_keys=True, indent=2) + "\n").encode()
-    atomic_write(fetched_path, raw)
+    atomic_write(fetched_path, raw, state_root_path=state_root(args))
     print(fetched_path)
 
 
@@ -197,7 +244,7 @@ def render_candidate(data: dict[str, Any]) -> str:
     lines = [
         "---", "status: staged", f"repository: {data['repository']}",
         f"pull_request: {data['pull_request']}", f"source_url: {data['source_url']}",
-        f"source_revision: {data['source_revision']}",
+        f"upstream_revision: {data['upstream_revision']}",
         f"review_ids: {json.dumps(review_ids)}", f"comment_ids: {json.dumps(comment_ids)}",
         f"redaction_version: {data['redaction']['version']}",
         f"redacted_fields: {data['redaction']['redacted_fields']}",
@@ -220,13 +267,13 @@ def stage(args: argparse.Namespace) -> None:
     _, fetched_path, staged_path = state_paths(args)
     data = load_evidence(fetched_path)
     owner, repository, pr, revision = validate_scope(args)
-    if (data.get("repository"), data.get("pull_request"), data.get("source_revision")) != (f"{owner}/{repository}", pr, revision):
+    if (data.get("repository"), data.get("pull_request"), data.get("upstream_revision")) != (f"{owner}/{repository}", pr, revision):
         raise ExpertiseError("evidence provenance does not match requested scope")
     counters = {"redacted_fields": 0, "truncated_fields": 0}
     rendered = redact(render_candidate(data), counters)
     if residual_secret(rendered):
         raise ExpertiseError("residual secret or personal data in staged candidate")
-    atomic_write(staged_path, rendered.encode())
+    atomic_write(staged_path, rendered.encode(), state_root_path=state_root(args))
     print(staged_path)
 
 
@@ -250,7 +297,7 @@ def approve(args: argparse.Namespace) -> None:
         raise ExpertiseError(f"cannot read staged candidate: {staged_path}") from exc
     metadata = _candidate_metadata(candidate)
     expected = (f"{owner}/{repository}", str(pr), revision)
-    if (metadata.get("repository"), metadata.get("pull_request"), metadata.get("source_revision")) != expected:
+    if (metadata.get("repository"), metadata.get("pull_request"), metadata.get("upstream_revision")) != expected:
         raise ExpertiseError("candidate provenance does not match requested scope")
     known_ids = {str(item["id"]) for item in data.get("reviews", []) + data.get("comments", [])}
     candidate_ids = set(re.findall(r"(?:Review|Comment)\s+(\d+)", candidate))
@@ -280,7 +327,7 @@ def approve(args: argparse.Namespace) -> None:
     body = candidate.split("\n---\n", 1)[1].lstrip()
     approved = "\n".join([
         "---", "type: note", "tags: [github-reviewed, expertise]", "status: active",
-        "source_kind: github-reviewed", f"source_revision: {revision}",
+        "source_kind: github-reviewed", f"upstream_revision: {revision}",
         f"repository: {owner}/{repository}", f"pull_request: {pr}",
         f"source_url: {data['source_url']}", f"review_ids: {json.dumps(review_ids)}",
         f"comment_ids: {json.dumps(comment_ids)}", "---", body.rstrip(), "",

--- a/scripts/brain-index.py
+++ b/scripts/brain-index.py
@@ -13,7 +13,7 @@ from typing import Any
 
 RESULT_METADATA = (
     "type", "tags", "status", "source_kind", "source_revision", "observed_at",
-    "valid_from", "valid_until", "superseded_by",
+    "upstream_revision", "valid_from", "valid_until", "superseded_by",
 )
 
 

--- a/scripts/brain-ingest-moc.sh
+++ b/scripts/brain-ingest-moc.sh
@@ -9,17 +9,31 @@
 #   --brain-repo   Path to the brain wiki repository
 #   --chunks       Chunk manifest TSV (from brain-chunk.sh via brain-ingest.sh)
 #   --state        State file path (for slug lookup)
+#   --source-root  Bachelorprojekt source root
+#   --manifest     Ingest source manifest
+#   --metadata-script Deterministic metadata filter
+#   --observed-at / --valid-from Fixed lifecycle time for this ingest run
 set -euo pipefail
 
 BRAIN_REPO=""
 CHUNKS_TSV=""
 STATE_FILE=""
+SOURCE_ROOT=""
+MANIFEST=""
+METADATA_SCRIPT=""
+OBSERVED_AT=""
+VALID_FROM=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --brain-repo) BRAIN_REPO="${2:?--brain-repo requires a value}"; shift ;;
     --chunks)     CHUNKS_TSV="${2:?--chunks requires a value}"; shift ;;
     --state)      STATE_FILE="${2:?--state requires a value}"; shift ;;
+    --source-root) SOURCE_ROOT="${2:?--source-root requires a value}"; shift ;;
+    --manifest) MANIFEST="${2:?--manifest requires a value}"; shift ;;
+    --metadata-script) METADATA_SCRIPT="${2:?--metadata-script requires a value}"; shift ;;
+    --observed-at) OBSERVED_AT="${2:?--observed-at requires a value}"; shift ;;
+    --valid-from) VALID_FROM="${2:?--valid-from requires a value}"; shift ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
   shift
@@ -28,6 +42,51 @@ done
 [ -n "$BRAIN_REPO" ] || { echo "error: --brain-repo required" >&2; exit 1; }
 [ -f "$CHUNKS_TSV" ] || { echo "error: chunks TSV not found: $CHUNKS_TSV" >&2; exit 1; }
 [ -f "$STATE_FILE" ] || { echo "error: state file not found: $STATE_FILE" >&2; exit 1; }
+[ -d "$SOURCE_ROOT" ] || { echo "error: source root not found: $SOURCE_ROOT" >&2; exit 1; }
+[ -f "$MANIFEST" ] || { echo "error: manifest not found: $MANIFEST" >&2; exit 1; }
+[ -f "$METADATA_SCRIPT" ] || { echo "error: metadata script not found: $METADATA_SCRIPT" >&2; exit 1; }
+[ -n "$OBSERVED_AT" ] || { echo "error: --observed-at required" >&2; exit 1; }
+[ -n "$VALID_FROM" ] || { echo "error: --valid-from required" >&2; exit 1; }
+
+# shellcheck source=./brain-group-match.sh
+source "$(dirname "${BASH_SOURCE[0]}")/brain-group-match.sh"
+brain_group_section_for_manifest "$MANIFEST"
+GROUPS_SECTION="$_BRAIN_GROUP_SECTION"
+
+source_kind_for_group() {
+  case "$1" in
+    ssot-specs) echo openspec ;;
+    runbooks) echo runbook ;;
+    adr) echo adr ;;
+    gotchas-footguns) echo gotcha ;;
+    agent-guide-maps) echo agent-guide ;;
+    core-docs) echo core-doc ;;
+    health-goals) echo health-goal ;;
+    diagrams) echo diagram ;;
+    github-reviewed) echo github-reviewed ;;
+    *) return 1 ;;
+  esac
+}
+
+write_moc() {
+  local content="$1" destination="$2" source_file="$3" source_kind="$4"
+  local temporary upstream_revision
+  local -a metadata_args
+  [ -f "$source_file" ] || { echo "error: MOC source missing: $source_file" >&2; return 1; }
+  temporary="$(mktemp "$(dirname "$destination")/.moc.XXXXXX")"
+  metadata_args=(--source "$source_file" --source-kind "$source_kind" \
+    --observed-at "$OBSERVED_AT" --valid-from "$VALID_FROM")
+  if [ "$source_kind" = github-reviewed ]; then
+    upstream_revision="$(awk -F': *' '/^upstream_revision:/{print $2; exit}' "$source_file" | tr -d "\"'")"
+    [ -n "$upstream_revision" ] || { rm -f "$temporary"; echo "error: reviewed source lacks upstream_revision" >&2; return 1; }
+    metadata_args+=(--upstream-revision "$upstream_revision")
+  fi
+  if ! printf '%s' "$content" | python3 "$METADATA_SCRIPT" "${metadata_args[@]}" > "$temporary"; then
+    rm -f "$temporary"
+    return 1
+  fi
+  mv "$temporary" "$destination"
+}
 
 echo "=== Phase 2b: MOC Generation ==="
 
@@ -52,7 +111,12 @@ while IFS=$'\t' read -r src_path chunk_file chunk_slug idx heading; do
       filtered+="$line"$'\n'
     fi
   done < "$chunk_file"
-  printf '%s' "$filtered" > "$moc_dest"
+  brain_group_for "$src_path" "$GROUPS_SECTION" || {
+    echo "error: no manifest group for parent MOC source: $src_path" >&2
+    exit 1
+  }
+  source_kind="$(source_kind_for_group "$_BRAIN_GROUP_OUT")" || exit 1
+  write_moc "$filtered" "$moc_dest" "$SOURCE_ROOT/$src_path" "$source_kind"
 
   # Write state entry for the MOC
   (
@@ -68,7 +132,7 @@ done < "$CHUNKS_TSV"
 echo "Parent MOCs: $moc_count"
 
 # ── Generate sub-MOCs per group ──────────────────────────────────────────
-for group in ssot-specs runbooks adr gotchas-footguns agent-guide-maps core-docs health-goals diagrams; do
+for group in ssot-specs runbooks adr gotchas-footguns agent-guide-maps core-docs health-goals diagrams github-reviewed; do
   pages="$(jq -r --arg g "$group" '
     to_entries[] |
     select(.value.type != null) |
@@ -102,7 +166,7 @@ ${page_count} Seiten aus der Gruppe \`${group}\`.
 "
   done <<< "$pages"
 
-  echo "$moc_content" > "$BRAIN_REPO/wiki/${group}-moc.md"
+  write_moc "$moc_content" "$BRAIN_REPO/wiki/${group}-moc.md" "$MANIFEST" core-doc
   echo "  Created ${group}-moc.md ($page_count pages)"
 done
 
@@ -119,7 +183,7 @@ index_content="---
 type: moc
 tags: [moc, meta]
 status: active
-source:: Bachelorprojekt brain-initial-ingest (T001861)
+source:: Bachelorprojekt scripts/brain/ingest-sources.yaml
 ---
 # Wiki — Map of Content
 
@@ -174,5 +238,5 @@ for page_slug in $existing_pages; do
   fi
 done
 
-echo "$index_content" > "$BRAIN_REPO/index.md"
+write_moc "$index_content" "$BRAIN_REPO/index.md" "$MANIFEST" core-doc
 echo "  Updated index.md"

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -261,7 +261,8 @@ source_kind_for_group() {
 process_page() {
   local src_path="$1" chunk_file="$2" chunk_slug="$3" index="$4"
   local src_hash existing_hash type tag_defaults transformed group tmp chunk_chars
-  local src_file source_kind target_tmp
+  local src_file source_kind target_tmp upstream_revision
+  local -a metadata_args
 
   [ -f "$chunk_file" ] || { echo "WARN: chunk not found: $chunk_file ($src_path)" >&2; return 1; }
 
@@ -307,9 +308,18 @@ process_page() {
   fi
 
   target_tmp="$(mktemp "$BRAIN_REPO/wiki/.${chunk_slug}.XXXXXX")"
-  if ! printf '%s\n' "$transformed" \
-    | python3 "$METADATA_SCRIPT" --source "$src_file" --source-kind "$source_kind" \
-        --observed-at "$OBSERVED_AT" --valid-from "$VALID_FROM" > "$target_tmp"; then
+  metadata_args=(--source "$src_file" --source-kind "$source_kind" \
+    --observed-at "$OBSERVED_AT" --valid-from "$VALID_FROM")
+  if [ "$source_kind" = "github-reviewed" ]; then
+    upstream_revision="$(awk -F': *' '/^upstream_revision:/{print $2; exit}' "$src_file" | tr -d "\"'")"
+    [ -n "$upstream_revision" ] || {
+      rm -f "$target_tmp"
+      echo "WARN: Missing upstream_revision: $src_path chunk $index" >&2
+      return 1
+    }
+    metadata_args+=(--upstream-revision "$upstream_revision")
+  fi
+  if ! printf '%s\n' "$transformed" | python3 "$METADATA_SCRIPT" "${metadata_args[@]}" > "$target_tmp"; then
     rm -f "$target_tmp"
     echo "WARN: Metadata annotation failed: $src_path chunk $index" >&2
     return 1
@@ -475,7 +485,9 @@ fi
 # ============================================================
 # Phase 2b: MOC Generation (delegated to brain-ingest-moc.sh)
 # ============================================================
-bash "$HERE/brain-ingest-moc.sh" --brain-repo "$BRAIN_REPO" --chunks "$CHUNKS_TSV" --state "$STATE_FILE"
+bash "$HERE/brain-ingest-moc.sh" --brain-repo "$BRAIN_REPO" --chunks "$CHUNKS_TSV" --state "$STATE_FILE" \
+  --source-root "$REPO_ROOT" --manifest "$MANIFEST" --metadata-script "$METADATA_SCRIPT" \
+  --observed-at "$OBSERVED_AT" --valid-from "$VALID_FROM"
 
 # ============================================================
 # Phase 2c: Prune (Deletion-Sync, T001963) — default dry, --prune schaltet scharf

--- a/scripts/brain-lifecycle-audit.py
+++ b/scripts/brain-lifecycle-audit.py
@@ -139,6 +139,8 @@ def collect_findings(pages: list[PageRecord], source_root: Path, as_of: datetime
     root = source_root.resolve()
     for page in pages:
         missing = [key for key in REQUIRED_LIFECYCLE if not page.metadata.get(key)]
+        if page.metadata.get("source_kind") == "github-reviewed" and not page.metadata.get("upstream_revision"):
+            missing.append("upstream_revision")
         if missing:
             findings.append({"code": "metadata_unknown", "slug": page.slug, "missing": missing})
         if page.valid_from is not None and page.valid_until is not None and page.valid_until <= page.valid_from:
@@ -148,7 +150,11 @@ def collect_findings(pages: list[PageRecord], source_root: Path, as_of: datetime
         target = page.metadata.get("superseded_by")
         if target and target not in slugs:
             findings.append({"code": "missing_superseded_target", "slug": page.slug, "target": target})
-        if page.source_path and page.metadata.get("source_kind") != "github-reviewed":
+        upstream = page.metadata.get("upstream_revision")
+        if upstream and not re.fullmatch(r"[0-9a-f]{40}", str(upstream)):
+            findings.append({"code": "invalid_upstream_revision", "slug": page.slug,
+                             "upstream_revision": upstream})
+        if page.source_path:
             candidate = (root / page.source_path).resolve()
             try:
                 candidate.relative_to(root)
@@ -168,6 +174,8 @@ def collect_findings(pages: list[PageRecord], source_root: Path, as_of: datetime
                                  "recorded_revision": recorded, "current_revision": current})
     claims: dict[str, list[tuple[PageRecord, str]]] = {}
     for page in pages:
+        if page.metadata.get("status") != "active":
+            continue
         for key, value in page.claims:
             claims.setdefault(key, []).append((page, value))
     for key, entries in claims.items():

--- a/scripts/brain-page-metadata.py
+++ b/scripts/brain-page-metadata.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,7 +16,7 @@ SOURCE_KINDS = {
     "health-goal", "diagram", "github-reviewed",
 }
 LIFECYCLE_KEYS = (
-    "source_kind", "source_revision", "observed_at", "valid_from",
+    "source_kind", "source_revision", "upstream_revision", "observed_at", "valid_from",
     "valid_until", "superseded_by",
 )
 
@@ -90,6 +91,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--source-kind", required=True)
     parser.add_argument("--observed-at", required=True)
     parser.add_argument("--valid-from", required=True)
+    parser.add_argument("--upstream-revision")
     parser.add_argument("--valid-until")
     parser.add_argument("--superseded-by")
     return parser
@@ -114,6 +116,10 @@ def run(argv: list[str] | None = None) -> int:
             "observed_at": args.observed_at,
             "valid_from": args.valid_from,
         }
+        if args.upstream_revision:
+            if not re.fullmatch(r"[0-9a-fA-F]{40}", args.upstream_revision):
+                raise MetadataError("upstream-revision must be a 40-character hexadecimal SHA")
+            metadata["upstream_revision"] = args.upstream_revision.lower()
         if args.valid_until:
             metadata["valid_until"] = args.valid_until
         if args.superseded_by:

--- a/scripts/brain-retrieval-eval.py
+++ b/scripts/brain-retrieval-eval.py
@@ -108,18 +108,23 @@ def evaluate(wiki_dir: Path, eval_set: Path, default_k: int) -> dict[str, Any]:
         reports.append({
             "id": case["id"], "query": case["query"], "top_k": top_k,
             "filters": filters, "relevant_slugs": case["relevant_slugs"],
-            "returned_slugs": returned, "recall_at_k": round(recall, 6),
-            "reciprocal_rank": round(reciprocal, 6), "returned_results": len(results),
+            "returned_slugs": returned, "recall_at_k": recall,
+            "reciprocal_rank": reciprocal, "returned_results": len(results),
             "stale_results": stale, "future_results": future, "unknown_results": unknown,
         })
     count = len(reports)
     metrics = {
-        "recall_at_k": round(sum(item["recall_at_k"] for item in reports) / count, 6),
-        "mrr": round(sum(item["reciprocal_rank"] for item in reports) / count, 6),
-        "stale_result_rate": round(total_stale / total_returned, 6) if total_returned else 0.0,
+        "recall_at_k": sum(item["recall_at_k"] for item in reports) / count,
+        "mrr": sum(item["reciprocal_rank"] for item in reports) / count,
+        "stale_result_rate": total_stale / total_returned if total_returned else 0.0,
         "returned_results": total_returned, "stale_results": total_stale,
         "future_results": total_future, "unknown_results": total_unknown,
     }
+    for case in reports:
+        case["recall_at_k"] = round(case["recall_at_k"], 6)
+        case["reciprocal_rank"] = round(case["reciprocal_rank"], 6)
+    for key in ("recall_at_k", "mrr", "stale_result_rate"):
+        metrics[key] = round(metrics[key], 6)
     return {"schema_version": 1, "eval_set": str(eval_set), "top_k": default_k,
             "case_count": count, "metrics": metrics, "cases": reports}
 

--- a/templates/brain/SCHEMA.md
+++ b/templates/brain/SCHEMA.md
@@ -40,7 +40,9 @@ Feldern — `raw/` und `README.md` sind vom Frontmatter-Lint ausgenommen:
 
 Neu kompilierte Seiten tragen zusätzlich die flachen Felder `source_kind`,
 `source_revision`, `observed_at` und `valid_from`, optional auch `valid_until` und
-`superseded_by`. Legacy-Seiten nur mit `type`, `tags` und `status` bleiben gültig;
+`superseded_by`. `github-reviewed`-Seiten tragen zusätzlich `upstream_revision`: die validierte
+GitHub-Head-SHA bleibt dort getrennt von `source_revision`, dem SHA-256 des lokalen approved-
+Artefakts. Legacy-Seiten nur mit `type`, `tags` und `status` bleiben gültig;
 Lifecycle-Werkzeuge melden ihre zeitliche Einordnung als unbekannt, statt Werte zu erfinden.
 
 `source_kind` ist einer von `openspec`, `runbook`, `adr`, `gotcha`, `agent-guide`,

--- a/tests/spec/brain-foundation/knowledge-lifecycle.bats
+++ b/tests/spec/brain-foundation/knowledge-lifecycle.bats
@@ -127,6 +127,24 @@ PY
   [ "$status" -eq 2 ]
 }
 
+@test "lifecycle audit ignores contradictory claims on draft and archived pages" {
+  local revision json
+  revision="$(sha256sum "$SRC" | awk '{print $1}')"
+  page active-page 2026-01-01 2027-01-01 blue "$revision"
+  page draft-page 2026-01-01 2027-01-01 green "$revision"
+  page archived-page 2026-01-01 2027-01-01 red "$revision"
+  sed -i 's/status: active/status: draft/' "$WIKI/draft-page.md"
+  sed -i 's/status: active/status: archived/' "$WIKI/archived-page.md"
+
+  run python3 "$AUDIT" --brain-repo "$BATS_TEST_TMPDIR/brain" --source-root "$BATS_TEST_TMPDIR" --as-of 2026-08-19 --format json
+  [ "$status" -eq 0 ]
+  json="$output"
+  python3 - "$json" <<'PY'
+import json, sys
+assert all(item["code"] != "conflicting_claim" for item in json.loads(sys.argv[1])["findings"])
+PY
+}
+
 @test "expertise fetch stage approve is explicit scoped redacted and allowlisted" {
   local stub="$BATS_TEST_TMPDIR/bin" state="$BATS_TEST_TMPDIR/state" repo="$BATS_TEST_TMPDIR/repo"
   local sha="0123456789abcdef0123456789abcdef01234567"
@@ -140,9 +158,11 @@ case "$*" in
   'api repos/Paddione/Bachelorprojekt/pulls/123')
     printf '%s\n' '{"number":123,"html_url":"https://github.com/Paddione/Bachelorprojekt/pull/123","title":"Decision","body":"mail a@b.test token=ghp_abcdefghijklmnopqrstuvwxyz123456","head":{"sha":"0123456789abcdef0123456789abcdef01234567"},"user":{"login":"private-user"}}' ;;
   'api --paginate repos/Paddione/Bachelorprojekt/pulls/123/files')
-    printf '%s\n' '[{"filename":"scripts/a.py","status":"modified","patch":"+ Authorization: Bearer abc.def.ghi"}]' ;;
+    printf '%s\n' '[{"filename":"scripts/a.py","status":"modified","patch":"+ Authorization: Bearer abc.def.ghi"}]'
+    printf '%s\n' '[{"filename":"scripts/b.py","status":"added","patch":"+ bounded second page"}]' ;;
   'api --paginate repos/Paddione/Bachelorprojekt/pulls/123/reviews')
-    printf '%s\n' '[{"id":91,"html_url":"https://github.com/x/r/91","state":"APPROVED","body":"use bounded scope","user":{"login":"reviewer-name"}}]' ;;
+    printf '%s\n' '[{"id":91,"html_url":"https://github.com/x/r/91","state":"APPROVED","body":"use bounded scope","user":{"login":"reviewer-name"}}]'
+    printf '%s\n' '[{"id":93,"html_url":"https://github.com/x/r/93","state":"COMMENTED","body":"second page review"}]' ;;
   'api --paginate repos/Paddione/Bachelorprojekt/issues/123/comments')
     printf '%s\n' '[{"id":92,"html_url":"https://github.com/x/c/92","body":"password=hunter2","user":{"login":"commenter-name"}}]' ;;
   *) exit 90 ;;
@@ -157,6 +177,10 @@ SH
   ! grep -Eq 'search|pr list|orgs/' "$GH_LOG"
   ! grep -R -E 'private-user|reviewer-name|commenter-name|a@b.test|hunter2|ghp_' "$state"
   grep -R -q '\[REDACTED:' "$state"
+  grep -R -q 'scripts/b.py' "$state"
+  grep -R -q '"id": 93' "$state"
+  [ "$(find "$state" -type d -printf '%m\n' | sort -u)" = 700 ]
+  [ "$(find "$state" -type f -printf '%m\n' | sort -u)" = 600 ]
 
   run python3 "$EXPERTISE" --repo-root "$repo" --state-dir "$state" stage --repo Paddione/Bachelorprojekt --pr 123 --revision "$sha"
   [ "$status" -eq 0 ]
@@ -175,8 +199,9 @@ SH
   approved="$(find "$repo/docs/brain-expertise/approved" -type f -name '*.md')"
   [ -f "$approved" ]
   grep -q 'source_kind: github-reviewed' "$approved"
-  grep -q "$sha" "$approved"
-  grep -q 'review_ids: \[91\]' "$approved"
+  grep -q "upstream_revision: $sha" "$approved"
+  ! grep -q '^source_revision:' "$approved"
+  grep -q 'review_ids: \[91, 93\]' "$approved"
   run bash "$REPO_ROOT/scripts/brain-ingest-worklist.sh" --root "$repo" --manifest "$REPO_ROOT/scripts/brain/ingest-sources.yaml"
   [ "$status" -eq 0 ]
   [[ "$output" == *$'\tgithub-reviewed'* ]]
@@ -186,4 +211,23 @@ SH
 
   run python3 "$EXPERTISE" --repo-root "$repo" --state-dir "$repo/state" stage --repo Paddione/Bachelorprojekt --pr 123 --revision "$sha"
   [ "$status" -eq 2 ]
+
+  run python3 "$EXPERTISE" --repo-root "$repo" --state-dir "$state" fetch --repo ../Bachelorprojekt --pr 123 --revision "$sha"
+  [ "$status" -eq 2 ]
+
+  local compiled="$BATS_TEST_TMPDIR/compiled.md" local_hash response
+  local_hash="$(sha256sum "$approved" | awk '{print $1}')"
+  printf '%s\n' '---' 'type: note' 'tags: [github-reviewed, expertise]' 'status: active' '---' 'bounded expertise evidence' \
+    | python3 "$METADATA" --source "$approved" --source-kind github-reviewed \
+        --upstream-revision "$sha" --observed-at 2026-08-19T12:00:00Z --valid-from 2026-08-19 > "$compiled"
+  grep -q "source_revision: \"$local_hash\"" "$compiled"
+  grep -q "upstream_revision: \"$sha\"" "$compiled"
+  mkdir -p "$BATS_TEST_TMPDIR/retrieval-wiki"
+  cp "$compiled" "$BATS_TEST_TMPDIR/retrieval-wiki/reviewed.md"
+  response="$(BRAIN_WIKI_DIR="$BATS_TEST_TMPDIR/retrieval-wiki" python3 "$REPO_ROOT/scripts/brain-mcp-server.py" <<'EOF'
+{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"brain_search","arguments":{"query":"bounded expertise","source_kind":"github-reviewed"}}}
+EOF
+)"
+  [[ "$response" == *"$local_hash"* ]]
+  [[ "$response" == *"$sha"* ]]
 }

--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -188,6 +188,45 @@ EOF
   }
 }
 
+@test "multi-chunk parent group and index MOCs receive deterministic lifecycle metadata" {
+  local source_root="$WORK/source-root" brain="$WORK/brain" chunks="$WORK/chunks.tsv"
+  local state="$WORK/state.json" observed="2026-08-19T12:00:00Z"
+  mkdir -p "$source_root/openspec/specs" "$source_root/scripts/brain" "$brain/wiki"
+  printf 'authoritative multi chunk source\n' > "$source_root/openspec/specs/example.md"
+  cp "$MANIFEST" "$source_root/scripts/brain/ingest-sources.yaml"
+  cat > "$WORK/parent-moc.md" <<'EOF'
+---
+type: moc
+tags: [example, moc]
+status: active
+---
+# Example MOC
+- [[example-part-1]]
+- [[example-part-2]]
+EOF
+  printf '%s\n' '# part one' > "$brain/wiki/example-part-1.md"
+  printf '%s\n' '# part two' > "$brain/wiki/example-part-2.md"
+  printf 'openspec/specs/example.md\t%s\texample\t0\tMap of Content\n' "$WORK/parent-moc.md" > "$chunks"
+  cat > "$state" <<'EOF'
+{"openspec/specs/example.md#1":{"slug":"example-part-1","type":"note"},"openspec/specs/example.md#2":{"slug":"example-part-2","type":"note"}}
+EOF
+
+  run bash "$MOC" --brain-repo "$brain" --chunks "$chunks" --state "$state" \
+    --source-root "$source_root" --manifest "$source_root/scripts/brain/ingest-sources.yaml" \
+    --metadata-script "$REPO_ROOT/scripts/brain-page-metadata.py" \
+    --observed-at "$observed" --valid-from 2026-08-19
+  [ "$status" -eq 0 ]
+
+  local source_hash manifest_hash
+  source_hash="$(sha256sum "$source_root/openspec/specs/example.md" | awk '{print $1}')"
+  manifest_hash="$(sha256sum "$source_root/scripts/brain/ingest-sources.yaml" | awk '{print $1}')"
+  grep -q "source_kind: \"openspec\"" "$brain/wiki/example.md"
+  grep -q "source_revision: \"$source_hash\"" "$brain/wiki/example.md"
+  grep -q "observed_at: \"$observed\"" "$brain/wiki/example.md"
+  grep -q "source_revision: \"$manifest_hash\"" "$brain/wiki/ssot-specs-moc.md"
+  grep -q "source_revision: \"$manifest_hash\"" "$brain/index.md"
+}
+
 # --- Type mapping tests ---
 
 @test "type_map overrides take precedence over defaults" {
@@ -288,8 +327,11 @@ YAML
   # The loop moved from brain-ingest.sh to brain-ingest-moc.sh with the Phase 2b
   # extraction (T002679). What T001884 guards is that the two groups are covered,
   # not which file happens to hold the loop — so the assertion follows the code.
-  grep -q 'for group in ssot-specs runbooks adr gotchas-footguns agent-guide-maps core-docs health-goals diagrams; do' \
-    "$MOC" || { echo "FAIL: Phase 2b loop not extended with new groups"; return 1; }
+  local loop
+  loop="$(grep '^for group in ' "$MOC")"
+  for group in ssot-specs runbooks adr gotchas-footguns agent-guide-maps core-docs health-goals diagrams github-reviewed; do
+    [[ "$loop" == *"$group"* ]] || { echo "FAIL: Phase 2b loop missing $group"; return 1; }
+  done
   # Positiv-Anker: brain-ingest.sh must still reach that loop, otherwise the
   # groups would be covered in a script nobody calls.
   grep -q 'brain-ingest-moc.sh' "$INGEST" \

--- a/tests/spec/brain-k4-brain-wiki/retrieval-eval.bats
+++ b/tests/spec/brain-k4-brain-wiki/retrieval-eval.bats
@@ -81,3 +81,21 @@ PY
   run python3 "$RUNNER" --wiki-dir "$WIKI" --eval-set "$evalset" --format json
   [ "$status" -eq 2 ]
 }
+
+@test "aggregate recall uses raw zero and one-third values before output rounding" {
+  local evalset="$BATS_TEST_TMPDIR/fractional.jsonl" json
+  cat > "$evalset" <<'EOF'
+{"id":"one-third","query":"alpha banana","relevant_slugs":["alpha","missing-a","missing-b"],"top_k":1}
+{"id":"zero","query":"does-not-exist","relevant_slugs":["alpha"],"top_k":1}
+EOF
+  run python3 "$RUNNER" --wiki-dir "$WIKI" --eval-set "$evalset" --format json
+  [ "$status" -eq 0 ]
+  json="$output"
+  python3 - "$json" <<'PY'
+import json, sys
+d = json.loads(sys.argv[1])
+assert d["cases"][0]["recall_at_k"] == 0.333333
+assert d["cases"][1]["recall_at_k"] == 0.0
+assert d["metrics"]["recall_at_k"] == 0.166667
+PY
+}


### PR DESCRIPTION
## Summary
- ensure every generated MOC receives deterministic lifecycle metadata
- preserve immutable GitHub upstream revisions separately from approved artifact hashes
- harden expertise pagination, state permissions, and path containment
- correct raw retrieval metric aggregation and active-only contradiction audits

## Test Plan
- Brain ingest BATS: 25/25
- knowledge lifecycle BATS: 5/5
- Brain MCP BATS: 9/9
- retrieval evaluation BATS: 2/2
- `bash scripts/openspec.sh validate`
- `task freshness:check` (quality: 0 violations)

Follow-up to merged PR #4854.
Closes T012957