### PR TITLE
fix(agents): filter Brain expertise group MOCs [T012958]

### DIFF
--- a/docs/brain-expertise/approved/source-policy.md
+++ b/docs/brain-expertise/approved/source-policy.md
@@ -7,7 +7,10 @@ status: active
 
 Diese Policy ist selbst ein bewusst freigegebenes Dokument der Gruppe `github-reviewed`.
 Sie enthält keine PR-Evidenz; ihre lokale `source_revision` und die Lifecycle-Felder ergänzt
-der allgemeine Brain-Ingest aus dieser Ursprungsdatei.
+der allgemeine Brain-Ingest aus dieser Ursprungsdatei. Die Gruppenzugehörigkeit oder das Tag
+`github-reviewed` allein machen eine Quelle nicht zu einem PR-Artefakt: Nur die vom
+Approval-Schritt geschriebenen Frontmatter-Felder `source_kind`, `repository`, `pull_request`
+und `upstream_revision` kennzeichnen diese unveränderliche Upstream-Provenienz.
 
 Der Pilot verarbeitet ausschließlich ein ausdrücklich genanntes Repository, eine Pull Request
 und deren unveränderliche Head-SHA. Die Bedienfolge lautet:

--- a/openspec/changes/brain-knowledge-lifecycle/design.md
+++ b/openspec/changes/brain-knowledge-lifecycle/design.md
@@ -24,12 +24,13 @@ Seiten erhalten flache, YAML-parserfreundliche Felder:
   `github-reviewed`;
 - `source_revision`: deterministischer Hash der lokalen Quelldatei;
 - optional `upstream_revision`: validierte unveränderliche GitHub-Head-SHA für
-  `github-reviewed`-Artefakte;
+  PR-abgeleitete `github-reviewed`-Artefakte; lokale Policies derselben Manifest-Gruppe
+  bleiben ausschließlich über ihren lokalen Hash verankert;
 - `observed_at`: ISO-8601-Zeitpunkt der Quellenbeobachtung;
 - `valid_from`: ISO-Datum oder Zeitpunkt, ab dem der Inhalt gilt;
 - optional `valid_until` und `superseded_by`.
 
-Beim Kompilieren eines reviewed-Artefakts bleibt `upstream_revision` erhalten, während
+Beim Kompilieren eines PR-abgeleiteten reviewed-Artefakts bleibt `upstream_revision` erhalten, während
 `source_revision` deterministisch die Bytes des lokalen approved-Artefakts bezeichnet.
 
 Alte Seiten ohne diese Felder bleiben lesbar. Zeitintervalle sind halboffen

--- a/openspec/changes/brain-knowledge-lifecycle/specs/brain-foundation.md
+++ b/openspec/changes/brain-knowledge-lifecycle/specs/brain-foundation.md
@@ -4,10 +4,12 @@
 
 The Brain ingest pipeline SHALL add deterministic, flat provenance metadata to newly compiled
 pages: `source_kind`, `source_revision`, `observed_at`, and `valid_from`. It MAY add
-`valid_until`, `superseded_by`, and `upstream_revision`. For `github-reviewed` sources,
-`source_revision` SHALL identify the approved local artifact bytes while `upstream_revision`
-SHALL retain the validated immutable GitHub head SHA. Existing pages without these fields SHALL remain valid and
-readable. When `valid_until` is present, the validity interval SHALL be interpreted as half-open:
+`valid_until`, `superseded_by`, and `upstream_revision`. For PR-derived approved artifacts in
+the `github-reviewed` group, `source_revision` SHALL identify the approved local artifact bytes
+while `upstream_revision` SHALL retain the validated immutable GitHub head SHA. Local policy
+documents in that group SHALL use only their local `source_revision` and SHALL NOT fabricate an
+upstream revision. Existing pages without these fields SHALL remain valid and readable. When
+`valid_until` is present, the validity interval SHALL be interpreted as half-open:
 `valid_from <= as_of < valid_until`.
 
 #### Scenario: New pages receive deterministic provenance
@@ -23,6 +25,13 @@ readable. When `valid_until` is present, the validity interval SHALL be interpre
 - **WHEN** the pipeline compiles it into a Brain page
 - **THEN** `source_revision` is the SHA-256 of the approved local artifact
 - **AND** `upstream_revision` remains the validated GitHub head SHA
+
+#### Scenario: Local review policy remains locally sourced
+
+- **GIVEN** a local policy document in the `github-reviewed` manifest group with no PR provenance
+- **WHEN** the pipeline compiles it into a Brain page and audits the result
+- **THEN** `source_revision` is derived from the local policy bytes
+- **AND** no `upstream_revision` is required or fabricated
 
 #### Scenario: Legacy pages remain compatible
 

--- a/scripts/brain-ingest-moc.sh
+++ b/scripts/brain-ingest-moc.sh
@@ -50,6 +50,8 @@ done
 
 # shellcheck source=./brain-group-match.sh
 source "$(dirname "${BASH_SOURCE[0]}")/brain-group-match.sh"
+# shellcheck source=./brain-source-provenance.sh
+source "$(dirname "${BASH_SOURCE[0]}")/brain-source-provenance.sh"
 brain_group_section_for_manifest "$MANIFEST"
 GROUPS_SECTION="$_BRAIN_GROUP_SECTION"
 
@@ -70,16 +72,25 @@ source_kind_for_group() {
 
 write_moc() {
   local content="$1" destination="$2" source_file="$3" source_kind="$4"
-  local temporary upstream_revision
+  local temporary upstream_revision reviewed_marker reviewed_repo reviewed_pr
   local -a metadata_args
   [ -f "$source_file" ] || { echo "error: MOC source missing: $source_file" >&2; return 1; }
   temporary="$(mktemp "$(dirname "$destination")/.moc.XXXXXX")"
   metadata_args=(--source "$source_file" --source-kind "$source_kind" \
     --observed-at "$OBSERVED_AT" --valid-from "$VALID_FROM")
   if [ "$source_kind" = github-reviewed ]; then
-    upstream_revision="$(awk -F': *' '/^upstream_revision:/{print $2; exit}' "$source_file" | tr -d "\"'")"
-    [ -n "$upstream_revision" ] || { rm -f "$temporary"; echo "error: reviewed source lacks upstream_revision" >&2; return 1; }
-    metadata_args+=(--upstream-revision "$upstream_revision")
+    reviewed_marker="$(brain_source_frontmatter_value "$source_file" source_kind || true)"
+    reviewed_repo="$(brain_source_frontmatter_value "$source_file" repository || true)"
+    reviewed_pr="$(brain_source_frontmatter_value "$source_file" pull_request || true)"
+    if [ "$reviewed_marker" = github-reviewed ] || [ -n "$reviewed_repo" ] || [ -n "$reviewed_pr" ]; then
+      upstream_revision="$(brain_source_frontmatter_value "$source_file" upstream_revision || true)"
+      [ -n "$upstream_revision" ] || {
+        rm -f "$temporary"
+        echo "error: PR-derived source lacks frontmatter upstream_revision" >&2
+        return 1
+      }
+      metadata_args+=(--upstream-revision "$upstream_revision")
+    fi
   fi
   if ! printf '%s' "$content" | python3 "$METADATA_SCRIPT" "${metadata_args[@]}" > "$temporary"; then
     rm -f "$temporary"
@@ -115,15 +126,16 @@ while IFS=$'\t' read -r src_path chunk_file chunk_slug idx heading; do
     echo "error: no manifest group for parent MOC source: $src_path" >&2
     exit 1
   }
-  source_kind="$(source_kind_for_group "$_BRAIN_GROUP_OUT")" || exit 1
+  parent_group="$_BRAIN_GROUP_OUT"
+  source_kind="$(source_kind_for_group "$parent_group")" || exit 1
   write_moc "$filtered" "$moc_dest" "$SOURCE_ROOT/$src_path" "$source_kind"
 
   # Write state entry for the MOC
   (
     flock -x 200
     tmp="$(mktemp)"
-    jq --arg k "${src_path}#moc" --arg s "$moc_slug" \
-      '.[$k] = {slug:$s, type:"moc", transformed_at:(now | todate)}' \
+    jq --arg k "${src_path}#moc" --arg s "$moc_slug" --arg g "$parent_group" \
+      '.[$k] = {slug:$s, type:"moc", group:$g, transformed_at:(now | todate)}' \
       "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
   ) 200>"$STATE_FILE.lock"
 
@@ -133,18 +145,31 @@ echo "Parent MOCs: $moc_count"
 
 # ── Generate sub-MOCs per group ──────────────────────────────────────────
 for group in ssot-specs runbooks adr gotchas-footguns agent-guide-maps core-docs health-goals diagrams github-reviewed; do
-  pages="$(jq -r --arg g "$group" '
-    to_entries[] |
+  pages=""
+  while IFS=$'\t' read -r page_slug page_path stored_group; do
+    [ -n "$page_slug" ] || continue
+    page_group="$stored_group"
+    if [ -z "$page_group" ] || [ "$page_group" = null ]; then
+      source_path="${page_path%%#*}"
+      brain_group_for "$source_path" "$GROUPS_SECTION" || continue
+      page_group="$_BRAIN_GROUP_OUT"
+    fi
+    [ "$page_group" = "$group" ] || continue
+    pages+="${page_slug}"$'\t'"${page_path}"$'\n'
+  done < <(jq -r '
+    to_entries | sort_by(.key)[] |
     select(.value.type != null) |
     select(.key | startswith("openspec/") or startswith("docs/") or startswith("CLAUDE") or startswith("AGENTS")) |
-    "\(.value.slug)\t\(.key)"
-  ' "$STATE_FILE" 2>/dev/null || echo "")"
+    "\(.value.slug)\t\(.key)\t\(.value.group // "")"
+  ' "$STATE_FILE" 2>/dev/null || echo "")
 
   if [ -z "$pages" ]; then
+    rm -f "$BRAIN_REPO/wiki/${group}-moc.md"
     continue
   fi
 
-  page_count="$(echo "$pages" | wc -l)"
+  pages="${pages%$'\n'}"
+  page_count="$(printf '%s\n' "$pages" | wc -l)"
 
   moc_content="---
 type: moc

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -34,6 +34,8 @@ METADATA_SCRIPT="$HERE/brain-page-metadata.py"
 
 # shellcheck source=./brain-group-match.sh
 source "$HERE/brain-group-match.sh"
+# shellcheck source=./brain-source-provenance.sh
+source "$HERE/brain-source-provenance.sh"
 # shellcheck source=./brain-ingest-reset.sh
 source "$RESET_HELPERS"
 
@@ -261,7 +263,7 @@ source_kind_for_group() {
 process_page() {
   local src_path="$1" chunk_file="$2" chunk_slug="$3" index="$4"
   local src_hash existing_hash type tag_defaults transformed group tmp chunk_chars
-  local src_file source_kind target_tmp upstream_revision
+  local src_file source_kind target_tmp upstream_revision reviewed_marker reviewed_repo reviewed_pr
   local -a metadata_args
 
   [ -f "$chunk_file" ] || { echo "WARN: chunk not found: $chunk_file ($src_path)" >&2; return 1; }
@@ -311,13 +313,18 @@ process_page() {
   metadata_args=(--source "$src_file" --source-kind "$source_kind" \
     --observed-at "$OBSERVED_AT" --valid-from "$VALID_FROM")
   if [ "$source_kind" = "github-reviewed" ]; then
-    upstream_revision="$(awk -F': *' '/^upstream_revision:/{print $2; exit}' "$src_file" | tr -d "\"'")"
-    [ -n "$upstream_revision" ] || {
-      rm -f "$target_tmp"
-      echo "WARN: Missing upstream_revision: $src_path chunk $index" >&2
-      return 1
-    }
-    metadata_args+=(--upstream-revision "$upstream_revision")
+    reviewed_marker="$(brain_source_frontmatter_value "$src_file" source_kind || true)"
+    reviewed_repo="$(brain_source_frontmatter_value "$src_file" repository || true)"
+    reviewed_pr="$(brain_source_frontmatter_value "$src_file" pull_request || true)"
+    if [ "$reviewed_marker" = "github-reviewed" ] || [ -n "$reviewed_repo" ] || [ -n "$reviewed_pr" ]; then
+      upstream_revision="$(brain_source_frontmatter_value "$src_file" upstream_revision || true)"
+      [ -n "$upstream_revision" ] || {
+        rm -f "$target_tmp"
+        echo "WARN: PR-derived source missing frontmatter upstream_revision: $src_path chunk $index" >&2
+        return 1
+      }
+      metadata_args+=(--upstream-revision "$upstream_revision")
+    fi
   fi
   if ! printf '%s\n' "$transformed" | python3 "$METADATA_SCRIPT" "${metadata_args[@]}" > "$target_tmp"; then
     rm -f "$target_tmp"
@@ -329,9 +336,9 @@ process_page() {
   (
     flock -x 200
     tmp="$(mktemp)"
-    jq --arg k "$state_key" --arg h "$src_hash" --arg s "$chunk_slug" --arg t "$type" \
+    jq --arg k "$state_key" --arg h "$src_hash" --arg s "$chunk_slug" --arg t "$type" --arg g "$group" \
       --arg ci "$index" --argjson cc "$chunk_chars" \
-      '.[$k] = {hash:$h, slug:$s, type:$t, chunk_index:$ci, chars:$cc, transformed_at:(now | todate)}' \
+      '.[$k] = {hash:$h, slug:$s, type:$t, group:$g, chunk_index:$ci, chars:$cc, transformed_at:(now | todate)}' \
       "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
   ) 200>"$STATE_FILE.lock"
   return 0

--- a/scripts/brain-lifecycle-audit.py
+++ b/scripts/brain-lifecycle-audit.py
@@ -139,10 +139,8 @@ def collect_findings(pages: list[PageRecord], source_root: Path, as_of: datetime
     root = source_root.resolve()
     for page in pages:
         missing = [key for key in REQUIRED_LIFECYCLE if not page.metadata.get(key)]
-        if page.metadata.get("source_kind") == "github-reviewed" and not page.metadata.get("upstream_revision"):
-            missing.append("upstream_revision")
-        if missing:
-            findings.append({"code": "metadata_unknown", "slug": page.slug, "missing": missing})
+        requires_upstream = bool(page.metadata.get("repository") or page.metadata.get("pull_request"))
+        source_upstream: str | None = None
         if page.valid_from is not None and page.valid_until is not None and page.valid_until <= page.valid_from:
             findings.append({"code": "invalid_interval", "slug": page.slug,
                              "valid_from": page.metadata.get("valid_from"),
@@ -166,12 +164,30 @@ def collect_findings(pages: list[PageRecord], source_root: Path, as_of: datetime
                 findings.append({"code": "source_unavailable", "slug": page.slug,
                                  "source_path": page.source_path})
                 continue
+            if page.metadata.get("source_kind") == "github-reviewed":
+                source_metadata, _ = _frontmatter(candidate.read_text(encoding="utf-8"))
+                source_is_pr = (
+                    source_metadata.get("source_kind") == "github-reviewed"
+                    or bool(source_metadata.get("repository"))
+                    or bool(source_metadata.get("pull_request"))
+                )
+                if source_is_pr:
+                    requires_upstream = True
+                    source_upstream = str(source_metadata.get("upstream_revision", ""))
             current = _hash(candidate)
             recorded = str(page.metadata.get("source_revision", ""))
             if recorded and recorded != current:
                 findings.append({"code": "stale_source", "slug": page.slug,
                                  "source_path": page.source_path,
                                  "recorded_revision": recorded, "current_revision": current})
+        upstream = page.metadata.get("upstream_revision")
+        if requires_upstream and not upstream:
+            missing.append("upstream_revision")
+        if source_upstream and upstream and str(upstream) != source_upstream:
+            findings.append({"code": "upstream_revision_mismatch", "slug": page.slug,
+                             "recorded_revision": upstream, "source_revision": source_upstream})
+        if missing:
+            findings.append({"code": "metadata_unknown", "slug": page.slug, "missing": missing})
     claims: dict[str, list[tuple[PageRecord, str]]] = {}
     for page in pages:
         if page.metadata.get("status") != "active":

--- a/scripts/brain-source-provenance.sh
+++ b/scripts/brain-source-provenance.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared, frontmatter-only provenance parsing for Brain ingest sources.
+# Source bodies are untrusted prose: a body line that merely mentions an
+# upstream revision must never become lifecycle metadata.
+
+brain_source_frontmatter_value() {
+  local file="$1" wanted="$2" line value first=1
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$first" -eq 1 ]; then
+      [ "$line" = "---" ] || return 1
+      first=0
+      continue
+    fi
+    [ "$line" = "---" ] && return 1
+    case "$line" in
+      "$wanted":*)
+        value="${line#*:}"
+        value="${value#"${value%%[![:space:]]*}"}"
+        value="${value%"${value##*[![:space:]]}"}"
+        value="${value#\"}"; value="${value%\"}"
+        value="${value#\'}"; value="${value%\'}"
+        printf '%s\n' "$value"
+        return 0
+        ;;
+    esac
+  done < "$file"
+  return 1
+}

--- a/templates/brain/SCHEMA.md
+++ b/templates/brain/SCHEMA.md
@@ -40,10 +40,12 @@ Feldern — `raw/` und `README.md` sind vom Frontmatter-Lint ausgenommen:
 
 Neu kompilierte Seiten tragen zusätzlich die flachen Felder `source_kind`,
 `source_revision`, `observed_at` und `valid_from`, optional auch `valid_until` und
-`superseded_by`. `github-reviewed`-Seiten tragen zusätzlich `upstream_revision`: die validierte
-GitHub-Head-SHA bleibt dort getrennt von `source_revision`, dem SHA-256 des lokalen approved-
-Artefakts. Legacy-Seiten nur mit `type`, `tags` und `status` bleiben gültig;
-Lifecycle-Werkzeuge melden ihre zeitliche Einordnung als unbekannt, statt Werte zu erfinden.
+`superseded_by`. PR-abgeleitete `github-reviewed`-Seiten tragen zusätzlich
+`upstream_revision`: die validierte GitHub-Head-SHA bleibt dort getrennt von
+`source_revision`, dem SHA-256 des lokalen approved-Artefakts. Lokale Policies in derselben
+Manifest-Gruppe haben keine Upstream-SHA und werden ausschließlich lokal gehasht. Legacy-Seiten
+nur mit `type`, `tags` und `status` bleiben gültig; Lifecycle-Werkzeuge melden ihre zeitliche
+Einordnung als unbekannt, statt Werte zu erfinden.
 
 `source_kind` ist einer von `openspec`, `runbook`, `adr`, `gotcha`, `agent-guide`,
 `core-doc`, `health-goal`, `diagram` oder `github-reviewed`. `source_revision` ist bei

--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -191,8 +191,10 @@ EOF
 @test "multi-chunk parent group and index MOCs receive deterministic lifecycle metadata" {
   local source_root="$WORK/source-root" brain="$WORK/brain" chunks="$WORK/chunks.tsv"
   local state="$WORK/state.json" observed="2026-08-19T12:00:00Z"
-  mkdir -p "$source_root/openspec/specs" "$source_root/scripts/brain" "$brain/wiki"
+  mkdir -p "$source_root/openspec/specs" "$source_root/docs/runbooks" \
+    "$source_root/scripts/brain" "$brain/wiki"
   printf 'authoritative multi chunk source\n' > "$source_root/openspec/specs/example.md"
+  printf 'authoritative runbook source\n' > "$source_root/docs/runbooks/guide.md"
   cp "$MANIFEST" "$source_root/scripts/brain/ingest-sources.yaml"
   cat > "$WORK/parent-moc.md" <<'EOF'
 ---
@@ -206,9 +208,10 @@ status: active
 EOF
   printf '%s\n' '# part one' > "$brain/wiki/example-part-1.md"
   printf '%s\n' '# part two' > "$brain/wiki/example-part-2.md"
+  printf '%s\n' '# runbook' > "$brain/wiki/runbook-guide.md"
   printf 'openspec/specs/example.md\t%s\texample\t0\tMap of Content\n' "$WORK/parent-moc.md" > "$chunks"
   cat > "$state" <<'EOF'
-{"openspec/specs/example.md#1":{"slug":"example-part-1","type":"note"},"openspec/specs/example.md#2":{"slug":"example-part-2","type":"note"}}
+{"openspec/specs/example.md#1":{"slug":"example-part-1","type":"note"},"openspec/specs/example.md#2":{"slug":"example-part-2","type":"note"},"docs/runbooks/guide.md#1":{"slug":"runbook-guide","type":"runbook"}}
 EOF
 
   run bash "$MOC" --brain-repo "$brain" --chunks "$chunks" --state "$state" \
@@ -225,6 +228,100 @@ EOF
   grep -q "observed_at: \"$observed\"" "$brain/wiki/example.md"
   grep -q "source_revision: \"$manifest_hash\"" "$brain/wiki/ssot-specs-moc.md"
   grep -q "source_revision: \"$manifest_hash\"" "$brain/index.md"
+  grep -q '\[\[example-part-1\]\]' "$brain/wiki/ssot-specs-moc.md"
+  grep -q '\[\[example-part-2\]\]' "$brain/wiki/ssot-specs-moc.md"
+  ! grep -q '\[\[runbook-guide\]\]' "$brain/wiki/ssot-specs-moc.md"
+  grep -q '\[\[runbook-guide\]\]' "$brain/wiki/runbooks-moc.md"
+  ! grep -q '\[\[example-part-' "$brain/wiki/runbooks-moc.md"
+  [ ! -e "$brain/wiki/github-reviewed-moc.md" ]
+}
+
+@test "local github-reviewed policy completes normal and parent-MOC ingest without upstream provenance" {
+  local source_root="$WORK/source-root" brain="$WORK/brain" fake_bin="$WORK/bin"
+  local state="$WORK/state.json" observed="2026-08-19T12:00:00Z"
+  mkdir -p "$source_root/scripts/brain" "$source_root/docs/brain-expertise/approved" \
+    "$brain/wiki" "$brain/scripts" "$fake_bin"
+  for script in brain-ingest.sh brain-ingest-transform.sh brain-chunk.sh brain-ingest-reset.sh \
+    brain-group-match.sh brain-source-provenance.sh brain-ingest-worklist.sh \
+    brain-page-metadata.py brain-ingest-moc.sh brain-ingest-prune.sh brain-ingest-coverage.sh; do
+    cp "$REPO_ROOT/scripts/$script" "$source_root/scripts/$script"
+  done
+  cp "$REPO_ROOT/docs/brain-expertise/approved/source-policy.md" \
+    "$source_root/docs/brain-expertise/approved/source-policy.md"
+  printf '\nupstream_revision: ffffffffffffffffffffffffffffffffffffffff\n' \
+    >> "$source_root/docs/brain-expertise/approved/source-policy.md"
+  cat > "$source_root/docs/brain-expertise/approved/paddione-example-pr-7.md" <<'EOF'
+---
+type: note
+tags: [github-reviewed, expertise]
+status: active
+source_kind: github-reviewed
+upstream_revision: 0123456789abcdef0123456789abcdef01234567
+repository: Paddione/example
+pull_request: 7
+source_url: https://github.com/Paddione/example/pull/7
+---
+# Approved PR evidence
+
+Reviewed evidence.
+EOF
+  cat > "$source_root/scripts/brain/ingest-sources.yaml" <<'YAML'
+exclude: []
+groups:
+  github-reviewed: docs/brain-expertise/approved/*.md
+type_map:
+  defaults:
+    github-reviewed: note
+  overrides: []
+tag_defaults:
+  github-reviewed: [github-reviewed, expertise]
+YAML
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+content="$(printf '%s\n' '---' 'type: note' 'tags: [github-reviewed, expertise]' \
+  'status: active' '---' '# Reviewed source' '' \
+  "source:: Bachelorprojekt ${BRAIN_SOURCE_PATH:?}" '' 'See [[index-moc]].')"
+jq -n --arg content "$content" '{choices:[{message:{content:$content}}]}'
+SH
+  chmod +x "$fake_bin/curl"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$brain/scripts/lint-frontmatter.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$brain/scripts/lint-wikilinks.sh"
+  chmod +x "$brain/scripts/lint-frontmatter.sh" "$brain/scripts/lint-wikilinks.sh"
+  git -C "$brain" init -q -b main
+  git -C "$brain" config user.email test@test
+  git -C "$brain" config user.name test
+  printf '# fixture brain\n' > "$brain/README.md"
+  git -C "$brain" add README.md scripts
+  git -C "$brain" commit -q -m init
+
+  run env PATH="$fake_bin:$PATH" LM_STUDIO_URL=http://fixture.invalid LM_MODEL=fixture \
+    MAX_PARALLEL=1 BRAIN_CHUNK_TARGET_CHARS=800 BRAIN_OBSERVED_AT="$observed" \
+    bash "$source_root/scripts/brain-ingest.sh" --brain-repo "$brain" --state "$state" --dry-run
+  [ "$status" -eq 0 ]
+
+  local policy_hash policy_pages approved_hash approved_pages
+  policy_hash="$(sha256sum "$source_root/docs/brain-expertise/approved/source-policy.md" | awk '{print $1}')"
+  policy_pages="$(find "$brain/wiki" -maxdepth 1 -type f -name 'docs-brain-expertise-approved-source-policy*.md' -print)"
+  [ -n "$policy_pages" ]
+  while IFS= read -r page; do
+    grep -q 'source_kind: "github-reviewed"' "$page"
+    grep -q "source_revision: \"$policy_hash\"" "$page"
+    ! grep -q '^upstream_revision:' "$page"
+  done <<< "$policy_pages"
+  approved_hash="$(sha256sum "$source_root/docs/brain-expertise/approved/paddione-example-pr-7.md" | awk '{print $1}')"
+  approved_pages="$(find "$brain/wiki" -maxdepth 1 -type f -name 'docs-brain-expertise-approved-paddione-example-pr-7*.md' -print)"
+  [ -n "$approved_pages" ]
+  while IFS= read -r page; do
+    grep -q "source_revision: \"$approved_hash\"" "$page"
+    grep -q 'upstream_revision: "0123456789abcdef0123456789abcdef01234567"' "$page"
+  done <<< "$approved_pages"
+  grep -q '\[\[docs-brain-expertise-approved-source-policy-' "$brain/wiki/github-reviewed-moc.md"
+  grep -q '\[\[docs-brain-expertise-approved-paddione-example-pr-7-' "$brain/wiki/github-reviewed-moc.md"
+
+  run python3 "$REPO_ROOT/scripts/brain-lifecycle-audit.py" --brain-repo "$brain" \
+    --source-root "$source_root" --as-of "$observed" --format json
+  [ "$status" -eq 0 ]
+  [ "$(jq -r '.summary.finding_count' <<< "$output")" -eq 0 ]
 }
 
 # --- Type mapping tests ---


### PR DESCRIPTION
## Summary
- treat the local approved-source policy separately from PR-derived expertise provenance
- persist exact manifest groups and generate group MOCs from only their own pages
- skip empty groups instead of emitting misleading empty or global MOCs

## Test Plan
- focused Brain BATS: 42/42
- `task test:changed`: 758/758 unit, 104/104 selected spec, 23/23 OpenSpec Vitest, 52/52 quality
- `bash scripts/openspec.sh validate`
- `task freshness:check`
- shell syntax and Python compilation

Follow-up to merged PRs #4854 and #4856.
Closes T012958