### PR TITLE
fix(agents): derive Brain MOCs from current manifest [T012959]

### DIFF
--- a/scripts/brain-ingest-moc.sh
+++ b/scripts/brain-ingest-moc.sh
@@ -146,21 +146,17 @@ echo "Parent MOCs: $moc_count"
 # ── Generate sub-MOCs per group ──────────────────────────────────────────
 for group in ssot-specs runbooks adr gotchas-footguns agent-guide-maps core-docs health-goals diagrams github-reviewed; do
   pages=""
-  while IFS=$'\t' read -r page_slug page_path stored_group; do
+  while IFS=$'\t' read -r page_slug page_path; do
     [ -n "$page_slug" ] || continue
-    page_group="$stored_group"
-    if [ -z "$page_group" ] || [ "$page_group" = null ]; then
-      source_path="${page_path%%#*}"
-      brain_group_for "$source_path" "$GROUPS_SECTION" || continue
-      page_group="$_BRAIN_GROUP_OUT"
-    fi
-    [ "$page_group" = "$group" ] || continue
+    source_path="${page_path%%#*}"
+    brain_group_for "$source_path" "$GROUPS_SECTION" || continue
+    [ "$_BRAIN_GROUP_OUT" = "$group" ] || continue
     pages+="${page_slug}"$'\t'"${page_path}"$'\n'
   done < <(jq -r '
     to_entries | sort_by(.key)[] |
     select(.value.type != null) |
-    select(.key | startswith("openspec/") or startswith("docs/") or startswith("CLAUDE") or startswith("AGENTS")) |
-    "\(.value.slug)\t\(.key)\t\(.value.group // "")"
+    select(.value.slug != null) |
+    "\(.value.slug)\t\(.key)"
   ' "$STATE_FILE" 2>/dev/null || echo "")
 
   if [ -z "$pages" ]; then

--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -236,6 +236,34 @@ EOF
   [ ! -e "$brain/wiki/github-reviewed-moc.md" ]
 }
 
+@test "group MOCs follow current manifest for dot paths and ignore stale stored groups" {
+  local source_root="$WORK/source-root" brain="$WORK/brain" chunks="$WORK/chunks.tsv"
+  local state="$WORK/state.json" observed="2026-08-19T12:00:00Z"
+  mkdir -p "$source_root/.claude/lib" "$source_root/docs/runbooks" \
+    "$source_root/scripts/brain" "$brain/wiki"
+  printf '# Goals\n' > "$source_root/.claude/lib/goals.md"
+  printf '# Guide\n' > "$source_root/docs/runbooks/guide.md"
+  cp "$MANIFEST" "$source_root/scripts/brain/ingest-sources.yaml"
+  printf '# compiled goals\n' > "$brain/wiki/quality-goals.md"
+  printf '# compiled guide\n' > "$brain/wiki/guide.md"
+  : > "$chunks"
+  cat > "$state" <<'EOF'
+{".claude/lib/goals.md#1":{"slug":"quality-goals","type":"decision","group":"runbooks"},"docs/runbooks/guide.md#1":{"slug":"guide","type":"runbook","group":"health-goals"}}
+EOF
+
+  run bash "$MOC" --brain-repo "$brain" --chunks "$chunks" --state "$state" \
+    --source-root "$source_root" --manifest "$source_root/scripts/brain/ingest-sources.yaml" \
+    --metadata-script "$REPO_ROOT/scripts/brain-page-metadata.py" \
+    --observed-at "$observed" --valid-from 2026-08-19
+  [ "$status" -eq 0 ]
+
+  [ "$(grep -o '\[\[[^]]*\]\]' "$brain/wiki/health-goals-moc.md")" = '[[quality-goals]]' ]
+  grep -q '1 Seiten aus der Gruppe `health-goals`' "$brain/wiki/health-goals-moc.md"
+  [ "$(grep -o '\[\[[^]]*\]\]' "$brain/wiki/runbooks-moc.md")" = '[[guide]]' ]
+  ! grep -q '\[\[guide\]\]' "$brain/wiki/health-goals-moc.md"
+  ! grep -q '\[\[quality-goals\]\]' "$brain/wiki/runbooks-moc.md"
+}
+
 @test "local github-reviewed policy completes normal and parent-MOC ingest without upstream provenance" {
   local source_root="$WORK/source-root" brain="$WORK/brain" fake_bin="$WORK/bin"
   local state="$WORK/state.json" observed="2026-08-19T12:00:00Z"


### PR DESCRIPTION
## Summary
- derive every Brain group MOC from the current ingest manifest rather than stale persisted group values
- include dot-prefixed sources such as `.claude/lib/goals.md` through normal manifest matching
- verify exact membership and manifest-only regrouping with integration fixtures

## Test Plan
- focused Brain suites: 43/43
- changed spec tests: 105/105
- code-quality tests: 52/52
- OpenSpec validation and freshness check

Draft pending independent review.
Closes T012959