### PR TITLE
chore: gitignore deepseek harness T012960

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ unsloth_compiled_cache
 # Nicht mehr committet (T001717) — wird pro Session/Checkout bei Bedarf lokal neu gebaut.
 .codebase-memory/
 
+# ── deepseek-harness: externer Baum im Repo-Root (T012960) ──
+# Kein Submodul, kein eigenes .git — 7.462 Dateien / 1,5 GB, nichts davon getrackt.
+# Ungeignoriert verrauschte es jede status-Ansicht und machte `git add -A` zur Falle.
+/deepseek-harness/
+
 # ── Secrets (niemals committen!) ────────────────
 .env
 .env.*


### PR DESCRIPTION
## Was

`/deepseek-harness/` in die getrackte `.gitignore` aufgenommen (root-verankert).

## Warum

`deepseek-harness/` liegt als externer Baum im Repo-Root: **7.462 ungetrackte Dateien, 1,5 GB**, kein eigenes `.git`, kein Submodul-Eintrag, nicht ignoriert.

`git status` fasste das zu einer `??`-Zeile zusammen, IDEs und `git status -uall` zeigten 7.463 Aenderungen. Belastet hat es Git bisher nicht — es war kein einziges Git-Objekt. Das Risiko lag im naechsten `git add -A`: 1,5 GB waeren irreversibel in die History gewandert, wie es `.codebase-memory/graph.db.zst` (107 Versionen, 1,68 GB von 1,8 GB `.git`) bereits ist.

## MESSUNG (2026-08-19, Commit 774b1e787)

```bash
git status --porcelain -uall | grep -c '^??'                    # 7462
git status --porcelain -uall | awk '$1=="??"{print $2}' | cut -d/ -f1 | sort -u   # deepseek-harness
du -sh deepseek-harness                                          # 1.5G
git ls-tree -r origin/main --name-only | grep -c deepseek-harness # 0
```

## Verifikation

- `git check-ignore -v deepseek-harness/` → `.gitignore:26:/deepseek-harness/`
- 0 getrackte Pfade mit dem Namen → kein `git rm --cached` noetig, nichts faellt aus dem Tracking
- `task test:changed` → 52/52 gruen, networks-check OK
- `task freshness:regenerate` → keine Artefakt-Aenderung; `task freshness:check` → Exit 0
- Diff: genau 1 Datei, 5 Zeilen

Root-verankert (`/deepseek-harness/` statt `deepseek-harness/`), damit gleichnamige Unterverzeichnisse unberuehrt bleiben.