### PR TITLE
chore(infra): delete pvc-backup + tests-results-retention from korczewski overlay [T012964]

### DIFF
--- a/prod-fleet/korczewski/kustomization.yaml
+++ b/prod-fleet/korczewski/kustomization.yaml
@@ -24,3 +24,22 @@ patches:
       kind: Job
       metadata:
         name: any-job
+  # T012964: pvc-backup + tests-results-retention CronJobs cannot work in
+  # workspace-korczewski — nextcloud/website pods are scaled to 0 here.
+  # The mounter job needs podAffinity to app=nextcloud (which only runs in
+  # workspace); tests-results-retention exec's into website-korczewski (empty).
+  # Delete them from the overlay to stop the daily failure noise.
+  - target: { group: batch, version: v1, kind: CronJob, name: pvc-backup }
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: pvc-backup
+  - target: { group: batch, version: v1, kind: CronJob, name: tests-results-retention }
+    patch: |-
+      $patch: delete
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: tests-results-retention


### PR DESCRIPTION
## Problem

pvc-backup and tests-results-retention CronJobs in workspace-korczewski fail every day since weeks.

- **pvc-backup**: mounter job needs podAffinity to app=nextcloud — nextcloud pods are scaled to 0 in korczewski
- **tests-results-retention**: execs into website-korczewski — no website pod exists there

All deployments in workspace-korczewski are scaled to 0/0. The PVCs exist but the workloads that use them do not run.

## Fix

Delete both CronJobs from the korczewski Kustomize overlay via $patch: delete. The mentolder overlay (workspace namespace) keeps working copies unaffected.