### PR TITLE
fix(agents): dsh web UI startet — Klon-Aufloesung, Cordis-apply-API, Laufzeit-Overlay [T012965]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -3270,6 +3270,12 @@
     "kind": "shell"
   },
   {
+    "id": "dsh-harness-integration/taskfile-runtime",
+    "file": "tests/spec/dsh-harness-integration/taskfile-runtime.bats",
+    "category": "dsh-harness-integration",
+    "kind": "shell"
+  },
+  {
     "id": "e2e-skill-selfpatch",
     "file": "tests/local/e2e-skill-selfpatch.bats",
     "category": "e2e-skill-selfpatch",

--- a/scripts/dsh/resolve-clone.sh
+++ b/scripts/dsh/resolve-clone.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# scripts/dsh/resolve-clone.sh — Pfad zum deepseek-harness-Klon ermitteln.
+#
+# [T012965] Der Klon ist gitignoriert (T012960) und liegt deshalb NUR im
+# Haupt-Checkout. In einem Worktree legt scripts/worktree-create.sh lediglich
+# einen `deepseek-harness/node_modules`-Symlink an — ein Verzeichnis ohne
+# package.json. Eine Pruefung auf "node_modules existiert" ist dort wahr und
+# der anschliessende `pnpm` bricht mit ERR_PNPM_NO_PKG_MANIFEST ab.
+#
+# Reihenfolge: $DSH_DIR (Override) > Repo-lokaler Klon > Haupt-Checkout.
+# Ein Kandidat zaehlt nur mit package.json — das unterscheidet den echten Klon
+# vom Symlink-Gerippe.
+#
+# Usage:  clone_dir="$(bash scripts/dsh/resolve-clone.sh "$REPO")"  # Exit 2 wenn keiner
+resolve_dsh_clone() {
+  local repo="$1" candidate common_dir main_checkout
+
+  # Ein explizit gesetztes DSH_DIR ist eine Anweisung, kein Vorschlag: ist es
+  # ungueltig, wird es gemeldet statt still durch einen anderen Klon ersetzt —
+  # sonst startet man unbemerkt den falschen Baum.
+  if [[ -n "${DSH_DIR:-}" ]]; then
+    [[ -f "$DSH_DIR/package.json" ]] && { printf '%s\n' "$DSH_DIR"; return 0; }
+    return 2
+  fi
+
+  candidate="$repo/deepseek-harness"
+  [[ -f "$candidate/package.json" ]] && { printf '%s\n' "$candidate"; return 0; }
+
+  # Worktree: ueber das gemeinsame gitdir zurueck auf den Haupt-Checkout.
+  common_dir="$(git -C "$repo" rev-parse --git-common-dir 2>/dev/null)" || return 2
+  [[ "$common_dir" != /* ]] && common_dir="$repo/$common_dir"
+  main_checkout="$(dirname "$common_dir")"
+  [[ -f "$main_checkout/deepseek-harness/package.json" ]] && {
+    printf '%s\n' "$main_checkout/deepseek-harness"; return 0
+  }
+  return 2
+}
+
+# Direktaufruf: Pfad auf stdout, Exit 2 wenn nicht auffindbar.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if ! resolve_dsh_clone "${1:-$PWD}"; then
+    echo "resolve-clone: no deepseek-harness checkout with a package.json found" >&2
+    echo "  looked at: \${DSH_DIR:-<unset>}, <repo>/deepseek-harness, <main-checkout>/deepseek-harness" >&2
+    exit 2
+  fi
+fi

--- a/scripts/dsh/web-up.sh
+++ b/scripts/dsh/web-up.sh
@@ -1,48 +1,77 @@
 #!/usr/bin/env bash
-# scripts/dsh/web-up.sh — Start the DSH Web UI and register in the Session Hub.
+# scripts/dsh/web-up.sh — Start the DSH Web UI and register it in the Session Hub.
 #
-# Checks that deepseek-harness is built (node_modules + dist), starts the
-# web UI with the repo bundle as overlay, registers in the session hub,
-# and waits for the process to end (reaping the registration on exit).
+# Prueft, dass der Harness-Klon gebaut ist, startet die Web-Oberflaeche mit dem
+# Repo-Bundle als Overlay, registriert die Sitzung im Hub und raeumt den Eintrag
+# beim Beenden wieder ab.
 #
-# Usage: web-up.sh [port]
-# Default port: 3080
+# Usage: web-up.sh [port]        Default: 3080
+#
+# Exit-Codes:
+#   0  Oberflaeche lief und wurde regulaer beendet
+#   2  Klon fehlt oder ist nicht gebaut (Ursache steht in der Meldung)
+#
+# [T012965] Drei Korrekturen gegenueber der ersten Fassung, jede einzeln belegt:
+#   - Der Start laeuft ueber `pnpm dsh` im Klon. `node_modules/.bin/dsh` gibt es
+#     im Workspace nicht (ls => No such file), der Aufruf endete immer mit Exit 2.
+#   - Das Overlay-Flag heisst `--patch`, nicht `--bundle` (`pnpm dsh --help`).
+#     Mit dem falschen Flag waeren Hook-Bridge und Guard-Plugin nicht geladen
+#     gewesen — der Nachweis haette nichts belegt.
+#   - `session-hub.sh register` kennt `--name --port --type --title`, nicht
+#     `--slug`/`--url` (cmd_register in scripts/session-hub.sh).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-DSH_DIR="${DSH_DIR:-$REPO/deepseek-harness}"
 DSH_WEB_PORT="${1:-${DSH_WEB_PORT:-3080}}"
-BUNDLE_DIR="$REPO/tools/dsh"
+PATCH_FILE="$REPO/tools/dsh/cordis.patch.yml"
 
-# --- Check prerequisites -----------------------------------------------------------
+# --- Vorbedingungen ----------------------------------------------------------------
+# [T012965] Der Klon wird aufgeloest, nicht geraten: im Worktree existiert nur ein
+# node_modules-Symlink ohne package.json, und `pnpm` bricht dort mit
+# ERR_PNPM_NO_PKG_MANIFEST ab.
+if ! DSH_DIR="$(bash "$HERE/resolve-clone.sh" "$REPO" 2>/dev/null)"; then
+  echo "web-up: deepseek-harness checkout not built — no clone with a package.json found" >&2
+  echo "  set DSH_DIR, or run: task dsh:dsh:build" >&2
+  exit 2
+fi
 if [[ ! -d "$DSH_DIR/node_modules" ]]; then
   echo "web-up: deepseek-harness not built (node_modules missing). Run:" >&2
-  echo "  cd $DSH_DIR && pnpm install && pnpm run build" >&2
+  echo "  task dsh:dsh:build" >&2
+  exit 2
+fi
+if [[ ! -f "$PATCH_FILE" ]]; then
+  echo "web-up: bundle overlay missing at $PATCH_FILE" >&2
   exit 2
 fi
 
-DSH_BIN="$DSH_DIR/node_modules/.bin/dsh"
-if [[ ! -x "$DSH_BIN" ]]; then
-  echo "web-up: dsh binary not found at $DSH_BIN" >&2
+# --- Laufzeit-Overlay aus der Vorlage bauen -----------------------------------------
+# [T012965] Die eingecheckte Vorlage traegt Platzhalter; die realen Pfade stehen
+# erst hier fest (gitignorierter Klon an maschinenabhaengigem Ort).
+RUNTIME_PATCH="$(mktemp -t dsh-patch-XXXXXX.yml)"
+trap 'rm -f "$RUNTIME_PATCH"' EXIT
+sed -e "s#@@DSH_CLONE@@#${DSH_DIR}#g" -e "s#@@REPO@@#${REPO}#g" "$PATCH_FILE" > "$RUNTIME_PATCH"
+
+if grep -q '@@' "$RUNTIME_PATCH"; then
+  echo "web-up: unresolved placeholder left in the runtime overlay:" >&2
+  grep -n '@@' "$RUNTIME_PATCH" >&2
   exit 2
 fi
 
-# --- Start the web UI with the bundle overlay --------------------------------------
-echo "web-up: starting dsh web UI on port $DSH_WEB_PORT with bundle from $BUNDLE_DIR" >&2
+echo "web-up: starting dsh web UI on port $DSH_WEB_PORT (clone: $DSH_DIR)" >&2
 
-"$DSH_BIN" --profile web --bundle "$BUNDLE_DIR" --port "$DSH_WEB_PORT" &
+( cd "$DSH_DIR" && pnpm dsh --profile web --patch "$RUNTIME_PATCH" --port "$DSH_WEB_PORT" ) &
 DSH_PID=$!
 
-# --- Register in Session Hub -------------------------------------------------------
-HUB_SLUG="dsh-web-${DSH_WEB_PORT}"
+# --- Im Session-Hub registrieren ---------------------------------------------------
+HUB_NAME="dsh-web-${DSH_WEB_PORT}"
+trap 'rm -f "$RUNTIME_PATCH"; bash "$REPO/scripts/session-hub.sh" deregister --name "$HUB_NAME" >/dev/null 2>&1 || true' EXIT
+
 bash "$REPO/scripts/session-hub.sh" register \
-  --slug "$HUB_SLUG" \
+  --name "$HUB_NAME" \
+  --port "$DSH_WEB_PORT" \
   --type "dsh-web" \
   --title "DSH Web UI (port $DSH_WEB_PORT)" \
-  --url "http://127.0.0.1:$DSH_WEB_PORT" \
-  2>/dev/null || true
+  >/dev/null 2>&1 || echo "web-up: session-hub registration skipped" >&2
 
-# --- Wait and reap -----------------------------------------------------------------
-trap "bash '$REPO/scripts/session-hub.sh' deregister --slug '$HUB_SLUG' 2>/dev/null || true" EXIT
 wait "$DSH_PID" || true

--- a/taskfiles/Taskfile.dsh.yml
+++ b/taskfiles/Taskfile.dsh.yml
@@ -1,42 +1,56 @@
 # taskfiles/Taskfile.dsh.yml — DSH build, web, and doctor tasks.
+#
+# [T012965] Pfade gehen ueber {{.ROOT_DIR}}. `{{.ROOT}}` gibt es in go-task nicht:
+# es expandiert leer, und der Klon wurde dann unter `/deepseek-harness` gesucht.
+#
+# Der Harness wird ueber `pnpm dsh` im Klon gestartet, nicht ueber
+# node_modules/.bin/dsh — dieses Bin-Link existiert im Workspace nicht.
 version: "3"
 
 tasks:
   dsh:build:
     desc: "Build deepseek-harness (pnpm install + build)"
-    dir: "{{.ROOT}}/deepseek-harness"
     cmds:
-      - pnpm install --frozen-lockfile 2>/dev/null || pnpm install
-      - pnpm run build
-      - pnpm dsh --version
+      - cd "$(bash {{.ROOT_DIR}}/scripts/dsh/resolve-clone.sh {{.ROOT_DIR}})" && pnpm install --frozen-lockfile 2>/dev/null || pnpm install
+      - cd "$(bash {{.ROOT_DIR}}/scripts/dsh/resolve-clone.sh {{.ROOT_DIR}})" && pnpm run build
+      - cd "$(bash {{.ROOT_DIR}}/scripts/dsh/resolve-clone.sh {{.ROOT_DIR}})" && pnpm dsh --version
 
   dsh:web:
     desc: "Start the DSH Web UI on port 3080"
     vars:
-      DSH_WEB_PORT: "{{.DSH_WEB_PORT | default 3080}}"
+      DSH_WEB_PORT: '{{.DSH_WEB_PORT | default 3080}}'
     cmds:
-      - bash "{{.ROOT}}/scripts/dsh/web-up.sh {{.DSH_WEB_PORT}}"
+      # Pfad und Argument getrennt quoten — zusammen in einem Quote las bash beides
+      # als einen Dateinamen (T012965).
+      - bash "{{.ROOT_DIR}}/scripts/dsh/web-up.sh" {{.DSH_WEB_PORT}}
 
   dsh:doctor:
     desc: "Check DSH prerequisites (clone, build, CLI)"
     cmds:
       - |
         echo "=== DSH Doctor ==="
-        DSH_DIR="{{.ROOT}}/deepseek-harness"
-        if [ ! -d "$DSH_DIR" ]; then
-          echo "❌ deepseek-harness clone not found at $DSH_DIR"
+        if ! DSH_DIR=$(bash "{{.ROOT_DIR}}/scripts/dsh/resolve-clone.sh" "{{.ROOT_DIR}}" 2>/dev/null); then
+          echo "❌ deepseek-harness clone not found (checked \$DSH_DIR, repo, main checkout)"
           exit 1
         fi
-        echo "✅ Clone found"
+        echo "✅ Clone found: $DSH_DIR"
         if [ ! -d "$DSH_DIR/node_modules" ]; then
-          echo "❌ node_modules missing — run: cd deepseek-harness && pnpm install"
+          echo "❌ node_modules missing — run: task dsh:dsh:build"
           exit 1
         fi
         echo "✅ node_modules present"
-        DSH_BIN="$DSH_DIR/node_modules/.bin/dsh"
-        if [ ! -x "$DSH_BIN" ]; then
-          echo "❌ dsh binary not found — run: cd deepseek-harness && pnpm run build"
+        if ! version=$(cd "$DSH_DIR" && pnpm dsh --version 2>/dev/null | tail -1); then
+          echo "❌ dsh CLI did not answer — run: task dsh:dsh:build"
           exit 1
         fi
-        echo "✅ dsh binary found: $("$DSH_BIN" --version 2>/dev/null || echo 'unknown version')"
+        if [ -z "$version" ]; then
+          echo "❌ dsh CLI returned no version — run: task dsh:dsh:build"
+          exit 1
+        fi
+        echo "✅ dsh CLI answers: $version"
+        if [ ! -f "{{.ROOT_DIR}}/tools/dsh/cordis.patch.yml" ]; then
+          echo "❌ bundle overlay missing at tools/dsh/cordis.patch.yml"
+          exit 1
+        fi
+        echo "✅ bundle overlay present"
         echo "=== All checks passed ==="

--- a/tests/spec/dsh-harness-integration/taskfile-runtime.bats
+++ b/tests/spec/dsh-harness-integration/taskfile-runtime.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# T012965 — Laufverhalten der dsh-Tasks, nicht ihre Struktur.
+#
+# Die Guards aus T012962 pruefen, DASS Taskfile.dsh.yml und web-up.sh existieren
+# und die erwarteten Zeichenketten tragen. Genau deshalb ist ein Taskfile gemergt
+# worden, das mit `{{.ROOT}}` eine nicht existierende go-task-Variable benutzt und
+# den Klon unter `/deepseek-harness` sucht. Diese Datei prueft stattdessen, was
+# beim Ausfuehren herauskommt.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+}
+
+@test "dsh:doctor findet den Klon und endet mit Exit 0" {
+  [ -d "$REPO/deepseek-harness/node_modules" ] || skip "deepseek-harness checkout not built"
+
+  run --separate-stderr bash -c "cd '$REPO' && task dsh:dsh:doctor 2>&1"
+  [ "$status" -eq 0 ]
+  # Positiv-Anker: der Lauf muss den Abschluss melden, nicht nur nicht scheitern.
+  [[ "$output" == *"All checks passed"* ]]
+  # Der leere-Variable-Fehler darf nicht zurueckkommen.
+  [[ "$output" != *"not found at /deepseek-harness"* ]]
+}
+
+# Die folgenden drei Faelle greppen den Quelltext — bewusst nur die CODE-Zeilen.
+# Ein Kommentar, der die alte fehlerhafte Form erklaert ("frueher stand hier
+# --bundle"), ist Dokumentation und darf den Guard nicht ausloesen; ein Guard, der
+# das nicht trennt, erzwingt kommentarlosen Code.
+code_lines() { grep -vE '^[[:space:]]*#' "$1"; }
+
+@test "Taskfile.dsh.yml benutzt keine leere Task-Variable" {
+  run bash -c "code_lines() { grep -vE '^[[:space:]]*#' \"\$1\"; }; code_lines '$REPO/taskfiles/Taskfile.dsh.yml' | grep -c '{{\.ROOT}}' || true"
+  [ "$output" -eq 0 ]
+  # Positiv-Anker: die korrekte Variable wird tatsaechlich benutzt.
+  run bash -c "grep -c '{{\.ROOT_DIR}}' '$REPO/taskfiles/Taskfile.dsh.yml'"
+  [ "$output" -ge 1 ]
+}
+
+@test "web-up.sh ruft dsh mit dem existierenden --patch-Overlay auf" {
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/scripts/dsh/web-up.sh' | grep -c -- '--bundle' || true"
+  [ "$output" -eq 0 ]
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/scripts/dsh/web-up.sh' | grep -c -- '--patch' || true"
+  [ "$output" -ge 1 ]
+}
+
+@test "web-up.sh registriert mit den Flags, die session-hub.sh kennt" {
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/scripts/dsh/web-up.sh' | grep -c -- '--slug' || true"
+  [ "$output" -eq 0 ]
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/scripts/dsh/web-up.sh' | grep -c -- '--name' || true"
+  [ "$output" -ge 1 ]
+}
+
+@test "web-up.sh bricht ohne gebauten Klon mit Exit 2 und genannter Ursache ab" {
+  run env DSH_DIR=/nonexistent-dsh-checkout bash "$REPO/scripts/dsh/web-up.sh" 3099
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"not built"* ]] || [[ "$output" == *"nicht gebaut"* ]]
+}
+
+@test "resolve-clone findet den Klon aus einem Worktree heraus" {
+  [ -f "$REPO/../../deepseek-harness/package.json" ] || [ -f "$REPO/deepseek-harness/package.json" ] || skip "no deepseek-harness clone on this host"
+  run bash "$REPO/scripts/dsh/resolve-clone.sh" "$REPO"
+  [ "$status" -eq 0 ]
+  [ -f "$output/package.json" ]
+}
+
+@test "ein ungueltiges DSH_DIR wird gemeldet statt still ersetzt" {
+  run env DSH_DIR=/nonexistent-dsh bash "$REPO/scripts/dsh/resolve-clone.sh" "$REPO"
+  [ "$status" -eq 2 ]
+  [[ "$output" != *"/deepseek-harness"* ]] || [[ "$output" == *"no deepseek-harness checkout"* ]]
+}
+
+@test "Plugins exportieren apply, nicht setup — sonst lehnt Cordis sie ab" {
+  # Beleg: Cordis meldet 'invalid plugin, expect function or object with an
+  # "apply" method'. Mit `setup` wurde KEIN Plugin aus T012962 je geladen.
+  for f in "$REPO"/tools/dsh/plugins/*.mjs "$REPO/tools/dsh/index.js"; do
+    run bash -c "grep -cE '^export (async )?function apply\\(' '$f' || true"
+    [ "$output" -ge 1 ]
+    run bash -c "grep -cE '^export (async )?function setup\\(' '$f' || true"
+    [ "$output" -eq 0 ]
+  done
+}
+
+@test "die Patch-Vorlage traegt Platzhalter, keine unaufloesbaren Paketnamen" {
+  run bash -c "grep -c '@@REPO@@\\|@@DSH_CLONE@@' '$REPO/tools/dsh/cordis.patch.yml'"
+  [ "$output" -ge 1 ]
+  # Der frueher eingecheckte, per Node nicht aufloesbare Kurzname darf weg sein.
+  run bash -c "grep -vE '^[[:space:]]*#' '$REPO/tools/dsh/cordis.patch.yml' | grep -c \"name: dsh-hooks-claude-code\" || true"
+  [ "$output" -eq 0 ]
+}

--- a/tools/dsh/cordis.patch.yml
+++ b/tools/dsh/cordis.patch.yml
@@ -1,10 +1,20 @@
 # cordis.patch.yml — DSH bundle patch layer for Bachelorprojekt.
-# Configures the CC-Hook bridge and the bundle entry point.
+#
+# [T012965] Die Plugin-Rows tragen PLATZHALTER, keine Paketnamen. Grund: weder
+# das Repo-Bundle noch die Hook-Bridge sind ueber Node-Resolution auffindbar —
+# das Bundle ist nicht ins Profil installiert, und die Bridge ist ein
+# Workspace-Paket des gitignorierten Klons (`require.resolve` => MODULE_NOT_FOUND).
+# Cordis akzeptiert in `name:` einen Modulpfad; scripts/dsh/web-up.sh setzt die
+# Platzhalter zur Laufzeit auf die aufgeloesten absoluten Pfade und uebergibt
+# das Ergebnis per `--patch`.
+#
+# Absolute Pfade koennen hier nicht eingecheckt werden: der Klon ist
+# gitignoriert und sein Ort maschinenabhaengig.
 - insert:
     - id: cc-hooks
-      name: dsh-hooks-claude-code
+      name: '@@DSH_CLONE@@/packages/hooks/hooks-claude-code/lib/index.js'
       config:
-        configPath: ./.claude/settings.json
-        projectDir: .
+        configPath: '@@REPO@@/.claude/settings.json'
+        projectDir: '@@REPO@@'
     - id: bachelorprojekt
-      name: dsh-bachelorprojekt
+      name: '@@REPO@@/tools/dsh/index.js'

--- a/tools/dsh/index.js
+++ b/tools/dsh/index.js
@@ -18,7 +18,7 @@ const pluginsDir = join(__dirname, 'plugins')
 
 export const name = 'dsh-bachelorprojekt'
 
-export async function setup(ctx) {
+export async function apply(ctx) {
   let entries
   try {
     entries = await readdir(pluginsDir)
@@ -31,7 +31,7 @@ export async function setup(ctx) {
     if (!entry.endsWith('.mjs')) continue
     try {
       const mod = await import(join(pluginsDir, entry))
-      if (typeof mod.setup === 'function') {
+      if (typeof mod.apply === 'function' || typeof mod === 'function') {
         ctx.plugin(mod)
       }
     } catch (err) {

--- a/tools/dsh/plugins/audit-log.mjs
+++ b/tools/dsh/plugins/audit-log.mjs
@@ -25,7 +25,7 @@ export const name = 'audit-log'
 /**
  * @param {import('@deepseek-ai/cordis').Context} ctx
  */
-export function setup(ctx) {
+export function apply(ctx) {
   const ticketId = process.env.TICKET_ID || ''
   if (!ticketId) {
     // No ticket context — silent no-op. Ad-hoc sessions must not fill the timeline.

--- a/tools/dsh/plugins/repo-guard.mjs
+++ b/tools/dsh/plugins/repo-guard.mjs
@@ -23,7 +23,7 @@ export const name = 'repo-guard'
 /**
  * @param {import('@deepseek-ai/cordis').Context} ctx
  */
-export function setup(ctx) {
+export function apply(ctx) {
   ctx.on('tools/pre-execute', async (exec, next) => {
     // Only intercept write tools.
     if (!WRITE_TOOLS.has(exec.name)) {


### PR DESCRIPTION
## Warum

Der Merge aus T012962 (PR #4867) war grün, weil die Guards **Struktur** prüfen — Dateien existieren, Zeichenketten stehen drin. Der Plan-Schritt p6.5 (Vorführung an der laufenden Oberfläche) lief nie. Beim ersten echten Start fielen zehn Defekte an, die jeden Start verhinderten.

Der schwerste: **kein einziges Plugin aus T012962 konnte je geladen werden.** Cordis verlangt `apply()`, die Module exportierten `setup()` — der Loader lehnt sie ab mit *"invalid plugin, expect function or object with an apply method"*. Guard und Audit-Log liefen also nie.

## Was

| # | Defekt | Fix |
|---|---|---|
| B1 | `{{.ROOT}}` ist keine go-task-Variable, expandierte leer → Klon unter `/deepseek-harness` gesucht | `{{.ROOT_DIR}}` |
| B2 | Pfad + Argument in einem Quote → als ein Dateiname gelesen | getrennt gequotet |
| B3 | `node_modules/.bin/dsh` existiert nicht | Start über `pnpm dsh` |
| B4 | `--bundle` ist kein dsh-Flag | `--patch` (belegt via `pnpm dsh --help`) |
| B5 | `session-hub register` kennt `--slug`/`--url` nicht | `--name/--port/--type/--title` |
| B7 | Klon liegt gitignoriert nur im Haupt-Checkout; im Worktree nur ein `node_modules`-Symlink ohne `package.json` → `ERR_PNPM_NO_PKG_MANIFEST` | `scripts/dsh/resolve-clone.sh` |
| B8 | Paketname `dsh-hooks-claude-code` statt `@deepseek-ai/dsh-hooks-claude-code` | korrigiert |
| B9 | Bundle und Bridge per Node-Resolution nicht auffindbar → `ERR_MODULE_NOT_FOUND` | `cordis.patch.yml` als Vorlage, Platzhalter zur Laufzeit ersetzt |
| B10 | `setup()` statt `apply()` — Plugins nie geladen | in allen drei Modulen korrigiert |

Ein gesetztes `DSH_DIR` ist jetzt **bindend**: ungültig heißt Fehler, nicht stiller Ersatz durch einen anderen Klon.

## Nachweis

```
task dsh:dsh:doctor                  # Exit 0: Klon, node_modules, CLI 0.1.0-rc.7, Overlay
task dsh:dsh:web DSH_WEB_PORT=3083   # Listener 127.0.0.1:3083, HTTP 200
tests/unit/lib/bats-core/bin/bats tests/spec/dsh-harness-integration/ tests/spec/harness-workflow-split/
# 27/27 ok
```

Zusätzlich ein positiver Ladebeleg: ein temporäres `console.error` in `apply()` zeigte `repo-guard` als aufgerufen (danach zurückgenommen). Ohne diesen Beleg hätte "keine Fehler im Log" nichts bewiesen.

Die vier neuen Fälle in `taskfile-runtime.bats` prüfen **Laufverhalten** statt Struktur — der `doctor`-Fall läuft den Task tatsächlich und erwartet Exit 0. Genau dieser Fall hätte B1 sofort gefangen.

## Offen (nicht in diesem PR)

`repo-guard.mjs` vergleicht gegen `process.cwd()` — das Verzeichnis des Harness-Klons, nicht die Sitzungs-cwd (dsh führt `session/new.cwd` je Sitzung). Der Guard prüft damit gegen den falschen Baum: er lehnt Schreibzugriffe ins Repo ab und erlaubt sie in den Klon. Das ist ein inhaltlicher Fehler der Guard-Logik und braucht einen eigenen Vorgang.