### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1136,
+      "file_count": 1137,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -571,6 +571,7 @@
         "tests/spec/dsh-harness-integration/bundle.bats",
         "tests/spec/dsh-harness-integration/executor.bats",
         "tests/spec/dsh-harness-integration/hook-bridge.bats",
+        "tests/spec/dsh-harness-integration/taskfile-runtime.bats",
         "tests/spec/e2e-test-infrastructure.bats",
         "tests/spec/e2e-test-infrastructure/bats-missing-file-exit0.bats",
         "tests/spec/e2e-test-infrastructure/purge-test-data-missing-table.bats",
@@ -3558,7 +3559,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 788,
+      "file_count": 789,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3791,6 +3792,7 @@
         "scripts/docs.Dockerfile",
         "scripts/downloads-index.html",
         "scripts/downloads.Dockerfile",
+        "scripts/dsh/resolve-clone.sh",
         "scripts/dsh/session-audit.sh",
         "scripts/dsh/web-up.sh",
         "scripts/env-generate.sh",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32307095505).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
