### PR TITLE
fix(ops): llama.cpp-Upgrade — get_datetime -> get_info, opencode-Default auf gemma12-vision

### DIFF
--- a/.opencode/agent-models.jsonc
+++ b/.opencode/agent-models.jsonc
@@ -13,7 +13,7 @@
     // und die Fallback-Kette lokal -> deepseek -> zen greift auch hier [T002558].
     "llamacpp-local": {
       "npm": "@ai-sdk/openai-compatible",
-      "name": "llama.cpp b10225 via llm-proxy (Unsloth-Build, CUDA 13.3)",
+      "name": "llama.cpp via llm-proxy (~/opt/llama-current, aktuell Build 61 / 0adcc3bb5)",
       "options": {
         "baseURL": "http://127.0.0.1:18235/v1",
         "timeout": 600000,

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,13 +1,22 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  // Lokales Gemma 4 26B A4B (IT-Quant, IQ4_XS) als Standard [T012409]. Es ist das
-  // einzige Modell, das das Gateway auf :18235 listet — die Backend-Registry
-  // tickets.llm_proxy_backends hat nur llamacpp-gemma (Port 8091) aktiv.
-  // Gemessen 2026-08-18: 167.168 Kontext gesamt / 55.722 je Slot, 122-128 tok/s.
+  // Lokales Gemma 4 12B QAT mit drei Slots als Standard — das Loadout
+  // gemma12-vision auf Port 8089 (Backend llamacpp-gemma12). Es ist das einzige
+  // vision-faehige lokale Loadout, hat mit 262.144 den groessten Kontext und
+  // faehrt MTP-Speculative-Decoding.
+  //
+  // WARUM NICHT MEHR gemma26-factory [2026-08-20]: Alle chat-gpu-Loadouts teilen
+  // eine exclusiveGroup, es laeuft also immer nur eines. Solange der Default auf
+  // ein anderes Loadout zeigte als das, mit dem gearbeitet wird, stoppte jede
+  // neue opencode-Session zuerst das laufende, um den Default zu starten. Als
+  // gemma26-factory nach dem llama.cpp-Upgrade nicht mehr startete (Tool-Name
+  // get_datetime -> get_info), riss dieser Wechsel gemma12-vision jedes Mal mit
+  // herunter und opencode meldete durchgehend "no healthy backend". Der Default
+  // gehoert deshalb auf das Loadout, das tatsaechlich laufen soll.
   //
   // Fallback-Kette bleibt: bei Ausfall des lokalen Servers greifen die
   // deepseek-*-Agenten (direkte API, nicht ueber den Proxy).
-  "model": "llamacpp-local/gemma26-factory",
+  "model": "llamacpp-local/gemma12-vision",
   "permission": {
     "read": "allow",
     "edit": "allow",

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -3792,6 +3792,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/llama-tool-names-match-binary",
+    "file": "tests/spec/local-llm-proxy/llama-tool-names-match-binary.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/loadout-aux-files-exist",
     "file": "tests/spec/local-llm-proxy/loadout-aux-files-exist.bats",
     "category": "local-llm-proxy",

--- a/scripts/llm-proxy/loadouts.mjs
+++ b/scripts/llm-proxy/loadouts.mjs
@@ -34,7 +34,8 @@ const LOADOUT_KEYS = new Set([
   // andere Bedeutung.
   'enabled',
 ]);
-// T002550 — Namen aus `llama-server --help` (b10223). llama.cpp akzeptiert
+// T002550 — Namen aus `llama-server --help`, gegengeprueft gegen den Build, den
+// ~/opt/llama-current aufloest (0.1.2-dev, build 61, 0adcc3bb5). llama.cpp akzeptiert
 // zusaetzlich das Sammelwort 'all'; hier ist es bewusst NICHT gueltig.
 //
 // llama.cpp kennt weder Sandbox noch Wurzelverzeichnis-Beschraenkung: mit
@@ -44,9 +45,18 @@ const LOADOUT_KEYS = new Set([
 // sich nicht hinter einem Wort verstecken, das nach Bequemlichkeit aussieht;
 // sie gehoert namentlich dorthin, wo sie erteilt wird. Ein spaeter
 // hinzugefuegtes llama-Tool erweitert 'all' still — die Allowlist nicht.
+//
+// Die Namen sind an den Build gebunden und wandern mit ihm: 'get_datetime' hiess
+// bis b10241 so und heisst seither 'get_info'. Ein Loadout, das den alten Namen
+// fuehrt, laesst llama-server beim Start mit Exit 1 abbrechen
+// ("tools setup failed: unknown tool") — der Prozess kommt nie ans Modell-Laden,
+// und der Proxy meldet fuer JEDES Modell dieses Ports 'no healthy backend'.
+// Beim naechsten llama.cpp-Upgrade diese Liste gegen `llama-server --help`
+// abgleichen; tests/spec/local-llm-proxy/llama-tool-names.bats prueft sie
+// gegen das laufende Binary, sofern eines vorhanden ist.
 const TOOL_NAMES = new Set([
   'read_file', 'file_glob_search', 'grep_search',
-  'exec_shell_command', 'write_file', 'edit_file', 'get_datetime',
+  'exec_shell_command', 'write_file', 'edit_file', 'get_info',
 ]);
 const ARG_KEYS = new Set([
   'ctx', 'ngl', 'parallel', 'cacheTypeK', 'cacheTypeV', 'loadMode',
@@ -63,9 +73,32 @@ const ARG_KEYS = new Set([
   // T002579 — Argumente des Chat-Templates, insbesondere enable_thinking.
   // Getrennt von 'reasoning' (= '-rea'): jenes steuert das PARSEN von
   // reasoning_content, dieses, ob das Modell ueberhaupt denkt.
+  //
+  // Fuer enable_thinking ist dieser Weg im aktuellen Build DEPRECATED —
+  // llama-server warnt beim Start "Setting 'enable_thinking' via
+  // --chat-template-kwargs is deprecated. Use --reasoning on / --reasoning off
+  // instead." und meint damit 'reasoning'. Das Feld bleibt fuer die uebrigen
+  // Template-Argumente; fuer die Denkphase gehoert der Wert nach 'reasoning'.
   'chatTemplateKwargs',
+  // Abgestufte Staerke der Denkphase (--reasoning-effort). Neu in dem Build,
+  // den ~/opt/llama-current aufloest; wirkt nur, wenn ueberhaupt gedacht wird.
+  'reasoningEffort',
 ]);
 const LOAD_MODES = new Set(['none', 'mmap', 'mlock', 'mmap+mlock', 'dio']);
+// Werte aus `llama-server --help`. 'default' laesst die Vorlage entscheiden.
+//
+// Die Stufen sind NICHT monoton: gemessen am 2026-08-20 gegen gemma12-vision
+// (Build 61, 0adcc3bb5) denkt 'minimal' LAENGER als 'low' und lieferte im
+// 300-Token-Fenster gar keine Antwort mehr, weil die Denkphase es fuellte.
+// Die Gemma-4-Vorlage kennt die Stufe offenbar nicht und faellt auf ein
+// laengeres Denken zurueck. Wer hier eine Stufe waehlt, misst sie nach:
+//   curl -s -m 90 -X POST http://127.0.0.1:8089/v1/chat/completions \
+//     -H 'Content-Type: application/json' \
+//     -d '{"model":"gemma12-vision","max_tokens":300,"reasoning_effort":"low",
+//          "messages":[{"role":"user","content":"What is 17*23? Answer with the number only."}]}'
+const REASONING_EFFORTS = new Set([
+  'default', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max',
+]);
 
 function fail(msg) { throw new Error(`loadouts.json: ${msg}`); }
 
@@ -100,6 +133,9 @@ function validateLoadout(l, index, seen) {
   }
   if (args.loadMode != null && !LOAD_MODES.has(args.loadMode)) {
     fail(`${l.slug}: loadMode '${args.loadMode}' unbekannt (${[...LOAD_MODES].join('|')})`);
+  }
+  if (args.reasoningEffort != null && !REASONING_EFFORTS.has(args.reasoningEffort)) {
+    fail(`${l.slug}: reasoningEffort '${args.reasoningEffort}' unbekannt (${[...REASONING_EFFORTS].join('|')})`);
   }
 
   // Ohne --fit bedeutet ein ungesetztes -c den llama.cpp-Default 0 ("aus dem

--- a/scripts/llm-proxy/loadouts.test.mjs
+++ b/scripts/llm-proxy/loadouts.test.mjs
@@ -107,9 +107,9 @@ test('parseLoadouts: model path mit .. wird abgelehnt', () => {
 
 // ── T002550: eingebaute llama-Tools ──────────────────────────────────────────
 //
-// Die Namen stammen aus `llama-server --help` (b10223) und sind bewusst als
-// Allowlist gefuehrt: read_file, file_glob_search, grep_search,
-// exec_shell_command, write_file, edit_file, get_datetime.
+// Die Namen stammen aus `llama-server --help` (Build 61, 0adcc3bb5) und sind bewusst
+// als Allowlist gefuehrt: read_file, file_glob_search, grep_search,
+// exec_shell_command, write_file, edit_file, get_info.
 //
 // 'all' waere ebenfalls ein gueltiger llama-Wert, wird hier aber ABGELEHNT.
 // llama.cpp kennt weder Sandbox noch Wurzelverzeichnis-Beschraenkung; wer
@@ -267,4 +267,48 @@ test('T003204: isLoadoutEnabled ist der EINE Ort der Default-Regel', () => {
   assert.equal(isLoadoutEnabled({ slug: 'x' }), true)
   assert.equal(isLoadoutEnabled({ slug: 'x', enabled: true }), true)
   assert.equal(isLoadoutEnabled({ slug: 'x', enabled: false }), false)
+})
+
+// ── reasoningEffort (--reasoning-effort) ─────────────────────────────────────
+//
+// Das Feld kam mit dem Build, den ~/opt/llama-current aufloest. Die Validierung
+// ist eine Allowlist, weil llama-server einen unbekannten Wert nicht etwa
+// ignoriert: er faellt auf die Vorlagen-Voreinstellung zurueck, und die
+// Fehlkonfiguration bleibt als stille Verhaltensaenderung stehen.
+
+test('parseLoadouts: bekannte reasoningEffort-Stufe ist gueltig', () => {
+  const ok = structuredClone(valid)
+  ok.loadouts[0].args.reasoningEffort = 'low'
+  assert.equal(parseLoadouts(JSON.stringify(ok)).loadouts[0].args.reasoningEffort, 'low')
+})
+
+test('parseLoadouts: reasoningEffort ist optional', () => {
+  // Positiv-Anker: ohne das Feld bleibt das Dokument gueltig.
+  const doc = parseLoadouts(JSON.stringify(valid))
+  assert.equal(doc.loadouts[0].args.reasoningEffort, undefined)
+})
+
+test('parseLoadouts: unbekannte reasoningEffort-Stufe wird abgelehnt', () => {
+  const bad = structuredClone(valid)
+  bad.loadouts[0].args.reasoningEffort = 'aus'
+  assert.throws(() => parseLoadouts(JSON.stringify(bad)), /reasoningEffort 'aus'/)
+})
+
+// ── Tool-Namen wandern mit dem llama.cpp-Build ───────────────────────────────
+//
+// 'get_datetime' hiess bis b10241 so und heisst seither 'get_info'. Der alte
+// Name laesst llama-server beim Start mit Exit 1 abbrechen, bevor das Modell
+// geladen wird — der Proxy meldet dann fuer jedes Modell dieses Ports
+// 'no healthy backend'. Der Test haelt den erledigten Umstieg fest.
+
+test('parseLoadouts: get_datetime ist kein gueltiger Tool-Name mehr', () => {
+  const bad = structuredClone(valid)
+  bad.loadouts[0].tools = 'read_file,get_datetime'
+  assert.throws(() => parseLoadouts(JSON.stringify(bad)), /get_datetime/)
+})
+
+test('parseLoadouts: get_info ist der aktuelle Name', () => {
+  const ok = structuredClone(valid)
+  ok.loadouts[0].tools = 'read_file,get_info'
+  assert.equal(parseLoadouts(JSON.stringify(ok)).loadouts[0].tools, 'read_file,get_info')
 })

--- a/scripts/llm-proxy/runner.mjs
+++ b/scripts/llm-proxy/runner.mjs
@@ -3,7 +3,8 @@
 // reine Funktion herausgezogen, damit sie ohne GPU getestet werden kann.
 //
 // WARUM null-Felder WEGGELASSEN werden (gemessen 2026-07-28):
-//   llama.cpp b10155 hat --fit per Default auf 'on' und passt nur UNGESETZTE
+//   llama.cpp hat --fit per Default auf 'on' (gegengeprueft b10155 bis Build 61)
+//   und passt nur UNGESETZTE
 //   Argumente an das freie VRAM an. Ein serialisiertes `-c 0` waere ein GESETZTES
 //   Argument und schaltet die Anpassung ab. Handgesetzt -ngl 19 -c 65536 lieferte
 //   30,9 tok/s decode; ungesetzt mit -fitt 2400 waren es 158-166 tok/s bei
@@ -47,6 +48,10 @@ export function buildServerArgv(loadout, modelPath, defaults, resolved = {}) {
   if (a.metrics) argv.push('--metrics');
   if (a.reasoning != null) argv.push('-rea', a.reasoning);
   if (a.reasoningBudget != null) argv.push('--reasoning-budget', String(a.reasoningBudget));
+  // Abgestufte Staerke der Denkphase. Wirkungslos, solange nicht gedacht wird —
+  // es ersetzt weder '-rea' (Denken an/aus) noch '--reasoning-budget'
+  // (harte Token-Obergrenze), sondern gibt der Vorlage eine Stufe vor.
+  if (a.reasoningEffort != null) argv.push('--reasoning-effort', a.reasoningEffort);
 
   // T002579 — Sampling. Bis hierher setzte kein Loadout Sampling-Parameter, es
   // galten also stillschweigend die llama.cpp-Defaults (temp 0.8, top-k 40).
@@ -68,6 +73,12 @@ export function buildServerArgv(loadout, modelPath, defaults, resolved = {}) {
   //
   // Serialisierung hier statt in der Konfiguration: der Wert steht in
   // loadouts.json als echtes Objekt, damit ihn niemand von Hand escapen muss.
+  //
+  // Fuer 'enable_thinking' ist dieser Weg im aktuellen Build deprecated:
+  // llama-server warnt "Setting 'enable_thinking' via --chat-template-kwargs is
+  // deprecated. Use --reasoning on / --reasoning off instead." Kein Loadout
+  // fuehrt den Schluessel noch; wer ihn wieder einsetzt, nimmt die Warnung in
+  // Kauf und riskiert, dass ein spaeterer Build ihn ganz fallen laesst.
   if (a.chatTemplateKwargs != null) {
     argv.push('--chat-template-kwargs', JSON.stringify(a.chatTemplateKwargs));
   }
@@ -77,13 +88,14 @@ export function buildServerArgv(loadout, modelPath, defaults, resolved = {}) {
   if (mmproj != null) argv.push('--mmproj', mmproj);
   const s = loadout.speculative ?? {};
   // T002633: '--spec-type' MUSS gesetzt werden, sonst ist der ganze Block wirkungslos.
-  // llama.cpp b10225 hat den Default 'none'; ein uebergebenes '--spec-draft-model' wird
+  // llama.cpp hat den Default 'none' (b10225 bis Build 61); ein uebergebenes '--spec-draft-model' wird
   // dann geladen (belegt also VRAM) und nie benutzt. Bis hierher setzte der Runner nur
   // '--spec-draft-model' — spekulatives Dekodieren war auf dem Proxy-Pfad also durchgehend
   // aus, waehrend der '.ps1'-Pfad es korrekt mit '--spec-type draft-mtp' startete. Der
   // Fehler ist still: kein Startabbruch, keine Logzeile.
   //
-  // Gueltige Werte des Builds: none, draft-simple, draft-eagle3, draft-mtp, draft-dflash,
+  // Gueltige Werte des Builds (unveraendert b10225 bis Build 61, 0adcc3bb5): none,
+  // draft-simple, draft-eagle3, draft-mtp, draft-dflash,
   // draft-dspark, ngram-simple, ngram-map-k, ngram-map-k4v, ngram-mod, ngram-cache.
   // Die 'ngram-*'-Varianten brauchen KEIN Draft-Modell, kosten also kein VRAM — auf einer
   // 16-GB-Karte mit einem 12-GB-Modell die einzige Variante, die noch hineinpasst.

--- a/scripts/llm-proxy/runner.test.mjs
+++ b/scripts/llm-proxy/runner.test.mjs
@@ -362,3 +362,25 @@ test('ohne speculative-Felder erscheint kein einziges spec-Flag', () => {
   const argv = buildServerArgv(specBase({ draftHfRepo: null, draftNgl: null }), MODEL, defaults)
   assert.equal(argv.filter((x) => String(x).startsWith('--spec-')).length, 0)
 })
+
+// ── --reasoning-effort ───────────────────────────────────────────────────────
+//
+// Dritte, unabhaengige Stellschraube der Denkphase neben '-rea' (denkt das
+// Modell ueberhaupt) und '--reasoning-budget' (harte Token-Obergrenze): sie
+// gibt der Chat-Vorlage eine Stufe vor. Wie ueberall hier erzeugt nur ein
+// gesetzter Wert ein Argument.
+
+test('gesetzter reasoningEffort erscheint als --reasoning-effort', () => {
+  const l = structuredClone(base)
+  l.args.reasoningEffort = 'low'
+  const argv = buildServerArgv(l, MODEL, defaults)
+  assert.deepEqual(argv.slice(argv.indexOf('--reasoning-effort'), argv.indexOf('--reasoning-effort') + 2),
+    ['--reasoning-effort', 'low'])
+})
+
+test('ohne reasoningEffort erscheint kein --reasoning-effort', () => {
+  const argv = buildServerArgv(base, MODEL, defaults)
+  assert.equal(argv.includes('--reasoning-effort'), false)
+  // Positiv-Anker: die uebrigen reasoning-Flags sind davon unberuehrt.
+  assert.deepEqual(argv.slice(argv.indexOf('-rea'), argv.indexOf('-rea') + 2), ['-rea', 'auto'])
+})

--- a/scripts/llm/bench-guff.sh
+++ b/scripts/llm/bench-guff.sh
@@ -6,7 +6,7 @@
 # optionalem MTP (--spec-type draft-mtp).
 #
 # Nutzung:
-#   LLAMA_DIR=$HOME/opt/llama-b10442/llama-b10442 bash scripts/llm/bench-guff.sh <modell.gguf>
+#   LLAMA_DIR=$HOME/opt/llama-current/bin bash scripts/llm/bench-guff.sh <modell.gguf>
 #
 # Env-Parameter:
 #   PORT       Server-Port (Default 8090)
@@ -20,7 +20,10 @@
 # Ausgabe: eine JSON-Zeile mit quant, mtp, ctx, kv_t, pp_tps, gen_tps, vram_mb
 set -euo pipefail
 
-: "${LLAMA_DIR:=$HOME/opt/llama-b10442/llama-b10442}"
+# Versionsneutral wie in scripts/llm-proxy/server.mjs (T002536): der Symlink
+# ~/opt/llama-current zeigt auf den jeweils aktuellen Build. Ein gepinnter
+# Pfad misst nach jedem Upgrade still gegen das alte Binary weiter.
+: "${LLAMA_DIR:=$HOME/opt/llama-current/bin}"
 : "${PORT:=8090}"
 : "${CTX:=32768}"
 : "${KV_T:=q8_0}"

--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -63,14 +63,11 @@
         "flashAttention": true,
         "jinja": true,
         "metrics": true,
-        "reasoning": "auto",
+        "reasoning": "on",
         "reasoningBudget": null,
         "temperature": 1,
         "topP": 0.95,
-        "topK": 64,
-        "chatTemplateKwargs": {
-          "enable_thinking": true
-        }
+        "topK": 64
       },
       "speculative": {
         "draftModelPath": null,
@@ -86,8 +83,8 @@
         "/home/patrick/Bachelorprojekt/scripts/llm/templates/gemma4-26b-tools.jinja"
       ],
       "exclusiveGroup": "chat-gpu",
-      "notes": "UD-IQ4_XS (13,6 GB) in gemma4-26A4-it/. Gemessen bei np=3 mit -kvu und q4_0 KV: 166.912 Kontext, 130-132 tok/s. Kein mmproj.",
-      "tools": "read_file,file_glob_search,grep_search,write_file,edit_file,get_datetime,exec_shell_command"
+      "notes": "UD-IQ4_XS (13,6 GB) in gemma4-26A4-it/. Gemessen bei np=3 mit -kvu und q4_0 KV: 166.912 Kontext, 130-132 tok/s. Kein mmproj. STARTBLOCKER 2026-08-20: 'get_info' hiess bis llama.cpp b10241 'get_datetime'. Mit dem alten Namen bricht llama-server VOR dem Modell-Laden mit Exit 1 ab (\"tools setup failed: unknown tool 'get_datetime'. available tools: read_file, file_glob_search, grep_search, exec_shell_command, write_file, edit_file, get_info\"); systemd zaehlte 40 Restarts, der Proxy meldete 'Server wurde nicht gesund'. Weil dieses Loadout die exclusiveGroup chat-gpu haelt UND bis dahin opencodes Default-Modell war, stoppte jede opencode-Session zuerst gemma12-vision, um dieses hier zu starten — das starb sofort, und danach lief gar nichts mehr. Die Stoerung sah deshalb nach einem gemma12-Problem aus. DENKPHASE: 'enable_thinking' ueber --chat-template-kwargs ist im aktuellen Build deprecated (Startwarnung: \"Use --reasoning on / --reasoning off instead\") und daher auf args.reasoning='on' umgestellt — gleiche Wirkung, nicht-deprecatetes Flag.",
+      "tools": "read_file,file_glob_search,grep_search,write_file,edit_file,get_info,exec_shell_command"
     },
     {
       "slug": "bge-embed-cpu",
@@ -303,6 +300,7 @@
         "metrics": true,
         "reasoning": "auto",
         "reasoningBudget": null,
+        "reasoningEffort": "low",
         "temperature": 1,
         "topP": 0.95,
         "topK": 64,
@@ -323,7 +321,7 @@
         "-ub",
         "2048"
       ],
-      "notes": "Auf Durchsatz mit DREI Slots und geteiltem KV ausgelegt (T012414). Messung scripts/llm/measurements/2026-08-19-gemma12-slots.md: mit -np 3 -kvu 307-489 tok/s gesamt gegen 255 bei einem Slot, Einzelstrom 106-183 statt 289, MTP-Annahme 92-95 %. Der Kontext wird NICHT gedrittelt (n_ctx_slot bleibt 262144), der VRAM-Bedarf steigt kaum (15909 statt 15869 MiB). -np 4 ist SCHLECHTER als 3 (319 tok/s), -np 6 laedt gar nicht erst — der MTP-Drafter bricht mit vector::_M_range_check ab. Drei ist also gemessen, nicht gewaehlt. Der Proxy muss mitziehen: ohne max_inflight=3 auf dem Backend serialisiert er trotzdem alles (scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql). MESSUNG 2026-08-18 auf RTX 5070 Ti 16 GiB, llama.cpp b10241, scripts/llm/bench-decode.sh 8089 (n_predict=512, cache_prompt=false); A/B durch VOLLSTAENDIGES Entfernen der Spec-Flags, nicht durch ein angehaengtes --spec-type none — das ueberschreibt die fruehere Angabe NICHT, der Drafter lief weiter und beide Seiten massen dasselbe. Decode: 246-287 tok/s mit MTP gegen 80-86 tok/s ohne, also ~3,2x; MTP-Annahmequote 93-99 %. Prefill (6902-Token-Prompt): 1797 tok/s mit MTP gegen 3380 tok/s ohne — der Drafter verarbeitet den Prompt mit, MTP HALBIERT den Prefill. Umschlagpunkt daraus: MTP lohnt, sobald mehr als etwa ein Token je 33 Prompt-Token erzeugt wird (bei 7k Prompt ab ~210 erzeugten Token) — fuer Chat und Codegenerierung immer, fuer reines Prompt-Durchreichen nicht. Belegt geladen: 262144 Kontext (n_ctx_slot), n_slots=1, kv_unified=true, 15869 von 16303 MiB. KV-Rechnung aus den GGUF-Metadaten: 48 Layer im Muster 5x SWA + 1x global; die 40 SWA-Layer (8 KV-Heads, 256+256, Fenster 1024) kosten fest ~320 MiB @f16, die 8 globalen Layer haben nur EINEN KV-Head (512+512, unified) und kosten 16 KiB/Token — der volle Kontext also 4,0 GiB. Reicht es nicht, zuerst -ub auf 1024 senken, erst danach den Kontext. MTP: der Drafter ist eine eigene Datei (gemma4-assistant, 423M, nextn_predict_layers=4) — im Haupt-GGUF steckt er NICHT (667 Tensoren, alle textuell, geprueft mit scripts/llm/gguf-tensor-names.py); die Auto-Erkennung der Modellkarte greift nur beim Start ueber -hf, nicht ueber einen lokalen -m-Pfad. Vorher: -fit on, q8_0-KV, 137-149 tok/s Prosa ohne wirksames MTP.",
+      "notes": "Auf Durchsatz mit DREI Slots und geteiltem KV ausgelegt (T012414). Messung scripts/llm/measurements/2026-08-19-gemma12-slots.md: mit -np 3 -kvu 307-489 tok/s gesamt gegen 255 bei einem Slot, Einzelstrom 106-183 statt 289, MTP-Annahme 92-95 %. Der Kontext wird NICHT gedrittelt (n_ctx_slot bleibt 262144), der VRAM-Bedarf steigt kaum (15909 statt 15869 MiB). -np 4 ist SCHLECHTER als 3 (319 tok/s), -np 6 laedt gar nicht erst — der MTP-Drafter bricht mit vector::_M_range_check ab. Drei ist also gemessen, nicht gewaehlt. Der Proxy muss mitziehen: ohne max_inflight=3 auf dem Backend serialisiert er trotzdem alles (scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql). MESSUNG 2026-08-18 auf RTX 5070 Ti 16 GiB, llama.cpp b10241, scripts/llm/bench-decode.sh 8089 (n_predict=512, cache_prompt=false); A/B durch VOLLSTAENDIGES Entfernen der Spec-Flags, nicht durch ein angehaengtes --spec-type none — das ueberschreibt die fruehere Angabe NICHT, der Drafter lief weiter und beide Seiten massen dasselbe. Decode: 246-287 tok/s mit MTP gegen 80-86 tok/s ohne, also ~3,2x; MTP-Annahmequote 93-99 %. Prefill (6902-Token-Prompt): 1797 tok/s mit MTP gegen 3380 tok/s ohne — der Drafter verarbeitet den Prompt mit, MTP HALBIERT den Prefill. Umschlagpunkt daraus: MTP lohnt, sobald mehr als etwa ein Token je 33 Prompt-Token erzeugt wird (bei 7k Prompt ab ~210 erzeugten Token) — fuer Chat und Codegenerierung immer, fuer reines Prompt-Durchreichen nicht. Belegt geladen: 262144 Kontext (n_ctx_slot), n_slots=1, kv_unified=true, 15869 von 16303 MiB. KV-Rechnung aus den GGUF-Metadaten: 48 Layer im Muster 5x SWA + 1x global; die 40 SWA-Layer (8 KV-Heads, 256+256, Fenster 1024) kosten fest ~320 MiB @f16, die 8 globalen Layer haben nur EINEN KV-Head (512+512, unified) und kosten 16 KiB/Token — der volle Kontext also 4,0 GiB. Reicht es nicht, zuerst -ub auf 1024 senken, erst danach den Kontext. MTP: der Drafter ist eine eigene Datei (gemma4-assistant, 423M, nextn_predict_layers=4) — im Haupt-GGUF steckt er NICHT (667 Tensoren, alle textuell, geprueft mit scripts/llm/gguf-tensor-names.py); die Auto-Erkennung der Modellkarte greift nur beim Start ueber -hf, nicht ueber einen lokalen -m-Pfad. Vorher: -fit on, q8_0-KV, 137-149 tok/s Prosa ohne wirksames MTP. DENKPHASE (2026-08-20, Build 61/0adcc3bb5): Dieses Modell denkt unter dem aktuellen llama.cpp, unter b10241 tat es das nicht — die Antwort landet vollstaendig in reasoning_content und 'content' bleibt leer, bis das Denken abgeschlossen ist. Jeder Aufrufer mit engem Token-Fenster bekommt dadurch eine LEERE Antwort statt einer kurzen (in opencode betrifft das den title-Agenten, der mit small=true laeuft). MESSUNG gegen den laufenden Server, Prompt 'What is 17*23? Answer with the number only.' bei max_tokens=300: default/'high'/'medium' antworten korrekt mit rund 90-95 Denk-Token, 'low' mit rund 61 — 'minimal' dagegen fuellt das ganze Fenster mit Denken und liefert GAR KEINE Antwort. Die Stufen sind also nicht monoton; die Gemma-4-Vorlage kennt 'minimal' offenbar nicht. Deshalb 'low'. Befehl zur Nachstellung: curl -s -m 90 -X POST http://127.0.0.1:8089/v1/chat/completions -H 'Content-Type: application/json' -d '{\"model\":\"gemma12-vision\",\"max_tokens\":300,\"reasoning_effort\":\"low\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 17*23? Answer with the number only.\"}]}'. Wer das Denken ganz abschalten will, setzt args.reasoning='off' — NICHT chatTemplateKwargs.",
       "exclusiveGroup": "chat-gpu"
     },
     {

--- a/tests/spec/local-llm-proxy/llama-tool-names-match-binary.bats
+++ b/tests/spec/local-llm-proxy/llama-tool-names-match-binary.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# tests/spec/local-llm-proxy/llama-tool-names-match-binary.bats
+# SSOT: openspec/specs/local-llm-proxy.md
+#
+# PRUEFMODUS (Test-Resultats-Konvention T002448-M4): ERGEBNIS-basiert. Der Test
+# fragt das installierte Binary mit `llama-server --help` nach seiner Tool-Liste
+# und vergleicht sie mit der Allowlist in scripts/llm-proxy/loadouts.mjs sowie
+# mit den `tools`-Feldern in scripts/llm/loadouts.json. Er greppt keine
+# Buildnummer — die sagt nichts darueber, welche Namen das Binary annimmt.
+#
+# WARUM: `--tools` ist fail-closed und BRICHT DEN START AB, wenn ein Name
+# unbekannt ist ("tools setup failed: unknown tool ..."), noch bevor das Modell
+# geladen wird. Am 2026-08-20 hatte ein llama.cpp-Upgrade 'get_datetime' in
+# 'get_info' umbenannt; gemma26-factory fuehrte den alten Namen weiter, wurde
+# von systemd 40 mal neu gestartet und war nie gesund. Weil es die
+# exclusiveGroup 'chat-gpu' haelt, stoppte der Proxy bei jedem Startversuch
+# zuvor das laufende gemma12-vision — die Stoerung zeigte sich also an einem
+# Loadout, das gar nicht defekt war. Ein Guard, der nur die Repo-Dateien
+# untereinander vergleicht, haette das nicht gesehen: beide waren in sich
+# stimmig und beide falsch.
+#
+# SKIP statt Fehlschlag ohne Binary: auf CI-Runnern gibt es kein llama.cpp. Ein
+# Guard, der dort gruen meldet, ohne geprueft zu haben, waere schlimmer als
+# einer, der sich als uebersprungen ausweist.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  LOADOUTS="${REPO_ROOT}/scripts/llm/loadouts.json"
+  LLAMA_BIN="${LLAMA_SERVER_BIN:-${HOME}/opt/llama-current/bin/llama-server}"
+}
+
+# Die vom Binary angebotenen Tool-Namen, einer je Zeile.
+_binary_tools() {
+  "${LLAMA_BIN}" --help 2>&1 \
+    | sed -n '/available tools:/,/^ *note:/p' \
+    | sed 's/.*available tools://' \
+    | tr ',' '\n' \
+    | sed 's/note:.*//' \
+    | tr -d ' ' \
+    | grep -E '^[a-z_]+$' \
+    | sort -u
+}
+
+# Die Namen der Allowlist in loadouts.mjs, einer je Zeile.
+_allowlist_tools() {
+  node --input-type=module -e "
+    const src = await import('${REPO_ROOT}/scripts/llm-proxy/loadouts.mjs')
+    // Die Menge ist modulprivat; sie wird ueber ihr Verhalten erhoben, damit
+    // der Test nicht an einem Export haengt, den es nur fuer ihn gaebe.
+    const probe = JSON.parse(await (await import('node:fs/promises')).readFile('${LOADOUTS}', 'utf8'))
+    const one = structuredClone(probe.loadouts[0])
+    // Nur EIN Loadout, und ohne 'roles': die Rollenketten verweisen auf die
+    // uebrigen Slugs und wuerden den Probelauf aus einem Grund scheitern
+    // lassen, der mit Tool-Namen nichts zu tun hat.
+    const { roles, ...rest } = probe
+    const doc = { ...rest, loadouts: [one] }
+    for (const name of process.argv.slice(1)) {
+      one.tools = name
+      try { src.parseLoadouts(JSON.stringify(doc)); console.log(name) } catch { /* abgelehnt */ }
+    }
+  " -- $(_binary_tools) | sort -u
+}
+
+@test "T012970: die Allowlist akzeptiert jeden Tool-Namen des installierten Binaries" {
+  [ -x "${LLAMA_BIN}" ] || skip "kein llama-server unter ${LLAMA_BIN}"
+
+  run _binary_tools
+  [ "$status" -eq 0 ]
+  # Positiv-Anker: die Liste wurde ueberhaupt gelesen. Ohne ihn wuerde ein
+  # geaendertes Hilfe-Format als leere Menge durchgehen und alles bestehen.
+  [ -n "$output" ]
+  echo "$output" | grep -qx 'read_file'
+
+  local from_binary="$output"
+  run _allowlist_tools
+  [ "$status" -eq 0 ]
+
+  local missing
+  missing="$(comm -23 <(echo "$from_binary") <(echo "$output"))"
+  [ -z "$missing" ] || {
+    echo "Vom Binary angeboten, von der Allowlist abgelehnt: ${missing}" >&2
+    echo "Reparatur: TOOL_NAMES in scripts/llm-proxy/loadouts.mjs angleichen." >&2
+    false
+  }
+}
+
+@test "T012970: kein Loadout fuehrt einen Tool-Namen, den das Binary nicht kennt" {
+  [ -x "${LLAMA_BIN}" ] || skip "kein llama-server unter ${LLAMA_BIN}"
+
+  run _binary_tools
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  local from_binary="$output"
+
+  local declared
+  declared="$(node -e "
+    const doc = require('${LOADOUTS}')
+    const out = new Set()
+    for (const l of doc.loadouts) for (const t of (l.tools ?? '').split(',')) if (t) out.add(t)
+    console.log([...out].sort().join('\n'))
+  ")"
+
+  # Positiv-Anker: mindestens ein Loadout deklariert ueberhaupt Tools. Ohne ihn
+  # bestuende der Test auch dann, wenn das Feld ueberall verschwunden waere.
+  [ -n "$declared" ]
+
+  local unknown
+  unknown="$(comm -13 <(echo "$from_binary") <(echo "$declared"))"
+  [ -z "$unknown" ] || {
+    echo "In loadouts.json deklariert, vom Binary nicht angeboten: ${unknown}" >&2
+    echo "Diese Namen brechen den Start ab (exit 1, 'tools setup failed')." >&2
+    false
+  }
+}


### PR DESCRIPTION
## Befund

Das llama.cpp-Upgrade hat das eingebaute Tool **`get_datetime` in `get_info` umbenannt**. `--tools` ist fail-closed — llama-server bricht mit Exit 1 ab, **bevor** das Modell geladen wird:

```
E srv llama_server: tools setup failed: unknown tool "get_datetime".
  available tools: read_file, file_glob_search, grep_search,
                   exec_shell_command, write_file, edit_file, get_info
```

Das Loadout `gemma26-factory` fuehrte den alten Namen weiter. systemd zaehlte 40 Restarts, der Proxy meldete `Server wurde nicht gesund`.

**Warum sich das an gemma12-vision zeigte:** `gemma26-factory` war opencodes Default-Modell und teilt sich mit `gemma12-vision` die `exclusiveGroup: chat-gpu`. Jede opencode-Session stoppte deshalb zuerst das laufende `gemma12-vision`, um den Default zu starten — der sofort starb. Danach lief gar nichts, und opencode meldete fuer **beide** Modelle `no healthy backend`. Das defekte Loadout war nicht das, an dem der Fehler auftrat.

## Aenderungen

| # | Aenderung | Warum |
|---|---|---|
| 1 | `TOOL_NAMES` und `gemma26-factory.tools` auf `get_info` | Startblocker |
| 2 | opencode-Default auf `llamacpp-local/gemma12-vision` | Bei einer exclusiveGroup reisst jeder andere Default das laufende Modell bei jeder neuen Session herunter |
| 3 | `chatTemplateKwargs.enable_thinking` -> `args.reasoning: "on"` | Im aktuellen Build deprecated (Startwarnung nennt `--reasoning` als Ersatz) |
| 4 | Neues Registry-Feld `args.reasoningEffort` (`--reasoning-effort`), fuer `gemma12-vision` auf `low` | Gemma 4 12B **denkt** unter dem neuen Build, unter b10241 nicht. Bis zum Ende des Denkens landet alles in `reasoning_content` und `content` bleibt leer — Aufrufer mit engem Token-Fenster bekommen eine leere Antwort statt einer kurzen |
| 5 | Guard `llama-tool-names-match-binary.bats` | Vergleicht gegen `llama-server --help` des installierten Binaries |
| 6 | Versionsneutrale Pfade statt gepinnter Buildnummern | `bench-guff.sh` zeigte auf `~/opt/llama-b10442` |

## Messung

Prompt `What is 17*23? Answer with the number only.`, `max_tokens=300`, gegen den laufenden `gemma12-vision` (Build 61 / 0adcc3bb5) am 2026-08-20:

| `reasoning_effort` | Antwort | Denk-Token |
|---|---|---|
| `minimal` | **keine** (Fenster voll) | ~162 |
| `low` | `391` | ~61 |
| `medium` | `391` | ~89 |
| `high` | `391` | ~94 |

Die Stufen sind **nicht monoton** — die Gemma-4-Vorlage kennt `minimal` offenbar nicht. Daher `low`.

```bash
curl -s -m 90 -X POST http://127.0.0.1:8089/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"gemma12-vision","max_tokens":300,"reasoning_effort":"low",
       "messages":[{"role":"user","content":"What is 17*23? Answer with the number only."}]}'
```

## Nachweis

- `node --test scripts/llm-proxy/loadouts.test.mjs scripts/llm-proxy/runner.test.mjs` — 66/66
- `bats tests/spec/local-llm-proxy/` — 121/121, keine Regression
- Neuer Guard in **beiden** Richtungen belegt: mit `get_datetime` in `loadouts.json` schlaegt er fehl und benennt den Namen, nach Wiederherstellung ist er gruen
- Direkt gegen das Binary: mit `get_info` kommt llama-server bis `load_model`, mit `get_datetime` bricht er bei `tools setup` mit Exit 1 ab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaPMNzBzjKnJjYNeDn7ePJ