### PR TITLE
chore(agents): dsh schedule- und terminal-Fähigkeit ins Repo-Bundle [T012971]

### DIFF
--- a/tools/dsh/cordis.patch.yml
+++ b/tools/dsh/cordis.patch.yml
@@ -18,3 +18,33 @@
         projectDir: '@@REPO@@'
     - id: bachelorprojekt
       name: '@@REPO@@/tools/dsh/index.js'
+
+    # [T012971] Zwei optionale Faehigkeiten, die dsh-base nicht mitbringt.
+    # Beide sind Host-Plane-Rows: der Patch-Layer patcht den Host-Tree, nicht
+    # die Agent-Presets.
+    #
+    # schedule — durable Reminder ueber den Session-Ereignisstrom
+    # (schedule_create/-list/-cancel). Registriert seine Werkzeuge selbst ueber
+    # `agent.ctx`, sobald ein Root-Agent entsteht, und ist deshalb vom Host aus
+    # vollstaendig. Nur spaetere `agent/created`-Ereignisse zaehlen: Agenten,
+    # die beim Laden schon existierten, bekommen kein Schedule.
+    - id: schedule
+      name: '@@DSH_CLONE@@/packages/schedule/schedule/lib/index.js'
+
+    # terminal — persistente PTY-Sitzungen (terminal_open/_send/_read/_signal/
+    # _close/_list). Drei Rows, weil die Faehigkeit auf drei Rollen aufgeteilt
+    # ist: Service (`terminal`), Backend (`terminal-bash`, laeuft unter der
+    # gemeinsamen sandboxPolicy) und die modellseitigen Werkzeuge
+    # (`tool-terminal`). Ohne Backend gaebe es einen Service ohne Ausfuehrung,
+    # ohne tool-Row sieht das Modell nichts.
+    - id: terminal
+      name: '@@DSH_CLONE@@/packages/terminal/terminal/lib/index.js'
+    - id: terminal-bash
+      name: '@@DSH_CLONE@@/packages/terminal/terminal-bash/lib/index.js'
+    - id: tool-terminal
+      name: '@@DSH_CLONE@@/packages/terminal/tool-terminal/lib/index.js'
+
+    # lsp bleibt bewusst draussen: `dsh-lsp-stdio` verlangt eine `servers`-
+    # Tabelle (welcher Sprachserver, welches Binary, welche Dateiendungen) und
+    # bricht ohne sie beim Boot ab — `$.servers missing required value`. Welche
+    # Server hier installiert sein sollen, ist eine eigene Entscheidung.


### PR DESCRIPTION
## Was

`tools/dsh/cordis.patch.yml` mountet zwei Fähigkeiten, die `dsh-base` nicht mitbringt:

- **schedule** — durable Reminder über den Session-Ereignisstrom (`schedule_create` und Geschwister). Registriert seine Werkzeuge selbst über `agent.ctx`, sobald ein Root-Agent entsteht, und ist deshalb als reine Host-Row vollständig.
- **terminal** — persistente PTY-Sitzungen. Drei Rows, weil die Fähigkeit auf drei Rollen verteilt ist: Service (`terminal`), Backend (`terminal-bash`, läuft unter der gemeinsamen `sandboxPolicy`) und die modellseitigen Werkzeuge (`tool-terminal`).

## Warum kein lsp

`dsh-lsp-stdio` verlangt eine `servers`-Tabelle — welcher Sprachserver, welches Binary, welche Dateiendungen — und bricht ohne sie beim Boot ab:

```
ValidationError: invalid config:
  - $.servers missing required value (at servers)
```

Welche Server hier laufen sollen und ob ihre Binaries auf dem Host liegen, ist eine eigene Entscheidung mit eigener Prüfung, kein Beiwerk dieses Chores.

## Verifikation

```bash
sed -e "s#@@DSH_CLONE@@#$PWD/deepseek-harness#g" -e "s#@@REPO@@#$PWD#g" \
  tools/dsh/cordis.patch.yml > /tmp/a3-runtime.yml
dsh --profile headless --patch /tmp/a3-runtime.yml \
  "welche dieser Werkzeuge hast du - schedule_create, terminal_open, terminal_list, bash?"
# -> "Ich habe: schedule_create, terminal_open, terminal_list, bash."
```

Der Lauf ging gegen die echte Datei dieses Branches mit ersetzten Platzhaltern. `bash` ist mitgeprüft, damit belegt ist, dass die bestehenden Rows weiter greifen.

`tests/spec/dsh-harness-integration`: 29 Tests, alle grün (zwei Skips, weil im Worktree kein gebauter Klon liegt).

## Offen

Geprüft ist das `headless`-Profil, das ohne Agent-Preset läuft. Im `web`-Profil komponiert `dsh-agent-presets` die modellseitigen Rows auf der Agent-Ebene; ob `tool-terminal` aus dem globalen Layer dort bei einem Preset-Agenten ankommt, zeigt erst eine Web-Sitzung. Falls nicht, gehört die tool-Row in ein Preset statt in den Host-Patch — das wäre eine Folgekorrektur, keine andere Architektur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Tf1rHSknbx2tLywK8AorX
