### PR TITLE
chore: dev admin session T012980

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -4974,6 +4974,12 @@
     "kind": "shell"
   },
   {
+    "id": "sdlc/dev-admin-session-guards",
+    "file": "tests/spec/sdlc/dev-admin-session-guards.bats",
+    "category": "sdlc",
+    "kind": "shell"
+  },
+  {
     "id": "sealed-secret-cluster-drift",
     "file": "tests/spec/sealed-secret-cluster-drift.bats",
     "category": "sealed-secret-cluster-drift",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1141,
+      "file_count": 1142,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -872,6 +872,7 @@
         "tests/spec/sdlc-isolation/kubelet-cert-guard.bats",
         "tests/spec/sdlc-isolation/llm-up-health.bats",
         "tests/spec/sdlc-isolation/sdlc-up-command.bats",
+        "tests/spec/sdlc/dev-admin-session-guards.bats",
         "tests/spec/sealed-secret-cluster-drift.bats",
         "tests/spec/secret-rotation-exposure.bats",
         "tests/spec/secret-rotation.bats",
@@ -3563,7 +3564,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 791,
+      "file_count": 792,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -3750,6 +3751,7 @@
         "scripts/code-quality/validate.test.mjs",
         "scripts/context-retrieve.mjs",
         "scripts/db-schema-diagram.py",
+        "scripts/dev-admin-session.mjs",
         "scripts/dev-cluster-autostart.sh",
         "scripts/dev-db-refresh.sh",
         "scripts/dev-reset.sh",

--- a/scripts/dev-admin-session.mjs
+++ b/scripts/dev-admin-session.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// scripts/dev-admin-session.mjs — lokale Admin-Session fuer den Astro-Dev-Server.
+//
+// Schreibt eine Zeile in web_sessions und gibt das Cookie aus, mit dem
+// /sdlc/* ohne OIDC-Anmeldung erreichbar ist. Das ist ein Auth-Bypass und
+// gehoert ausschliesslich in die lokale Entwicklung — deshalb die Guards
+// unten: das Skript weigert sich gegen alles, was nicht localhost ist.
+//
+// Der regulaere Weg ist die Anmeldung ueber Pocket ID. Diesen hier gibt es,
+// weil `auth.ts` mit `issueSession()` denselben Pfad schon fuer die
+// System-Test-Nutzer oeffnet (Magic-Link-Redeem) und lokal kein Pocket ID
+// erreichbar sein muss.
+//
+// Aufruf:
+//   cd components/website && set -a && . ./.env && set +a
+//   node ../../scripts/dev-admin-session.mjs
+//
+// Danach die ausgegebene Zeile im Browser als Cookie setzen (DevTools →
+// Application → Cookies → http://localhost:4321), oder direkt:
+//   curl -b "workspace_session=<ID>" http://127.0.0.1:4321/sdlc/cockpit
+
+import { Client } from 'pg';
+import crypto from 'node:crypto';
+
+const url = process.env.SESSIONS_DATABASE_URL;
+if (!url) {
+  console.error('SESSIONS_DATABASE_URL ist nicht gesetzt.');
+  console.error('Vorher:  set -a && . ./.env && set +a   (in components/website)');
+  process.exit(2);
+}
+
+// Guard 1: nur lokale Datenbanken. Eine Session in einer Cluster-DB waere
+// ein echter Zugang zu einer echten Umgebung, kein Entwicklungsbehelf.
+const host = new URL(url).hostname;
+if (!['127.0.0.1', 'localhost', '::1'].includes(host)) {
+  console.error(`Verweigert: SESSIONS_DATABASE_URL zeigt auf ${host}, nicht auf localhost.`);
+  console.error('Dieses Skript schreibt eine Session ohne Anmeldung — das ist nur lokal vertretbar.');
+  process.exit(2);
+}
+
+const username = process.env.DEV_ADMIN_USERNAME || 'patrick';
+const email = process.env.DEV_ADMIN_EMAIL || 'p.korczewski@gmail.com';
+const days = Number(process.env.DEV_ADMIN_SESSION_DAYS || 7);
+
+const client = new Client({ connectionString: url });
+await client.connect();
+
+// Guard 2: die Tabelle muss existieren. Sie wird sonst von ensureSessionsTable()
+// erst beim ersten Request angelegt — eine Session in eine gerade erfundene
+// Tabelle zu schreiben verschleierte, dass der Server nie lief.
+const { rows: [{ t }] } = await client.query("select to_regclass('public.web_sessions') as t");
+if (!t) {
+  console.error('web_sessions existiert nicht. Den Dev-Server einmal starten und eine Seite aufrufen,');
+  console.error('damit ensureSessionsTable() die Tabelle anlegt.');
+  await client.end();
+  process.exit(2);
+}
+
+const id = crypto.randomBytes(32).toString('hex');
+const expiresAt = Date.now() + days * 24 * 3600 * 1000;
+
+// realmRoles: ['admin'] ist das Signal, das isAdmin() zuerst prueft
+// (auth.ts:229). PORTAL_ADMIN_USERNAME waere der Fallback.
+const user = {
+  sub: `local-dev-${username}`,
+  email,
+  name: `${username} (lokal)`,
+  preferred_username: username,
+  realmRoles: ['admin'],
+  brand: null,
+  access_token: 'local-dev-no-oidc',
+  refresh_token: 'local-dev-no-oidc',
+  expires_at: expiresAt,
+};
+
+await client.query(
+  'INSERT INTO web_sessions (id, data, expires_at) VALUES ($1, $2, $3)',
+  [id, JSON.stringify(user), new Date(expiresAt)],
+);
+await client.end();
+
+console.log(`Cookie:   workspace_session=${id}`);
+console.log(`Nutzer:   ${username} (realmRoles: admin)`);
+console.log(`Gueltig:  bis ${new Date(expiresAt).toISOString()}`);
+console.log('');
+console.log('Testen:');
+console.log(`  curl -s -o /dev/null -w '%{http_code}\\n' -b "workspace_session=${id}" \\`);
+console.log("    http://127.0.0.1:4321/sdlc/cockpit");

--- a/taskfiles/Taskfile.sdlc.yml
+++ b/taskfiles/Taskfile.sdlc.yml
@@ -261,6 +261,36 @@ tasks:
         export BUILD_TARGET=sdlc
         pnpm dev -- --force
 
+  sdlc:admin-session:
+    desc: "Lokale Admin-Session fuer den Astro-Devserver anlegen (Cookie ausgeben, ohne OIDC)"
+    # T012980: Der regulaere Weg in /sdlc/* ist die Anmeldung ueber Pocket ID. Lokal muss
+    # dafuer kein Pocket ID erreichbar sein — auth.ts oeffnet mit issueSession() denselben
+    # Pfad bereits fuer die System-Testnutzer (Magic-Link-Redeem). Das Skript schreibt eine
+    # Zeile in web_sessions und gibt das Cookie aus.
+    #
+    # Es ist ein Auth-Bypass und verweigert daher alles, was nicht localhost ist: zeigt
+    # SESSIONS_DATABASE_URL auf einen anderen Host, bricht es mit Exit 2 ab, BEVOR es
+    # schreibt. Eine Session in einer Cluster-DB waere ein echter Zugang zu einer echten
+    # Umgebung, kein Entwicklungsbehelf.
+    #
+    # Vorbedingung: der Devserver lief mindestens einmal (task sdlc:dev), damit
+    # ensureSessionsTable() die Tabelle web_sessions angelegt hat. Fehlt sie, bricht das
+    # Skript ebenfalls ab — eine Session in eine gerade erfundene Tabelle zu schreiben
+    # verschleierte, dass der Server nie lief.
+    #
+    # Die .env wird ausdruecklich aus components/website geladen, nicht aus dem Repo-Root:
+    # SESSIONS_DATABASE_URL steht nur dort. Ohne  exportiert das Sourcen die
+    # Variablen nicht in die Kindumgebung, und node saehe sie nicht.
+    cmds:
+      - |
+        set -e
+        if [ ! -f components/website/.env ]; then
+          echo "components/website/.env fehlt — SESSIONS_DATABASE_URL kann nicht geladen werden." >&2
+          exit 2
+        fi
+        set -a; . ./components/website/.env; set +a
+        node scripts/dev-admin-session.mjs
+
   sdlc:refresh:
     desc: "SDLC-Console nach einem main-Merge auf die aktuelle :latest nachziehen (T003740)"
     # T003740: imagePullPolicy Always in k3d/sdlc-stack/sdlc-console.yaml sorgt dafuer,

--- a/tests/spec/sdlc/dev-admin-session-guards.bats
+++ b/tests/spec/sdlc/dev-admin-session-guards.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+#
+# Ticket: T012980 — scripts/dev-admin-session.mjs
+#
+# PRUEFMODUS: Command-Output-Verifikation (T002448-M4). Die Tests FUEHREN das Skript
+# aus und pruefen Exit-Code und Meldung. Es wird NICHT sein Quelltext gegreppt — ein
+# Muster im Source belegt nur, dass Text existiert, nicht dass der Guard greift.
+#
+# WARUM DIESE TESTS: Das Skript ist ein Auth-Bypass. Es schreibt eine Session mit
+# realmRoles: ['admin'] direkt in web_sessions und umgeht damit die Anmeldung ueber
+# Pocket ID. Vertretbar ist es NUR, weil es sich gegen alles ausser localhost
+# verweigert. Genau diese Schranke ist hier zugesichert: faellt sie unbemerkt weg,
+# legt ein Fehlgriff in SESSIONS_DATABASE_URL einen echten Admin-Zugang in einer
+# echten Umgebung an. Das ist die eine Zusicherung, die nicht stillschweigend
+# verrotten darf.
+#
+# Zugesichert wird die SEMANTIK (T002716): Exit-Code ungleich 0 und die Nennung des
+# abgelehnten Hosts. Der genaue Wortlaut ist nicht festgeschrieben.
+#
+# Kein DB-Zugriff noetig: alle Tests hier enden VOR dem Verbindungsaufbau. Der
+# Positiv-Anker prueft deshalb nicht das Schreiben, sondern dass ein localhost-Wert
+# die Host-Schranke PASSIERT — sichtbar daran, dass die Fehlermeldung dann eine
+# andere ist (naechste Stufe erreicht) und nicht mehr den Host nennt.
+
+setup() {
+  PROJECT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+  SCRIPT="$PROJECT_DIR/scripts/dev-admin-session.mjs"
+}
+
+@test "T012980: ohne SESSIONS_DATABASE_URL bricht es ab und nennt die Vorbedingung" {
+  run env -u SESSIONS_DATABASE_URL node "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [ "$(printf '%s\n' "$output" | grep -ci 'SESSIONS_DATABASE_URL')" -ge 1 ]
+}
+
+@test "T012980: ein entfernter Host wird abgelehnt, bevor geschrieben wird" {
+  run env SESSIONS_DATABASE_URL="postgres://u:p@db.example.com:5432/x" node "$SCRIPT"
+  [ "$status" -ne 0 ]
+  # Die Meldung nennt den abgelehnten Host — das ist der Beleg, dass die Host-Schranke
+  # gegriffen hat und nicht ein beliebiger spaeterer Fehler.
+  [ "$(printf '%s\n' "$output" | grep -c 'db.example.com')" -ge 1 ]
+}
+
+@test "T012980: auch eine IP ausserhalb von localhost wird abgelehnt" {
+  # 10.0.0.5 ist privat, aber nicht localhost. Ohne diesen Fall bliebe offen, ob die
+  # Schranke am Hostnamen oder an der Erreichbarkeit haengt.
+  run env SESSIONS_DATABASE_URL="postgres://u:p@10.0.0.5:5432/x" node "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [ "$(printf '%s\n' "$output" | grep -c '10.0.0.5')" -ge 1 ]
+}
+
+@test "T012980 Positiv-Anker: 127.0.0.1 passiert die Host-Schranke" {
+  # Ohne diesen Anker waeren die Ablehnungen oben vakuos: ein Skript, das IMMER
+  # abbricht, bestuende sie ebenfalls. Hier zeigt ein nicht erreichbarer Port, dass
+  # der Lauf die Host-Pruefung hinter sich gelassen hat — die Meldung nennt dann
+  # NICHT mehr den Host als Ablehnungsgrund.
+  run env SESSIONS_DATABASE_URL="postgres://u:p@127.0.0.1:59999/x" node "$SCRIPT"
+  [ "$(printf '%s\n' "$output" | grep -ci 'Verweigert')" -eq 0 ]
+}


### PR DESCRIPTION
## Warum

`scripts/dev-admin-session.mjs` lag untracked im Hauptcheckout. Als S4-Waise — keine Referenz in einer konfigurierten Quelle — ließ es `task quality:check` scheitern und blockierte über den pre-push-Hook **jeden** lokalen Push. Auch das Löschen bereits gemergter Branches, das gar keinen Code überträgt.

Der Ausweg wäre `SKIP_CI_CHECK=1` gewesen: einen Guard überspringen wegen einer Datei, die einfach ins Repo gehört.

## Was das Skript tut

Es schreibt eine Session mit `realmRoles: ['admin']` in `web_sessions`, damit `/sdlc/*` lokal ohne erreichbares Pocket ID nutzbar ist. `auth.ts` öffnet mit `issueSession()` denselben Pfad bereits für die System-Testnutzer (Magic-Link-Redeem).

**Es ist ein Auth-Bypass** und nur deshalb vertretbar, weil es sich gegen alles außer localhost verweigert.

## Änderungen

- `scripts/dev-admin-session.mjs` — unverändert übernommen, wie es im Hauptcheckout lag.
- `taskfiles/Taskfile.sdlc.yml` — `task sdlc:admin-session` neben `sdlc:dev`. Der Task lädt `components/website/.env` ausdrücklich mit `set -a`: nur dort steht `SESSIONS_DATABASE_URL`, und ohne Export sähe node sie nicht. Fehlt die Datei, bricht er mit einer nennenden Meldung ab statt mit einem Folgefehler aus dem Skript.
- `tests/spec/sdlc/dev-admin-session-guards.bats` — vier Tests auf die Host-Schranke. Fällt sie unbemerkt weg, legt ein Fehlgriff in `SESSIONS_DATABASE_URL` einen echten Admin-Zugang in einer echten Umgebung an. Der Positiv-Anker belegt, dass `127.0.0.1` die Schranke passiert — ohne ihn bestünden die Ablehnungen vakuos, weil ein immer abbrechendes Skript sie ebenfalls bestünde.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `dev-admin-session-guards.bats` | 4 Tests grün |
| `task sdlc:admin-session` ende-zu-ende | legt eine Session an, gibt das Cookie aus |
| Dasselbe ohne `components/website/.env` | Exit 2 mit Vorbedingungsmeldung |
| `task quality:check` | 0 Violations — die S4-Waise ist aufgelöst |