### PR TITLE
fix(scripts): branch-reaper erkennt Netzfehler und Scope-Allowlist [T012967]

### DIFF
--- a/.opencode/skills/opencode-flow-chore/SKILL.md
+++ b/.opencode/skills/opencode-flow-chore/SKILL.md
@@ -73,6 +73,8 @@ Delegate to **`opencode-git-workflow` Steps 2–6** (SSOT):
 - Commit-Verifikation: `HEAD_SHA != BASE_SHA`
 - Scope-Preflight: `bash scripts/preflight-pr-scope.sh`
 - PR-Titel: `chore(<scope>): <subject> [$TICKET_EXT_ID]`
+  - Scope muss aus der Allowlist stammen (`bash scripts/validate-commit-msg.sh scopes`)
+  - Oder Ticket-Scope verwenden: `chore($TICKET_EXT_ID): <subject>` (bypassed die Allowlist)
 
 ## Schritt 5: Merge wenn CI grün
 

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2508,6 +2508,12 @@
     "kind": "shell"
   },
   {
+    "id": "branch-reaper-netzausfall",
+    "file": "tests/spec/branch-reaper-netzausfall.bats",
+    "category": "branch-reaper-netzausfall",
+    "kind": "shell"
+  },
+  {
     "id": "brett",
     "file": "tests/spec/brett.bats",
     "category": "brett",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1143,
+      "file_count": 1144,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -443,6 +443,7 @@
         "tests/spec/brain-merge-hook.bats",
         "tests/spec/brain-quality-goals.bats",
         "tests/spec/brain-quartz-deploy.bats",
+        "tests/spec/branch-reaper-netzausfall.bats",
         "tests/spec/brett.bats",
         "tests/spec/centralized-logging.bats",
         "tests/spec/chat-inbox.bats",

--- a/scripts/branch-reaper.sh
+++ b/scripts/branch-reaper.sh
@@ -206,15 +206,26 @@ mapfile -t WORKTREE_BRANCHES < <(git worktree list --porcelain | sed -n 's|^bran
 # Kandidaten: Remote-Branches. Im Einzel-Ticket-Modus nur die, deren Name die Ticket-ID
 # trägt (case-insensitiv). Im Sweep-Modus alle — die Ticket-ID wird je Branch aus dem
 # Branch-Namen extrahiert.
+#
+# T012967: Exit-Code von git ls-remote getrennt auswerten — ein Netzfehler ist kein
+# "leeres Repo". stderr sichtbar lassen, damit der Aufrufer die Fehlerursache sieht.
+LS_REMOTE_RAW=$(git ls-remote --heads "$REMOTE" 2>&1) || LS_REMOTE_RC=$?
+if [ "${LS_REMOTE_RC:-0}" -ne 0 ]; then
+  echo "Fehler: git ls-remote gegen $REMOTE schlug fehl (rc=$LS_REMOTE_RC)." >&2
+  echo "$LS_REMOTE_RAW" >&2
+  exit 1
+fi
+
 mapfile -t CANDIDATES < <(
+  [ -z "$LS_REMOTE_RAW" ] && exit 0
   if [ -n "$TICKET_ID" ]; then
-    git ls-remote --heads "$REMOTE" 2>/dev/null \
+    printf '%s\n' "$LS_REMOTE_RAW" \
       | awk '{print $2}' \
       | sed 's|^refs/heads/||' \
       | grep -i -- "$TICKET_ID" \
       || true
   else
-    git ls-remote --heads "$REMOTE" 2>/dev/null \
+    printf '%s\n' "$LS_REMOTE_RAW" \
       | awk '{print $2}' \
       | sed 's|^refs/heads/||' \
       || true

--- a/tests/spec/branch-reaper-netzausfall.bats
+++ b/tests/spec/branch-reaper-netzausfall.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# SA-branch-reaper-netzausfall-T012967
+# branch-reaper.sh soll bei Netzfehler (git ls-remote rc != 0) einen Fehler
+# melden und mit rc != 0 beenden, statt "Keine Remote-Branches gefunden" auszugeben.
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  REAPER="$REPO/scripts/branch-reaper.sh"
+}
+
+@test "branch-reaper exits non-zero when git ls-remote fails (network error)" {
+  # Run branch-reaper with a mock that makes git ls-remote return rc=1
+  run bash -c '
+    # Override git to make ls-remote fail
+    git() {
+      if [[ "$1" == "ls-remote" ]]; then
+        echo "fatal: unable to access" >&2
+        return 1
+      fi
+      command git "$@"
+    }
+    export -f git
+    export REPO="'"$REPO"'"
+    bash "'"$REAPER"'" --sweep --dry-run 2>&1
+  '
+  # Must NOT exit 0 — a network error is not "no branches found"
+  [ "$status" -ne 0 ]
+  # Must NOT claim success
+  [[ "$output" != *"Keine Remote-Branches gefunden"* ]]
+}
+
+@test "branch-reaper still succeeds when git ls-remote returns 0 with no branches" {
+  run bash -c '
+    git() {
+      if [[ "$1" == "ls-remote" ]]; then
+        echo ""
+        return 0
+      fi
+      command git "$@"
+    }
+    export -f git
+    export REPO="'"$REPO"'"
+    bash "'"$REAPER"'" --sweep --dry-run 2>&1
+  '
+  # Empty result with rc=0 is genuinely "no branches" — exit 0 is correct
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Keine Remote-Branches gefunden"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes two actionable items from the mishap rollups:

**1. branch-reaper: Netzfehler erkennen (T012967)**
`git ls-remote` Exit-Code wird jetzt getrennt ausgewertet. Bei rc != 0 (z.B. DNS-Ausfall) meldet der Reaper einen Fehler und bricht mit rc=1 ab — statt still "Keine Remote-Branches gefunden" zu melden und mit rc=0 zu beenden.

- `scripts/branch-reaper.sh`: Exit-Code-Auswertung, stderr sichtbar
- `tests/spec/branch-reaper-netzausfall.bats`: Zwei Tests (network error → rc!=0, empty repo → rc=0)

**2. dev-flow-chore: Scope-Allowlist erwähnen (T012909 #2)**
SKILL.md Schritt 4 nennt jetzt explizit, dass `<scope>` aus einer Allowlist stammt, und empfiehlt den Ticket-Scope als Default.

## Test Plan

- [x] `bats tests/spec/branch-reaper-netzausfall.bats` — 2/2 grün
- [x] `bats tests/spec/ci-cd/branch-reaper*.bats` — 41/41 grün
- [x] `bats tests/spec/ticket-system/list-status-comma-list.bats` — 4/4 grün
- [x] `task test:changed` — alle Tests grün (vor Timeout abgebrochen, aber alle parallelen Läufe grün)
- [x] `task freshness:regenerate` — OK