### PR TITLE
chore: stash follow-up brain-ingest disable-thinking + gitleaks allowlist [T012998]

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -70,6 +70,11 @@
     # den Arbeitsbaum mit --no-git und wuerde sonst jeden Commit blockieren.
     "(?i)^\\.env$",
     "(?i)^deep\\.sh$",
+    # [T012960] Externer Arbeitsbaum deepseek-harness im Repo-Root, gitignored
+    # (verifiziert per git check-ignore) — kann nie in einen Commit gelangen.
+    # Enthaelt eine echte .env mit DeepSeek-API-Key; der Hook scannt mit
+    # --no-git den Arbeitsbaum und wuerde sonst jeden Commit blockieren.
+    "(?i)^deepseek-harness/.*",
   ]
 
 # ── Standard rules ─────────────────────────────────────────────────────

--- a/openspec/changes/archive/2026-08-19-brain-knowledge-lifecycle/tasks.md
+++ b/openspec/changes/archive/2026-08-19-brain-knowledge-lifecycle/tasks.md
@@ -2,7 +2,7 @@
 title: "brain-knowledge-lifecycle — Implementation Plan"
 ticket_id: T012913
 domains: [plan-authoring]
-status: active
+status: completed
 file_locks: []
 shared_changes: false
 batch_id: null

--- a/scripts/brain-ingest-transform.sh
+++ b/scripts/brain-ingest-transform.sh
@@ -109,7 +109,9 @@ Gib NUR das fertige Markdown aus:"
 call_llm() {
   local prompt="$1" response curl_cfg="" think='{}'
   [ -n "$LM_API_KEY" ] && curl_cfg="$(printf 'header = "Authorization: Bearer %s"' "$LM_API_KEY")"
-  [ "${LM_DISABLE_THINKING:-0}" = "1" ] && think='{"thinking":{"type":"disabled"}}'
+  # Gemma 4 uses chat_template_kwargs.enable_thinking; DeepSeek uses thinking.type.
+  # Send both — unknown keys are harmlessly ignored by each provider. [T002533]
+  [ "${LM_DISABLE_THINKING:-0}" = "1" ] && think='{"thinking":{"type":"disabled"},"chat_template_kwargs":{"enable_thinking":false}}'
   response="$(printf '%s\n' "$curl_cfg" | curl -sf --config - --max-time "$LM_TIMEOUT" "${LM_URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d "$(jq -n \


### PR DESCRIPTION
## Zusammenfassung

Drei Nachzieher aus der Repo-Hygiene-Runde 2026-08-21:

1. **brain-ingest LM_DISABLE_THINKING (Gemma-Fix)** — lag bisher nur im Stash auf `chore/brain-ingest-kv-q8-T012961`. Der Request schickt jetzt zusätzlich `chat_template_kwargs.enable_thinking=false` neben dem DeepSeek-Format `thinking.type=disabled`; Gemma-4-Loadouts ignorieren letzteres und dachten sonst bis zum Token-Budget. Unbekannte Keys ignoriert jeder Provider.
2. **tasks.md brain-knowledge-lifecycle**: `status: active` → `completed` (archivierter Change, Nachzieher T012913).
3. **.gitleaks.toml**: gitignorierten externen Baum `deepseek-harness/` (echte .env, T012960) allowlistet — der pre-commit-Hook scannt mit `--no-git` den Arbeitsbaum und blockierte sonst **jeden** Commit im Repo. Gleiche Konstellation wie die [T002554]-Einträge; Pfad per `git check-ignore` verifiziert.

Verworfen aus dem Stash (bewusst): `.gitignore`-Hunk (main hat bereits die bessere `/deepseek-harness/`-Variante) und 422 Zeilen veralteten package-lock-Churn.

## Gates
- `task test:changed` ✅ · `task freshness:check` ✅ · gitleaks --no-git clean ✅

Closes T012998