### PR TITLE
feat(infra): Prod-Passkeys im lokalen SDLC-Stack nutzbar machen [T012999]

### DIFF
--- a/components/website/src/lib/auth.test.ts
+++ b/components/website/src/lib/auth.test.ts
@@ -80,6 +80,35 @@ describe('getLoginUrl', () => {
     expect(url).toContain(encodeURIComponent('/api/auth/callback'));
   });
 
+  // Der lokale SDLC-Stack meldet sich im Prod-Auth-Modus gegen die
+  // Prod-Pocket-ID an, damit dort registrierte Passkeys nutzbar sind. Dort ist
+  // der `website`-Client fuer web.<PROD_DOMAIN> reserviert, die localhost-
+  // Console braucht also einen eigenen client_id. Ohne die Env-Ueberschreibung
+  // sendet sie client_id=website mit einer redirect_uri, die dieser Client
+  // nicht kennt — Pocket ID weist den Authorize-Request ab.
+  it('nimmt den client_id aus POCKET_ID_CLIENT_ID, wenn gesetzt', async () => {
+    process.env.POCKET_ID_CLIENT_ID = 'website-local';
+    vi.resetModules();
+    try {
+      const m = await loadModule();
+      const url = m.getLoginUrl();
+      expect(new URL(url).searchParams.get('client_id')).toBe('website-local');
+    } finally {
+      delete process.env.POCKET_ID_CLIENT_ID;
+      vi.resetModules();
+    }
+  });
+
+  // Positiv-Anker zum Test darueber: ohne gesetzte Variable bleibt es bei
+  // 'website'. Sonst koennte die Ueberschreibung auch dadurch "gruen" sein,
+  // dass der Default versehentlich mitgeaendert wurde.
+  it('faellt ohne POCKET_ID_CLIENT_ID auf website zurueck', async () => {
+    delete process.env.POCKET_ID_CLIENT_ID;
+    vi.resetModules();
+    const m = await loadModule();
+    expect(new URL(m.getLoginUrl()).searchParams.get('client_id')).toBe('website');
+  });
+
   // [T002497] Bis 372729d7d reichte getLoginUrl das Argument als state-Parameter
   // durch; der Test hiess entsprechend "echoes the supplied state parameter".
   // Seither ist das Argument ein returnTo, das INTERN unter einem zufällig

--- a/components/website/src/lib/auth.ts
+++ b/components/website/src/lib/auth.ts
@@ -3,7 +3,15 @@
 import { logger } from './logger';
 import { resolveEndpoints, resolveEndpointsSync, clearProviderCache, AuthUnavailableError } from './auth/provider';
 
-const CLIENT_ID = 'website';
+// Normalerweise 'website' — der Client, den pocket-id-client-seed anlegt.
+// Überschreibbar für den Fall, dass eine Instanz gegen eine FREMDE Pocket ID
+// spricht, in der dieser Deployment-Stand einen eigenen Client hat: der lokale
+// SDLC-Stack, der sich gegen die Prod-Pocket-ID anmeldet, damit dort
+// registrierte Passkeys nutzbar sind (siehe docs/sdlc-stack/prod-auth.md).
+// Ein Passkey ist per WebAuthn an die RP-ID der Pocket-ID-Domain gebunden;
+// der Authorize-Schritt MUSS deshalb auf der Prod-Domain stattfinden, und
+// dort ist der Prod-`website`-Client für web.<PROD_DOMAIN> reserviert.
+const CLIENT_ID = process.env.POCKET_ID_CLIENT_ID || 'website';
 const CLIENT_SECRET = process.env.POCKET_ID_WEBSITE_SECRET || process.env.WEBSITE_OIDC_SECRET || '';
 if (!CLIENT_SECRET) {
   // Fail hard at boot instead of silently falling back to a well-known dev

--- a/docs/sdlc-stack/prod-auth.md
+++ b/docs/sdlc-stack/prod-auth.md
@@ -1,0 +1,139 @@
+# Prod-Passkeys im lokalen SDLC-Stack
+
+Ziel: sich an der Console auf `http://web.localhost` mit dem Passkey anmelden,
+der in der Produktion (`auth.mentolder.de`) registriert ist.
+
+## Warum ein Passkey nicht einfach lokal funktioniert
+
+Ein Passkey ist eine WebAuthn-Credential und an die **RP-ID** gebunden — die
+Domain, auf der er registriert wurde. Der private Schlüssel verlässt den
+Authenticator nie, und die RP-ID geht in die Signatur ein.
+
+Daraus folgen zwei Dinge, die oft zuerst versucht werden und beide nicht gehen
+können:
+
+- **Passkey in die lokale Pocket ID kopieren.** Es gibt nichts zu kopieren; der
+  private Teil ist nicht exportierbar.
+- **Die Pocket-ID-Datenbank aus Prod ziehen.** Die Credential-Zeilen wären da,
+  aber die RP-ID lautet `auth.mentolder.de`. Auf `auth.localhost` bietet der
+  Browser den Schlüssel gar nicht erst zur Auswahl an.
+
+Der einzige gangbare Weg ist deshalb: **der Authorize-Schritt findet auf der
+Prod-Domain statt**, und Pocket ID leitet danach nach `http://web.localhost`
+zurück. Die Console tauscht den Code ebenfalls gegen die Prod-Instanz ein.
+
+```
+Browser ──1── http://web.localhost/api/auth/login
+        ──2── https://auth.mentolder.de/authorize   ← hier greift der Passkey
+        ──3── http://web.localhost/api/auth/callback?code=…
+Console ──4── POST https://auth.mentolder.de/api/oidc/token
+```
+
+## Umschalten
+
+```bash
+task sdlc:sdlc:auth:prod     # Login läuft über auth.mentolder.de
+task sdlc:sdlc:auth:status   # zeigt den aktuellen Modus
+task sdlc:sdlc:auth:local    # zurück auf die mitgelieferte Pocket ID
+```
+
+Alternativ beim Deploy direkt: `SDLC_AUTH=prod task sdlc:sdlc:deploy`, danach einmal
+`task sdlc:sdlc:auth:prod` für Client und Secret.
+
+**Login-Host ist `web.localhost`, nicht `sdlc.localhost`.** Nur `web.localhost`
+ist als `redirect_uri` registriert; Pocket ID vergleicht exakt. Beide Hosts
+zeigen auf dieselbe Console.
+
+## Was `task sdlc:sdlc:auth:prod` anfasst
+
+In der **Prod-Pocket-ID**: legt genau einen zusätzlichen OIDC-Client
+`website-local` an, mit `http://web.localhost/api/auth/callback` als einziger
+Callback-URL, und erzeugt dessen Secret.
+
+**Lokal**: setzt `POCKET_ID_FRONTEND_URL`, `POCKET_ID_URL` und
+`POCKET_ID_CLIENT_ID` in der ConfigMap `sdlc-console-config`, schreibt das
+Secret in `workspace-secrets` und `website-secrets`, startet die Console neu.
+
+Der Prod-`website`-Client bleibt unangetastet. Das ist der Grund für den
+eigenen Client statt einer zusätzlichen Callback-URL am bestehenden: ein
+Fehlgriff hier kann niemanden aus `web.mentolder.de` aussperren, und der
+Entwickler-Client lässt sich jederzeit ersatzlos löschen.
+
+## Sicherheitslage
+
+Die Callback-URL zeigt auf den Loopback. Ein abgefangener Authorization Code
+wäre nur einlösbar, wenn der Angreifer zusätzlich das Client-Secret hat — der
+Client ist confidential (`isPublic: false`). Der Angriff setzt außerdem einen
+Listener auf `web.localhost:80` des Opfers voraus.
+
+Der Client hat Zugriff auf dieselben Scopes wie jeder andere Pocket-ID-Client:
+er authentifiziert nur, er autorisiert nichts zusätzlich. Wer ihn nicht mehr
+braucht, löscht ihn in der Pocket-ID-Admin-UI.
+
+## Nach jedem `task sdlc:sdlc:deploy` erneut aufrufen
+
+`sdlc:deploy` appliziert `k3d/secrets.yaml` und setzt
+`POCKET_ID_WEBSITE_SECRET` auf den festen Dev-Wert zurück. Danach kennt die
+Prod-Pocket-ID ein anderes Secret als die Console, und der Token-Exchange
+scheitert mit `invalid_client`. Ein erneutes `task sdlc:sdlc:auth:prod` rotiert das
+Secret des Entwickler-Clients und schreibt es wieder in beide K8s-Secrets.
+
+Das ist dieselbe Mechanik, gegen die im lokalen Modus `task sdlc:sdlc:oidc:sync`
+läuft.
+
+## Voraussetzung: Console-Image kennt `POCKET_ID_CLIENT_ID`
+
+Die Variable wird erst ab dem Image ausgewertet, das nach dem Merge dieser
+Änderung gebaut wird (`.github/workflows/build-sdlc-console.yml`). Ein älteres
+Image sendet weiterhin `client_id=website`, und die Prod-Pocket-ID weist den
+Authorize-Request mit unbekannter `redirect_uri` ab.
+
+Nach dem Merge:
+
+```bash
+task sdlc:sdlc:refresh   # zieht die frische :latest
+```
+
+Vorher überbrückt ein lokal gebautes Image:
+
+```bash
+docker build -f components/website/Dockerfile --build-arg BUILD_TARGET=sdlc \
+  -t ghcr.io/paddione/website-sdlc:prodauth-local .
+k3d image import ghcr.io/paddione/website-sdlc:prodauth-local -c mentolder-dev
+kubectl --context k3d-mentolder-dev -n workspace set image \
+  deploy/sdlc-console sdlc-console=ghcr.io/paddione/website-sdlc:prodauth-local
+kubectl --context k3d-mentolder-dev -n workspace patch deploy/sdlc-console \
+  -p '{"spec":{"template":{"spec":{"containers":[{"name":"sdlc-console","imagePullPolicy":"IfNotPresent"}]}}}}'
+```
+
+`imagePullPolicy` muss dabei mit, sonst versucht der Kubelet den lokalen Tag
+aus der Registry zu ziehen. `task sdlc:sdlc:deploy` stellt beides zurück.
+
+## Voraussetzung: entsperrtes git-crypt
+
+Der Prod-Admin-API-Key kommt aus `environments/.secrets/mentolder.yaml`. Bei
+verschlossenem git-crypt ist die Datei Binärmüll; das Skript bricht mit einem
+Hinweis ab, statt in ein unerklärliches `401` zu laufen.
+
+## Fehlerbilder
+
+| Symptom | Ursache |
+|---|---|
+| `auth_error=exchange_failed` nach der Passkey-Eingabe | Client-Secret-Drift, meist nach einem `sdlc:deploy`. `task sdlc:sdlc:auth:prod` erneut ausführen. |
+| Pocket ID zeigt „invalid redirect_uri" | Login lief über `sdlc.localhost`. Über `http://web.localhost` einsteigen. |
+| Login-Seite fragt nach Passwort statt Passkey | Der Authorize-Schritt lief gegen `auth.localhost` — Modus prüfen mit `task sdlc:sdlc:auth:status`. |
+| Console startet nicht, Log nennt `POCKET_ID_WEBSITE_SECRET` | Secret leer; `task sdlc:sdlc:auth:prod` bzw. `task sdlc:sdlc:auth:local` setzt es. |
+
+## Bekannte Nebenbaustelle
+
+Der Prod-Job `pocket-id-client-seed` ist seit dem 2026-08-08 fehlgeschlagen: der
+Flux-Renderer (`scripts/flux-render-artifact.sh`) sammelt alle `${VAR}` aus dem
+Manifest ein und ersetzt auch `${SCHEME}`/`${SUFFIX}` — die im Job aber erst
+zur **Laufzeit** in der Container-Shell entstehen sollen. Im gerenderten
+Manifest steht deshalb `://web./api/auth/callback`.
+
+Für diesen Ablauf hier ist das folgenlos (der Entwickler-Client wird über die
+Admin-API gepflegt, nicht über den Job), aber es heißt: **Client-Änderungen in
+Prod sind derzeit nicht deklarativ.** Die Behebung wäre, die Laufzeit-Variablen
+im Job als `$${SCHEME}`/`$${SUFFIX}` zu schreiben — das ist die Konvention, die
+`flux-render-artifact.sh` für genau diesen Fall vorsieht (T002306).

--- a/k3d/sdlc-stack/sdlc-console.yaml
+++ b/k3d/sdlc-stack/sdlc-console.yaml
@@ -13,9 +13,22 @@ data:
   # web.<suffix>/api/auth/callback aus POCKET_ID_FRONTEND_URL ab. Mit
   # sdlc.localhost sendet die Console eine redirect_uri, die Pocket ID nicht
   # kennt. sdlc.localhost bleibt als zweiter Ingress-Host erreichbar.
-  SITE_URL: "http://web.localhost"
-  POCKET_ID_FRONTEND_URL: "http://auth.localhost"
-  POCKET_ID_URL: "http://pocket-id:1411"
+  #
+  # Die drei Werte kommen aus SDLC_CONSOLE_* (Taskfile.sdlc.yml), NICHT aus
+  # POCKET_ID_FRONTEND_URL/POCKET_ID_URL: dieselben Namen steuern im selben
+  # Kustomize-Build den pocket-id-client-seed-Job, der daraus seine
+  # Callback-Hosts ableitet. Ein gemeinsamer Name haette den lokalen Seed-Job
+  # im Prod-Auth-Modus dazu gebracht, Callbacks fuer web.<PROD_DOMAIN> in die
+  # LOKALE Pocket ID zu schreiben.
+  #
+  # Prod-Auth-Modus (SDLC_AUTH=prod): zeigt auf https://auth.<PROD_DOMAIN>.
+  # Grund ist WebAuthn, nicht Bequemlichkeit — ein Passkey ist an die RP-ID
+  # der Pocket-ID-Domain gebunden und gegen auth.localhost nicht verwendbar.
+  # Siehe docs/sdlc-stack/prod-auth.md.
+  SITE_URL: "${SDLC_CONSOLE_SITE_URL}"
+  POCKET_ID_FRONTEND_URL: "${SDLC_CONSOLE_POCKET_ID_FRONTEND_URL}"
+  POCKET_ID_URL: "${SDLC_CONSOLE_POCKET_ID_URL}"
+  POCKET_ID_CLIENT_ID: "${SDLC_CONSOLE_POCKET_ID_CLIENT_ID}"
   POCKET_ID_FALLBACK_FRONTEND_URL: "${POCKET_ID_FALLBACK_FRONTEND_URL}"
   POCKET_ID_FALLBACK_URL: "${POCKET_ID_FALLBACK_URL}"
   PORTAL_ADMIN_USERNAME: "gekko,paddione,quamain,test-admin,tina-merlin@web.de"

--- a/scripts/sdlc-auth-mode.sh
+++ b/scripts/sdlc-auth-mode.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# scripts/sdlc-auth-mode.sh
+#
+# Schaltet den Login der lokalen SDLC-Console zwischen der mitgelieferten
+# Pocket ID (auth.localhost) und der PRODUKTIONS-Pocket-ID um.
+#
+# ── Warum das ueberhaupt noetig ist ──────────────────────────────────────────
+# Ein Passkey ist eine WebAuthn-Credential und an die RP-ID der Domain
+# gebunden, auf der er registriert wurde. Ein auf auth.mentolder.de angelegter
+# Passkey existiert in der lokalen Pocket ID auf auth.localhost nicht — der
+# Browser bietet ihn dort nicht einmal zur Auswahl an. Passkeys "kopieren" geht
+# per Konstruktion nicht: der private Schluessel verlaesst den Authenticator
+# nie, und die RP-ID ist Teil der Signatur.
+#
+# Der einzige Weg, mit einem Prod-Passkey in die localhost-Console zu kommen,
+# ist deshalb, den Authorize-Schritt AUF der Prod-Domain stattfinden zu lassen
+# und Pocket ID danach nach http://web.localhost/api/auth/callback
+# zurueckleiten zu lassen.
+#
+# ── Was der prod-Modus anfasst ──────────────────────────────────────────────
+# In PROD: legt genau EINEN zusaetzlichen OIDC-Client an (`website-local`) mit
+#   der localhost-Callback-URL. Der Prod-`website`-Client bleibt unberuehrt —
+#   deshalb ein eigener Client statt einer zusaetzlichen Callback-URL am
+#   bestehenden: ein Fehlgriff hier sperrt niemanden aus web.<PROD_DOMAIN> aus,
+#   und der Client laesst sich jederzeit ersatzlos loeschen.
+# LOKAL: setzt ConfigMap sdlc-console-config und das Client-Secret in
+#   workspace-secrets/website-secrets, dann Rollout-Restart.
+#
+# Der Client ist confidential (isPublic=false): ein abgefangener Auth-Code ist
+# ohne das Secret nicht einloesbar.
+#
+# ── Verwendung ──────────────────────────────────────────────────────────────
+#   scripts/sdlc-auth-mode.sh prod    [--domain mentolder.de]
+#   scripts/sdlc-auth-mode.sh local
+#   scripts/sdlc-auth-mode.sh status
+#
+# Nach jedem `task sdlc:sdlc:deploy` erneut aufrufen: der Deploy appliziert
+# k3d/secrets.yaml und setzt POCKET_ID_WEBSITE_SECRET auf den Dev-Wert zurueck
+# (dieselbe Mechanik, gegen die sdlc:oidc:sync im local-Modus laeuft).
+set -euo pipefail
+
+MODE="${1:-status}"
+shift || true
+
+CONTEXT="k3d-mentolder-dev"
+NS="workspace"
+DOMAIN="mentolder.de"
+CLIENT="website-local"
+CALLBACK="http://web.localhost/api/auth/callback"
+SECRETS_FILE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --context) CONTEXT="$2"; shift 2 ;;
+    --namespace) NS="$2"; shift 2 ;;
+    --domain) DOMAIN="$2"; shift 2 ;;
+    --client) CLIENT="$2"; shift 2 ;;
+    --secrets-file) SECRETS_FILE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,45p' "$0"; exit 0 ;;
+    *) echo "Unbekannte Option: $1" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+: "${SECRETS_FILE:=${REPO_ROOT}/environments/.secrets/$(printf '%s' "$DOMAIN" | cut -d. -f1).yaml}"
+AUTH_BASE="https://auth.${DOMAIN}"
+
+kube() { kubectl --context "$CONTEXT" -n "$NS" "$@"; }
+
+require_cluster() {
+  if ! kube get deploy/sdlc-console >/dev/null 2>&1; then
+    echo "FEHLER: deployment/sdlc-console in ${CONTEXT}/${NS} nicht gefunden." >&2
+    echo "  Zuerst: task sdlc:sdlc:deploy" >&2
+    exit 1
+  fi
+}
+
+show_status() {
+  echo "Kontext:   ${CONTEXT}/${NS}"
+  kube get configmap sdlc-console-config \
+    -o jsonpath='  SITE_URL:      {.data.SITE_URL}{"\n"}  Pocket ID:     {.data.POCKET_ID_FRONTEND_URL}{"\n"}  intern:        {.data.POCKET_ID_URL}{"\n"}  client_id:     {.data.POCKET_ID_CLIENT_ID}{"\n"}' \
+    2>/dev/null || echo "  (ConfigMap nicht lesbar)"
+}
+
+# ── git-crypt-Guard ─────────────────────────────────────────────────────────
+# Bei verschlossenem git-crypt ist die Datei Binaermuell; ein grep darauf
+# liefert einfach nichts und der Fehler faellt erst als "401 vom Admin-API"
+# auf. Deshalb hier explizit pruefen, was gelesen wurde.
+read_secret_value() {
+  local key="$1"
+  if [ ! -f "$SECRETS_FILE" ]; then
+    echo "FEHLER: ${SECRETS_FILE} existiert nicht." >&2
+    exit 1
+  fi
+  local val
+  val=$(grep -m1 "^${key}:" "$SECRETS_FILE" 2>/dev/null | sed -E 's/^[^:]+: *"?([^"]*)"?[[:space:]]*$/\1/') || true
+  if [ -z "$val" ]; then
+    echo "FEHLER: ${key} konnte aus ${SECRETS_FILE} nicht gelesen werden." >&2
+    echo "  Haeufigste Ursache: git-crypt ist verschlossen (git-crypt unlock)." >&2
+    exit 1
+  fi
+  printf '%s' "$val"
+}
+
+api() {
+  local method="$1" path="$2"; shift 2
+  curl -fsS -X "$method" -H "X-API-KEY: ${API_KEY}" -H "Content-Type: application/json" \
+    --connect-timeout 10 --max-time 30 "$@" "${AUTH_BASE}${path}"
+}
+
+ensure_prod_client() {
+  echo "→ pruefe OIDC-Client '${CLIENT}' auf ${AUTH_BASE}"
+  local existing
+  existing=$(api GET "/api/oidc/clients/${CLIENT}" 2>/dev/null || true)
+
+  local body
+  body=$(printf '{"id":"%s","name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":["http://web.localhost"],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' \
+    "$CLIENT" "$CLIENT" "$CALLBACK")
+
+  if [ -n "$existing" ]; then
+    api PUT "/api/oidc/clients/${CLIENT}" -d "$body" >/dev/null
+    echo "  Client existiert — Callback-URL auf ${CALLBACK} gesetzt"
+  else
+    api POST "/api/oidc/clients" -d "$body" >/dev/null
+    echo "  Client angelegt (Callback ${CALLBACK})"
+  fi
+}
+
+rotate_prod_client_secret() {
+  # Immer rotieren statt zu versuchen, den alten Wert zu lesen: Pocket ID gibt
+  # ein Client-Secret nur EINMAL heraus, bei der Erzeugung. Fuer einen reinen
+  # Entwickler-Client ist die Rotation folgenlos — er hat genau einen
+  # Konsumenten, naemlich diese lokale Console.
+  local gen
+  gen=$(api POST "/api/oidc/clients/${CLIENT}/secret")
+  local plain
+  plain=$(printf '%s' "$gen" | sed -E 's/.*"secret":"([^"]+)".*/\1/')
+  if [ -z "$plain" ] || [ "$plain" = "$gen" ]; then
+    echo "FEHLER: Client-Secret nicht aus der Antwort lesbar: ${gen}" >&2
+    exit 1
+  fi
+  printf '%s' "$plain"
+}
+
+apply_local_configmap() {
+  local frontend="$1" internal="$2" client_id="$3"
+  kube patch configmap sdlc-console-config --type merge -p "$(printf \
+    '{"data":{"POCKET_ID_FRONTEND_URL":"%s","POCKET_ID_URL":"%s","POCKET_ID_CLIENT_ID":"%s","SITE_URL":"http://web.localhost"}}' \
+    "$frontend" "$internal" "$client_id")" >/dev/null
+}
+
+restart_console() {
+  echo "→ starte sdlc-console neu (Env wird nur beim Start gelesen)"
+  kube rollout restart deploy/sdlc-console >/dev/null
+  kube rollout status deploy/sdlc-console --timeout=300s
+}
+
+case "$MODE" in
+  prod)
+    require_cluster
+    API_KEY="$(read_secret_value POCKET_ID_API_KEY)"
+
+    if ! curl -fsS -o /dev/null --connect-timeout 10 "${AUTH_BASE}/.well-known/openid-configuration"; then
+      echo "FEHLER: ${AUTH_BASE} ist nicht erreichbar." >&2
+      exit 1
+    fi
+
+    ensure_prod_client
+    SECRET="$(rotate_prod_client_secret)"
+    echo "  Secret erzeugt (${#SECRET} Zeichen)"
+
+    for s in workspace-secrets website-secrets; do
+      if kube get secret "$s" >/dev/null 2>&1; then
+        kube patch secret "$s" --type merge \
+          -p "{\"stringData\":{\"POCKET_ID_WEBSITE_SECRET\":\"${SECRET}\"}}" >/dev/null
+        echo "  → ${s}/POCKET_ID_WEBSITE_SECRET aktualisiert"
+      fi
+    done
+
+    apply_local_configmap "$AUTH_BASE" "$AUTH_BASE" "$CLIENT"
+    restart_console
+    echo
+    echo "✓ Console meldet sich jetzt gegen ${AUTH_BASE} an."
+    echo "  Login: http://web.localhost  (NICHT sdlc.localhost — nur web.localhost"
+    echo "  ist als redirect_uri registriert)."
+    echo "  Dort greift dein Prod-Passkey, weil der Authorize-Schritt auf"
+    echo "  auth.${DOMAIN} laeuft."
+    echo "  Zurueck: scripts/sdlc-auth-mode.sh local"
+    ;;
+
+  local)
+    require_cluster
+    apply_local_configmap "http://auth.localhost" "http://pocket-id:1411" "website"
+    echo "→ gleiche das Client-Secret der lokalen Pocket ID ab"
+    "${REPO_ROOT}/scripts/sdlc-sync-oidc-secret.sh" --context "$CONTEXT" --namespace "$NS"
+    echo "✓ Console meldet sich wieder gegen http://auth.localhost an."
+    ;;
+
+  status)
+    show_status
+    ;;
+
+  *)
+    echo "Verwendung: $0 {prod|local|status} [--domain <d>] [--context <ctx>]" >&2
+    exit 2
+    ;;
+esac

--- a/taskfiles/Taskfile.sdlc.yml
+++ b/taskfiles/Taskfile.sdlc.yml
@@ -54,6 +54,33 @@ tasks:
         export POCKET_ID_DOMAIN="${POCKET_ID_DOMAIN:-auth.localhost}"
         export POCKET_ID_FALLBACK_FRONTEND_URL="${POCKET_ID_FALLBACK_FRONTEND_URL:-https://auth.mentolder.de}"
         export POCKET_ID_FALLBACK_URL="${POCKET_ID_FALLBACK_URL:-https://auth.mentolder.de}"
+        # ── Auth-Modus der Console (SDLC_AUTH=local|prod) ────────────────────
+        # local (Default): Login gegen die mitgelieferte Pocket ID auf
+        #   auth.localhost. Passkeys, die dort registriert wurden, funktionieren
+        #   — Prod-Passkeys nicht, weil WebAuthn-Credentials an die RP-ID der
+        #   Domain gebunden sind und auth.localhost eine andere RP-ID ist.
+        # prod: Der Authorize-Schritt laeuft auf https://auth.<PROD_DOMAIN>,
+        #   also genau dort, wo die Passkeys registriert sind; danach leitet
+        #   Pocket ID nach http://web.localhost/api/auth/callback zurueck. Der
+        #   Token-Exchange spricht ebenfalls die Prod-Instanz an.
+        #   Voraussetzungen (beide stellt `task sdlc:sdlc:auth:prod` her): ein
+        #   eigener OIDC-Client in der Prod-Pocket-ID mit dieser Callback-URL,
+        #   und dessen Secret in den lokalen K8s-Secrets.
+        #   Der Prod-`website`-Client bleibt bewusst unangetastet.
+        SDLC_AUTH="${SDLC_AUTH:-local}"
+        if [ "$SDLC_AUTH" = "prod" ]; then
+          SDLC_AUTH_DOMAIN="${SDLC_AUTH_DOMAIN:-mentolder.de}"
+          export SDLC_CONSOLE_POCKET_ID_FRONTEND_URL="https://auth.${SDLC_AUTH_DOMAIN}"
+          export SDLC_CONSOLE_POCKET_ID_URL="https://auth.${SDLC_AUTH_DOMAIN}"
+          export SDLC_CONSOLE_POCKET_ID_CLIENT_ID="${SDLC_AUTH_CLIENT_ID:-website-local}"
+        else
+          export SDLC_CONSOLE_POCKET_ID_FRONTEND_URL="http://auth.localhost"
+          export SDLC_CONSOLE_POCKET_ID_URL="http://pocket-id:1411"
+          export SDLC_CONSOLE_POCKET_ID_CLIENT_ID="website"
+        fi
+        # SITE_URL bleibt in beiden Modi web.localhost: es ist der Host, unter
+        # dem der Browser die Console erreicht, und bildet die redirect_uri.
+        export SDLC_CONSOLE_SITE_URL="${SDLC_CONSOLE_SITE_URL:-http://web.localhost}"
         export PROD_DOMAIN="${PROD_DOMAIN:-localhost}"
         export WEBSITE_SITE_URL="${WEBSITE_SITE_URL:-http://sdlc.localhost}"
         export SMTP_HOST="${SMTP_HOST:-}"
@@ -96,7 +123,7 @@ tasks:
         # "DO \$ BEGIN" und der Rollen-Block scheitert an einem Syntaxfehler.
         # Vor Leerzeichen oder ';' bleibt $$ deshalb unangetastet.
         kubectl kustomize --load-restrictor=LoadRestrictionsNone k3d/sdlc-stack \
-          | envsubst '$POCKET_ID_FRONTEND_URL $POCKET_ID_URL $POCKET_ID_DOMAIN $POCKET_ID_FALLBACK_FRONTEND_URL $POCKET_ID_FALLBACK_URL $POCKET_ID_SMTP_TLS $PROD_DOMAIN $WEBSITE_SITE_URL $SMTP_HOST $SMTP_PORT $SMTP_USER $SMTP_FROM $WEBSITE_NAMESPACE $WORKSPACE_NAMESPACE' \
+          | envsubst '$POCKET_ID_FRONTEND_URL $POCKET_ID_URL $POCKET_ID_DOMAIN $POCKET_ID_FALLBACK_FRONTEND_URL $POCKET_ID_FALLBACK_URL $POCKET_ID_SMTP_TLS $PROD_DOMAIN $WEBSITE_SITE_URL $SMTP_HOST $SMTP_PORT $SMTP_USER $SMTP_FROM $WEBSITE_NAMESPACE $WORKSPACE_NAMESPACE $SDLC_CONSOLE_SITE_URL $SDLC_CONSOLE_POCKET_ID_FRONTEND_URL $SDLC_CONSOLE_POCKET_ID_URL $SDLC_CONSOLE_POCKET_ID_CLIENT_ID' \
           | sed -E 's/\$\$(\{?[A-Za-z_])/$\1/g' \
           | kubectl --context k3d-mentolder-dev apply -f -
         echo "---"
@@ -129,6 +156,28 @@ tasks:
     # scheitert mit invalid_client.
     cmds:
       - bash scripts/sdlc-sync-oidc-secret.sh
+
+  sdlc:auth:prod:
+    desc: "Console-Login auf die PROD-Pocket-ID umstellen (Prod-Passkeys nutzbar)"
+    # Passkeys sind an die RP-ID ihrer Domain gebunden — ein auf
+    # auth.mentolder.de registrierter Passkey ist gegen auth.localhost
+    # unbrauchbar. Diese Task laesst den Authorize-Schritt auf der Prod-Domain
+    # stattfinden und danach nach http://web.localhost zurueckleiten.
+    # Legt dafuer in Prod EINEN eigenen Client `website-local` an; der
+    # Prod-`website`-Client bleibt unangetastet. Nach jedem sdlc:sdlc:deploy erneut
+    # aufrufen (der Deploy setzt das Client-Secret auf den Dev-Wert zurueck).
+    cmds:
+      - bash scripts/sdlc-auth-mode.sh prod
+
+  sdlc:auth:local:
+    desc: "Console-Login zurueck auf die lokale Pocket ID (auth.localhost)"
+    cmds:
+      - bash scripts/sdlc-auth-mode.sh local
+
+  sdlc:auth:status:
+    desc: "Zeigt, gegen welche Pocket ID sich die Console anmeldet"
+    cmds:
+      - bash scripts/sdlc-auth-mode.sh status
 
   # --- E3/T002626: Datenhoheit ------------------------------------------------
   # Der Cutover ist ein Betriebsvorgang, kein Task-Lauf. Diese Tasks sind die


### PR DESCRIPTION
## Problem

Ein Passkey ist eine WebAuthn-Credential und an die **RP-ID** der Domain gebunden, auf der er registriert wurde. Ein auf `auth.mentolder.de` angelegter Passkey ist gegen die lokale Pocket ID auf `auth.localhost` per Definition unbrauchbar — der Browser bietet ihn dort nicht einmal zur Auswahl an. Kopieren geht nicht (der private Schlüssel verlässt den Authenticator nie), und ein DB-Dump hilft auch nicht (die RP-ID stimmt nicht).

## Lösung

Der Authorize-Schritt findet auf der **Prod-Domain** statt, Pocket ID leitet danach nach `http://web.localhost/api/auth/callback` zurück. Der Token-Exchange läuft ebenfalls gegen die Prod-Instanz.

```
Browser ──1── http://web.localhost/api/auth/login
        ──2── https://auth.mentolder.de/authorize   ← hier greift der Passkey
        ──3── http://web.localhost/api/auth/callback?code=…
Console ──4── POST https://auth.mentolder.de/api/oidc/token
```

Bedienung:

```bash
task sdlc:sdlc:auth:prod     # umschalten
task sdlc:sdlc:auth:status   # Modus anzeigen
task sdlc:sdlc:auth:local    # zurück
```

## Änderungen

- `auth.ts`: `CLIENT_ID` aus `POCKET_ID_CLIENT_ID`, Default unverändert `website`.
- `k3d/sdlc-stack/sdlc-console.yaml`: die vier Auth-Werte aus `SDLC_CONSOLE_*`. Bewusst eigene Variablennamen — `POCKET_ID_FRONTEND_URL` steuert im selben Kustomize-Build den `pocket-id-client-seed`-Job, der daraus seine Callback-Hosts ableitet.
- `taskfiles/Taskfile.sdlc.yml`: `SDLC_AUTH=local|prod` + drei Tasks.
- `scripts/sdlc-auth-mode.sh`: legt in Prod **einen eigenen** OIDC-Client `website-local` an und verdrahtet Secret + ConfigMap lokal.
- `docs/sdlc-stack/prod-auth.md`.

## Warum ein eigener Client statt einer zusätzlichen Callback-URL am `website`-Client

Der Prod-`website`-Client bleibt unangetastet. Ein Fehlgriff dort könnte Nutzer aus `web.mentolder.de` aussperren; der Entwickler-Client lässt sich dagegen jederzeit ersatzlos löschen.

Sicherheitslage: Die Callback-URL zeigt auf den Loopback, der Client ist confidential (`isPublic: false`). Ein abgefangener Authorization Code ist ohne das Client-Secret nicht einlösbar, und der Angriff setzt zusätzlich einen Listener auf `web.localhost:80` des Opfers voraus.

## Nebenbefund (nicht in diesem PR behoben)

Der Prod-Job `pocket-id-client-seed` ist seit 2026-08-08 fehlgeschlagen: `scripts/flux-render-artifact.sh` sammelt alle `${VAR}` aus dem Manifest ein und leert dabei `${SCHEME}`/`${SUFFIX}`, die erst zur Laufzeit in der Container-Shell entstehen sollen. Im gerenderten Manifest steht `://web./api/auth/callback`. Behebung wäre die `$${VAR}`-Schreibweise (T002306-Konvention). Für diesen PR folgenlos — der Entwickler-Client wird über die Admin-API gepflegt.

## Verifikation

- `npx vitest run src/lib/auth.test.ts` → 21/21 grün (inkl. zwei neuer Tests für Override und Default).
- Kustomize-Render für beide Modi geprüft; der Seed-Job behält in beiden `http://auth.localhost`.
- `task test:all`: 356 grün, 3 vorbestehende Fehler in `save-proposal.test.ts` (`vi.mocked(...).mockReset is not a function`) — reproduziert unverändert auf `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNCugRMwKVhtEqUYYUUaDg