### PR TITLE
chore(infra): pin foreign container images with @sha256 digests [T013000]

### DIFF
--- a/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
+++ b/k3d/gitlab-runner-stack/gitlab-runner-rendered.yaml
@@ -383,7 +383,7 @@ spec:
       serviceAccountName: "gitlab-runner"
       containers:
       - name: gitlab-runner
-        image: registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v19.2.2
+        image: registry.gitlab.com/gitlab-org/gitlab-runner:alpine-v19.2.2@sha256:c3e28c921328c4a81404482b3ae7c73565fa4ddb218b2665bc3324ec98840bfa
         imagePullPolicy: "IfNotPresent"
         securityContext: 
           allowPrivilegeEscalation: false

--- a/k3d/gitlab-runner-stack/registry-cache.yaml
+++ b/k3d/gitlab-runner-stack/registry-cache.yaml
@@ -50,7 +50,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: registry
-          image: registry:2
+          image: registry:2@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
           ports:
             - containerPort: 5000
           env:

--- a/k3d/llm-gpu.yaml
+++ b/k3d/llm-gpu.yaml
@@ -76,7 +76,7 @@ spec:
         fsGroup: 101
       initContainers:
         - name: model-download
-          image: curlimages/curl:8.21.0
+          image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
           command: ["sh", "-c"]
           args:
             - |
@@ -98,7 +98,7 @@ spec:
               memory: 256Mi
       containers:
         - name: llama-cpp
-          image: ghcr.io/ggml-org/llama.cpp:server-b10223
+          image: ghcr.io/ggml-org/llama.cpp:server-b10223@sha256:2ab03529fa9ea9b7a0bcafad00b14619d733c255a9817232c450fe316e03f557
           args:
             - "-m"
             - "/models/bge-m3-Q8_0.gguf"
@@ -230,7 +230,7 @@ spec:
         fsGroup: 101
       initContainers:
         - name: model-download
-          image: curlimages/curl:8.21.0
+          image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
           command: ["sh", "-c"]
           args:
             - |
@@ -252,7 +252,7 @@ spec:
               memory: 256Mi
       containers:
         - name: llama-cpp
-          image: ghcr.io/ggml-org/llama.cpp:server-b10223
+          image: ghcr.io/ggml-org/llama.cpp:server-b10223@sha256:2ab03529fa9ea9b7a0bcafad00b14619d733c255a9817232c450fe316e03f557
           args:
             - "-m"
             - "/models/bge-reranker-v2-m3-Q8_0.gguf"

--- a/k3d/sdlc-stack/k3d-config.yaml
+++ b/k3d/sdlc-stack/k3d-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mentolder-dev
 servers: 1
 agents: 1
-image: rancher/k3s:v1.32.13-k3s1
+image: rancher/k3s:v1.32.13-k3s1@sha256:7534b63e02277917f77c584ed5532b31562c760d6bb8fe88059002e9bdeee033
 kubeAPI:
   host: "127.0.0.1"
   hostIP: "127.0.0.1"


### PR DESCRIPTION
Pins 5 unpinned third-party container images with exact multi-arch @sha256 digests to satisfy G-IMG01 (target: 0).