### PR TITLE
chore(ops): disable dead proxy backend llamacpp-gemma in registry [T013003]

### DIFF
--- a/scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql
+++ b/scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql
@@ -1,0 +1,19 @@
+-- 2026-08-21-disable-dead-llm-proxy-backends.sql
+-- Schaltet inaktive/tote Proxy-Backends ab (T013003, G-LLM05).
+--
+-- llamacpp-gemma (:8091) war das Loadout gemma26-factory.
+-- Seit T012414 laufen alle lokalen Agenten auf gemma12-vision (:8089).
+--
+-- Idempotent: UPDATE … WHERE name IN (…).
+--
+-- Apply to BOTH brands (separate per-brand DBs):
+--   BRAND=mentolder  bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql'
+--   BRAND=korczewski bash -c 'source scripts/factory/lib.sh; factory_resolve; factory_psql < scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql'
+BEGIN;
+
+UPDATE tickets.llm_proxy_backends
+   SET enabled    = false,
+       updated_at = now()
+ WHERE name IN ('llamacpp-gemma');
+
+COMMIT;


### PR DESCRIPTION
Disables stale backend llamacpp-gemma (:8091) in tickets.llm_proxy_backends via SQL migration, resolving dead-endpoints (G-LLM05 -> 0).