### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1157,7 +1157,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 64,
+      "file_count": 65,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -1222,7 +1222,8 @@
         "scripts/migrations/2026-08-10-llm-proxy-request-log.sql",
         "scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql",
         "scripts/migrations/2026-08-19-factory-model-gemma12.sql",
-        "scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql"
+        "scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql",
+        "scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql"
       ]
     },
     {


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32517679674).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
