### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1231,7 +1231,7 @@
       "id": "website",
       "name": "Astro + Svelte website",
       "owner_agent": "bachelorprojekt-website",
-      "file_count": 1802,
+      "file_count": 1803,
       "files": [
         "components/website/.build-trigger",
         "components/website/.design-sync/NOTES.md",
@@ -1836,6 +1836,7 @@
         "components/website/src/db/migrations/20260804_cockpit_notify_triggers.sql",
         "components/website/src/db/migrations/20260813_coaching_questionnaire_insights_cache.sql",
         "components/website/src/db/migrations/20260813_coaching_session_summary.sql",
+        "components/website/src/db/migrations/20260821_add_missing_fk_indexes_and_brand_checks.sql",
         "components/website/src/db/migrations/error-log-schema.test.ts",
         "components/website/src/env.d.ts",
         "components/website/src/i18n/de.ts",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32522163685).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
