### PR TITLE
fix(scripts): make brain frontmatter check SIGPIPE-safe [T013039]

### DIFF
--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -304,7 +304,12 @@ process_page() {
     return 1
   }
 
-  if ! echo "$transformed" | head -20 | grep -q "^---"; then
+  # Do not pipe the potentially very large page through head under pipefail.
+  # Once head has its 20 lines it closes the pipe, echo receives SIGPIPE, and
+  # the successful grep is turned into a false "Invalid frontmatter" result.
+  # transform.sh already requires a delimiter; this guard intentionally scans
+  # the shell-owned value directly, with no early-closing upstream process.
+  if ! grep -q -m1 "^---" <<< "$transformed"; then
     echo "WARN: Invalid frontmatter: $src_path chunk $index" >&2
     return 1
   fi

--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -99,6 +99,22 @@ EOF
   [ -x "$INGEST" ] || { echo "FAIL: orchestrator script not executable"; return 1; }
 }
 
+@test "T013039 large transformed pages use a SIGPIPE-safe frontmatter guard" {
+  # The production failure needs output larger than the pipe buffer: head then
+  # closes before echo finishes, and pipefail reports echo's SIGPIPE as failure.
+  local large_page=$'---\ntype: note\n---\n'
+  large_page+="$(awk 'BEGIN { for (i = 0; i < 50000; i++) print "x" }')"
+  local large_file="$WORK/large-page.md"
+  printf '%s' "$large_page" > "$large_file"
+
+  run bash -o pipefail -c 'cat "$1" | head -20 | grep -q "^---"' _ "$large_file"
+  [ "$status" -ne 0 ] || { echo "FAIL: regression fixture did not trigger SIGPIPE"; return 1; }
+
+  run grep -q -m1 '^---' "$large_file"
+  [ "$status" -eq 0 ]
+  grep -Fq 'grep -q -m1 "^---" <<< "$transformed"' "$INGEST"
+}
+
 @test "orchestrator requires --brain-repo argument" {
   run bash "$INGEST" 2>&1
   [ "$status" -ne 0 ] || { echo "FAIL: should fail without --brain-repo"; return 1; }


### PR DESCRIPTION
## Summary
- scan transformed frontmatter directly instead of piping through `head` under `pipefail`
- add a 50,000-line regression fixture that reproduces the old SIGPIPE failure

## Test plan
- task freshness:check
- task test:changed
- task workspace:validate
- focused brain-ingest BATS suites