### PR TITLE
fix(scripts): scan current brain deliverable for secrets [T013040]

### DIFF
--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -564,7 +564,11 @@ echo "  Wikilink lint: PASS"
 # Secret scan (if gitleaks available)
 if command -v gitleaks &>/dev/null; then
   echo "Running secret scan..."
-  if ! gitleaks detect --source . --no-banner 2>&1; then
+  # Scan the deliverable tree, including generated/untracked pages, rather than
+  # immutable commits already present in the external Brain repository. A
+  # history scan makes every future ingest fail forever on any pre-existing
+  # historical finding, even when the complete current tree is clean.
+  if ! gitleaks detect --source . --no-git --no-banner 2>&1; then
     echo "FAIL: Secret scan failed" >&2
     cd "$REPO_ROOT"
     exit 1

--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -115,6 +115,10 @@ EOF
   grep -Fq 'grep -q -m1 "^---" <<< "$transformed"' "$INGEST"
 }
 
+@test "T013040 secret gate scans the current deliverable instead of immutable history" {
+  grep -Fq 'gitleaks detect --source . --no-git --no-banner' "$INGEST"
+}
+
 @test "orchestrator requires --brain-repo argument" {
   run bash "$INGEST" 2>&1
   [ "$status" -ne 0 ] || { echo "FAIL: should fail without --brain-repo"; return 1; }


### PR DESCRIPTION
## Summary
- run gitleaks over the complete current Brain working tree with `--no-git`
- keep current generated and untracked pages fail-closed
- stop immutable history-only findings from blocking every future ingest

## Verification
- current Brain tree: 0 findings with `--no-git`
- task freshness:check
- task test:changed
- task workspace:validate