### PR TITLE
fix(scripts): default brain ingest to local Gemma [T013042]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -2448,6 +2448,12 @@
     "kind": "shell"
   },
   {
+    "id": "brain-ingest-task-defaults",
+    "file": "tests/spec/brain-ingest-task-defaults.bats",
+    "category": "brain-ingest-task-defaults",
+    "kind": "shell"
+  },
+  {
     "id": "brain-initial-ingest",
     "file": "tests/spec/brain-initial-ingest.bats",
     "category": "brain-initial-ingest",

--- a/taskfiles/Taskfile.brain.yaml
+++ b/taskfiles/Taskfile.brain.yaml
@@ -53,17 +53,41 @@ tasks:
   ingest:run:
     desc: "Full brain ingestion pipeline (LLM-assisted, creates PR)"
     cmds:
-      - bash scripts/brain-ingest.sh --brain-repo ~/brain "$@"
+      - |-
+        LM_STUDIO_URL="${LM_STUDIO_URL:-http://127.0.0.1:8089}" \
+        LM_MODEL="${LM_MODEL:-gemma12-vision}" \
+        LM_DISABLE_THINKING="${LM_DISABLE_THINKING:-1}" \
+        LM_MAX_TOKENS="${LM_MAX_TOKENS:-65536}" \
+        LM_TIMEOUT="${LM_TIMEOUT:-3600}" \
+        MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-150000}" \
+        MAX_PARALLEL="${MAX_PARALLEL:-1}" \
+          bash scripts/brain-ingest.sh --brain-repo ~/brain "$@"
 
   ingest:pilot:
     desc: "Run ingestion on 20 pages (pilot batch)"
     cmds:
-      - bash scripts/brain-ingest.sh --brain-repo ~/brain --pilot 20 "$@"
+      - |-
+        LM_STUDIO_URL="${LM_STUDIO_URL:-http://127.0.0.1:8089}" \
+        LM_MODEL="${LM_MODEL:-gemma12-vision}" \
+        LM_DISABLE_THINKING="${LM_DISABLE_THINKING:-1}" \
+        LM_MAX_TOKENS="${LM_MAX_TOKENS:-65536}" \
+        LM_TIMEOUT="${LM_TIMEOUT:-3600}" \
+        MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-150000}" \
+        MAX_PARALLEL="${MAX_PARALLEL:-1}" \
+          bash scripts/brain-ingest.sh --brain-repo ~/brain --pilot 20 "$@"
 
   ingest:dry:
     desc: "Dry-run ingestion (no PR, no writes to brain repo)"
     cmds:
-      - bash scripts/brain-ingest.sh --brain-repo ~/brain --dry-run "$@"
+      - |-
+        LM_STUDIO_URL="${LM_STUDIO_URL:-http://127.0.0.1:8089}" \
+        LM_MODEL="${LM_MODEL:-gemma12-vision}" \
+        LM_DISABLE_THINKING="${LM_DISABLE_THINKING:-1}" \
+        LM_MAX_TOKENS="${LM_MAX_TOKENS:-65536}" \
+        LM_TIMEOUT="${LM_TIMEOUT:-3600}" \
+        MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-150000}" \
+        MAX_PARALLEL="${MAX_PARALLEL:-1}" \
+          bash scripts/brain-ingest.sh --brain-repo ~/brain --dry-run "$@"
 
   brain:chunk:
     desc: "Run the section-aware chunker (T002679)"

--- a/tests/spec/brain-ingest-task-defaults.bats
+++ b/tests/spec/brain-ingest-task-defaults.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  TASKFILE="$REPO_ROOT/taskfiles/Taskfile.brain.yaml"
+  FAKE_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$FAKE_BIN"
+  cat > "$FAKE_BIN/bash" <<'EOF'
+#!/bin/sh
+printf '%s\n' \
+  "$LM_STUDIO_URL" "$LM_MODEL" "$LM_DISABLE_THINKING" "$LM_MAX_TOKENS" \
+  "$LM_TIMEOUT" "$MAX_SOURCE_CHARS" "$MAX_PARALLEL"
+EOF
+  chmod +x "$FAKE_BIN/bash"
+}
+
+@test "T013042 brain ingest task supplies local Gemma defaults" {
+  run env -u LM_STUDIO_URL -u LM_MODEL -u LM_DISABLE_THINKING \
+    -u LM_MAX_TOKENS -u LM_TIMEOUT -u MAX_SOURCE_CHARS -u MAX_PARALLEL \
+    PATH="$FAKE_BIN:$PATH" task --taskfile "$TASKFILE" ingest:run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'http://127.0.0.1:8089\ngemma12-vision\n1\n65536\n3600\n150000\n1' ]]
+}
+
+@test "T013042 pre-set brain ingest values override every default" {
+  run env PATH="$FAKE_BIN:$PATH" \
+    LM_STUDIO_URL=http://example.test:9999 LM_MODEL=custom-model \
+    LM_DISABLE_THINKING=0 LM_MAX_TOKENS=42 LM_TIMEOUT=43 \
+    MAX_SOURCE_CHARS=44 MAX_PARALLEL=2 \
+    task --taskfile "$TASKFILE" ingest:run
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *$'http://example.test:9999\ncustom-model\n0\n42\n43\n44\n2' ]]
+}
+
+@test "T013042 run pilot and dry share the same fallback block" {
+  for task_name in ingest:run ingest:pilot ingest:dry; do
+    run env -u LM_STUDIO_URL -u LM_MODEL -u LM_DISABLE_THINKING \
+      -u LM_MAX_TOKENS -u LM_TIMEOUT -u MAX_SOURCE_CHARS -u MAX_PARALLEL \
+      PATH="$FAKE_BIN:$PATH" task --taskfile "$TASKFILE" "$task_name"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'http://127.0.0.1:8089\ngemma12-vision\n1\n65536\n3600\n150000\n1' ]]
+  done
+}


### PR DESCRIPTION
## Summary
- default Brain run, pilot, and dry tasks to the working local Gemma endpoint
- preserve every explicitly pre-set environment value
- test both fallback and complete override behavior through the real Task runner

## Test plan
- task freshness:check
- task test:changed
- task workspace:validate
- focused brain-ingest task BATS tests