### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1145,
+      "file_count": 1146,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -432,6 +432,7 @@
         "tests/spec/brain-foundation/knowledge-lifecycle.bats",
         "tests/spec/brain-foundation/state-file-type-repair.bats",
         "tests/spec/brain-gekko-inbox.bats",
+        "tests/spec/brain-ingest-task-defaults.bats",
         "tests/spec/brain-ingest.bats",
         "tests/spec/brain-initial-ingest.bats",
         "tests/spec/brain-k4-brain-wiki/brain-mcp-server.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32531424672).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
