### PR TITLE
chore(infra): suspend db-backup CronJob im korczewski-Overlay [T013037]

### DIFF
--- a/prod-korczewski/kustomization.yaml
+++ b/prod-korczewski/kustomization.yaml
@@ -308,3 +308,21 @@ patches:
       kind: CronJob
       metadata:
         name: error-log-retention
+
+  # db-backup CronJob: suspendiert solange die korczewski-Brand eingefroren
+  # ist (T002479, Kosten/Wartung seit 2026-07-26). shared-db laeuft mit 0
+  # Replicas, der naechtliche Job scheiterte daher an der pg_isready-
+  # Pre-flight mit BackoffLimitExceeded — letzter Erfolg 2026-07-28
+  # [T013037]. Bewusst spec.suspend statt Delete-Patch (Gegenstueck zu
+  # pvc-backup/T012964): beim Unfreeze genuegt das Zuruecksetzen des Flags,
+  # die CronJob-Definition bleibt sichtbar. Inline-target statt Pfad-Patch,
+  # weil der Base-CronJob metadata.namespace=workspace traegt und ein
+  # namespace-loser SMP-Patch sonst kein Ziel findet.
+  - target: { group: batch, version: v1, kind: CronJob, name: db-backup }
+    patch: |-
+      apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: db-backup
+      spec:
+        suspend: true


### PR DESCRIPTION
## Kontext

Die korczewski-Brand ist seit **T002479** eingefroren (Kosten/Wartung, 2026-07-26): alle Deployments in `workspace-korczewski` laufen mit 0 Replicas — inklusive `shared-db`. Der nächtliche `db-backup` CronJob lief trotzdem weiter und scheitert seit **2026-07-28** (letzter erfolgreicher Lauf) an der `pg_isready`-Pre-flight:

```
FATAL: shared-db is not reachable — refusing to write empty dumps.
```

→ 3 schnelle Fehlversuche → `BackoffLimitExceeded`, jede Nacht ein nutzloser Failed Job. T012964 hatte seinerzeit `pvc-backup` + `error-log-retention` aus dem Overlay entfernt, `db-backup` wurde übersehen.

## Fix

`spec.suspend: true` via Inline-Target-Patch in `prod-korczewski/kustomization.yaml`:

- **suspend statt Delete-Patch** (bewusst anders als T012964): beim Unfreeze der Brand genügt das Zurücksetzen des Flags, die CronJob-Definition bleibt sichtbar und Backups laufen wieder an.
- Live ist der CronJob bereits per `kubectl patch` suspendiert; der Patch kodiert den Zustand in Git für den Moment, in dem `flux-korczewski` (aktuell `suspend: true`) wieder reconciliert.
- Patch-Stil: Inline-target statt `path:`-SMP, weil der Base-CronJob `metadata.namespace=workspace` trägt und ein namespace-loser Pfad-Patch kein Ziel findet.

## Verifikation

- `kubectl kustomize prod-korczewski` → `db-backup … suspend: true` ✓
- `kubectl kustomize prod-fleet/korczewski` → exit 0, `suspend: true` ✓
- Gates: `freshness:check` ✓ · `workspace:validate` ✓ · `test:code-quality` 52/0 ✓
- `test:e2e:korczewski` lokal rot (Admin-Auth gegen die eingefrorene Prod-Site) — pre-existing, nicht diff-attribuierbar; CI läuft diesen Task nicht (vgl. #4890, gleiche Datei, grün).

Closes #T013037 (korczewski-Teil; mentolder-2FA-Teil folgt separat)