### PR TITLE
chore(infra): db-backup Filen-Reroute vorbereiten — Override-Creds + Upload-Timeout [T013037]

### DIFF
--- a/environments/sealed-secrets/fleet-mentolder.yaml
+++ b/environments/sealed-secrets/fleet-mentolder.yaml
@@ -346,3 +346,24 @@ spec:
       name: otel-collector-auth
       namespace: monitoring
     type: Opaque
+
+# T013037: Temporaerer Filen-Backend-Reroute fuer den mentolder db-backup.
+# Das mentolder-Filen-Konto hat 2FA aktiviert (~2026-07-25) — der Upload-Sidecar
+# haengt am interaktiven 2FA-Prompt bis zum Deadline-Tod. Bis das Konto wieder
+# ohne 2FA nutzbar ist, weicht der Job auf das korczewski-Filen-Konto (ohne 2FA)
+# aus. Wird von k3d/backup-cronjob.yaml (FILEN_*_OVERWRITE, optional) gelesen;
+# fehlt das Secret, gilt workspace-secrets wie bisher. Entfernen nach Reroute-Ende.
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: filen-upload-credentials
+  namespace: workspace
+spec:
+  encryptedData:
+    EMAIL: AgB6ov+Xu9pYWzZ2LXHVEAWfCdFNWYAzMdYkMLvq6gLp2+DG9V4jLrswEji0LaDn5ZrTLLUqQ6JlROcunVZ8NBnTEl4BU6zaEDLGwWWexZx0WgkpxPOANPtEWltwEhr/Ky49mNm37B+Ifz1zfVRj4srqkw7bFGu603SPQ4z2fCLBc+DyKUlTHZ9ODT9peBuH7lS0NeUJno23SKtd547H78Mv8A3xz9N2OAmgdOZKKe84fjS5Jiz9OYTq1/yFXPpi4vclO9tBd+QyjAH3JUaNJGFdxTdyFmHAvwKB9jQ74KWl/poGToYcIsvJzRJCuviFbUXjps/jm/GYfz4h5t9t9+FxKZ7zESpfoO99UxF15O/JRt2ppfaVekG+5XyNyd0Tu61Mj+02eEP0Z2aMrtg7jLPWK9Imrp+ITXOT4A6Eyi8rT6CccscK/h5aM8s1l67nJFflLVZVeHJI2Dw2NMZvc11vU2dxEgzGXBEtpFP8RwY79C/uLT+Degb7Gr5j33NRPMXG+NWS1tSpiXb50+jEBmrQ/FzAoosTTQVl04y4A3FpzUFZusJFsc6oQrJzkjwY98+PharDWCox/xV5OiBnYm8t5nWw3S+lHMFUEwCshB0xbTNcx9VbcBosiCPu9cR4NhKX1ioIHRCTNz3yXn/Sk1IUI7dotZ+0ZybRtTrpfRIldTrWEaF4rj50QedoegYn6EpLT0s/GDz+TU/1Vpd3/9oyNGt3dwkt
+    PASSWORD: AgA5fxWfy68YwMfd8BqCFyRIc9KIfWk0ngPxab44i0DyBpPaF5d9pQllcJbV6pLm3b7RJBcF5axo2QfXFBCxEpI/54HFz3E64j6Q7nTCQRMLmZ9TurnKJm6lZHcgdDfh8K+5k6BPiCUkkpFZqs8iCbKY+tJTLSQknlFYfjrXz/3mUGGUusK1FQ0ElT4cJ+yYgzLgwQjnqWDVsjJAOHkYi4dMYQu8dhOxP9Q1w1PBY6XULzykDTtWEx0jEtnFUxKcszyGS/HFnqpIWKd/Y2ua+TWVNbARF8XAWpK5FgYKZQrtM5SA3n8MdeG9/lrq6JehAieFHY/f40wa8AGKOlesoOVxH0jmDXNtr9+7MhB4ce+zyi4P0/C9ApzixXRmShdnOsu0IXVZYL/4hMWaqiXl+b1A4r78IjGFi43HWpWNfJNqqlfpqMM87mZsjrdyevVODkCXFXPJE/uHUFH61SCBCl3+K7AjpzIY02zsZbkQt/Vptd/ljqrfoopYdRwj1pJgv3FVXVEExYs9NNwsHTJ0QO40Zkm+cXy+zYE0iCshzt6gMNXmjkSmUrxbsRh6aZLHzwPzICYFpk17/1J/bRqmRHxsA5OVHAhZmBXDxGljjC2qonXRI1fkV/jXMANVxfaPEoA633eR4O+WqMYNphj5dPZHEtMW5mZ77FcD3uElD8cI6lhFspgialTSaov6isJyroObqh2+rgLv7xh4X88uAPV0zw==
+  template:
+    metadata:
+      name: filen-upload-credentials
+      namespace: workspace

--- a/k3d/backup-cronjob.yaml
+++ b/k3d/backup-cronjob.yaml
@@ -203,6 +203,20 @@ spec:
               # STAMP and UPLOAD_PATH below are read from /staging at runtime — NOT envsubst targets.
               args:
                 - |
+                  # Credential-Auflösung: Die optionale Secret filen-upload-credentials
+                  # gewinnt gegenüber workspace-secrets [T013037]. Hintergrund: Das
+                  # mentolder-Filen-Konto hat 2FA aktiviert (~2026-07-25), worauf die
+                  # CLI mit einem interaktiven Prompt antwortet und den Job bis zum
+                  # Deadline-Tod aufhängt. Bis das Konto wieder ohne 2FA nutzbar ist,
+                  # wird auf das korczewski-Filen-Konto (ohne 2FA) ausgewichen.
+                  FILEN_EMAIL="$${FILEN_EMAIL:-}"
+                  FILEN_PASSWORD="$${FILEN_PASSWORD:-}"
+                  if [ -n "$${FILEN_EMAIL_OVERRIDE:-}" ] && [ -n "$${FILEN_PASSWORD_OVERRIDE:-}" ]; then
+                    echo "Using override Filen credentials (filen-upload-credentials) [T013037]"
+                    FILEN_EMAIL="$${FILEN_EMAIL_OVERRIDE}"
+                    FILEN_PASSWORD="$${FILEN_PASSWORD_OVERRIDE}"
+                  fi
+
                   if [ -z "$${FILEN_EMAIL}" ] || [ -z "$${FILEN_PASSWORD}" ]; then
                     echo "Filen not configured — skipping remote backup"
                     until [ -f /staging/.done ]; do sleep 2; done
@@ -224,12 +238,15 @@ spec:
                   # @filen/cli authenticates with raw email+password; it derives the
                   # PBKDF2 key / master keys / API token internally (Filen auth v2).
                   # This invocation passes NO 2FA code, so it assumes 2FA is OFF on the
-                  # Filen account — an invariant that holds for both mentolder and
-                  # korczewski. If 2FA is ever enabled, login fails permanently here.
-                  if ! filen --email "$${FILEN_EMAIL}" --password "$${FILEN_PASSWORD}" \
+                  # Filen account. If 2FA is enabled, the CLI blocks on an interactive
+                  # prompt forever — der timeout unten verwandelt diesen Hang in einen
+                  # sichtbaren Fehler statt 2h Deadline-Tod [T013037].
+                  UPLOAD_TIMEOUT="$${FILEN_UPLOAD_TIMEOUT:-1800}"
+                  if ! timeout "$${UPLOAD_TIMEOUT}" filen --email "$${FILEN_EMAIL}" --password "$${FILEN_PASSWORD}" \
                        upload "/backups/$${STAMP}/" "$${UPLOAD_PATH}/$${STAMP}/"; then
                     echo "ERROR: Filen remote upload failed for $${STAMP} — the LOCAL encrypted backup on backup-pvc is intact."
-                    echo "       Likely cause: invalid FILEN_EMAIL/FILEN_PASSWORD, or 2FA was enabled on the Filen account (this job requires 2FA OFF)."
+                    echo "       Likely cause: invalid FILEN_EMAIL/FILEN_PASSWORD, 2FA enabled on the account (requires 2FA OFF),"
+                    echo "       or the $${UPLOAD_TIMEOUT}s upload timeout hit a stalled transfer."
                     echo "       Exiting non-zero so the broken remote backup surfaces as a Failed Job instead of being silently swallowed."
                     # restartPolicy: OnFailure retries transients in-pod; a permanent
                     # failure escalates to a Failed Job (failedJobsHistoryLimit keeps it visible).
@@ -249,6 +266,22 @@ spec:
                     secretKeyRef:
                       name: workspace-secrets
                       key: FILEN_PASSWORD
+                      optional: true
+                # T013037: Optionale Credential-Überschreibung für den temporären
+                # Backend-Reroute (korczewski-Filen-Konto statt mentolder, solange
+                # dort 2FA aktiv ist). Secret fehlt ⇒ beide Variablen leer ⇒
+                # workspace-secrets wird verwendet — Verhalten wie bisher.
+                - name: FILEN_EMAIL_OVERRIDE
+                  valueFrom:
+                    secretKeyRef:
+                      name: filen-upload-credentials
+                      key: EMAIL
+                      optional: true
+                - name: FILEN_PASSWORD_OVERRIDE
+                  valueFrom:
+                    secretKeyRef:
+                      name: filen-upload-credentials
+                      key: PASSWORD
                       optional: true
               volumeMounts:
                 - name: backup-storage


### PR DESCRIPTION
## Kontext (T013037)

Live-Diagnose der Backup-Kette hat **drei getrennte Befunde** ergeben:

1. **mentolder-Filen-Konto:** 2FA aktiviert (~2026-07-25) → CLI blockt am interaktiven 2FA-Prompt (`Please enter your 2FA code or recovery key:`), null Sockets, null Transfer → Job stirbt an `activeDeadlineSeconds: 7200`. Lokale Dumps sind jede Nacht intakt.
2. **korczewski-Filen-Konto:** kein 2FA, Login sauber — aber **`APIError: Maximum storage reached.`** Quota voll (~70 DB- + ~55 PVC-Generationen bis zum Brand-Freeze 2026-07-28). Empirisch: 1–10 MB ✅, ≥30 MB ❌ schnell+sichtbar.
3. **korczewski-Stack** selbst ist seit T002479 eingefroren (→ #4928, suspendiert den dortigen CronJob).

## Dieser PR rüstet den temporären Reroute

- `k3d/backup-cronjob.yaml`:
  - Optionale Secret `filen-upload-credentials` (`FILEN_EMAIL_OVERRIDE`/`FILEN_PASSWORD_OVERRIDE`) gewinnt gegenüber `workspace-secrets`; fehlt sie ⇒ Verhalten exakt wie bisher.
  - `timeout` um den `filen`-Aufruf (`FILEN_UPLOAD_TIMEOUT`, Default 1800s) — künftige Hänge werden zu sichtbaren Fehlern statt 2h Deadline-Tod.
- `environments/sealed-secrets/fleet-mentolder.yaml`: SealedSecret mit den korczewski-Credentials (kubeseal gegen fleet-Controller).

## Wirksamkeit & offene Owner-Entscheidung

Nach Merge rendert der Artefakt-Build die Override-Envs in den CronJob. **Solange das korczewski-Konto voll ist, schlägt der nächtliche Upload dann schnell und sichtbar fehl** (`Maximum storage reached` im Job-Log) statt still zu hängen. Die Backups laufen automatisch, sobald Speicher freigegeben ist — Optionen:

- (a) Alte korczewski-Remote-Generationen löschen (z.B. nur letzte 14 Tage behalten) — Owner-Freigabe nötig, löschend
- (b) Filen-Speicherplan erweitern
- (c) Alternativ mentolder-Konto reparieren (2FA deaktivieren oder Recovery Key hinterlegen) — dann Override-Secret entfernen

## Verifikation

- `bash -n` auf gerendertem Sidecar-Script ✓ · `kubectl kustomize k3d` ✓
- Live-Secret bereits angelegt (identisch zum SealedSecret); End-to-End-Lauf folgt nach Speicherfreigabe
- Gates: `freshness:check` ✓ · `workspace:validate` ✓ · `test:code-quality` 52/0 ✓

Closes #T013037 nicht vollständig — Reroute-Aktivierung wartet auf Speicherfreigabe (Owner).