### PR TITLE
chore(agents): make qwen38 the default [T013141]

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -1,22 +1,21 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  // Lokales Gemma 4 12B QAT mit drei Slots als Standard — das Loadout
-  // gemma12-vision auf Port 8089 (Backend llamacpp-gemma12). Es ist das einzige
-  // vision-faehige lokale Loadout, hat mit 262.144 den groessten Kontext und
-  // faehrt MTP-Speculative-Decoding.
+  // Qwen 3.8 27B IQ3_XXS als Standard — das Loadout qwen38-220k auf Port 8094
+  // (Backend llamacpp-qwen38). Es ist der textbasierte Primary mit 220.000
+  // Kontext. Fuer Vision muss gemma12-primary bzw. gemma26-vision explizit
+  // gewaehlt werden.
   //
-  // WARUM NICHT MEHR gemma26-factory [2026-08-20]: Alle chat-gpu-Loadouts teilen
+  // WARUM DER DEFAULT DAS GEWUENSCHTE LOADOUT SEIN MUSS: Alle chat-gpu-Loadouts teilen
   // eine exclusiveGroup, es laeuft also immer nur eines. Solange der Default auf
   // ein anderes Loadout zeigte als das, mit dem gearbeitet wird, stoppte jede
   // neue opencode-Session zuerst das laufende, um den Default zu starten. Als
-  // gemma26-factory nach dem llama.cpp-Upgrade nicht mehr startete (Tool-Name
-  // get_datetime -> get_info), riss dieser Wechsel gemma12-vision jedes Mal mit
-  // herunter und opencode meldete durchgehend "no healthy backend". Der Default
-  // gehoert deshalb auf das Loadout, das tatsaechlich laufen soll.
+  // ein anderes Default-Loadout fordert, wird qwen38-220k gestoppt und der Client
+  // meldet "no healthy backend", waehrend stattdessen Gemma geladen wird. Der
+  // Default gehoert deshalb auf das Loadout, das tatsaechlich laufen soll.
   //
   // Fallback-Kette bleibt: bei Ausfall des lokalen Servers greifen die
   // deepseek-*-Agenten (direkte API, nicht ueber den Proxy).
-  "model": "llamacpp-local/gemma12-vision",
+  "model": "llamacpp-local/qwen38-220k",
   "permission": {
     "read": "allow",
     "edit": "allow",

--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -3882,6 +3882,12 @@
     "kind": "shell"
   },
   {
+    "id": "local-llm-proxy/qwen38-default-backend",
+    "file": "tests/spec/local-llm-proxy/qwen38-default-backend.bats",
+    "category": "local-llm-proxy",
+    "kind": "shell"
+  },
+  {
     "id": "local-llm-proxy/support-model-slots",
     "file": "tests/spec/local-llm-proxy/support-model-slots.bats",
     "category": "local-llm-proxy",

--- a/scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql
+++ b/scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql
@@ -1,0 +1,29 @@
+-- Registriert den Qwen-3.8-Primary dauerhaft im LLM-Proxy [T013141].
+--
+-- loadouts.json und .opencode/agent-models.jsonc allein reichen nicht: Der Proxy
+-- routet nur zu Backends aus tickets.llm_proxy_backends. Fehlt diese Zeile nach
+-- einem frischen Setup, meldet OpenCode "no healthy backend" und eine Anfrage an
+-- den alten Projekt-Default kann stattdessen das exklusive Gemma-Loadout starten.
+--
+-- Idempotent und fuer die gemeinsame lokale Ticket-Datenbank bestimmt.
+BEGIN;
+
+INSERT INTO tickets.llm_proxy_backends
+  (name, kind, base_url, api_key_env, enabled, priority, fixups, model_aliases, max_inflight)
+VALUES
+  ('llamacpp-qwen38', 'llamacpp', 'http://127.0.0.1:8094/v1', NULL, true, 1, '[]'::jsonb,
+   '{"qwen38-220k":"qwen38-220k"}'::jsonb, 1)
+ON CONFLICT (name) DO UPDATE
+  SET kind          = EXCLUDED.kind,
+      base_url      = EXCLUDED.base_url,
+      enabled       = true,
+      priority      = EXCLUDED.priority,
+      fixups        = EXCLUDED.fixups,
+      model_aliases = EXCLUDED.model_aliases,
+      max_inflight  = EXCLUDED.max_inflight,
+      updated_at    = now();
+
+COMMIT;
+
+-- Danach den Proxy die Registry neu lesen lassen:
+--   curl -sf -XPOST http://127.0.0.1:18235/admin/reload

--- a/tests/spec/local-llm-proxy/qwen38-default-backend.bats
+++ b/tests/spec/local-llm-proxy/qwen38-default-backend.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# T013141 — OpenCode-Default und persistente Proxy-Registry muessen gemeinsam
+# auf qwen38-220k zeigen; sonst kann ein Default-Request Gemma laden und Qwen aus
+# der gemeinsamen chat-gpu exclusiveGroup verdraengen.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  CONFIG="${REPO_ROOT}/.opencode/opencode.jsonc"
+  MIGRATION="${REPO_ROOT}/scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql"
+}
+
+@test "T013141: project default selects qwen38-220k" {
+  run grep -F '"model": "llamacpp-local/qwen38-220k"' "${CONFIG}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "T013141: migration registers the qwen38 proxy backend" {
+  [ -f "${MIGRATION}" ]
+
+  run grep -F "'llamacpp-qwen38', 'llamacpp', 'http://127.0.0.1:8094/v1'" "${MIGRATION}"
+  [ "${status}" -eq 0 ]
+
+  run grep -F "'{\"qwen38-220k\":\"qwen38-220k\"}'::jsonb, 1" "${MIGRATION}"
+  [ "${status}" -eq 0 ]
+
+  run grep -F 'ON CONFLICT (name) DO UPDATE' "${MIGRATION}"
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- select `llamacpp-local/qwen38-220k` as the project-wide OpenCode default
- persist the `llamacpp-qwen38` proxy backend on port 8094 through an idempotent migration
- guard the default/backend pairing with a BATS regression test

## Verification
- `task test:changed`
- `task freshness:check`
- migration applied successfully to the local ticket database

Closes T013141