### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1148,
+      "file_count": 1149,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -677,6 +677,7 @@
         "tests/spec/local-llm-proxy/pick-small-model-deterministic.bats",
         "tests/spec/local-llm-proxy/proxy-env-token-guard.bats",
         "tests/spec/local-llm-proxy/proxy-tests-registered.bats",
+        "tests/spec/local-llm-proxy/qwen38-default-backend.bats",
         "tests/spec/local-llm-proxy/support-model-slots.bats",
         "tests/spec/local-llm-proxy/tools-runtime-sandbox.bats",
         "tests/spec/local-llm-proxy/ui-config-seed.bats",
@@ -1161,7 +1162,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 65,
+      "file_count": 66,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -1227,7 +1228,8 @@
         "scripts/migrations/2026-08-10-provider-config-baseurl-drop-v1.sql",
         "scripts/migrations/2026-08-19-factory-model-gemma12.sql",
         "scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql",
-        "scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql"
+        "scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql",
+        "scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql"
       ]
     },
     {


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32538797582).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
