### PR TITLE
chore(skills): cleanup stale references across dev-flow and opencode skills [T013142]

### DIFF
--- a/.claude/skills/dev-flow-e2e/SKILL.md
+++ b/.claude/skills/dev-flow-e2e/SKILL.md
@@ -8,7 +8,7 @@ agent: bachelorprojekt-test
 
 ## Wann diese Skill greift
 
-`dev-flow-execute` hat fertig implementiert und gemergt. Jetzt soll die implementierte Funktion mit echten Browser-E2E-Tests abgesichert werden. Die Live-Erkundung nutzt die `chrome-devtools-axi`-Skill (CLI, kein MCP-Browser-Server).
+`dev-flow-execute` hat fertig implementiert und gemergt. Jetzt soll die implementierte Funktion mit echten Browser-E2E-Tests abgesichert werden. Für die Live-Erkundung werden Standard-Browser/HTTP-Tools oder native Playwright-Mittel eingesetzt.
 
 **Sage zu Beginn:** "Ich nutze dev-flow-e2e für Playwright E2E Tests."
 
@@ -47,7 +47,7 @@ gh pr view "$PR_NUM" --json files -q '.files[].path' | sort
 
 Ermittle daraus:
 - **Welche URLs/Endpunkte** wurden neu erstellt oder verändert?
-- **Welches Playwright-Projekt** passt: `website` (web.*), `services` (brett.*, files.*, vault.*), `korczewski` (korczewski brand on fleet)?
+- **Welches Playwright-Projekt** passt: `website` (web.*), `services` (brett.*, files.*, vault.*)?
 - **Ticket-ID** aus dem PR-Titel (Format `T######`)?
 
 ---
@@ -55,12 +55,11 @@ Ermittle daraus:
 ## Schritt 1: Ziel-URL bestimmen
 
 | Geänderte Dateien | Live-URL | Playwright project |
-|---|---|---|---|
+|---|---|---|
 | `components/website/src/**` | `https://web.mentolder.de` | `website` |
 | `components/brett/**` | `https://brett.mentolder.de` | `services`, `brett-mentolder` |
 | `k3d/nextcloud*.yaml` | `https://files.mentolder.de` | `services` |
-# LiveKit removed per T002184
-| korczewski-spezifisch (fleet cluster) | `https://web.korczewski.de` | `korczewski` |
+| korczewski-spezifisch (fleet cluster) | `https://web.korczewski.de` | `korczewski` *(deaktiviert / frozen per T002602)* |
 | Übergreifender Smoke-Test | — | `smoke` |
 | System-Test (DB, Config, API) | — | `systemtest` |
 | Unit-Tests | — | `unit` |
@@ -71,7 +70,7 @@ Ermittle daraus:
 BASE_URL="https://web.mentolder.de"   # anpassen falls nötig
 ```
 
-### Credentials
+### Credentials & Brand-Status
 
 Es gibt **kein** separates E2E-Test-Passwort für Korczewski: Der Brand ist
 eingefroren (T002602 — Flux-Kustomizations suspendiert, Deployments in
@@ -83,14 +82,16 @@ in `.github/workflows/e2e.yml`).
 
 ---
 
-## Schritt 2: Live-Erkundung mit chrome-devtools-axi
+## Schritt 2: Live-Erkundung & Endpunkt-Prüfung
 
-Navigiere mit der `chrome-devtools-axi`-Skill zur implementierten Funktion und verschaffe dir ein vollständiges Bild: welche Seiten, welche API-Endpunkte, welche Auth-Anforderungen.
+Verschaffe dir ein vollständiges Bild der implementierten Funktion: welche Seiten, welche API-Endpunkte, welche Auth-Anforderungen und DOM-Elemente existieren.
 
 ```bash
-# Beispiel (chrome-devtools-axi CLI):
-chrome-devtools-axi navigate "$BASE_URL/<pfad>"
-chrome-devtools-axi snapshot
+# HTTP-Erreichbarkeit & Headers prüfen
+curl -sI "$BASE_URL/<pfad>"
+
+# Falls nötig HTML-Struktur / Selektoren sichten
+curl -sL "$BASE_URL/<pfad>" | head -n 50
 ```
 
 ---
@@ -250,8 +251,8 @@ Details/Architektur: `openspec/specs/e2e-test-infrastructure.md` (REQ-k8-01…RE
 
 ## Schritt 9: Beendigung und Nachbereitung
 
-1. **Mishap Report**: Melde am Ende dieses Skills alle aufgetretenen Fehler über `mishap-tracker`.
-2. **Operations**: Fahre danach mit `operations-management` fort, um den Status des zugehörigen PRs oder Tickets zu überwachen.
+1. **Mishap Report**: Melde am Ende dieses Skills alle aufgetretenen Frictions über `mishap-tracker`.
+2. **Operations & Pipeline-Abschluss**: Fahre danach mit `operations-management` fort, um den Status des zugehörigen PRs / Tests zu überwachen bzw. `agent-lock release ticket <id>` durchzuführen.
 
 ## Übergabe — Kreislauf geschlossen
 
@@ -270,8 +271,9 @@ Details/Architektur: `openspec/specs/e2e-test-infrastructure.md` (REQ-k8-01…RE
 |-------|-----------|
 | `dev-flow-execute` | **Vorgänger im Kreislauf** — Feature muss deployt sein |
 | `git-workflow` | Commit/Push-Konventionen für Schritt 7 (Freshness Guard, Scope-Preflight) |
-| `cluster-deployment` | Querschnitt — Cross-Brand-Tests |
+| `infra-ops` | Querschnitt — Infrastruktur- und Service-Status |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |
+| `operations-management` | Nachbereitung — PRs/Tickets/Locks aufräumen |
 
 
 ## Framework mapping

--- a/.claude/skills/dev-flow-execute/SKILL.md
+++ b/.claude/skills/dev-flow-execute/SKILL.md
@@ -239,7 +239,7 @@ Orchestrator-Kontext bleibt nur für die CI-Fix-Schleife (5.5) zuständig, solan
 
 ## Schritt 4: Dev-Iteration (optional)
 
-Rufe `dev-flow-iterate` auf, um Änderungen im dev-Cluster zu testen.
+Für schnelles iteratives Testen von Änderungen im lokalen k3d Dev-Cluster (siehe [deploy-routing.md](file:///home/patrick/Bachelorprojekt/.claude/skills/references/deploy-routing.md)): `task dev:redeploy:website` bzw. `task dev:redeploy:brett`.
 > **⚠ Freshness-Guard (vor dem Commit):** Wenn Schritt 3 (`task freshness:regenerate`) übersprungen oder der Subagent es vergessen hat, schlägt CI mit "stale artifact" fehl. Prüfe: `git diff --name-only` sollte keine generierten Indexdateien zeigen. Falls doch: `task freshness:regenerate && git add` nachholen. Der Pre-commit-Hook automatisiert das nach `task secrets:install-hooks`.
 
 ## Schritt 5: PR erstellen
@@ -356,7 +356,6 @@ Führe danach `dev-flow-e2e` aus, um E2E-Tests gegen die Live-Umgebung zu schrei
 | Skill | Beziehung |
 |-------|-----------|
 | `dev-flow-plan` | **Vorgänger im Kreislauf** — liefert Branch + committiertem Plan |
-| `dev-flow-iterate` | Alternative — inkrementelle Dev-Iteration |
 | `dev-flow-e2e` | Folge — schreibt E2E-Tests nach Deploy |
 | `mishap-tracker` | Abschluss — protokolliert Frictions |
 

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -91,7 +91,7 @@ Invoke `mishap-tracker` with your accumulated `MISHAP_LOG`.
 |-------|--------------|
 | `ticket-ops` | Follow-up: PR management, ticket triage for human-fixable items |
 | `mishap-tracker` | Converts execution mishaps to tickets |
-| `cluster-deployment` | Cross-brand incident handling (Phase 5) |
+| `infra-ops` | Cross-brand incident handling and infrastructure deployment (Phase 5) |
 
 
 ## Framework mapping

--- a/.claude/skills/references/deploy-routing.md
+++ b/.claude/skills/references/deploy-routing.md
@@ -2,7 +2,7 @@
 
 Diese Tabelle ist die **einzige** verbindliche Quelle dafür, welcher Deploy-Task zu welchen
 geänderten Pfaden gehört. `dev-flow-execute` (Post-Merge-Deploy), `dev-flow-chore` (Schritt 7)
-und `dev-flow-iterate` (Dev-Cluster-Redeploy) verweisen alle hierher — **nicht** die Tabelle
+und lokale Dev-Redeploys (k3d) verweisen alle hierher — **nicht** die Tabelle
 kopieren, sondern verlinken.
 
 > **Pull-basiertes Deploy-Modell (Flux, T002083).** Prod wird auf dem fleet-Cluster von
@@ -56,7 +56,7 @@ kubectl --context fleet get pods -n workspace            | grep -v Running
 kubectl --context fleet get pods -n workspace-korczewski | grep -v Running
 ```
 
-### Dev-Cluster-Redeploy (für `dev-flow-iterate`, k3d)
+### Dev-Cluster-Redeploy (k3d)
 
 | SURFACE | Redeploy-Task | Watched pods |
 |---------|--------------|--------------|

--- a/.opencode/skills/opencode-flow-execute/SKILL.md
+++ b/.opencode/skills/opencode-flow-execute/SKILL.md
@@ -426,7 +426,7 @@ Nur bei deploy-pflichtigen Bereichen:
 bash scripts/devflow-post-merge-deploy.sh "$TICKET_ID"
 ```
 
-Deploy-Mapping: `.claude/skills/references/deploy-routing.md`.
+Deploy-Mapping: `.agents/skills/references/deploy-routing.md`.
 
 ## Nachbereitung & Mishap Report
 

--- a/.opencode/skills/opencode-git-workflow/SKILL.md
+++ b/.opencode/skills/opencode-git-workflow/SKILL.md
@@ -92,7 +92,7 @@ Erst danach `task freshness:regenerate` ausführen — sonst regeneriert man geg
 veraltete Basis und der Zyklus beginnt von vorn.
 
 Vollständiger Verify-Block (die vier Befehle, S1-Ratchet, Freshness-Artefakt-Liste zum Stagen):
-**SSOT** in `.claude/skills/references/verification-block.md`.
+**SSOT** in `.agents/skills/references/verification-block.md`.
 
 Kurzform: `task freshness:regenerate` + `task freshness:check` (CI-Äquivalent, S1-Ratchet).
 
@@ -202,7 +202,7 @@ EOF
 
 ## Schritt 5 — CI Fix Loop
 
-Nachdem der PR gepusht ist: CI überwachen und Fehler beheben **bevor** gemergt wird. SSOT: `.claude/skills/references/ci-fix-loop.md`.
+Nachdem der PR gepusht ist: CI überwachen und Fehler beheben **bevor** gemergt wird. SSOT: `.agents/skills/references/ci-fix-loop.md`.
 
 Kurzfassung:
 1. `gh pr checks <n> --watch` — warten bis alle Required Checks grün sind
@@ -307,7 +307,7 @@ bash scripts/worktree-create.sh <branch> .worktrees/<slug>
 | `opencode-flow-execute` | Feature/Fix-Ablauf (nutzt diesen Skill intern) |
 | `scripts/worktree-create.sh` | Git-crypt-safe worktree creator |
 | `worktree.ts` Plugin | Opencode-native primitive (git-crypt-limited) |
-| `.claude/skills/references/git-workflow-procedures.md` | Detail-Referenz (Schritt-Übersicht, Fehlertabelle) |
+| `.agents/skills/references/git-workflow-procedures.md` | Detail-Referenz (Schritt-Übersicht, Fehlertabelle) |
 | `using-git-worktrees` | Worktree korrekt anlegen (git-crypt-safe) |
 
 

--- a/tests/spec/dev-flow-plan/task-context.bats
+++ b/tests/spec/dev-flow-plan/task-context.bats
@@ -165,7 +165,7 @@ teardown() {
 }
 
 @test "TCC-gate: Plan ohne tasks.d/ wird von I1 nicht beruehrt" {
-  local single_plan="$REPO/openspec/changes/admin-fundament-konsolidierung/tasks.md"
+  local single_plan="$REPO/openspec/changes/archive/2026-08-04-gpu-arbitrierung-trainings-vorrang/tasks.md"
   [ -f "$single_plan" ] || { echo "Plan ohne tasks.d/ nicht gefunden"; false; }
   run bash "$REPO/scripts/plan-lint.sh" "$single_plan"
   [ "$status" -eq 0 ] || { echo "lint failed auf Plan ohne tasks.d/: $output"; false; }


### PR DESCRIPTION
Resolves T013142.

### Summary of Changes:
- **dev-flow-e2e:** Removed deprecated `chrome-devtools-axi` references; clarified Korczewski brand frozen/disabled status; replaced `cluster-deployment` with `infra-ops` and `operations-management`.
- **incident-response:** Updated `cluster-deployment` reference to `infra-ops`.
- **dev-flow-execute & deploy-routing:** Cleaned up non-existent `dev-flow-iterate` references in favor of explicit k3d local dev redeploy tasks.
- **opencode skills (`opencode-flow-execute`, `opencode-git-workflow`):** Fixed legacy `.claude/skills/` paths to `.agents/skills/`.