### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -3062,7 +3062,7 @@
       "id": "infra-manifests",
       "name": "Kubernetes manifests, overlays, env registry",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 519,
+      "file_count": 520,
       "files": [
         ".opencode/agent-models.jsonc",
         ".opencode/commands/opsx-apply.md",
@@ -3131,6 +3131,7 @@
         ".opencode/prompts/deepseek-helper.md",
         ".opencode/prompts/local-subagent.md",
         ".opencode/prompts/orchestrator.md",
+        ".opencode/prompts/primary-agent.md",
         ".opencode/skills/dev-flow/DEV-FLOW.SKILL.md",
         ".opencode/skills/dev-flow/background-agents.SKILL.md",
         ".opencode/skills/dev-flow/background-agents.ts",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32561092279).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
