### PR TITLE
chore(ci): hook up Laguna S 2.1 Free on OpenCode Zen for AI review [T013430]

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -62,8 +62,11 @@ jobs:
       - name: Run AI review
         if: steps.gate.outputs.skip != 'true'
         env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ANTHROPIC_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
           ANTHROPIC_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          CI_REVIEW_MODEL: ${{ vars.CI_REVIEW_MODEL || 'laguna-s-2.1-free' }}
           CLEAN_DIFF_PATH: ${{ runner.temp }}/clean.diff
           TIER_JSON_PATH: ${{ runner.temp }}/tier.json
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/factory/AI-REVIEW-SETUP.md
+++ b/scripts/factory/AI-REVIEW-SETUP.md
@@ -5,11 +5,13 @@ variables → Actions → New repository secret):
 
 | Secret | Value |
 |--------|-------|
-| `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/anthropic` (or the `ANTHROPIC_BASE_URL` from `environments/.secrets/deepseek.sh`) |
-| `DEEPSEEK_API_KEY`  | the `ANTHROPIC_AUTH_TOKEN` value from `environments/.secrets/deepseek.sh` |
+| `OPENCODE_API_KEY`  | OpenCode Zen API key / token (defaults to `laguna-s-2.1-free`, free tier Poolside coding model, 256k ctx) |
+| `GEMINI_API_KEY`    | Google Gemini API key (fallback / optional) |
+| `DEEPSEEK_BASE_URL` | `https://api.deepseek.com/anthropic` (fallback) |
+| `DEEPSEEK_API_KEY`  | the `ANTHROPIC_AUTH_TOKEN` value from `environments/.secrets/deepseek.sh` (fallback) |
 
 Notes:
 - The job is **advisory** — it is intentionally NOT a required status check. A model/network
   failure makes the job red but does not block merge.
 - If the secrets are absent, `ci-review.mjs` skips cleanly (exit 0) with a warning.
-- Model id is `deepseek-chat` by default; override with the `CI_REVIEW_MODEL` env in the workflow.
+- Model id defaults to `laguna-s-2.1-free` via OpenCode Zen (`https://opencode.ai/zen/v1`) when `OPENCODE_API_KEY` is set; override with the `CI_REVIEW_MODEL` env/repository variable.

--- a/scripts/factory/ci-review.mjs
+++ b/scripts/factory/ci-review.mjs
@@ -9,17 +9,26 @@ import Anthropic from '@anthropic-ai/sdk'
 import { parseChangedLines, filterFindings, formatChangedLinesHint } from './review-finding-filter.mjs'
 
 const {
+  OPENCODE_API_KEY, OPENCODE_ZEN_API_KEY,
+  OPENCODE_ZEN_BASE_URL = 'https://opencode.ai/zen/v1',
+  GEMINI_API_KEY, GOOGLE_API_KEY,
   ANTHROPIC_BASE_URL, ANTHROPIC_API_KEY,
+  OPENAI_BASE_URL, OPENAI_API_KEY,
   CLEAN_DIFF_PATH, TIER_JSON_PATH,
-  PR_NUMBER, CI_REVIEW_MODEL = 'deepseek-chat',
+  PR_NUMBER,
+  CI_REVIEW_MODEL,
   CI_REVIEW_CONFIDENCE_THRESHOLD,
 } = process.env
+
+const opencodeKey = OPENCODE_API_KEY || OPENCODE_ZEN_API_KEY
+const geminiKey = GEMINI_API_KEY || GOOGLE_API_KEY
+const model = CI_REVIEW_MODEL || (opencodeKey ? 'laguna-s-2.1-free' : geminiKey ? 'gemini-3.1-pro' : 'deepseek-chat')
 const confidenceThreshold = (() => { const v = Number(CI_REVIEW_CONFIDENCE_THRESHOLD); return Number.isNaN(v) ? 0.6 : v })()
 
 const PROMPT_DIR = new URL('.', import.meta.url).pathname
 
-if (!ANTHROPIC_API_KEY) {
-  console.warn('ci-review: ANTHROPIC_API_KEY unset — skipping AI review (advisory).')
+if (!opencodeKey && !geminiKey && !ANTHROPIC_API_KEY && !OPENAI_API_KEY) {
+  console.warn('ci-review: OPENCODE_API_KEY / GEMINI_API_KEY / ANTHROPIC_API_KEY unset — skipping AI review (advisory).')
   process.exit(0)
 }
 
@@ -37,7 +46,11 @@ const TIER_LENSES = {
 }
 
 const readPrompt = (lens) => readFileSync(PROMPT_DIR + LENS_FILE[lens], 'utf8')
-const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY, ...(ANTHROPIC_BASE_URL ? { baseURL: ANTHROPIC_BASE_URL } : {}) })
+
+let anthropicClient = null
+if (ANTHROPIC_API_KEY) {
+  anthropicClient = new Anthropic({ apiKey: ANTHROPIC_API_KEY, ...(ANTHROPIC_BASE_URL ? { baseURL: ANTHROPIC_BASE_URL } : {}) })
+}
 
 function parseJson(text, fallback) {
   // Strip Markdown code fences that LLMs wrap around JSON responses.
@@ -50,14 +63,91 @@ function parseJson(text, fallback) {
   try { return JSON.parse(m[0]) } catch { return fallback }
 }
 
-async function callModel(systemPrompt, userContent) {
-  const res = await client.messages.create({
-    model: CI_REVIEW_MODEL,
+async function callOpenCodeZen(systemPrompt, userContent) {
+  const endpoint = `${OPENCODE_ZEN_BASE_URL.replace(/\/+$/, '')}/chat/completions`
+  const payload = {
+    model,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userContent }
+    ],
+    max_tokens: 4096,
+    temperature: 0.2
+  }
+
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${opencodeKey}`
+    },
+    body: JSON.stringify(payload)
+  })
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '')
+    throw new Error(`OpenCode Zen API error (${res.status}): ${errText}`)
+  }
+
+  const data = await res.json()
+  return data.choices?.[0]?.message?.content || ''
+}
+
+async function callGemini(systemPrompt, userContent) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(geminiKey)}`
+  const payload = {
+    system_instruction: {
+      parts: [{ text: systemPrompt }]
+    },
+    contents: [
+      {
+        role: 'user',
+        parts: [{ text: userContent }]
+      }
+    ],
+    generationConfig: {
+      maxOutputTokens: 4096,
+      temperature: 0.2,
+      responseMimeType: 'application/json'
+    }
+  }
+
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '')
+    throw new Error(`Gemini API error (${res.status}): ${errText}`)
+  }
+
+  const data = await res.json()
+  return data.candidates?.[0]?.content?.parts?.map((p) => p.text).join('') || ''
+}
+
+async function callAnthropic(systemPrompt, userContent) {
+  const res = await anthropicClient.messages.create({
+    model,
     max_tokens: 4096,
     system: systemPrompt,
     messages: [{ role: 'user', content: userContent }],
   })
   return res.content.map((b) => (b.type === 'text' ? b.text : '')).join('')
+}
+
+async function callModel(systemPrompt, userContent) {
+  if (opencodeKey) {
+    return callOpenCodeZen(systemPrompt, userContent)
+  }
+  if (geminiKey) {
+    return callGemini(systemPrompt, userContent)
+  }
+  if (anthropicClient) {
+    return callAnthropic(systemPrompt, userContent)
+  }
+  throw new Error('No supported LLM provider configured')
 }
 
 async function runLens(lens, diff, hint) {


### PR DESCRIPTION
## Summary
- Configure Laguna S 2.1 Free on OpenCode Zen (`laguna-s-2.1-free`, Poolside agentic coding model, free tier, 256k context) as the primary model for the CI AI code review workflow (`ci-review.mjs` / `ai-review.yml`).
- Add native support for OpenCode Zen endpoint (`https://opencode.ai/zen/v1/chat/completions`) using `OPENCODE_API_KEY`.
- Retain multi-provider fallback support for Google Gemini (`GEMINI_API_KEY`) and Anthropic/DeepSeek (`ANTHROPIC_API_KEY` / `DEEPSEEK_API_KEY`).
- Update setup documentation in `scripts/factory/AI-REVIEW-SETUP.md`.

## Test Plan
- Run unit test suite for review finding filter: `cd scripts/factory && node --test review-finding-filter.test.mjs` (43/43 passing)
- Run Bats test suite for review pipeline: `npx bats tests/spec/agentic-review.bats` (21/21 passing)
- Validate manifests: `task workspace:validate` (passing)
- Verify freshness: `task freshness:check` (passing)