### PR TITLE
chore(ops): Factory-Routing auf qwen38-220k schwenken [T013434]

### DIFF
--- a/scripts/factory/mcp-go/main.go
+++ b/scripts/factory/mcp-go/main.go
@@ -50,6 +50,12 @@ func resolveAuthKey(apiKeyEnv string) string {
 }
 
 // resolveLLM calls route-provider.sh to get baseUrl + modelId + slotId + apiKeyEnv + ctx from provider_config DB.
+// [T013434] Der Fallback zeigte bis 2026-08-22 auf ein LM Studio unter
+// 192.168.100.10:1234 mit Modell "hermes-3-llama-3.1-8b" — beides existiert nicht
+// mehr. Wenn route-provider.sh ausfiel, antwortete factory_ask deshalb nicht mit
+// einem Transportfehler, sondern mit "no healthy backend" gegen ein Modell, das
+// der Proxy gar nicht fuehrt. Der Fallback zeigt jetzt auf dasselbe Gateway und
+// dasselbe Loadout wie der Normalpfad.
 func resolveLLM() (baseURL, model, slotID, apiKeyEnv string, ctx int) {
 	script := repo() + "/scripts/factory/route-provider.sh"
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -57,8 +63,8 @@ func resolveLLM() (baseURL, model, slotID, apiKeyEnv string, ctx int) {
 	out, err := exec.CommandContext(timeoutCtx, "bash", script, "factory-ask", "haiku").Output()
 	if err != nil {
 		// Fallback: env overrides (backwards compat for local dev)
-		return envOr("FACTORY_LLM_URL", "http://192.168.100.10:1234/v1"),
-			envOr("FACTORY_LLM_MODEL", "hermes-3-llama-3.1-8b"),
+		return envOr("FACTORY_LLM_URL", "http://127.0.0.1:18235/v1"),
+			envOr("FACTORY_LLM_MODEL", "qwen38-220k"),
 			"", "", 0
 	}
 	var route struct {
@@ -70,8 +76,8 @@ func resolveLLM() (baseURL, model, slotID, apiKeyEnv string, ctx int) {
 		Ctx       int     `json:"ctx"`
 	}
 	if err := json.Unmarshal(bytes.TrimSpace(out), &route); err != nil || route.BaseURL == nil || *route.BaseURL == "" {
-		return envOr("FACTORY_LLM_URL", "http://192.168.100.10:1234/v1"),
-			envOr("FACTORY_LLM_MODEL", "hermes-3-llama-3.1-8b"),
+		return envOr("FACTORY_LLM_URL", "http://127.0.0.1:18235/v1"),
+			envOr("FACTORY_LLM_MODEL", "qwen38-220k"),
 			"", "", 0
 	}
 	// Resolve nullable slotId/apiKeyEnv from pointers to empty strings.

--- a/scripts/factory/pipeline.mjs
+++ b/scripts/factory/pipeline.mjs
@@ -23,7 +23,7 @@ if (typeof process !== 'undefined' && !process.env.TICKET_PHASE_DRIVER) process.
 // Chat-Modell — die unterste Sprosse der Leiter war unbesetzt. Sie geht jetzt
 // ueber dasselbe Gateway wie alles andere; FACTORY_MODEL_ID bleibt der einzige
 // Regler fuer den Modellnamen.
-const LOCAL_MODEL_ID = process.env.FACTORY_MODEL_ID || 'gemma26-throughput'
+const LOCAL_MODEL_ID = process.env.FACTORY_MODEL_ID || 'qwen38-220k'
 const MODEL_TIERS = {
   flash:  { provider: 'llamacpp', modelId: LOCAL_MODEL_ID, baseUrl: 'http://127.0.0.1:18235' },
   haiku:  { provider: 'deepseek', modelId: 'deepseek-chat',  baseUrl: null },

--- a/scripts/factory/provider-register-local.sh
+++ b/scripts/factory/provider-register-local.sh
@@ -27,7 +27,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/lib.sh"
 
 PIN="$(factory_model_pin)"; IFS=$'\t' read -r PIN_MODEL _ <<< "${PIN:-}"
-MODEL_ID="${PIN_MODEL:-${FACTORY_MODEL_ID:-gemma26-throughput}}"
+MODEL_ID="${PIN_MODEL:-${FACTORY_MODEL_ID:-qwen38-220k}}"
 # Immer das vereinheitlichte Gateway, nie ein Backend-Port. Welches Backend
 # dahinter haengt, entscheidet die Registry tickets.llm_proxy_backends.
 # [T003492] OHNE '/v1' — die Konsumenten haengen '/v1/chat/completions' selbst an

--- a/scripts/factory/route-provider.sh
+++ b/scripts/factory/route-provider.sh
@@ -25,7 +25,7 @@ if [[ -n "$PIN" ]]; then
     exit 0
   fi
 fi
-FACTORY_DEFAULT_MODEL="${PIN_MODEL:-${FACTORY_MODEL_ID:-gemma26-throughput}}"
+FACTORY_DEFAULT_MODEL="${PIN_MODEL:-${FACTORY_MODEL_ID:-qwen38-220k}}"
 
 # Tier "opus": Modell aus der Registry, aber OHNE Slot-Claim.
 #

--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -420,7 +420,7 @@
     }
   },
   "factory": {
-    "model": "gemma26-throughput",
+    "model": "qwen38-220k",
     "locked": false
   }
 }

--- a/scripts/migrations/2026-08-22-factory-model-qwen38.sql
+++ b/scripts/migrations/2026-08-22-factory-model-qwen38.sql
@@ -1,0 +1,31 @@
+-- Schwenkt das lokale Factory-Routing auf das Loadout qwen38-220k [T013434].
+--
+-- BEFUND, der diese Migration ausgeloest hat: tickets.provider_config fuehrte
+-- fuer provider='llamacpp' ausschliesslich Zeilen mit model_id='gemma12-vision'
+-- (source='*' fuer haiku/sonnet/cheap/flash sowie factory-implement/sonnet,
+-- alle enabled, priority 0, updated_at 2026-08-18). scripts/factory/
+-- route-provider.sh liest diese Tabelle und gewinnt damit gegen den Pin in
+-- scripts/llm/loadouts.json (factory.model). Der Pin stand seinerseits auf
+-- gemma26-throughput. Beide Modelle teilen mit qwen38-220k die exclusiveGroup
+-- 'chat-gpu': jeder Factory-Dispatch stoppte also das Loadout, das die Factory
+-- eigentlich nutzen soll, und factory_ask meldete 'no healthy backend',
+-- solange qwen38 lief.
+--
+-- KONTEXT REICHT: groesster je protokollierter Prompt in
+-- tickets.llm_proxy_request_log ist 6445 Token; das abgeloeste
+-- gemma26-throughput fuhr gemessene 118016 ctx, qwen38-220k fuehrt 114688.
+--   SELECT max(prompt_tokens) FROM tickets.llm_proxy_request_log;
+--
+-- Idempotent, gezielt nur auf die aktiven llamacpp-Zeilen. Andere Provider
+-- (deepseek, anthropic, lmstudio) bleiben unberuehrt.
+BEGIN;
+
+UPDATE tickets.provider_config
+   SET model_id   = 'qwen38-220k',
+       base_url   = 'http://127.0.0.1:18235',
+       updated_at = now()
+ WHERE provider = 'llamacpp'
+   AND enabled
+   AND model_id <> 'qwen38-220k';
+
+COMMIT;

--- a/tests/spec/local-llm-proxy/factory-model-lock.bats
+++ b/tests/spec/local-llm-proxy/factory-model-lock.bats
@@ -1,8 +1,23 @@
 #!/usr/bin/env bats
 
+# [T013434] Der erste Test verglich bis 2026-08-22 gegen das Literal
+# 'gemma26-throughput'. Das war der Grund, warum der Factory-Pin bei jedem
+# Modellwechsel mitgeaendert werden musste — und warum er beim Wechsel auf
+# qwen38-220k stehenblieb. Geprueft wird jetzt die eigentliche Zusicherung:
+# factory.model benennt ein Loadout, das es im selben Dokument gibt, und
+# factory.locked ist boolesch. Beides driftet nicht mit dem Modell.
+
 @test "shipped loadouts carry a valid factory block" {
-  run node --input-type=module -e "import{readLoadouts}from'./scripts/llm-proxy/loadouts.mjs';const{doc}=readLoadouts();if(doc.factory.model!=='gemma26-throughput'||doc.factory.locked!==false)process.exit(1)"
+  run node --input-type=module -e "
+    import{readLoadouts}from'./scripts/llm-proxy/loadouts.mjs';
+    const{doc}=readLoadouts();
+    const slugs=doc.loadouts.map(l=>l.slug);
+    if(typeof doc.factory.locked!=='boolean'){console.log('locked-not-boolean');process.exit(1)}
+    if(!slugs.includes(doc.factory.model)){console.log('unknown-slug:'+doc.factory.model);process.exit(1)}
+    console.log('factory-model-ok:'+doc.factory.model)
+  "
   [ "$status" -eq 0 ]
+  [[ "$output" == *"factory-model-ok:"* ]]
 }
 
 @test "admin UI offers a select and lock toggle without text input" {


### PR DESCRIPTION
Die Factory nutzte das gestern optimierte Loadout nicht — sie verdrängte es. Zwei unabhängige Stellen zeigten woanders hin.

## Befund

**1. `tickets.provider_config` überstimmt den Pin.** Für `provider='llamacpp'` standen dort ausschließlich Zeilen mit `model_id='gemma12-vision'` (`source='*'` für haiku/sonnet/cheap/flash/opus sowie `factory-implement` und `factory-review`, alle `enabled`, priority 0). `route-provider.sh` liest diese Tabelle und gewinnt gegen `loadouts.json`.

**2. Der Pin selbst stand auf `gemma26-throughput`.**

Beide teilen mit `qwen38-220k` die `exclusiveGroup 'chat-gpu'`. Jeder Factory-Dispatch stoppte also genau das Loadout, das die Factory nutzen soll — und `factory_ask` meldete `no healthy backend`, solange qwen38 lief.

## Kontextprüfung vor dem Schwenk

`qwen38-220k` führt 114688 ctx, das abgelöste `gemma26-throughput` fuhr gemessene 118016.

```sql
SELECT max(prompt_tokens) FROM tickets.llm_proxy_request_log;  -- 6445
```

Kein protokollierter Prompt kommt in die Nähe des Fensters. Datenlage ist dünn (die Ticket-DB wurde am 18.08. neu aufgesetzt), die Richtung aber eindeutig.

## Änderungen

- **`scripts/migrations/2026-08-22-factory-model-qwen38.sql`** — die aktiven llamacpp-Zeilen auf `qwen38-220k` und das Gateway. Andere Provider (deepseek, anthropic, lmstudio) bleiben unberührt. Idempotent.
- **`loadouts.json`** — `factory.model` → `qwen38-220k`.
- **`route-provider.sh`, `provider-register-local.sh`, `pipeline.mjs`** — die drei Fallback-Literale `gemma26-throughput` → `qwen38-220k`.
- **`factory-model-lock.bats`** — prüft nicht mehr gegen ein Modell-Literal, sondern dass `factory.model` einen Slug benennt, den dasselbe Dokument führt. Das Literal war der Grund, warum der Pin bei Modellwechseln stehenblieb.
- **`mcp-go/main.go`** — der `resolveLLM`-Fallback zeigte auf ein LM Studio unter `192.168.100.10:1234` mit `hermes-3-llama-3.1-8b`; beides existiert nicht mehr. Bei jedem Ausfall von `route-provider.sh` antwortete `factory_ask` deshalb mit `no healthy backend` gegen ein Modell, das der Proxy gar nicht führt. Fallback zeigt jetzt auf dasselbe Gateway und Loadout wie der Normalpfad.

## Verifikation

```
route-provider.sh factory-ask haiku  → {"provider":"llamacpp","modelId":"qwen38-220k",...}
/admin/factory                       → {"model":"qwen38-220k","locked":false}
factory_ask                          → {"answer":"…","model":"qwen38-220k"}
```

`tests/spec/local-llm-proxy` und `tests/spec/software-factory`: drei Fehler (FA-SF-04 brand FK, zwei sandbox-egress) sind per `git stash` als vorbestehend nachgewiesen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FXH5VLgSSbhZT1VC3fex8