### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -1173,7 +1173,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 66,
+      "file_count": 67,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -1240,6 +1240,7 @@
         "scripts/migrations/2026-08-19-factory-model-gemma12.sql",
         "scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql",
         "scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql",
+        "scripts/migrations/2026-08-22-factory-model-qwen38.sql",
         "scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql"
       ]
     },


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32570578301).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
