### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1180,
+      "file_count": 1181,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -399,6 +399,7 @@
         "tests/spec/agent-skills/agent-lock-claim-help-flag.bats",
         "tests/spec/agent-skills/automerge-preflight-check.bats",
         "tests/spec/agent-skills/dev-flow-chore-step0-foreign-guard.bats",
+        "tests/spec/agent-skills/dev-flow-lifecycle-contract.bats",
         "tests/spec/agent-skills/devflow-worktree-cwd-guard.bats",
         "tests/spec/agent-skills/executor-post-merge-death.bats",
         "tests/spec/agent-skills/finalize-hardening.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32575255387).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
