### PR TITLE
feat(skills): add system-audit hub — one audit entry point ending in proposal-backed tickets [T013514]

### DIFF
--- a/.claude/skills/OVERVIEW.md
+++ b/.claude/skills/OVERVIEW.md
@@ -1,6 +1,6 @@
 # Skills Overview
 
-33 project-local skills grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
+34 project-local skills grouped by domain. Each skill has its own `SKILL.md` with full runbook details. Invoke any skill by its name.
 
 > **Konsolidierung (2026-06-21):** 7 Infra/Ops-Skills wurden in `infra-ops` zusammengeführt (nur bei explizitem Bedarf aufrufen). `update-dependencies` läuft als biweekly Cloud-Routine (https://claude.ai/code/routines/trig_01GiuyN6KP5iMcVUSvBQMKyQ). Die archivierten SKILL.md-Dateien haben kein `description`-Feld mehr und triggern nicht auto-matisch.
 
@@ -145,6 +145,7 @@ Fachspezifische Skills, die als Subagent dispatched werden:
 | [`incident-response`](incident-response/SKILL.md) | Production incident triage & recovery — scope, diagnose, fix/rollback, post-mortem. Use when a core service is down or degraded. |
 | [`ticket-ops`](ticket-ops/SKILL.md) | **Ticket-Inhalte** — Triage auf Vollständigkeit, fehlende Angaben beim Menschen erfragen, Parallelarbeit über Tickets planen. Nicht für Branch-/Worktree-/PR-Housekeeping — das ist [`repo-hygiene`](repo-hygiene/SKILL.md). |
 | [`repo-hygiene`](repo-hygiene/SKILL.md) | **Repo-Zustand** — veraltete Branches und Worktrees, offene PRs mergen und schließen, GitHub-Issue-Intake, Factory-Queue-Status. Nicht für Ticket-Inhalte — das ist [`ticket-ops`](ticket-ops/SKILL.md). |
+| [`system-audit`](system-audit/SKILL.md) | **Audit-Hub** — ein Einstiegspunkt für Audits aller Systeme (GitOps-Repo, Live-Cluster, Brand-Seiten, Repo-Zustand, Toolset, Security, DB, LLM-Pipeline, Brain-Wiki). Delegiert an die Spezial-Skills, schließt deren Audit-Lücken per Checkliste; jeder Critical/Warning-Befund endet als Ticket mit angehängtem OpenSpec-Proposal in der Factory-Backlog. Kein Merge-Gate. |
 | [`mishap-tracker`](mishap-tracker/SKILL.md) | **End-of-skill routine** — batches accumulated `MISHAP_LOG` entries from runbook skills into a single aggregate `tickets.tickets` row. Reuses an open "Mishap collection" ticket if one exists. |
 | [`update-dependencies`](update-dependencies/SKILL.md) | Update workspace packages, fix deprecation warnings, and handle security audits/Major version bumps across all directories. Läuft als biweekly Cloud-Routine; `archived: true`, deshalb ohne `description` und nicht in der Session-Liste. |
 

--- a/.claude/skills/system-audit/SKILL.md
+++ b/.claude/skills/system-audit/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: system-audit
+description: "Ein Audit-Einstiegspunkt fuer alle Systeme, die das Repo in separaten Skills abdeckt: GitOps-Repo-Manifeste, Live-Flux-Cluster, Brand-Seiten, Repo-Zustand/Factory-Queue, Tool-Registry, Security & Secrets, Datenbank, LLM-Pipeline, Brain-Wiki — oder alle auf einmal. Wiederverwendet die vorhandenen Audit-Skills (gitops-repo-audit, web-audit, repo-hygiene, toolset-curate) und schliesst die Luecken mit kompakten Checklisten (flux-cluster, security, database, llm-pipeline). Jeder Lauf endet mit einer Pflicht-Abschlussphase: jeder Critical/Warning-Befund wird zu einem Ticket mit DoR-Feldern plus angehaengtem OpenSpec-Proposal (scripts/openspec.sh propose --ticket) und in die Factory-Backlog enqueued. Triggers on system-audit, Systemaudit, Full-Audit, 'audit all systems', 'audit the cluster/repo/website/security/database/llm pipeline/toolset', 'audit report with tickets'."
+---
+
+# system-audit
+
+Ein Einstiegspunkt für Audits über alle Systeme, die das Repo in separaten Skills pflegt.
+Der Skill ersetzt die Spezial-Skills nicht — er orchestriert sie und schließt deren
+Audit-Lücken. Ein Lauf ist **read-only bis Phase C**: es wird nichts repariert, nichts
+deployed, kein PR entschieden. Die Folgearbeit entsteht ausschließlich als Tickets mit
+angehängten Proposals.
+
+> **Mishap Tracking:** Führe während dieses Skills ein `MISHAP_LOG` und rufe am Ende
+> `mishap-tracker` auf — Eintragsformat und Ablauf: siehe `mishap-tracker` §Input.
+
+## Zielkatalog
+
+| Ziel | System | Deckung | Modus |
+|---|---|---|---|
+| `gitops-repo` | Flux-Manifeste dieses Repos (`k3d/`, `prod-fleet/`, `flux/`) | Skill `gitops-repo-audit` | delegiert |
+| `flux-cluster` | Live-Fleet-Cluster (ns `workspace`, `workspace-korczewski`) | Checkliste [§1](references/checklists.md#1-flux-cluster-live-sweep) | eigen |
+| `website` | Brand-Seiten mentolder + korczewski | Skill `web-audit` | delegiert |
+| `repo` | Repo-Zustand, PRs, Factory-Queue | Skill `repo-hygiene` §0–§7 inkl. Runtime-Drift | delegiert |
+| `toolset` | Tool-Registry (`capabilities.yaml`) | Skill `toolset-curate` Schritt 1–2 | delegiert |
+| `security` | SealedSecrets, OIDC, DSGVO, Secret-Alter | Checkliste [§2](references/checklists.md#2-security-sealedsecrets-oidc-dsgvo) (+ infra-ops §6) | eigen |
+| `database` | PostgreSQL (Backups, Schema, Wachstum) | Checkliste [§3](references/checklists.md#3-datenbank-postgresql) (+ infra-ops §7) | eigen |
+| `llm-pipeline` | GPU-Host, llm-proxy, Loadouts | Checkliste [§4](references/checklists.md#4-llm-pipeline-gpu-proxy-loadouts) (+ infra-ops §5) | eigen |
+| `brain-wiki` | Brain-Wiki-Frische gegen die Quellen | Skill `brain-ingest` Dry-Run | delegiert |
+| `all` | alle Ziele oben | sequenziell, ein Sammelreport | — |
+
+## Grundregeln
+
+1. **Read-only bis Phase C.** Kein Fix, kein Deploy, kein Neustart. Diagnose-Kommandos
+   mit Schreibpotenzial (Restart, Scale, Delete) sind verboten — gehört zu
+   `incident-response` bzw. `infra-ops`.
+2. **Evidence-Pflicht.** Jeder Befund trägt seinen Beleg: Befehl + Ausgabe-Auszug oder
+   `datei:zeile`. Ein Befund ohne Evidence wird nicht gemeldet.
+3. **Severity-Modell** (gilt für alle Ziele):
+
+   | Severity | Bedeutung | Phase-C-Folge |
+   |---|---|---|
+   | Critical | broken, Sicherheitsrisiko, Datenverlustrisiko, Prod ausgefallen/degradiert | Ticket + Proposal (Pflicht) |
+   | Warning | Drift, Verschleiß, fehlende Absicherung, Inkonsistenz | Ticket + Proposal (Pflicht) |
+   | Info | Hygiene, Kosmetik, Beobachtung | bleibt im Report |
+
+4. **Kein Merge-Gate.** Der Skill läuft manuell und entscheidet nicht über PRs.
+5. **Eine Ursache, ein Ticket.** Mehrere Befunde mit derselben Wurzel werden in Phase C
+   zu einem Ticket zusammengefasst — nicht zu fünf Duplikaten.
+
+## Phase A — Audits ausführen
+
+Führe die Prozedur des angefragten Ziels aus. Bei `all`: alle Ziele der Reihe nach;
+ein einzelnes fehlgeschlagenes Ziel bricht den Lauf nicht ab — es wird im Report als
+`FAILED` markiert (Konvention wie `web-audit`).
+
+### gitops-repo → delegiert an `gitops-repo-audit`
+
+Führe den Analysis-Workflow des Skills auf diesem Repo aus (Discovery → Validation →
+API Compliance → Best Practices → Security → Report). Scope: `k3d/`, `prod-fleet/`,
+`flux/`. Dessen Report-Sektionen werden 1:1 in den Sammelreport übernommen; jede
+Empfehlung wird zu einem normierten Befund nach Phase B.
+
+### flux-cluster → Checkliste §1
+
+Read-only Sweep des Live-Clusters: Flux-Ressourcen-Readiness, suspendierte Ressourcen,
+Artefakt-Alter, Pod-Restarts, Node-Pressure. Details: [Checkliste §1](references/checklists.md#1-flux-cluster-live-sweep).
+Diagnose-Tiefe und Reparatur gehören zu `gitops-cluster-debug` — hier stoppt der Lauf
+bei der Befundliste.
+
+### website → delegiert an `web-audit`
+
+```bash
+task web:audit ENV=mentolder
+task web:audit ENV=korczewski
+```
+
+Beide Brands, Standard-Routen. Die axe/Lighthouse/LLM-Triage-Ergebnisse werden als
+Befunde übernommen (Rangliste des Web-Audits ≙ Priorisierung nach Severity-Mapping:
+axe critical/Lighthouse <50 ⇒ Critical, sonst Warning, kosmetisch ⇒ Info).
+
+### repo → delegiert an `repo-hygiene`
+
+Führe die acht Abschnitte der `repo-hygiene-ops`-Referenz aus (§0–§7) inklusive
+`bash scripts/runtime-drift-check.sh`. Die Top-3-Empfehlungen aus §6 und jeder
+Drift-/Aging-Befund werden zu normierten Befunden.
+
+### toolset → delegiert an `toolset-curate`
+
+```bash
+node scripts/toolset/collect.mjs --unreviewed
+node scripts/toolset/check.mjs
+```
+
+Jeder `unreviewed`-Eintrag ist ein Warning-Befund (Kuration fehlt); ein Nicht-null-Exit
+von `check.mjs` ist Critical. Die Kuration selbst führt dieser Skill **nicht** aus —
+dafür bleibt es bei `toolset-curate`.
+
+### security → Checkliste §2
+
+SealedSecrets-Status und -Alter, OIDC-Clients DB-vs-Manifest-Drift, Plaintext-Secrets
+im Git-Baum, DSGVO-Basics der Brand-Seiten. Details: [Checkliste §2](references/checklists.md#2-security-sealedsecrets-oidc-dsgvo).
+Rotationsprozeduren selbst: infra-ops §6.
+
+### database → Checkliste §3
+
+Backup-Frische und Restore-Verifikation (infra-ops §7 Audit), plus read-only SQL-Checks
+über `mcp-postgres`. Nie `SELECT *` von `tickets.ticket_plans` (Multi-MB-Content).
+Details: [Checkliste §3](references/checklists.md#3-datenbank-postgresql).
+
+### llm-pipeline → Checkliste §4
+
+Proxy-Erreichbarkeit, Backend-Gesundheit, Loadout-Konfiguration vs. laufende Realität,
+GPU-Speicher. Details: [Checkliste §4](references/checklists.md#4-llm-pipeline-gpu-proxy-loadouts).
+Betrieb und Loadout-Wechsel: infra-ops §5.
+
+### brain-wiki → delegiert an `brain-ingest`
+
+Dry-Run der Ingest-Pipeline (`task brain:ingest:dry` bzw. Worklist-Generierung). Jede
+Quelle, die eine Wiki-Seite ändern würde, ist ein Warning-Befund (Wiki driftet); ein
+fehlgeschlagener Dry-Run ist Critical.
+
+## Phase B — Befunde normalisieren und Report schreiben
+
+Jeder Befund erhält dieses Format (im Report und später im Ticket):
+
+```
+SA-<ZIEL>-<NN> | <severity> | <component>
+Evidence: <Befehl + Ausgabe-Auszug ODER datei:zeile>
+Vorschlag: <konkrete Änderung, ein Satz>
+```
+
+Schreibe den Report nach `tmp/claude-scratch/system-audit-<ziel>-<YYYY-MM-DD>.md`
+(bei `all`: `system-audit-all-<datum>.md`) mit diesem Skelett:
+
+```markdown
+# System-Audit <ziel> — <datum>
+## Zusammenfassung (<n> Critical, <n> Warning, <n> Info)
+## Befunde
+### SA-XXX-01 | critical | <component>
+Evidence / Vorschlag / (Phase-C: Ticket <T-ID>, Proposal <slug>)
+## Abgedeckte Quellen (welche Skills/Checklisten gelaufen sind, FAILED-Markierungen)
+## Info-Befunde (ohne Ticket)
+```
+
+Die Zeile `(Phase-C: …)` wird in Phase C nachgetragen — so ist der Report die
+Rückverfolgbarkeit von Befund zu Ticket.
+
+## Phase C — Abschlussphase: jeder Befund wird Ticket + Proposal (Pflicht)
+
+Ein Audit ohne Folge ist ein Bericht, den niemand liest. Deshalb ist diese Phase
+**Pflichtbestandteil jedes Laufs**, nicht optionaler Nachklapp. Scope: alle Critical-
+und Warning-Befunde. Info-Befunde bleiben im Report.
+
+### C0 — Worktree-Guard
+
+OpenSpec-Proposals erzeugen Dateien unter `openspec/changes/`. Das geschieht nur in
+einem Worktree (Fußnote: Archivierung NUR im Worktree — Main-Checkout-Commits leave
+orphaned files). Prüfe:
+
+```bash
+git rev-parse --git-dir | grep -q 'worktrees/' && echo WORKTREE || echo MAIN
+```
+
+- `WORKTREE` → voller Ablauf C1–C5.
+- `MAIN` → nur C1–C3 + C5; statt C4 bekommt jedes Ticket einen Kommentar
+  „Proposal folgt in dev-flow-plan (Audit lief auf Main-Checkout)". Der Fallback ist
+  im Report je Befund zu markieren.
+
+### C1 — Dedupe gegen offene Tickets
+
+Suche je Befund nach einem bereits offenen Ticket (Stichworte aus Titel/Component,
+Status ≠ done/archived). Existiert eins: **kein neues Ticket** — stattdessen Kommentar
+mit Evidence + aktuellem Datum ans bestehende Ticket. Erst danach zählt der Befund als
+abgearbeitet.
+
+### C2 — Ticket anlegen
+
+```bash
+scripts/ticket.sh create --type <t> --title "[SA-XXX-NN] <Befund-Titel>" \
+  --description "<Evidence + Vorschlag + Report-Pfad>" --areas <areas> [--severity s] [--priority p]
+```
+
+(MCP-first äquivalent: `ticket-mcp_create_ticket`.) Mapping:
+
+| Befund | Ticket-Typ | Severity→Priority |
+|---|---|---|
+| Etwas ist defekt/falsch | `fix` | Critical→hoch, Warning→mittel |
+| Fähigkeit/Absicherung fehlt | `feat` | Critical→hoch, Warning→mittel |
+| Hygiene/Doku/Konvention | `chore` | Warning→niedrig |
+
+`component`/`areas` aus dem Zielkatalog: gitops-repo/flux-cluster→`infra`,
+website→`website`, repo/toolset→`scripts`, security→`security`, database→`database`,
+llm-pipeline→`llm`, brain-wiki→`docs`.
+
+### C3 — DoR-Felder setzen („properly planned")
+
+Ein Ticket ohne Planungs-Metadaten ist nicht factory-reif:
+
+```bash
+scripts/ticket.sh plan-meta --id <T-ID> --value-prop "<Nutzen aus dem Evidence>" \
+  --effort <klein|mittel|gross> --areas <areas>
+```
+
+(MCP-first: `ticket-mcp_set_plan_meta`.) Readiness-Flags via `set_readiness_flag`:
+`spec_skizziert=true` (das Proposal IST die Skizze), `aufwand_geschaetzt=true`;
+`offene_fragen_geklaert` und `abhaengigkeiten_klar` nur auf `true` setzen, wenn
+wirklich nichts offen ist — sonst offen lassen und im Ticket kommentieren, was fehlt.
+Feature-Tickets: `prepare_feature` statt Einzelaufrufen.
+
+### C4 — OpenSpec-Proposal anhängen (nur im Worktree, siehe C0)
+
+```bash
+bash scripts/openspec.sh propose audit-<ziel>-<stichwort> --ticket <T-ID>
+```
+
+Danach die Artefakte füllen (Vollständiges How-to: Skill `openspec-propose`):
+`proposal.md` (Why/What aus dem Befund), `design.md`, `tasks.md`, Delta-Spec unter
+`openspec/changes/<slug>/specs/<parent-slug>.md` — Parent-SSOT-Slug laut
+`openspec/component-map.yaml`, nur bei genuinely new capability der eigene Slug.
+Jeder Requirement-Block braucht mindestens ein GIVEN/WHEN/THEN-Scenario. Dann:
+
+```bash
+bash scripts/openspec.sh validate
+```
+
+Validierung darf nicht rot bleiben: ein rotes Proposal ist kein Proposal. Mehrere
+Befunde mit derselben Wurzel (Regel 5) teilen sich ein Ticket **und** ein Proposal.
+
+### C5 — Enqueue + Rückverfolgbarkeit
+
+```bash
+scripts/ticket.sh enqueue --id <T-ID>
+```
+
+Damit greift die Factory nach dem Pipeline-Prinzip zu. Abschluss je Befund:
+Kommentar mit Evidence-Block, Report-Pfad und Proposal-Slug aufs Ticket; Report-Zeile
+`(Phase-C: Ticket <T-ID>, Proposal <slug>)` nachtragen.
+
+## Nachbereitung: Mishap Report
+
+Nach allen Phasen `mishap-tracker` mit dem akkumulierten `MISHAP_LOG` aufrufen.
+Ausgefallene Ziele (FAILED-Markierungen) sind Mishaps, keine stillen Auslassungen.
+
+## Abgrenzung
+
+- **Kein Ersatz für die Spezial-Skills**: Tiefe (z. B. Flux-Feldindex, Lighthouse-Profile,
+  Kurationsentscheidungen) bleibt bei `gitops-repo-audit`, `web-audit`, `toolset-curate`.
+- **Kein incident-response**: etwas läuft gerade heiß → `incident-response`, nicht Audit.
+- **Kein Auto-Fix**: Umsetzung läuft über die erzeugten Tickets in der normalen Pipeline.
+- **Kein CI-Job**: manueller Lauf, kein Merge-Gate.
+
+## Verwandte Skills
+
+| Skill | Beziehung |
+|-------|--------------|
+| `gitops-repo-audit`, `web-audit`, `repo-hygiene`, `toolset-curate` | delegierte Ziele dieses Skills |
+| `openspec-propose` | How-to für die Proposal-Artefakte in C4 |
+| `ticket-ops` | Weitertriage der erzeugten Tickets (Vollständigkeit, Klärung) |
+| `incident-response` | wenn Befunde akut sind — sofortiger Wechsel erlaubt |
+| `infra-ops` §5–§7 | Fachprozeduren hinter den Checklisten security/database/llm-pipeline |
+| `mishap-tracker` | Pflicht-Nachbereitung |
+
+## Framework mapping
+
+| Framework | Availability |
+|-----------|-------------|
+| **Claude Code** | Full — load via `load skill <name>` or matches on description triggers |
+| **opencode** | Full — available as a listed skill. All tools (CLI, MCP) are framework-agnostic |
+| **agy** | Full — treat the opencode path as authoritative. All CLI tools and MCP calls work identically |

--- a/.claude/skills/system-audit/references/checklists.md
+++ b/.claude/skills/system-audit/references/checklists.md
@@ -1,0 +1,73 @@
+# system-audit Checklisten
+
+Fachliche Prozeduren für die Ziele, die keinen delegierten Skill haben. Alle Kommandos
+sind **read-only** — jeder schreibende Zugriff gehört zu `incident-response`/`infra-ops`.
+Jeder Check liefert entweder „ok" oder einen Befund im Format `SA-<ZIEL>-<NN>` mit
+Evidence (Regel 2 des Skills).
+
+## 1. flux-cluster (Live-Sweep)
+
+Kontext `fleet`. MCP-first (`mcp-kubernetes_*`, Flux-MCP), Fallback `kubectl --context fleet`.
+
+1. **Flux-Readiness** — `kubectl get kustomization,helmrelease -A`:
+   jede Zeile mit `Ready=False` oder leerem Ready-Status ⇒ Befund (Critical bei
+   Prod-Namespaces `workspace*`, sonst Warning). `Suspended=True` ⇒ Warning (stille
+   Drift-Ressource; bewusste Ausnahmen dokumentieren).
+2. **Artefakt-Alter** — `kubectl get ocirepository,gitrepository -A -o wide`: Artefakt
+   älter als das Doppelte seines Intervalls ⇒ Warning (Reconciliation stockt).
+3. **Pod-Gesundheit** — Restarts > 5 in 24 h, `CrashLoopBackOff`, `Pending` > 15 min
+   in `workspace*` ⇒ Critical bei Kern-Services (website, brett, llm-proxy), sonst Warning.
+4. **Node-Pressure** — Node-Stats (Summary API): Memory > 85 % dauerhaft, DiskPressure-
+   Events ⇒ Warning.
+5. **Events** — Warning/Error-Events der letzten 24 h je Namespace, dedupliziert nach
+   Reason+Object; wiederkehrende Muster ⇒ Warning.
+
+## 2. security (SealedSecrets, OIDC, DSGVO)
+
+Fachprozeduren für Rotation/Seeding: infra-ops §6/§4. Hier nur Prüfungen:
+
+1. **Plaintext-Secrets im Git-Baum** — `kind: Secret` ohne `sops:`-Metadaten und ohne
+   SealedSecret-Bezug in `k3d/`, `prod-fleet/`, `flux/` ⇒ Critical.
+2. **SealedSecrets-Alter** — Erzeugungsdatum der SealedSecret-Manifeste gegen die
+   Rotationsrichtlinie (infra-ops §6): überfällig ⇒ Warning, deutlich überfällig (> 2×
+   Richtwert) ⇒ Critical.
+3. **OIDC-Client-Drift** — Clients in `pocket_id.oidc_clients` (read-only SQL) gegen die
+   im Repo dokumentierten/erwarteten Clients (infra-ops §4): fehlende, verwaiste oder
+   abweichende Redirect-URIs ⇒ Warning.
+4. **DSGVO-Basics der Brand-Seiten** — Impressum + Datenschutzerklärung erreichbar auf
+   jeder gerouteten Brand-Domain; Kontaktformulare ohne sichtbare Datenminimierung
+   ⇒ Warning. Tiefe (Inhalte) bleibt beim `web-audit`-LLM-Teil.
+5. **Zertifikate** — Ablauf < 30 Tage ⇒ Warning, < 7 Tage ⇒ Critical.
+
+## 3. Datenbank (PostgreSQL)
+
+Backup-Audit und Restore-Prozedur: infra-ops §7. Hier nur Prüfungen (read-only,
+`mcp-postgres`; nie `SELECT *` von `tickets.ticket_plans`):
+
+1. **Backup-Frische** — letzter erfolgreicher Backup-Lauf je Brand: älter als das
+   Backup-Intervall ⇒ Critical. Kein Backup-Nachweis auffindbar ⇒ Critical.
+2. **Restore-Verifikation** — letzter verifizierter Restore (infra-ops §7): älter als
+   der Richtwert ⇒ Warning (ein Backup ohne Restore-Test ist eine Hypothese).
+3. **Schema-Gesundheit** — `invalid` Indizes (`pg_index.indisvalid = false`) ⇒ Warning;
+   Tabellen ohne Primärschlüssel in `tickets` ⇒ Warning.
+4. **Wachstum/Laufzeit** — DB-Größen-Trend, langlebige Idle-In-Transaction-Verbindungen
+   (> 30 min) ⇒ Warning.
+5. **Ticket-DB-Hygiene** — verwaiste Plan-Zeilen ohne Ticketbezug, Rollup-Container-
+   Alter (mishap-tracker-Konvention) ⇒ Info/Warning je Ausprägung.
+
+## 4. llm-pipeline (GPU, Proxy, Loadouts)
+
+Betrieb und Loadout-Wechsel: infra-ops §5. Konfig-SSOT: `scripts/llm/loadouts.json`.
+
+1. **Proxy-Erreichbarkeit** — llm-proxy (:18235) antwortet nicht ⇒ Critical; einzelne
+   Backends unhealthy ⇒ Warning (Critical, wenn es der einzige Backend-Pfad einer
+   Agenten-Familie ist).
+2. **Loadout-Drift** — deklarierte Loadouts in `loadouts.json` vs. tatsächlich geladene
+   Modelle am GPU-Host: Abweichung ⇒ Warning (Prozess-Ebene prüft zusätzlich
+   `bash scripts/runtime-drift-check.sh` im repo-Ziel).
+3. **GPU-Speicher** — belegter VRAM > 90 % im Ruhezustand ⇒ Warning (OOM-Risiko beim
+   nächsten Loadout-Wechsel).
+4. **Roster-Konsistenz** — `tests/spec/agent-roster.bats` lokal laufen lassen: Fail
+   ⇒ Warning (Agent-Registry driftet gegen `.opencode/agent-models.jsonc`).
+5. **Gateway-Dienste** — LLM-Gateway-Services im Cluster nicht Ready (Überschneidung mit
+   Checkliste §1) ⇒ wie dort, hier nur wenn nicht schon erfasst.

--- a/docs/agent-guide/maps/toolset-map.md
+++ b/docs/agent-guide/maps/toolset-map.md
@@ -54,7 +54,7 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
   - _Wann:_ Read-only SQL gegen die mentolder-DB, Nicht-Ticket-Tabellen.
   - _Nicht:_ INSERT/UPDATE/DELETE/DDL — jede Query läuft READ ONLY und scheitert.
   - _Fallback:_ `kubectl exec -i … psql (ohne -i läuft psql mit leerem stdin durch)`
-  - _Rollen:_ `bachelorprojekt-db`, `orchestrator`
+  - _Rollen:_ `bachelorprojekt-db`, `orchestrator`, `big-pickle`
   - _Tiefe:_ `.claude/skills/references/mcp-tool-guide.md`
 
 ## Fähigkeit: `postgres-schreiben`
@@ -253,6 +253,14 @@ für einen Agent-Prompt liefert `bash scripts/toolset-context.sh <rolle>`.
   - _Nicht:_ Live-Cluster-Zustand — dafür gitops-cluster-debug.
   - _Rollen:_ `bachelorprojekt-infra`
   - _Tiefe:_ `.claude/skills/gitops-repo-audit/SKILL.md`
+
+## Fähigkeit: `system-audit`
+
+- **`skill:system-audit`** — Status `canonical` · Tier `safe`
+  - _Wann:_ Audit über alle Systeme anfragen (GitOps-Repo, Live-Cluster, Website, Repo, Toolset, Security, DB, LLM-Pipeline, Brain-Wiki) — endet je Befund in Ticket + OpenSpec-Proposal.
+  - _Nicht:_ Akute Störung — dafür incident-response; Tiefe eines Einzel-Audits bleibt beim Spezial-Skill.
+  - _Rollen:_ `orchestrator`
+  - _Tiefe:_ `.claude/skills/system-audit/SKILL.md`
 
 ## Fähigkeit: `security-analyse`
 

--- a/docs/agent-guide/registry/capabilities.yaml
+++ b/docs/agent-guide/registry/capabilities.yaml
@@ -317,6 +317,15 @@ capabilities:
       tier: safe
       deep_ref: ".claude/skills/gitops-repo-audit/SKILL.md"
 
+  system-audit:
+    skill:system-audit:
+      state: canonical
+      use_when: "Audit über alle Systeme anfragen (GitOps-Repo, Live-Cluster, Website, Repo, Toolset, Security, DB, LLM-Pipeline, Brain-Wiki) — endet je Befund in Ticket + OpenSpec-Proposal."
+      avoid_when: "Akute Störung — dafür incident-response; Tiefe eines Einzel-Audits bleibt beim Spezial-Skill."
+      roles: [orchestrator]
+      tier: safe
+      deep_ref: ".claude/skills/system-audit/SKILL.md"
+
   # ─── Sicherheit ─────────────────────────────────────────────────────────────────────
   security-analyse:
     skill:security-specialist:


### PR DESCRIPTION
## What

New project-owned skill `system-audit` (`.claude/skills/system-audit/`) — **one audit entry point for every system the repo covers in separate skills**, each run ending in a mandatory closing phase that turns findings into tickets with attached OpenSpec proposals.

### Zielkatalog (10 targets)

| Target | System | Coverage |
|---|---|---|
| `gitops-repo` | Flux manifests | delegates to `gitops-repo-audit` |
| `flux-cluster` | live fleet cluster | new checklist §1 (read-only sweep) |
| `website` | brand sites | delegates to `web-audit` |
| `repo` | repo state + factory queue | delegates to `repo-hygiene` §0–§7 incl. runtime-drift-check |
| `toolset` | tool registry | delegates to `toolset-curate` collect/check |
| `security` | SealedSecrets, OIDC, DSGVO | new checklist §2 (gap closed) |
| `database` | PostgreSQL backups/schema/growth | new checklist §3 (gap closed) |
| `llm-pipeline` | GPU/proxy/loadouts | new checklist §4 (gap closed) |
| `brain-wiki` | wiki freshness | delegates to `brain-ingest` dry-run |
| `all` | everything | sequential, combined report |

### Closing phase (the point of the skill)

Every Critical/Warning finding becomes:
1. deduped against open tickets,
2. a ticket via `scripts/ticket.sh create` / `ticket-mcp_create_ticket` with type/severity/priority/areas mapping,
3. DoR-complete (`plan-meta`, readiness flags — "properly planned"),
4. an attached OpenSpec proposal (`scripts/openspec.sh propose <slug> --ticket <T-ID>` + validate) — **worktree-guarded**: on main checkout the skill falls back to ticket-only with an explicit comment,
5. enqueued into the factory backlog (pipeline principle), with report↔ticket traceability.

Ground rules: read-only until Phase C, evidence-mandatory findings, Critical/Warning/Info severity model, one root cause = one ticket, no merge gate, mishap-tracker post-execution.

## Registry updates

- `.claude/skills/OVERVIEW.md`: count 33→34 + catalog row (G-AGENTIC06)
- `docs/agent-guide/registry/capabilities.yaml`: canonical `skill:system-audit` entry
- regenerated `docs/agent-guide/maps/toolset-map.md`

## Gates

- [x] `tests/spec/agent-skills.bats` 18/18 (description-Pflicht, G-AGENTIC09 ≤400 Zeilen: 270, YAML frontmatter)
- [x] `bash scripts/health-goals-check.sh` — G-AGENTIC06/07/08/09 all green
- [x] `task test:mcp-tooling` 9/9
- [x] `task test:code-quality` 52 pass / 0 fail
- [x] `task freshness:check`
- [x] `node scripts/toolset/check.mjs` fail-closed check passed

Ticket: T013514