### PR TITLE
fix(factory): dispatch nur den aktuell geladenen Subagenten (qwen38) [T013594]

### DIFF
--- a/scripts/factory/opencode-exec.sh
+++ b/scripts/factory/opencode-exec.sh
@@ -35,6 +35,15 @@ if [[ -z "${OPENCODE_BIN}" || ! -x "${OPENCODE_BIN}" ]]; then
   exit 2
 fi
 
+# --- Subagent-Restriktion: nur das aktuell geladene GPU-Modell -----------------------
+# Der Orchestrator-Prompt hat frueher vier lokale Familien (gptoss/devstral/gemma/
+# qwen) angeboten; wegen exclusiveGroup "chat-gpu" ist aber immer nur EIN Loadout
+# geladen. Beobachtet an T013044 (2026-08-22): der Lauf dispatchte "gptoss", obwohl
+# qwen38-220k der aktive Loadout ist. Der Prompt bietet jetzt genau den einen
+# erlaubten Subagenten an — Default qwen38 (np=1, ein Slot => strikt sequenziell),
+# Override per Env, wenn ein anderer Loadout aktiv geschaltet wird.
+DISPATCH_SUBAGENT="${FACTORY_DISPATCH_SUBAGENT:-qwen38}"
+
 # --- load plan body + extract the ## Partials manifest (best-effort) -----------------
 plan_body=""
 if [[ -n "$PLAN_PATH" && -f "$LAUNCH_DIR/$PLAN_PATH" ]]; then
@@ -161,9 +170,11 @@ PROMPT="$(printf '%s\n' \
   "Worktree (your cwd): ${LAUNCH_DIR}" \
   "Plan file: ${PLAN_PATH:-<none>}" \
   "" \
-  "Dispatch up to 4 local family subagents (gptoss/devstral/gemma/qwen) onto the" \
-  "DISJOINT partials below; each owns its partial end-to-end (edit, test) inside" \
-  "this worktree." \
+  "Dispatch ONLY the ${DISPATCH_SUBAGENT} subagent onto the DISJOINT partials" \
+  "below — ONE AT A TIME, strictly sequentially (the local GPU serves exactly one" \
+  "loadout, np=1). Do NOT dispatch gptoss/devstral/gemma/gemma12 or any other" \
+  "local family agent. Each partial is owned end-to-end (edit, test) inside this" \
+  "worktree." \
   "" \
   "## Partials" \
   "${partials_manifest}" \


### PR DESCRIPTION
## Summary
- Der Orchestrator-Prompt in `scripts/factory/opencode-exec.sh` bot vier lokale Familien an (`gptoss/devstral/gemma/qwen`); wegen `exclusiveGroup "chat-gpu"` ist aber immer nur EIN GPU-Loadout geladen. Beobachtet am T013044-Lauf (2026-08-22): dispatcht wurde `gptoss`, obwohl `qwen38-220k` der aktive Loadout ist.
- Der Prompt bietet jetzt genau den einen erlaubten Subagenten an: `DISPATCH_SUBAGENT="${FACTORY_DISPATCH_SUBAGENT:-qwen38}"`, strikt sequenziell (np=1), alle anderen lokalen Familien explizit verboten.
- Cloud-Eskalations-Guardrails (deepseek M2/M3, Empty-Return-Rule) bleiben unangetastet — sie sind nicht loadout-abhängig.
- Override: bei künftig anderem aktiven Loadout `FACTORY_DISPATCH_SUBAGENT=<subagent>` vor dem Tick setzen.

## Test Plan
- [x] Alle 10 opencode-exec-BATS-Suiten grün (71/71: result-check, pr-step, binary-resolution, already-running, ci-signal, prerun-shortcircuit, partial-deploy-gang, branch-lock-gate, readiness-gate, retry-limit)
- [x] `task freshness:check` grün
- [x] `task workspace:validate` grün
- [x] `bash scripts/preflight-pr-scope.sh` — scope `factory` ✓
- [ ] `task test:changed`: 703/707 grün; die 4 roten Tests sind umgebungsbedingt und reproduzieren sich unverändert auf sauberem main (feature_flags-FK + sandbox-egress ×2) bzw. waren Slot-Konkurrenz des laufenden T013044-Ticks (claim-gang, standalone grün)

Closes T013594