### PR TITLE
chore(deps): bump @opencode-ai/plugin to 1.18.21 [T013675]

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.18.18",
+        "@opencode-ai/plugin": "1.18.21",
         "jsonc-parser": "^3.3.1",
         "unique-names-generator": "^4.7.1"
       }
@@ -101,13 +101,13 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.18.18",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.18.tgz",
-      "integrity": "sha512-vqQeqJtn9c+J+tIQDzYk88xip/NVNN1hym1ATmckxo6zINHAoXoul4Sw/jgnvL00rLsfAvhja28qax4h3g/5Jg==",
+      "version": "1.18.21",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.21.tgz",
+      "integrity": "sha512-wQXMbSvg3pG75F8fYAiJxYuyr6Cl9Hd74lSCY2yznZnejpwa+ksd2kMphmgSo+/UgLhb2AId9KAI6dsRhprzTg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
-        "@opencode-ai/sdk": "1.18.18",
+        "@opencode-ai/sdk": "1.18.21",
         "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.18.18",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.18.tgz",
-      "integrity": "sha512-zJlwXskIR47V1dkPJqeKBgq7nejG1uU8lJaGIGqbX3MWRCT8vKn0fEotbxuPCKnTdmWsDyNGNg9q1qIliDSMDA==",
+      "version": "1.18.21",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.21.tgz",
+      "integrity": "sha512-k6iHQ5C8wOPglk+LgFyYnst168cGMQYumgpbVoeXJ+iC1AtvwD5zmjuF8CxMze/y9G1K2bOeO6p9yRvA7eHZLA==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@opencode-ai/plugin": "1.18.18",
+    "@opencode-ai/plugin": "1.18.21",
     "jsonc-parser": "^3.3.1",
     "unique-names-generator": "^4.7.1"
   }


### PR DESCRIPTION
## Was

Hebt `@opencode-ai/plugin` in `.opencode/` von **1.18.18** auf **1.18.21** an (package.json + package-lock.json).

## Warum

Der Bump entstand heute versehentlich als lokaler Drift im Worktree T013316-reuse (T004611-Pattern, Subagent lief npm install) und wurde dort revertiert — der Operator wünscht das Update bewusst. Vorbild: T011624 (Bump auf 1.18.18).

Closes T013675