### PR TITLE
chore(ops): Brain-Ingest-Loadout KV f16, ctx 262144, KV-Blöcke [T013676]

### DIFF
--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -383,14 +383,18 @@
         "ctx": 65536,
         "ngl": 999,
         "parallel": 3,
-        "cacheTypeK": "q8_0",
-        "cacheTypeV": "q8_0",
+        "cacheTypeK": "f16",
+        "cacheTypeV": "f16",
         "loadMode": "mmap",
         "flashAttention": true,
         "jinja": true,
         "metrics": true,
         "reasoning": "auto",
-        "reasoningBudget": 0
+        "reasoningBudget": null,
+        "reasoningEffort": "low",
+        "temperature": 1,
+        "topP": 0.95,
+        "topK": 64
       },
       "speculative": {
         "draftHfRepo": null,
@@ -399,7 +403,9 @@
       "mcp": {
         "serversConfig": null
       },
-      "extraArgs": [],
+      "extraArgs": [
+        "-kvu"
+      ],
       "notes": "Serverseite fuer scripts/brain-ingest.sh. Umgestellt von gpt-oss-20b auf Gemma 4 12B QAT (T012905, Operator-Entscheidung). BELEG: Spike am 2026-08-19 gegen Repo-Stand 73ca48ccc, drei echte Quellen durch scripts/brain-ingest-transform.sh gegen einen manuell gestarteten llama-server (/home/patrick/.unsloth/llama.cpp/build/bin/llama-server, Build b10241, -ngl 999 -c 32768 -fa on --jinja -np 1 --port 8100 --alias gemma-4-12b-qat). Ergebnis 3/3 rc=0 in 16/39/58 s, jeweils gueltiges Frontmatter und genau eine source::-Zeile; die bei Reasoning-Modellen bekannte Falle (Antwort in reasoning_content, content leer) trat nicht auf. Befehl zur Nachstellung: export LM_STUDIO_URL=http://127.0.0.1:8100 LM_MODEL=gemma-4-12b-qat; bash scripts/brain-ingest-transform.sh openspec/specs/phase-events.md note phase-events <slugs.json> '[\"note\"]'. PARAMETER: ctx auf 65536 erhoeht (T012911): Chunk-Ziel 8k chars (~4k tokens) + Prompt + 4k Output + headroom fuer parallel=3. parallel=3 bleibt gemessen optimal (siehe Notiz zu gemma12-vision, T012414: -np 4 liefert 319 statt 489 tok/s). KV auf f16 und fit deaktiviert mit explizitem ctx, analog gemma12-vision; -fit on laedt sonst n_ctx_train und bindet den Rest als KV-Cache. reasoningBudget=0 bleibt aus dem gpt-oss-Eintrag stehen: Gemma hat keine Denkphase, die Einstellung ist damit wirkungslos, aber auch unschaedlich. Port 8100 unveraendert (8093 belegt der kubectl-Forward auf llm-gateway-rerank, 8097 ein Factory-Provider). Kein mmproj und kein MTP-Drafter: der Ingest ist reiner Text, und der Drafter halbiert laut Messung den Prefill. HISTORIE zum reasoningBudget (aus T003204, gilt weiter, falls hier je wieder ein Reasoning-Modell laeuft): abgeschaltet wird das Denken ueber reasoningBudget (--reasoning-budget 0) und NICHT ueber args.reasoning — '-rea' steuert nur, ob llama-server reasoning_content PARST (siehe runner.mjs). args.reasoning auf null zu setzen laesst die Denkphase unberuehrt und unterdrueckt bloss deren Ausgabe, die Tokens fallen weiter an.",
       "exclusiveGroup": "chat-gpu"
     }
@@ -421,6 +427,6 @@
   },
   "factory": {
     "model": "qwen38-220k",
-    "locked": false
+    "locked": true
   }
 }

--- a/scripts/llm/loadouts.json
+++ b/scripts/llm/loadouts.json
@@ -380,7 +380,7 @@
         "enabled": false
       },
       "args": {
-        "ctx": 65536,
+        "ctx": 262144,
         "ngl": 999,
         "parallel": 3,
         "cacheTypeK": "f16",
@@ -404,7 +404,11 @@
         "serversConfig": null
       },
       "extraArgs": [
-        "-kvu"
+        "-kvu",
+        "-b",
+        "4096",
+        "-ub",
+        "2048"
       ],
       "notes": "Serverseite fuer scripts/brain-ingest.sh. Umgestellt von gpt-oss-20b auf Gemma 4 12B QAT (T012905, Operator-Entscheidung). BELEG: Spike am 2026-08-19 gegen Repo-Stand 73ca48ccc, drei echte Quellen durch scripts/brain-ingest-transform.sh gegen einen manuell gestarteten llama-server (/home/patrick/.unsloth/llama.cpp/build/bin/llama-server, Build b10241, -ngl 999 -c 32768 -fa on --jinja -np 1 --port 8100 --alias gemma-4-12b-qat). Ergebnis 3/3 rc=0 in 16/39/58 s, jeweils gueltiges Frontmatter und genau eine source::-Zeile; die bei Reasoning-Modellen bekannte Falle (Antwort in reasoning_content, content leer) trat nicht auf. Befehl zur Nachstellung: export LM_STUDIO_URL=http://127.0.0.1:8100 LM_MODEL=gemma-4-12b-qat; bash scripts/brain-ingest-transform.sh openspec/specs/phase-events.md note phase-events <slugs.json> '[\"note\"]'. PARAMETER: ctx auf 65536 erhoeht (T012911): Chunk-Ziel 8k chars (~4k tokens) + Prompt + 4k Output + headroom fuer parallel=3. parallel=3 bleibt gemessen optimal (siehe Notiz zu gemma12-vision, T012414: -np 4 liefert 319 statt 489 tok/s). KV auf f16 und fit deaktiviert mit explizitem ctx, analog gemma12-vision; -fit on laedt sonst n_ctx_train und bindet den Rest als KV-Cache. reasoningBudget=0 bleibt aus dem gpt-oss-Eintrag stehen: Gemma hat keine Denkphase, die Einstellung ist damit wirkungslos, aber auch unschaedlich. Port 8100 unveraendert (8093 belegt der kubectl-Forward auf llm-gateway-rerank, 8097 ein Factory-Provider). Kein mmproj und kein MTP-Drafter: der Ingest ist reiner Text, und der Drafter halbiert laut Messung den Prefill. HISTORIE zum reasoningBudget (aus T003204, gilt weiter, falls hier je wieder ein Reasoning-Modell laeuft): abgeschaltet wird das Denken ueber reasoningBudget (--reasoning-budget 0) und NICHT ueber args.reasoning — '-rea' steuert nur, ob llama-server reasoning_content PARST (siehe runner.mjs). args.reasoning auf null zu setzen laesst die Denkphase unberuehrt und unterdrueckt bloss deren Ausgabe, die Tokens fallen weiter an.",
       "exclusiveGroup": "chat-gpu"
@@ -427,6 +431,6 @@
   },
   "factory": {
     "model": "qwen38-220k",
-    "locked": true
+    "locked": false
   }
 }


### PR DESCRIPTION
Loadout-Umstellung für den Brain-Ingest-Server (T012905-Spike): cacheTypeK/V q8_0→f16, Sampling-Params, ctx 262144, extraArgs -b 4096 -ub 2048. Ticket: T013676.

Nach Merge: llm-proxy neu starten (neue loadouts.json-Felder brechen den laufenden Proxy).