### PR TITLE
fix(scripts): sichtbare curl-Fehler und TTY-faire Progress-Ausgabe im brain-ingest [T013712]

### DIFF
--- a/scripts/brain-ingest-transform.sh
+++ b/scripts/brain-ingest-transform.sh
@@ -139,18 +139,18 @@ call_llm() {
   # Gemma 4 uses chat_template_kwargs.enable_thinking; DeepSeek uses thinking.type.
   # Send both — unknown keys are harmlessly ignored by each provider. [T002533]
   [ "${LM_DISABLE_THINKING:-0}" = "1" ] && think='{"thinking":{"type":"disabled"},"chat_template_kwargs":{"enable_thinking":false}}'
-  response="$(jq -n --rawfile prompt /dev/fd/4 \
-      --arg model "$LM_MODEL" \
-      --argjson max_tokens "$LM_MAX_TOKENS" \
-      --argjson think "$think" \
-      '{model: $model, messages: [{role: "user", content: $prompt}], temperature: 0.2, max_tokens: $max_tokens, top_p: 0.9} + $think' \
-      4<<<"$prompt" \
-    | curl -sf --config /dev/fd/3 --max-time "$LM_TIMEOUT" "${LM_URL}/v1/chat/completions" \
-        -H "Content-Type: application/json" --data-binary @- 3<<<"$curl_cfg" 2>&1)" || {
-    echo "error: chat completion request failed (${LM_URL}, model ${LM_MODEL})" >&2
-    echo "$response" >&2
-    exit 1
-  }
+    response="$(jq -n --rawfile prompt /dev/fd/4 \
+        --arg model "$LM_MODEL" \
+        --argjson max_tokens "$LM_MAX_TOKENS" \
+        --argjson think "$think" \
+        '{model: $model, messages: [{role: "user", content: $prompt}], temperature: 0.2, max_tokens: $max_tokens, top_p: 0.9} + $think' \
+        4<<<"$prompt" \
+      | curl -s -S --config /dev/fd/3 --max-time "$LM_TIMEOUT" "${LM_URL}/v1/chat/completions" \
+          -H "Content-Type: application/json" --data-binary @- 3<<<"$curl_cfg" 2>&1)" || {
+      echo "error: chat completion request failed (${LM_URL}, model ${LM_MODEL})" >&2
+      echo "$response" >&2
+      exit 1
+    }
 
   OUTPUT="$(echo "$response" | jq -r '.choices[0].message.content // empty')"
   if [ -z "$OUTPUT" ]; then

--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -56,7 +56,6 @@ CHUNK_TARGET_CHARS="${BRAIN_CHUNK_TARGET_CHARS:-8000}"
 # leaving it alone would reject essentially every chunk this script produces.
 # Two chunk targets of headroom: brain-chunk.sh emits a single paragraph that is
 # larger than the target as one oversized chunk rather than dropping text, and
-# only a pathological source (one paragraph past 16k) should trip the guard.
 export MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-$((CHUNK_TARGET_CHARS * 2))}"
 export BRAIN_CHUNK_TARGET_CHARS="$CHUNK_TARGET_CHARS"
 # transform.sh runs as a child process per page — it needs its own copy of
@@ -422,7 +421,11 @@ while IFS=$'\t' read -r src_path chunk_file chunk_slug idx heading; do
     fi
     printf '%s\t%s\t%s\n' "$rc" "$src_path" "$chunk_chars" > "$RESULTS_DIR/$CURRENT"
   ) &
-  printf "\r[%d/%d] dispatched: %s " "$CURRENT" "$CHUNK_TOTAL" "$chunk_slug"
+  if [ -t 1 ]; then
+    printf "\r[%d/%d] dispatched: %s " "$CURRENT" "$CHUNK_TOTAL" "$chunk_slug"
+  else
+    printf "[%d/%d] dispatched: %s\n" "$CURRENT" "$CHUNK_TOTAL" "$chunk_slug"
+  fi
 done < "$CHUNKS_TSV"
 
 wait


### PR DESCRIPTION
transform.sh: curl -sf → -s -S in call_llm() — HTTP-Fehler erscheinen auf stderr statt nur als Exit 22. brain-ingest.sh: \r-Lebendzeile nur bei interaktivem stdout, zeilenweise bei Nicht-TTY. Ticket: T013712.