### PR TITLE
chore(website): lint/scan-Scope auf wiki/ verengen, Anker-toleranter Link-Fix [T013844]

### DIFF
--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -552,9 +552,9 @@ if ! bash scripts/lint-wikilinks.sh . 2>&1; then
     file="$(echo "$line" | awk '{print $2}')"
     dead_slug="$(echo "$line" | grep -oE '\[\[[A-Za-z0-9._-]+\]\]' | head -1 | tr -d '[]')"
     if [ -n "$file" ] && [ -n "$dead_slug" ] && [ -f "$file" ]; then
-      # Remove the dead wikilink (keep the text if aliased)
-      sed -i "s/\[\[${dead_slug}\]\]/${dead_slug}/g" "$file"
-      sed -i "s/\[\[${dead_slug}|[^]]*\]\]/${dead_slug}/g" "$file"
+      # Remove the dead wikilink (keep the text if aliased or anchored)
+      sed -i -E "s/\[\[${dead_slug}(#[^]|]*)?(\|([^]]*))?\]\]/\3\1${dead_slug}/g" "$file" 2>/dev/null \
+        || sed -i "s/\[\[${dead_slug}\]\]/${dead_slug}/g" "$file"
     fi
   done < <(bash scripts/lint-wikilinks.sh . 2>&1 | grep "dead wikilink:" || true)
 
@@ -570,11 +570,9 @@ echo "  Wikilink lint: PASS"
 # Secret scan (if gitleaks available)
 if command -v gitleaks &>/dev/null; then
   echo "Running secret scan..."
-  # Scan the deliverable tree, including generated/untracked pages, rather than
-  # immutable commits already present in the external Brain repository. A
-  # history scan makes every future ingest fail forever on any pre-existing
-  # historical finding, even when the complete current tree is clean.
-  if ! gitleaks detect --source . --no-git --no-banner 2>&1; then
+  # Scan the deliverable tree (wiki/), including generated/untracked pages, rather than
+  # immutable commits or exempt raw/ documents in the external Brain repository.
+  if ! gitleaks detect --source wiki --no-git --no-banner 2>&1; then
     echo "FAIL: Secret scan failed" >&2
     cd "$REPO_ROOT"
     exit 1

--- a/templates/brain/scripts/lint-wikilinks.sh
+++ b/templates/brain/scripts/lint-wikilinks.sh
@@ -5,12 +5,22 @@
 # no network. See ../SCHEMA.md and wiki/quality-goals.md (G-BRAIN01/04).
 set -euo pipefail
 root="${1:-.}"; rc=0
+list_targets() {
+  if [ -d "$root/wiki" ]; then
+    find "$root/wiki" -name '*.md' -type f
+  fi
+  for hub in index.md log.md SCHEMA.md; do
+    if [ -f "$root/$hub" ]; then printf '%s\n' "$root/$hub"; fi
+  done
+}
+
 mapfile -t slugs < <(find "$root" -name '*.md' -type f -exec basename {} .md \; | sort -u)
 in_slugs() { local s="$1"; for k in "${slugs[@]}"; do [[ "$k" == "$s" ]] && return 0; done; return 1; }
 while IFS= read -r f; do
+  [ -n "$f" ] || continue
   while IFS= read -r link; do
     slug="${link#\[\[}"; slug="${slug%\]\]}"; slug="${slug%%[#|]*}"
     in_slugs "$slug" || { echo "FAIL: $f dead wikilink: [[$slug]]"; rc=1; }
   done < <(grep -oE '\[\[[A-Za-z0-9._-]+([|#][^]]*)?\]\]' "$f" || true)
-done < <(find "$root" -name '*.md' -type f)
+done < <(list_targets)
 exit "$rc"

--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -116,7 +116,11 @@ EOF
 }
 
 @test "T013040 secret gate scans the current deliverable instead of immutable history" {
-  grep -Fq 'gitleaks detect --source . --no-git --no-banner' "$INGEST"
+  # T013844: Der Scan-Scope wurde von '.' auf 'wiki/' verengt (raw/-Dokumente sind
+  # exempt). Der semantische Anker dieses Tests ist --no-git — der Arbeitsbaum wird
+  # gescannt, nie die Historie — nicht das konkrete Source-Argument.
+  grep -Fq 'gitleaks detect' "$INGEST"
+  grep -Fq -- '--no-git' "$INGEST"
 }
 
 @test "orchestrator requires --brain-repo argument" {


### PR DESCRIPTION
## T013844 — funktionale Patches aus dem Hauptcheckout als PR

### Kontext
Das Ticket beschrieb vier uncommittete Patches vom 2026-08-22. Drei davon sind inzwischen eigenständig gemergt: **T013676** (#5015, Loadout-Retuning), **T013677** (#5017, Prune State-Reverse-Map), **T013712** (#5016, curl-Fehler + TTY-Progress). Dieser PR bringt die verbleibende, darauf aufbauende Folgearbeit als PR (Operator-Entscheidung: „Patches als PR bringen", nie verwerfen).

### Inhalt
1. **`templates/brain/scripts/lint-wikilinks.sh`**: Lint-Ziele statt aller `*.md` unter root jetzt `wiki/` plus Hub-Dateien (`index.md`, `log.md`, `SCHEMA.md`) — raw/ und Fremdseiten liefern keine False Positives mehr.
2. **`scripts/brain-ingest.sh` Dead-Wikilink-Autofix**: ein sed-Durchlauf mit Anchor- und Alias-Erhaltung (`[[slug#frag]]`, `[[slug|Alias]]`), Fallback auf den einfachen Fall.
3. **`scripts/brain-ingest.sh` gitleaks**: `--source` von `.` auf `wiki/` verengt — raw/ ist exempt; Kommentar erklärt die Abgrenzung.
4. **Test T013040**: auf Semantik-Anker (`--no-git`) umgestellt statt exaktem Source-Argument (Konvention „Semantik statt Darstellung", T002716).

### Verifikation
- bash -n + shellcheck sauber
- Sandbox-Smoke: stray außerhalb wiki/ ignoriert (Exit 0), Anker/Alias aufgelöst, Dead-Link in wiki/ failt weiter (Exit 1)
- 50/50 BATS grün (brain-ingest, brain-ingest-task-defaults, brain-quality-goals)
