### PR TITLE
fix(factory): review findings — Fail-open, Temp-Cleanup, Test-Pinning [T013915]

### DIFF
--- a/scripts/factory/mishap-rollup.sh
+++ b/scripts/factory/mishap-rollup.sh
@@ -263,13 +263,19 @@ JOIN tickets.tickets t ON t.id = c.ticket_id
 WHERE t.external_id = '${CONTAINER_ID}'
   AND c.body NOT LIKE 'FACTORY-PLAN-REF%';
 SQL
-)"
+)" || true
   if [[ -n "${oldest_ts:-}" ]]; then
     oldest_epoch="$(date -u -d "${oldest_ts}" +%s 2>/dev/null || true)"
     if [[ -n "${oldest_epoch:-}" ]]; then
       age_h=$(( ($(date -u +%s) - oldest_epoch) / 3600 ))
       if [[ "${age_h}" -lt "${ROLLUP_MAX_AGE_H}" ]]; then
         echo "mishap-rollup: Coalescing-Gate — ${BATCH_COUNT} Eintrag(e), aeltester ${age_h} h alt (< ${ROLLUP_MIN_ENTRIES} Eintraege, < ${ROLLUP_MAX_AGE_H} h) — Container sammelt weiter, kein stage-plan [T013915]" >&2
+        # [T013915] Der cleanup_wt-Trap ist hier noch nicht registriert
+        # (Worktree-Management laeuft erst hinter dem Gate) — Temps manuell
+        # raeumen, sonst bleiben COMMENTS_FILE und die Loop-Closure-Dateien
+        # pro Collect-Lauf in /tmp liegen.
+        rm -f "${COMMENTS_FILE:-}" 2>/dev/null || true
+        cleanup_loop_closure 2>/dev/null || true
         exit 0
       fi
     fi

--- a/tests/spec/mishap-rollup/rollup-coalescing.bats
+++ b/tests/spec/mishap-rollup/rollup-coalescing.bats
@@ -4,7 +4,8 @@
 # SSOT: openspec/specs/mishap-rollup.md
 # PRUEFMODUS (T002448-M4): Statement-Verifikation gegen das Generator-Skript —
 # das Coalescing-Gate wird ueber seine emittierten Marker gepinnt (Env-Defaults,
-# No-op-Pfad vor der Worktree-Anlage, Altersmessung ueber min(created_at)).
+# No-op-Pfad vor der Worktree-Anlage, Altersmessung ueber min(created_at),
+# Schwellen-Vergleiche als -lt, Fail-open-Guard der Altersmessung).
 #
 # Hintergrund: Am 2026-08-22 entstanden 18 Rollup-Container in 40 Minuten, weil
 # der Generator jeden Container sofort stagte (ab 1 Eintrag, inkl. Carry-over).
@@ -47,4 +48,41 @@ setup() {
   # Gates — gemessen wird der aelteste Batch-Kommentar auf dem Container.
   run grep -n "min(c.created_at)" "$SCRIPT"
   [ "$status" -eq 0 ]
+}
+
+@test "T013915: Schwelle erreicht → Gate greift nicht (-lt-Vergleich bleibt)" {
+  # Ein -gt-Regressionswurf (Gate blockt erst UEBER der Schwelle) wuerde die
+  # Coalescing-Semantik invertieren und bliebe ohne Pinning gruen — der
+  # Eintrags-Vergleich muss -lt sein.
+  run grep -F 'if [[ "${BATCH_COUNT}" -lt "${ROLLUP_MIN_ENTRIES}" ]]; then' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T013915: Alter-Zweig vergleicht age_h gegen Max-Alter (-lt)" {
+  # Der Alters-Fallback haengt am Vergleich des gemessenen Alters gegen die
+  # Max-Alter-Grenze — ein Vertauschen der Operanden wuerde den Alters-Zweig
+  # still aushebeln.
+  run grep -F 'if [[ "${age_h}" -lt "${ROLLUP_MAX_AGE_H}" ]]; then' "$SCRIPT"
+  [ "$status" -eq 0 ]
+}
+
+@test "T013915: Fail-open — leeres Alter blockt nicht (exit 0 nur hinter Alters-Guard)" {
+  # Negativ-Assert mit Positiv-Anker (T002356-M1): erst nachweisen, dass
+  # Alters-Guard und Alter-Vergleich existieren und in der richtigen
+  # Reihenfolge stehen; dann, dass das erste exit 0 nach dem Guard erst NACH
+  # dem Alter-Vergleich kommt. Ein leeres Altersergebnis passiert den Guard
+  # nicht, erreicht das Gate-exit 0 nie und laeuft in den Staging-Pfad —
+  # wuerde ein exit 0 vor den Guard rutschen, stuende der Fail-open-Kontrakt
+  # (Staging trotz fehlgeschlagener Altersmessung) auf dem Spiel.
+  guard_line=$(grep -nF 'if [[ -n "${oldest_ts:-}" ]]; then' "$SCRIPT" | head -1 | cut -d: -f1)
+  [ -n "$guard_line" ]
+  age_line=$(grep -nF 'if [[ "${age_h}" -lt "${ROLLUP_MAX_AGE_H}" ]]; then' "$SCRIPT" | head -1 | cut -d: -f1)
+  [ -n "$age_line" ]
+  [ "$guard_line" -lt "$age_line" ]
+  collect_line=$(grep -n 'sammelt weiter' "$SCRIPT" | head -1 | cut -d: -f1)
+  [ -n "$collect_line" ]
+  exit_line=$(awk -v s="$guard_line" 'NR > s && /exit 0/ { print NR; exit }' "$SCRIPT")
+  [ -n "$exit_line" ]
+  [ "$exit_line" -gt "$age_line" ]
+  [ "$collect_line" -lt "$exit_line" ]
 }


### PR DESCRIPTION
## Kontext

PR #5049 (Coalescing-Gate) wurde am 2026-08-22T22:14:17Z automatisch gemergt, bevor die drei Code-Review-Findings gepusht waren. Dieser PR liefert die Review-Fixes als Delta auf main nach (Branch auf origin/main rebased, Diff = genau die zwei Fix-Dateien).

## Findings

- **I1 (Important):** Alters-Query mit `|| true` abgesichert — unter `set -euo pipefail` galt die Zuweisung `oldest_ts="$(...)"` bei factory_psql-Fehler (kubectl/psql rc≠0) als fehlgeschlagenes Kommando und der Lauf starb hart statt Fail-open in den Staging-Pfad zu laufen. Empirisch verifiziert: `set -euo pipefail; x="$(false | head -1)"` → rc=1 (vorher), mit `|| true` → rc=0, x leer.
- **I2 (Important):** rollup-coalescing.bats um drei Statements erweitert: -lt-Vergleich der Eintrags-Schwelle (Regressionswurf auf -gt bliebe sonst grün), -lt-Vergleich von age_h gegen Max-Alter, Fail-open-Negativ-Assert mit Positiv-Anker (Alters-Guard und Alter-Vergleich müssen vor dem Gate-exit 0 liegen, T002356-M1).
- **M1 (Minor):** Gate-Exit räumt Temps manuell — der cleanup_wt-Trap ist an der Stelle noch nicht registriert; COMMENTS_FILE und Loop-Closure-Dateien blieben pro Collect-Lauf in /tmp.

## Verifikation

- `bash -n`: sauber
- `bats tests/spec/mishap-rollup/rollup-coalescing.bats`: 7/7 grün
- `bats -r tests/spec/mishap-rollup*`: 59/59 grün (bestehende Rollup-Tests unverändert)
- Branch-SHA: bd6c50a86 (1 Commit auf main, nur Fix-Delta)

Ref T013915 (Ticket durch Merge #5049 geschlossen; Fixes reichen hier nach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)