### PR TITLE
fix(website): remove unused LoadoutDocItem interface [T013918]

### DIFF
--- a/components/website/src/components/sdlc/factory/LlmLoadoutPanel.svelte
+++ b/components/website/src/components/sdlc/factory/LlmLoadoutPanel.svelte
@@ -12,15 +12,6 @@
     chosen: { ctx: number | null } | null;
   }
 
-  interface LoadoutDocItem {
-    slug: string;
-    label?: string;
-    model?: string;
-    port?: number;
-    enabled?: boolean;
-    exclusiveGroup?: string;
-  }
-
   interface PinStatus {
     pinned: boolean;
     slug?: string;

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1197,
+      "file_count": 1198,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -768,6 +768,7 @@
         "tests/spec/mishap-rollup/rollup-direct-dispatch.bats",
         "tests/spec/mishap-rollup/rollup-plan-lint-scope-examples.bats",
         "tests/spec/mishap-rollup/rollup-plan-per-entry-tasks.bats",
+        "tests/spec/mishap-rollup/sql-parameterized-queries.bats",
         "tests/spec/mishap-rollup/wakeup-single-run.bats",
         "tests/spec/mishap-rollup/watchlist-disposition.bats",
         "tests/spec/mishap-t002422.bats",


### PR DESCRIPTION
## What

Entfernt die ungenutzte `interface LoadoutDocItem` aus `LlmLoadoutPanel.svelte` (Zeilen 15-22). ESLint (`@typescript-eslint/no-unused-vars`) brach dadurch G-CQ03 (`task test:changed` / `pnpm lint`) auf main — vorbestehend aus T013909/PR #5041.

## Verification

- `eslint . --max-warnings 0` (identisch zu `pnpm lint`) im Worktree: RC=0, kein LoadoutDocItem-Fehler mehr, keine weiteren Fehler
- `task freshness:check`: grün

Closes T013918

🤖 Generated with [Claude Code](https://claude.com/claude-code)