### PR TITLE
chore(factory): turn the executed mishap-rollup REMOVED delta into evidence [T014104]

### DIFF
--- a/openspec/changes/mishap-rollup-teardown/removed-spec-mishap-rollup.md
+++ b/openspec/changes/mishap-rollup-teardown/removed-spec-mishap-rollup.md
@@ -1,3 +1,11 @@
+<!-- Kein Delta mehr, sondern Beleg [T014104].
+
+Diese Datei lag als `specs/mishap-rollup.md` im Change und listete die 18
+Requirements, die mit dem Abbau entfallen. Der Abbau hat `openspec/specs/mishap-rollup.md`
+im selben PR geloescht — damit ist das REMOVED bereits vollzogen und der
+Archiv-Merger kann es nicht mehr anwenden (`Target … does not exist`). Die Liste
+bleibt hier als Nachweis, welche Requirements weggefallen sind. -->
+
 ## REMOVED Requirements
 
 ### Requirement: Mishap rollup generates compliant change per run


### PR DESCRIPTION
Folgefix zu #5069.

Die Archivierung von `mishap-rollup-teardown` brach mit `Target 'openspec/specs/mishap-rollup.md' does not exist` ab: das REMOVED-Delta listet 18 Requirements, deren Wegfall #5069 bereits vollzogen hat — die SSOT-Datei ist dort gelöscht worden. Ein REMOVED gegen eine nicht mehr existierende Datei ist nicht anwendbar.

Die Liste wandert deshalb von `specs/mishap-rollup.md` nach `removed-spec-mishap-rollup.md` (Change-Root) und trägt einen Kommentar, der ihren Status als Beleg statt Delta erklärt. Das `mishap-tracking`-Delta bleibt unter `specs/` und ist anwendbar.

`task openspec:validate` grün (23/23).