### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1184,
+      "file_count": 1185,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -638,6 +638,7 @@
         "tests/spec/flux-artifact-versioning/flux-artifact-versioning.bats",
         "tests/spec/flux-render-security/bootstrap-envsubst.bats",
         "tests/spec/flux-render-security/immutable-image-refs.bats",
+        "tests/spec/flux-render-security/no-default-secrets.bats",
         "tests/spec/flux-render-security/runtime-var-unwrapping.bats",
         "tests/spec/freetoken-local-backend/routing.bats",
         "tests/spec/g-cq02-any-types.bats",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32630437552).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
