### PR TITLE
fix(mcp): expose factory_excluded/execution_released in set_readiness_flag schema [T014842]

### DIFF
--- a/scripts/ticket-mcp/go/internal/tools/planning.go
+++ b/scripts/ticket-mcp/go/internal/tools/planning.go
@@ -12,6 +12,11 @@ import (
 	"github.com/korczewski/bachelorprojekt/ticket-mcp/internal/runner"
 )
 
+// readinessFlags ist die gemeinsame Quelle für Schema-Enum und Handler-Validierung
+// von set_readiness_flag [T014842]: Drift zwischen beidem war die Ursache dafür, dass
+// MCP-Clients factory_excluded nicht senden konnten, obwohl der Handler es akzeptierte.
+var readinessFlags = []string{"spec_skizziert", "abhaengigkeiten_klar", "offene_fragen_geklaert", "aufwand_geschaetzt", "lastenheft_locked", "factory_excluded", "execution_released"}
+
 func RegisterPlanningTools(s *server.MCPServer) {
 	s.AddTool(
 		mcp.NewTool("set_plan_meta",
@@ -75,12 +80,12 @@ func RegisterPlanningTools(s *server.MCPServer) {
 
 	s.AddTool(
 		mcp.NewTool("set_readiness_flag",
-			mcp.WithDescription("Setzt ein einzelnes Readiness-Flag (spec_skizziert, abhaengigkeiten_klar, offene_fragen_geklaert, aufwand_geschaetzt, lastenheft_locked)."),
+			mcp.WithDescription("Setzt ein einzelnes Readiness-Flag (" + strings.Join(readinessFlags, ", ") + ")."),
 			mcp.WithString("id", mcp.Description("external_id z.B. T000123"), mcp.Required()),
 			mcp.WithString("brand", mcp.Description("mentolder oder korczewski (default: mentolder)"),
 				mcp.Enum("mentolder", "korczewski")),
-			mcp.WithString("flag", mcp.Description("spec_skizziert, abhaengigkeiten_klar, offene_fragen_geklaert, aufwand_geschaetzt, lastenheft_locked"),
-				mcp.Enum("spec_skizziert", "abhaengigkeiten_klar", "offene_fragen_geklaert", "aufwand_geschaetzt", "lastenheft_locked"),
+			mcp.WithString("flag", mcp.Description(strings.Join(readinessFlags, ", ")),
+				mcp.Enum(readinessFlags...),
 				mcp.Required(),
 			),
 			mcp.WithBoolean("value", mcp.Description("true oder false"), mcp.Required()),
@@ -95,9 +100,8 @@ func RegisterPlanningTools(s *server.MCPServer) {
 			flag, _ := a["flag"].(string)
 			value, _ := a["value"].(bool)
 
-			validFlags := []string{"spec_skizziert", "abhaengigkeiten_klar", "offene_fragen_geklaert", "aufwand_geschaetzt", "lastenheft_locked", "factory_excluded", "execution_released"}
-			if !slices.Contains(validFlags, flag) {
-				return mcp.NewToolResultError(fmt.Sprintf("Ungültiger flag: %s. Erlaubt: %s", flag, strings.Join(validFlags, ", "))), nil
+			if !slices.Contains(readinessFlags, flag) {
+				return mcp.NewToolResultError(fmt.Sprintf("Ungültiger flag: %s. Erlaubt: %s", flag, strings.Join(readinessFlags, ", "))), nil
 			}
 
 			readiness := fmt.Sprintf("%s=%t", flag, value)

--- a/scripts/ticket-mcp/go/internal/tools/planning_test.go
+++ b/scripts/ticket-mcp/go/internal/tools/planning_test.go
@@ -1,0 +1,26 @@
+package tools
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// T014842: Schema-Enum und Handler-Validierung von set_readiness_flag müssen aus
+// derselben Quelle (readinessFlags) gespeist werden. Realer Schaden am 2026-08-23:
+// das Schema-Enum kannte factory_excluded nicht, obwohl der Handler es validierte —
+// Clients mussten auf den CLI-Fallback ausweichen und schrieben dabei versehentlich
+// ein falsches Flag.
+func TestReadinessFlagListContainsFactoryExcludedAndExecutionReleased(t *testing.T) {
+	for _, flag := range []string{"factory_excluded", "execution_released"} {
+		if !slices.Contains(readinessFlags, flag) {
+			t.Errorf("readinessFlags fehlt %q — Dispatch-Gate (scripts/factory/queue.sh) wäre über MCP nicht setzbar", flag)
+		}
+	}
+}
+
+func TestRegisterPlanningToolsNoPanic(t *testing.T) {
+	s := server.NewMCPServer("test", "0.0.0")
+	RegisterPlanningTools(s) // must not panic
+}


### PR DESCRIPTION
## Problem

Der Handler von `set_readiness_flag` akzeptierte `factory_excluded`/`execution_released` (planning.go `validFlags`, Gate für den Factory-Dispatch in `scripts/factory/queue.sh`, T002361) — aber das MCP-Schema-Enum listete nur die 5 Standard-Flags. Clients konnten die Flags daher nicht senden.

Real am 2026-08-23: Beim Excluden von T014538/T014540 für Batch T014566 mussten zwei versehentliche `lastenheft_locked=false`-Schreibungen und ein CLI-Fallback herhalten (Mishap-Buffer 8/10).

## Fix

- Neue paketierte Liste `readinessFlags` speist **Schema-Enum, Description und Handler-Validierung** aus einer Quelle — Schema↔Handler-Drift kann strukturell nicht mehr entstehen.
- Regressionstest `planning_test.go`: factory_excluded/execution_released müssen in der Liste sein + No-Panic-Registration.

## Verification

- [x] `make vet test build` (scripts/ticket-mcp/go) grün
- [x] Smoke über stdio (`tools/list`): Enum enthält alle 7 Flags
- [x] End-to-end `tools/call set_readiness_flag {factory_excluded:true}` auf T014842 → DB-Readiness gesetzt, danach zurückgesetzt
- [x] `task test:mcp-tooling` (Guardrail tools ↔ mcp-tool-guide.md) grün