### PR TITLE
fix(scripts): abort delivery on diverged origin branch instead of blind rebase [T014737]

### DIFF
--- a/scripts/brain-ingest.sh
+++ b/scripts/brain-ingest.sh
@@ -626,7 +626,19 @@ if git remote get-url origin &>/dev/null; then
   # T013914 E9: Staleness-Gate fuer das Branch selbst. Bei zwei konkurrierenden
   # brain-ingest-Laeufen kann der zweite Push scheitern, weil das remote Branch
   # um Commits des ersten Läufs vorausgeschritten ist.
+  # [T014737] Der Rebase ist nur zulaessig, wenn der Remote-Branch ein
+  # Fast-Forward unserer Delivery-Basis ist (der konkurrierende Lauf haengt nur
+  # an). Ein divergierter Remote-Branch — etwa ein stale Delivery-Branch von
+  # einem aelteren main-Stand — bricht hier ab, statt vom Blind-Rebase geglaettet
+  # zu werden: sonst greift der Non-Fast-Forward-Schutz aus T013041 nie mehr.
   if git rev-parse --verify "origin/$BRANCH" &>/dev/null 2>&1; then
+    REMOTE_TIP="$(git rev-parse "origin/$BRANCH")"
+    LOCAL_BASE="$(git rev-parse HEAD~1)"
+    if ! git merge-base --is-ancestor "$LOCAL_BASE" "$REMOTE_TIP"; then
+      echo "ERROR: origin/$BRANCH diverged from delivery base (non-fast-forward) — delivery aborted"
+      cd "$REPO_ROOT"
+      exit 1
+    fi
     git rebase "origin/$BRANCH" 2>/dev/null || {
       echo "ERROR: rebase onto origin/$BRANCH failed — delivery aborted"
       cd "$REPO_ROOT"

--- a/tests/spec/brain-k4-brain-wiki/delivery-branch-staleness.bats
+++ b/tests/spec/brain-k4-brain-wiki/delivery-branch-staleness.bats
@@ -165,3 +165,29 @@ run_ingest() {
   pushed_remote="$(git -C "$WORK/origin.git" rev-parse "refs/heads/$BRANCH_NAME")"
   [ "$pushed_remote" = "$(git -C "$WORK/brain" rev-parse "$BRANCH_NAME")" ]
 }
+
+@test "[T014737] Angehaengter Remote-Commit am Delivery-Branch (Fast-Forward-Fall) liefert per Rebase sauber" {
+  # E9-Fall (T013914): ein konkurrierender Lauf haengt an den Delivery-Branch an,
+  # ohne die Basis zu veraendern — der Rebase muss diesen Anhang erhalten und
+  # sauber liefern (Gegenstueck zum Divergenz-Abbruch im Test darueber).
+  build_fixture no-stale-branch
+  git -C "$WORK/seed" checkout -q -b ff-append main
+  printf 'appended\n' > "$WORK/seed/appended.txt"
+  git -C "$WORK/seed" add appended.txt
+  git -C "$WORK/seed" commit -q -m e9-append
+  git -C "$WORK/seed" push -q origin "ff-append:$BRANCH_NAME"
+  git -C "$WORK/seed" checkout -q main
+  local appended_tip
+  appended_tip="$(git -C "$WORK/origin.git" rev-parse "refs/heads/$BRANCH_NAME")"
+
+  run_ingest ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Pushed to origin/$BRANCH_NAME"* ]]
+
+  # Positiv-Anker: der gelieferte Commit sitzt auf dem angehaengten Remote-Tip.
+  local remote_tip delivered_parent
+  remote_tip="$(git -C "$WORK/origin.git" rev-parse "refs/heads/$BRANCH_NAME")"
+  delivered_parent="$(git -C "$WORK/brain" rev-parse "$BRANCH_NAME~1")"
+  [ "$delivered_parent" = "$appended_tip" ]
+  [ "$remote_tip" = "$(git -C "$WORK/brain" rev-parse "$BRANCH_NAME")" ]
+}


### PR DESCRIPTION
## Problem

Der Test `[T013041] Abgelehnter Push (non-fast-forward) bricht die Lieferung mit Exit 1 ab` (`tests/spec/brain-k4-brain-wiki/delivery-branch-staleness.bats`, Test 671) fiel in CI scheinbar 'flaky' rot (PR #5099, #5107) und blockierte als Required Check.

## Root Cause (korrigierte Diagnose gegenüber T014737-Beschreibung)

Kein Random-Flake und kein Fixture-Race:

1. **Die 'empty repository'-Warnung ist harmloses Rauschen** — der erste `git clone` des frisch initiierten Bare-Repos im Fixture (erwartetes git-Verhalten).
2. **Echter Defekt:** Der E9-Staleness-Gate aus T013914 (#5060) macht `git rebase origin/$BRANCH` ohne Vorprüfung. Bei divergiertem Remote-Branch (Fixture: stale Branch s1 auf Basis c1, Delivery-Basis c2) replayiert der Rebase **main-History + Generat** auf den stale Branch (`s1 → c2' → gen'`) — der Push wird zum Fast-Forward, Exit 0 statt `delivery aborted`. Deterministisch reproduzierbar (lokal 3/3 rot vor dem Fix).
3. **Warum es 'flaky' wirkte:** Auf PRs läuft nur `task test:spec:changed` — der Test läuft nur bei Brain-Ingest-berührenden PRs. Main-CI blieb deshalb grün.

## Fix

`scripts/brain-ingest.sh` Phase 4: Der E9-Rebase läuft nur noch, wenn `origin/$BRANCH` ein **Fast-Forward der Delivery-Basis** ist (`git merge-base --is-ancestor`) — genau der konkurrierende-Lauf-Fall, für den E9 gebaut wurde. Bei Divergenz: Abbruch mit `delivery aborted`, Exit 1, Remote bleibt unberührt (T013041-Vertrag).

## Tests

- Bestehende 3 T013041-Tests: **5x lokal grün** (vorher Test 671: 3/3 rot)
- **Neu:** Regressionstest für den E9-Fast-Forward-Fall (konkurrierender Anhang liefert sauber per Rebase)
- `brain-k4-brain-wiki*` Sweep: 33/33 grün; `brain-ingest.bats`: 29/29 grün
- `task freshness:check` + `task workspace:validate`: grün
- `task test:changed`: 3 Failures, alle als pre-existing/environmental verifiziert (Parallelitäts-Isolation bzw. DB auf :15432 nicht erreichbar; der brain-ingest-Policy-Fail trat identisch in CI-Shard 3 OHNE diesen Fix auf)

Closes T014737