### PR TITLE
fix(ci): skip full-unit fallback when spec coverage exists [T014750]

### DIFF
--- a/scripts/find-changed-tests.sh
+++ b/scripts/find-changed-tests.sh
@@ -152,7 +152,19 @@ while IFS= read -r file; do
         fi
       else
         # For unit selection, fallback to run all for safety
-        _trigger_run_all "$file"
+        # UNLESS the script is covered by a spec test instead
+        has_spec=""
+        [ -f "tests/spec/$name.bats" ] && has_spec=1
+        [ -z "$has_spec" ] && [ -n "$(find tests/spec -mindepth 2 -name "$name.bats" -type f -print -quit 2>/dev/null)" ] && has_spec=1
+        [ -z "$has_spec" ] && [ -f "tests/spec/vda-$name.bats" ] && has_spec=1
+        [ -z "$has_spec" ] && [ -f "tests/spec/ticket-$name.bats" ] && has_spec=1
+        [ -z "$has_spec" ] && [ -f "tests/spec/factory-$name.bats" ] && has_spec=1
+        
+        if [ -n "$has_spec" ]; then
+          echo "note: '$file' changed — no unit match but spec test exists, skipping FULL unit suite fallback" >&2
+        else
+          _trigger_run_all "$file"
+        fi
       fi
     fi
     continue


### PR DESCRIPTION
## Ticket
T014750 — find-changed-tests: Full-Unit-Suite-Fallback für spec-abgedeckte Skripte vermeiden

## Verhaltenänderung
Ändert `scripts/find-changed-tests.sh`: Eine Skript-Änderung ohne Unit-Match löst nur dann den `_trigger_run_all`-Fallback aus, wenn KEIN Spec-Test existiert (`tests/spec/<name>.bats`, verschachtelt, bzw. `vda-/ticket-/factory-`-Präfixe). Mit Spec-Abdeckung erscheint stattdessen eine note-Zeile auf stderr und die Unit-Suite wird übersprungen.

## Operator-Freigabe
Klärungsrunde ticket-ops 2026-08-23: Patch übernehmen — Spec-Abdeckung ersetzt den Full-Unit-Fallback (Kommentar am Ticket T014750).

## Verifikation
- `bash -n scripts/find-changed-tests.sh` ✓
- Smoke Case A: `FIND_CHANGED_TESTS_FILES=scripts/factory/merge-hooks.sh` → `no unit match but spec test exists, skipping FULL unit suite fallback` ✓
- Smoke Case B: unbedecktes Skript → `falling back to the FULL unit suite` (altes Verhalten) ✓

## Herkunft
Patch portiert von `rescue/find-changed-tests-5a3f2f7b5` (Commit 5a3f2f7b5); dort enthaltene T013916-tasks.md-Statusänderung bewusst NICHT übernommen (out of scope).