### PR TITLE
chore: shard3 flake forensics T014937

### DIFF
--- a/tests/spec/brain-ingest.bats
+++ b/tests/spec/brain-ingest.bats
@@ -349,8 +349,13 @@ SH
   run env PATH="$fake_bin:$PATH" LM_STUDIO_URL=http://fixture.invalid LM_MODEL=fixture \
     MAX_PARALLEL=1 BRAIN_CHUNK_TARGET_CHARS=800 BRAIN_OBSERVED_AT="$observed" \
     bash "$source_root/scripts/brain-ingest.sh" --brain-repo "$brain" --state "$state" --dry-run
-  echo "$output"
-  [ "$status" -eq 0 ]
+  # T014937: Beim einzigen Flake-Vorkommen (CI Run 32638947716) fehlte genau
+  # diese Forensik — die Assertion saß blind, $output/$status wurden nie
+  # gedruckt. BATS zeigt ge-echo-te Zeilen nur bei Failure, im Gruenfall sind
+  # sie unsichtbar; deshalb hier bewusst redundant.
+  echo "brain-ingest --dry-run exit=${status}"
+  echo "${output}"
+  [ "${status}" -eq 0 ]
 
   local policy_hash policy_pages approved_hash approved_pages
   policy_hash="$(sha256sum "$source_root/docs/brain-expertise/approved/source-policy.md" | awk '{print $1}')"
@@ -373,7 +378,9 @@ SH
 
   run python3 "$REPO_ROOT/scripts/brain-lifecycle-audit.py" --brain-repo "$brain" \
     --source-root "$source_root" --as-of "$observed" --format json
-  [ "$status" -eq 0 ]
+  echo "lifecycle-audit exit=${status}"
+  echo "${output}"
+  [ "${status}" -eq 0 ]
   [ "$(jq -r '.summary.finding_count' <<< "$output")" -eq 0 ]
 }
 


### PR DESCRIPTION
## Hintergrund (T014937)

Der brain-ingest Policy-Test fiel einmalig in **Factory spec shard 3** aus (CI Run 32638947716, `not ok 67`, 2013 ms) — ohne dass der jeweilige PR den Test berührte.

## Diagnose

- Zum Zeitpunkt des Fails (Sha 119efe83) saß die Assertion `[ "$status" -eq 0 ]` **ohne jede Ausgabe** von `$output`/`$status` — die Ursache war per Konstruktion unsichtbar. Das Debug-Echo kam erst danach auf main (c0e3a2be), ein Rezidiv mit sichtbarem Output ist seither nicht aufgetreten.
- Evidenzstand: 1 Vorkommen in ~60 CI-Runs; ~1000 lokale Stress-Ausführungen unter `-j 4` Kreuzlast (4-CPU-affinitisiert, die vier betroffenen Dateien gemeinsam) — kein Repro.
- Die anderen drei Shard-Fails desselben Tages (Runs 32638285877/32639140492) waren echte Reds einer laufenden WIP-Repair-Serie (T014543), keine Flakes.

## Änderung

Vollständige Forensik für den nächsten Fail, statt spekulativer Pipeline-Änderung:

1. Policy-Test: `echo "brain-ingest --dry-run exit=${status}"` + volles `$output` vor der Assertion (bats druckt ge-echote Zeilen nur bei Failure).
2. Lifecycle-audit-Run im selben Test: dieselbe Forensik ergänzt — dieselbe Blindheitsklasse.

Kein Verhaltenschange an Skripten oder Assertions-Semantik.