### PR TITLE
chore(scripts): rewire brain ingest tasks off deprecated swap wrapper [T014939]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5434,9 +5434,9 @@ tasks:
       - bash scripts/brain-ingest-worklist.sh
 
   brain:ingest:dry:
-    desc: "Dry-Run der Brain-Ingest-Pipeline (setzt LM_MODEL-Default + Ingest-Pool :8093; SA-BW-01/T014543). Usage: task brain:ingest:dry"
+    desc: "Dry-Run der Brain-Ingest-Pipeline (FreeToken-native :1919, T014339-Default; SA-BW-01/T014543). Usage: task brain:ingest:dry"
     cmds:
-      - LM_MODEL="${LM_MODEL:-gemma-4-12b-qat}" LM_STUDIO_URL="${LM_STUDIO_URL:-http://localhost:8093}" bash scripts/brain-ingest.sh --brain-repo ~/brain --dry-run {{.CLI_ARGS}}
+      - LM_DISABLE_THINKING="${LM_DISABLE_THINKING:-1}" LM_MODEL="${LM_MODEL:-Qwen3.6-35B-A3B-NVFP4}" LM_STUDIO_URL="${LM_STUDIO_URL:-http://127.0.0.1:1919}" LM_TIMEOUT="${LM_TIMEOUT:-600}" bash scripts/brain-ingest.sh --brain-repo ~/brain --dry-run {{.CLI_ARGS}}
 
   brain:bootstrap:
     desc: "Seede (und optional erstelle/pushe) das brain-Wiki-Fundament. Usage: task brain:bootstrap -- <target-dir>|--create-remote --collaborator <handle>"

--- a/docs/runbooks/freetoken-native.md
+++ b/docs/runbooks/freetoken-native.md
@@ -36,6 +36,12 @@ Get-Process ft | Stop-Process -Force
 
 Bereitschaft: Log-Zeile `API server is ready to serve on 0.0.0.0:1919`.
 
+**KV-Budget:** Ohne Größenflag wählt `--moe-cache-auto` nur ~8200 KV-Tokens
+(0,16 GiB) — Requests über `prompt + generation > 8199` werden mit
+`context_length_exceeded` abgewiesen (beobachtet beim Brain-Ingest,
+2026-08-23). Für große Prompts explizit setzen, z. B. `--num-tokens 32768`
+(kostet ~0,62 GiB VRAM; Log-Zeile `Allocating N tokens for KV cache`).
+
 ## Messwerte (2026-08-23)
 
 | Metrik | Wert |

--- a/taskfiles/Taskfile.brain.yaml
+++ b/taskfiles/Taskfile.brain.yaml
@@ -50,25 +50,29 @@ tasks:
     cmds:
       - cut -f2 brain-worklist.txt | sort | uniq -c | sort -rn
 
+  # T014339 P3-Nachzug: der Swap-Wrapper ist obsolet — beide Tasks rufen
+  # brain-ingest.sh direkt auf. Backend-URL und Modell bewusst HIER NICHT
+  # gesetzt: das Skript ist die alleinige Quelle (FreeToken-native :1919,
+  # Qwen3.6-35B-A3B-NVFP4), damit es keinen zweiten Port-Default gibt, den
+  # der Guard in tests/spec/local-llm-proxy/brain-ingest-port.bats nicht
+  # sehen kann. Vorgesetzte LM_*/MAX_*-Werte gewinnen weiterhin (env-
+  # Vererbung), LM_MAX_TOKENS/MAX_SOURCE_CHARS/MAX_PARALLEL verwaltet das
+  # Skript selbst (Chunker-Ära: 3072 Output-Tokens, 16k-Chunks, np=4).
   ingest:run:
     desc: "Full brain ingestion pipeline (LLM-assisted, creates PR)"
     cmds:
       - |-
         LM_DISABLE_THINKING="${LM_DISABLE_THINKING:-1}" \
-        LM_MAX_TOKENS="${LM_MAX_TOKENS:-65536}" \
-        LM_TIMEOUT="${LM_TIMEOUT:-3600}" \
-        MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-150000}" \
-          bash scripts/brain-ingest-swap.sh --brain-repo ~/brain "$@"
+        LM_TIMEOUT="${LM_TIMEOUT:-600}" \
+          bash scripts/brain-ingest.sh --brain-repo ~/brain {{.CLI_ARGS}}
 
   ingest:pilot:
     desc: "Run ingestion on 20 pages (pilot batch)"
     cmds:
       - |-
         LM_DISABLE_THINKING="${LM_DISABLE_THINKING:-1}" \
-        LM_MAX_TOKENS="${LM_MAX_TOKENS:-65536}" \
-        LM_TIMEOUT="${LM_TIMEOUT:-3600}" \
-        MAX_SOURCE_CHARS="${MAX_SOURCE_CHARS:-150000}" \
-          bash scripts/brain-ingest-swap.sh --brain-repo ~/brain --pilot 20 "$@"
+        LM_TIMEOUT="${LM_TIMEOUT:-600}" \
+          bash scripts/brain-ingest.sh --brain-repo ~/brain --pilot 20 {{.CLI_ARGS}}
 
 
 

--- a/tests/spec/brain-ingest-task-defaults.bats
+++ b/tests/spec/brain-ingest-task-defaults.bats
@@ -1,32 +1,38 @@
 #!/usr/bin/env bats
-# T013042 — die brain:ingest:*-Tasks reichen Fallback-Defaults durch; explizit
+# Die brain:ingest:*-Tasks reichen ihre Fallback-Defaults durch; explizit
 # gesetzte Werte bleiben massgeblich.
 #
-# GEAENDERT DURCH T013593. T013042 hatte sieben Defaults festgeschrieben,
-# darunter LM_STUDIO_URL=http://127.0.0.1:8089, LM_MODEL=gemma12-vision und
-# MAX_PARALLEL=1. Diese drei sind entfallen: sie standen im Widerspruch zum
-# Requirement "Loadout-Ports und lokale Port-Forwards sind disjunkt", das
-# Loadout, Skript-Default und Backend-Migration auf denselben Port (8100)
-# festlegt — der Taskfile nannte 8089. Seit T013593 setzt sie
-# scripts/brain-ingest-swap.sh aus dem brain-ingest-Loadout, also aus genau der
-# Quelle, die das Port-Requirement meint. Ein zweiter Ort, der denselben Port
-# nennt, war die Drift, die T013593 behebt.
+# Historie: T013042 schrieb sieben Defaults fest (u.a. :8089/gemma12-vision),
+# T013593 liess die Tasks den Swap-Wrapper aufrufen und entfernte URL/Modell/
+# Slot-Zahl aus dem Taskfile. Seit dem T014339-Nachzug ist der Wrapper obsolet:
+# beide Tasks rufen scripts/brain-ingest.sh DIREKT auf und setzen nur noch
+# LM_DISABLE_THINKING=1 und LM_TIMEOUT=600.
 #
-# Die Zusicherung von T013042 bleibt unveraendert gueltig: vorgesetzte Werte
-# gewinnen gegen jeden Default.
+# Bewusst NICHT mehr im Taskfile: LM_STUDIO_URL, LM_MODEL, LM_MAX_TOKENS,
+# MAX_SOURCE_CHARS, MAX_PARALLEL. brain-ingest.sh ist die alleinige Quelle
+# dafuer (FreeToken-native :1919 / Qwen3.6-35B-A3B-NVFP4, 3072 Output-Tokens,
+# 16k-Chunks, np=4) — ein zweiter Port-Default im Taskfile waere genau die
+# Drift, wegen der der Guard in tests/spec/local-llm-proxy/brain-ingest-port.bats
+# existiert, und das Root-Taskfile hat mit brain:ingest:dry/:8093 (T014543)
+# gezeigt, dass genau diese Drift real passiert. Env-Vererbung reicht jede
+# vorgesetzte Variable trotzdem an das Skript durch; die Zusicherung von
+# T013042 ("vorgesetzte Werte gewinnen") bleibt unverändert gueltig.
+#
+# PRUEFMODUS: Output-Verifikation (T002448-M4) — ein Fake-bash protokolliert
+# die environment, mit der der eigentliche Einstiegspunkt gestartet wuerde.
 
 setup() {
   REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
   TASKFILE="$REPO_ROOT/taskfiles/Taskfile.brain.yaml"
   FAKE_BIN="$BATS_TEST_TMPDIR/bin"
   mkdir -p "$FAKE_BIN"
-  # Gibt zusaetzlich das aufgerufene Skript aus: welcher Einstiegspunkt laeuft,
-  # ist seit T013593 Teil der Zusicherung und nicht mehr nur Beiwerk.
+  # Gelabelte Zeilen statt roher Werte: leere Variablen ("das Taskfile setzt
+  # das bewusst nicht") sind damit vom Fehlen des Aufrufs unterscheidbar.
   cat > "$FAKE_BIN/bash" <<'SHEOF'
 #!/bin/sh
-printf '%s\n' \
+printf 'url=%s\nmodel=%s\ndisable_thinking=%s\nmax_tokens=%s\ntimeout=%s\nmax_source_chars=%s\nmax_parallel=%s\nscript=%s\n' \
   "$LM_STUDIO_URL" "$LM_MODEL" "$LM_DISABLE_THINKING" "$LM_MAX_TOKENS" \
-  "$LM_TIMEOUT" "$MAX_SOURCE_CHARS" "$MAX_PARALLEL" "script=$1"
+  "$LM_TIMEOUT" "$MAX_SOURCE_CHARS" "$MAX_PARALLEL" "$1"
 SHEOF
   chmod +x "$FAKE_BIN/bash"
 }
@@ -37,38 +43,46 @@ run_task() {  # <task-name>, ohne vorgesetzte Ingest-Variablen
     PATH="$FAKE_BIN:$PATH" task --taskfile "$TASKFILE" "$1"
 }
 
-@test "T013042 brain ingest task supplies the local fallback defaults" {
+@test "the ingest tasks call brain-ingest.sh directly with their two defaults" {
   run_task ingest:run
   [ "$status" -eq 0 ]
 
-  # POSITIV-ANKER: der Fake-bash muss ueberhaupt gelaufen sein. Ohne ihn waeren
-  # die Abwesenheits-Aussagen unten vakuos — eine leere Ausgabe enthaelt jeden
-  # verbotenen Wert nicht.
-  [[ "$output" == *"script="* ]]
+  # POSITIV-ANKER: der Fake-bash muss ueberhaupt gelaufen sein UND den neuen
+  # Einstiegspunkt sehen — sonst waeren alle Abwesenheits-Aussagen vakuos.
+  [[ "$output" == *"script=scripts/brain-ingest.sh"* ]]
 
-  # Die vier Defaults, die der Taskfile weiterhin setzt.
-  [[ "$output" == *$'1\n65536\n3600\n150000'* ]]
+  [[ "$output" == *"disable_thinking=1"* ]]
+  [[ "$output" == *$'\ntimeout=600\n'* ]]
+
+  # Die fünf bewusst nicht gesetzten Variablen kommen LEER an (Skript-Default
+  # gilt), sie sind also nicht nur unsichtbar, sondern belegt nicht gesetzt.
+  [[ "$output" == *$'\nurl=\n'* ]]
+  [[ "$output" == *$'\nmodel=\n'* ]]
+  [[ "$output" == *$'\nmax_tokens=\n'* ]]
+  [[ "$output" == *$'\nmax_source_chars=\n'* ]]
+  [[ "$output" == *$'\nmax_parallel=\n'* ]]
 }
 
-@test "T013593 the tasks name neither backend URL nor model nor slot count" {
-  run_task ingest:run
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"script="* ]]
-
-  # Diese drei kommen aus dem Loadout, nicht aus dem Taskfile.
-  [[ "$output" != *"8089"* ]]
-  [[ "$output" != *"gemma12-vision"* ]]
-}
-
-@test "T013593 the ingest tasks call the swap wrapper" {
+@test "the ingest tasks name no backend URL, model or retired endpoint" {
   for task_name in ingest:run ingest:pilot; do
     run_task "$task_name"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"script=scripts/brain-ingest-swap.sh"* ]]
+
+    # Positiv-Anker vor den Negativ-Aussagen (T002356-M1).
+    [[ "$output" == *"script=scripts/brain-ingest.sh"* ]]
+
+    # Keine der historischen Endpunkt-Angaben darf zurueckkehren: der
+    # Loadout-Port 8089 (T013042), der tote Ingest-Pool 8093 (T014543),
+    # die stillgelegten Modelle und der obsolete Wrapper (T014339).
+    [[ "$output" != *"8089"* ]]
+    [[ "$output" != *"8093"* ]]
+    [[ "$output" != *"gemma12-vision"* ]]
+    [[ "$output" != *"gemma-4-12b-qat"* ]]
+    [[ "$output" != *"swap.sh"* ]]
   done
 }
 
-@test "T013042 pre-set brain ingest values override every default" {
+@test "pre-set brain ingest values reach the script through env inheritance" {
   run env PATH="$FAKE_BIN:$PATH" \
     LM_STUDIO_URL=http://example.test:9999 LM_MODEL=custom-model \
     LM_DISABLE_THINKING=0 LM_MAX_TOKENS=42 LM_TIMEOUT=43 \
@@ -76,13 +90,22 @@ run_task() {  # <task-name>, ohne vorgesetzte Ingest-Variablen
     task --taskfile "$TASKFILE" ingest:run
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *$'http://example.test:9999\ncustom-model\n0\n42\n43\n44\n2'* ]]
+  [[ "$output" == *"url=http://example.test:9999"* ]]
+  [[ "$output" == *"model=custom-model"* ]]
+  [[ "$output" == *"disable_thinking=0"* ]]
+  [[ "$output" == *"max_tokens=42"* ]]
+  [[ "$output" == *$'\ntimeout=43\n'* ]]
+  [[ "$output" == *"max_source_chars=44"* ]]
+  [[ "$output" == *"max_parallel=2"* ]]
 }
 
-@test "T013042 run pilot and dry share the same fallback block" {
+@test "run pilot share the same fallback block and entrypoint" {
   for task_name in ingest:run ingest:pilot; do
     run_task "$task_name"
     [ "$status" -eq 0 ]
-    [[ "$output" == *$'1\n65536\n3600\n150000'* ]]
+    [[ "$output" == *"script=scripts/brain-ingest.sh"* ]]
+    [[ "$output" == *"disable_thinking=1"* ]]
+    [[ "$output" == *$'\ntimeout=600\n'* ]]
+    [[ "$output" == *$'\nurl=\n'* ]]
   done
 }


### PR DESCRIPTION
## Summary

Nachzug zu T014339 P3 und Reparatur des Task-Drifts aus T014543:

- `brain:ingest:run`/`brain:ingest:pilot` rufen jetzt direkt `scripts/brain-ingest.sh` auf statt des obsoleten Swap-Wrappers (Loadout-Swap zielte auf den stillgelegten `:8100`-Loadout). Defaults reduziert auf `LM_DISABLE_THINKING=1` + `LM_TIMEOUT=600`; Backend-URL/Modell bewusst allein in brain-ingest.sh (FreeToken-native `:1919`, Qwen3.6-35B-A3B-NVFP4) — kein zweiter Port-Default, den der Port-Guard nicht sieht.
- Defekte Args-Weiterleitung behoben: "$@" ist unter go-task immer leer → `{{.CLI_ARGS}}`.
- `brain:ingest:dry` im Root-Taskfile vom toten Ingest-Pool `:8093`/`gemma-4-12b-qat` auf FreeToken-native umgestellt (+ `LM_DISABLE_THINKING=1` gegen die Reasoning-Leerantwort-Falle, `LM_TIMEOUT=600`).
- Runbook `freetoken-native.md`: KV-Budget-Falle dokumentiert (`--moe-cache-auto` alloziert ohne Flag nur ~8199 Tokens; für Ingest-Chunks `--num-tokens 32768`).
- `tests/spec/brain-ingest-task-defaults.bats`: pinnt neuen Einstiegspunkt, die zwei Defaults, die fünf bewusst leeren Variablen und die Env-Inheritance-Garantie (vorgesetzte Werte gewinnen, T013042).

## Test plan

- [x] `bats tests/spec/brain-ingest-task-defaults.bats` — 4/4 grün
- [x] `brain-ingest-port.bats`, `brain-ingest-swap.bats`, `gateway-consumer-lint.bats` — grün
- [x] Smoke: `task brain:ingest:pilot -- --pilot 3 --dry-run` → exit 0, Pilot-Limit greift, keine Auslieferung
- [x] `task brain:ingest:dry` gegen laufende FreeToken-Engine → exit 0, Coverage 100 %, alle Gates PASS
- [x] `task freshness:check` + `task workspace:validate` grün
- [x] Fails in `task test:changed` (pgvector/gateway/repo-structure) sind vorbestehend — identisch auf clean main nachgewiesen