### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1188,
+      "file_count": 1189,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32646493433).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
