### PR TITLE
chore(test): [T015101] drop stale .gitignore entry for removed stray test T002664

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,4 +242,3 @@ out/
 # Hardware (MAC-Adressen) statt das Repo. Vorlage: scripts/iso/node-map.example
 build/iso/
 scripts/iso/node-map
-tests/spec/ci-cd/stray-ignored-test-T002664.bats


### PR DESCRIPTION
## Summary
- Entfernt die .gitignore-Zeile für `tests/spec/ci-cd/stray-ignored-test-T002664.bats` — die Datei existiert nicht mehr, die Zeile ist tot
- Löst den letzten Stash-Eintrag auf (foreign-leftover aus Session chore/brain-ingest-tasks-T014939, Befund des repo-hygiene-Laufs 2026-08-23); Referenz-Ticket T002664 ist archiviert

Ref: T015101

## Test Plan
- [x] `task freshness:check` — grün
- [x] `bash scripts/preflight-pr-scope.sh` — scope 'test' ✓