### PR TITLE
chore(scripts): add ticket.sh seq-repair for external_id_seq backfill [T015011]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -5604,6 +5604,12 @@
     "kind": "shell"
   },
   {
+    "id": "ticket-seq-integrity/seq-repair",
+    "file": "tests/spec/ticket-seq-integrity/seq-repair.bats",
+    "category": "ticket-seq-integrity",
+    "kind": "shell"
+  },
+  {
     "id": "ticket-system",
     "file": "tests/spec/ticket-system.bats",
     "category": "ticket-system",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1190,
+      "file_count": 1191,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -1012,6 +1012,7 @@
         "tests/spec/ticket-ops-claim-phase-a-T004602.bats",
         "tests/spec/ticket-ops/triage-status-ssot.bats",
         "tests/spec/ticket-ops/wave1-state-refetch.bats",
+        "tests/spec/ticket-seq-integrity/seq-repair.bats",
         "tests/spec/ticket-system.bats",
         "tests/spec/ticket-system/areas-csv-trim.bats",
         "tests/spec/ticket-system/backfill-id-sequence.bats",
@@ -3636,7 +3637,7 @@
       "id": "scripts-infra",
       "name": "Operational + build scripts",
       "owner_agent": "bachelorprojekt-infra",
-      "file_count": 808,
+      "file_count": 809,
       "files": [
         "scripts/README.md",
         "scripts/add-whiteboard-library.py",
@@ -4420,6 +4421,7 @@
         "scripts/vda/promote.sh",
         "scripts/vda/release-notes.sh",
         "scripts/vda/ticket.sh",
+        "scripts/vda/ticket/_seq-repair-sql.sh",
         "scripts/vda/ticket/_ticket-core.sh",
         "scripts/vda/ticket/assert-phase-chain.sh",
         "scripts/vda/ticket/backfill-id.sh",

--- a/scripts/lib/ticket-help.sh
+++ b/scripts/lib/ticket-help.sh
@@ -28,7 +28,7 @@ ticket_help_wanted() {
 
 ticket_usage() {
   echo "Usage: $0 <command> [options]"
-  echo "Commands: create, update-status, update-fields, set-parent, add-comment, add-pr-link, grill, archive-plan, get-attachments, get, set-touched-files, set-scout-drift, set-pipeline-slot, release-slot, reclaim, touch, enqueue, stage-plan, release-hold, assert-phase-chain, retry-count, unfactory, factory-control, dryrun-mark, dryrun-check, feature-flag, phase, inject, get-injections, plan-meta, lastenheft, list, backfill-id, triage, link-tickets, get-ticket-links, get-timeline, find-similar"
+  echo "Commands: create, update-status, update-fields, set-parent, add-comment, add-pr-link, grill, archive-plan, get-attachments, get, set-touched-files, set-scout-drift, set-pipeline-slot, release-slot, reclaim, touch, enqueue, stage-plan, release-hold, seq-repair, assert-phase-chain, retry-count, unfactory, factory-control, dryrun-mark, dryrun-check, feature-flag, phase, inject, get-injections, plan-meta, lastenheft, list, backfill-id, triage, link-tickets, get-ticket-links, get-timeline, find-similar"
 }
 
 ticket_help_subcommand() {
@@ -179,6 +179,14 @@ HELP
 Usage: ticket.sh release-hold --id <external_id>
   --id <external_id>      Ticket-ID (required)
   Setzt readiness.execution_released=true und weckt factory.service.
+HELP
+      ;;
+    seq-repair)
+      cat <<'HELP'
+Usage: ticket.sh seq-repair
+  Setzt tickets.external_id_seq auf GREATEST(last_value, max numerischer external_id).
+  Nach manuellen Imports/Backfills mit expliziten T-IDs ausführen, damit die
+  Sequenz keine vergebene Nummer wiederverwendet (Vorfall T015011/T014936).
 HELP
       ;;
     touch)

--- a/scripts/ticket.sh
+++ b/scripts/ticket.sh
@@ -390,6 +390,16 @@ EOF
   systemctl --user start --no-block factory.service 2>/dev/null || true
 }
 
+cmd_seq_repair() {
+  source "$(dirname "${BASH_SOURCE[0]}")/vda/ticket/_seq-repair-sql.sh"
+  if _ticket_offline_skip "seq-repair"; then return 0; fi
+  local pod; pod=$(_pgpod)
+  echo "Repairing tickets.external_id_seq against max numeric external_id..."
+  local out
+  out=$(_exec_sql "$pod" <<< "$(_seq_repair_sql)")
+  echo "external_id_seq now at: $out"
+}
+
 cmd_set_touched_files() {
   local id="" files=""
   while [[ $# -gt 0 ]]; do case "$1" in
@@ -1065,6 +1075,7 @@ case "$cmd" in
   enqueue)           cmd_enqueue "$@" ;;
   stage-plan)        cmd_stage_plan "$@" ;;
   release-hold)      cmd_release_hold "$@" ;;
+  seq-repair)        cmd_seq_repair "$@" ;;
   assert-phase-chain) cmd_assert_phase_chain "$@" ;;
   retry-count)       cmd_retry_count "$@" ;;
   unfactory)         cmd_unfactory "$@" ;;

--- a/scripts/vda/ticket/_seq-repair-sql.sh
+++ b/scripts/vda/ticket/_seq-repair-sql.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# _seq-repair-sql.sh — emittiert das idempotente Repair-Statement für
+# tickets.external_id_seq [T015011].
+#
+# Pure Output-Funktion: kein DB-Zugriff, nur stdout. Die Ausführung passiert in
+# `ticket.sh seq-repair` über _exec_sql.
+#
+# Warum MAX über external_id statt max(id): tickets.id ist eine UUID
+# (gen_random_uuid()), external_id ist TEXT ('T<seq>') und wird vom App-Code aus
+# genau dieser Sequenz vergeben (kein column default). Nach Imports/Backfills mit
+# expliziten T-IDs kann die Sequenz hinter dem Maximum zurückliegen — der nächste
+# Create vergibt dann eine bereits genutzte Nummer wieder (Vorfall T015011,
+# Ur-Vorfall T014936/T015005).
+
+_seq_repair_sql() {
+  cat <<'EOF'
+SELECT setval(
+  'tickets.external_id_seq',
+  GREATEST(
+    (SELECT last_value FROM tickets.external_id_seq),
+    (
+      SELECT COALESCE(MAX((substring(external_id FROM 2))::bigint), 0)
+      FROM tickets.tickets
+      WHERE external_id ~ '^T[0-9]+$'
+    )
+  )
+) AS repaired_value;
+EOF
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  _seq_repair_sql
+fi

--- a/tests/spec/ticket-seq-integrity/seq-repair.bats
+++ b/tests/spec/ticket-seq-integrity/seq-repair.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# Guard für ticket.sh seq-repair / external_id_seq-Backfill [T015011].
+#
+# Prüfmodus: Output-Verifikation. Der SQL-Emitter ist eine pure Funktion und
+# wird als Command-Output geprüft (T002448-M4); die Wiring-Zusicherung
+# (Dispatch-Eintrag in ticket.sh) manifestiert sich ausschließlich im Quelltext
+# und ist als struktureller Check dokumentiert.
+#
+# Hintergrund: Nach manuellen Imports mit expliziten T-IDs lag die Sequenz
+# hinter dem vergebenen Maximum; das nächste Create reusete die Nummer eines
+# gelöschten Tickets (T014936 → Folge-Incident T015005). Wichtig: tickets.id ist
+# eine UUID — der Repair muss gegen den numerischen Teil von external_id laufen.
+#
+# Run: tests/unit/lib/bats-core/bin/bats tests/spec/ticket-seq-integrity/
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
+  EMITTER="${REPO_ROOT}/scripts/vda/ticket/_seq-repair-sql.sh"
+  TICKET="${REPO_ROOT}/scripts/ticket.sh"
+}
+
+@test "T015011: emitter produces setval against max numeric external_id" {
+  local sql
+  sql="$(bash "$EMITTER")"
+  [ -n "$sql" ] || { echo "Emitter leer" >&2; return 1; }
+  [[ "$sql" == *"setval("* ]] || { echo "kein setval" >&2; return 1; }
+  [[ "$sql" == *"last_value"* ]] || { echo "last_value fehlt" >&2; return 1; }
+  [[ "$sql" == *"substring(external_id FROM 2)"* ]] || { echo "external_id-Numeric-Teil fehlt" >&2; return 1; }
+  [[ "$sql" == *"'^T[0-9]+\$'"* ]] || { echo "Format-Anker auf T-Zahlen fehlt" >&2; return 1; }
+}
+
+@test "T015011: emitter does NOT reference the uuid id column as sequence source" {
+  # Negativ-Aussage mit Positiv-Anker: Der korrekte external_id-Pfad ist oben
+  # verifiziert; hier darf der UUID-Pfad nicht auftauchen.
+  local sql
+  sql="$(bash "$EMITTER")"
+  [ -n "$sql" ] || return 1
+  if [[ "$sql" == *"MAX(id)"* ]]; then
+    echo "MAX(id) ist falsch — id ist eine UUID, nicht die Sequenzquelle" >&2
+    return 1
+  fi
+}
+
+@test "T015011: emitter output is a single statement terminated by semicolon" {
+  local sql
+  sql="$(bash "$EMITTER")"
+  [[ "$sql" == *";" ]] || { echo "kein Statement-Abschluss" >&2; return 1; }
+  [ "$(printf '%s\n' "$sql" | grep -c ';')" -le 1 ] || { echo "mehrere Statements" >&2; return 1; }
+}
+
+@test "T015011: ticket.sh wires seq-repair into its dispatch table (structural)" {
+  grep -q 'seq-repair)        cmd_seq_repair' "$TICKET" \
+    || { echo "seq-repair fehlt im Dispatch" >&2; return 1; }
+}
+
+@test "T015011: both scripts are syntactically valid bash" {
+  run bash -n "$EMITTER"
+  [ "$status" -eq 0 ] || { echo "emitter: $output" >&2; return 1; }
+  run bash -n "$TICKET"
+  [ "$status" -eq 0 ] || { echo "ticket.sh: $output" >&2; return 1; }
+}


### PR DESCRIPTION
## Was

Neues Verb `ticket.sh seq-repair`: setzt `tickets.external_id_seq` auf `GREATEST(last_value, max numerischer external_id)`.

## Warum

Nach manuellen Imports/Backfills mit expliziten T-IDs kann die Sequenz hinter dem vergebenen Maximum zurueckliegen — das naechste Create reuset dann eine bereits vergebene Nummer (Vorfall T014936, Folge-Incident T015005).

**Korrektur gegenueber der Ticket-Beschreibung:** Der Vorschlag `max(id)` waere falsch — `tickets.id` ist eine UUID (gen_random_uuid()), `external_id` ein TEXT ohne Column-Default; die Sequenz treibt App-Code. Der Repair laeuft deshalb gegen `(substring(external_id FROM 2))::bigint` mit Format-Anker \'^T[0-9]+$\'.

## Verification

- 5 neue BATS-Guards (tests/spec/ticket-seq-integrity/) gruen, inkl. Negativ-Guard gegen den UUID-Fehler
- Live-Lauf gegen die DB: external_id_seq now at 15101
- ticket-help Usage-Block ergaenzt

Closes T015011