### PR TITLE
fix(infra): sessions-server conf.d include filtert Main-Config aus [T015167]

### DIFF
--- a/k3d/sessions-server.yaml
+++ b/k3d/sessions-server.yaml
@@ -37,11 +37,16 @@ data:
     }
     server {
         listen 8080 default_server;
-        location /health {
+        # T015167: return ist eine Rewrite-Phasen-Direktive — auf Server-Level
+        # feuert sie VOR dem Location-Matching und wuerde /health mit 404
+        # abschiessen. Deshalb die 404er als Location statt server-level.
+        location = /health {
             return 200 "ok\n";
             add_header Content-Type text/plain;
         }
-        return 404;
+        location / {
+            return 404;
+        }
     }
 ---
 apiVersion: apps/v1
@@ -115,6 +120,12 @@ spec:
         - name: nginx-conf
           configMap:
             name: sessions-server-nginx
+            # T015167: items-Filter — ohne ihn landet der nginx.conf-Key mit im
+            # conf.d-Include-Verzeichnis und nginx bricht mit "[emerg]
+            # worker_processes directive is not allowed here" ab.
+            items:
+              - key: default.conf
+                path: default.conf
         - name: nginx-main-conf
           configMap:
             name: sessions-server-nginx

--- a/tests/spec/sessions-server.bats
+++ b/tests/spec/sessions-server.bats
@@ -30,3 +30,18 @@ setup() {
   echo "$dep_block" | grep -qE 'runAsNonRoot:[[:space:]]*true'
   echo "$dep_block" | grep -qE 'readOnlyRootFilesystem:[[:space:]]*true'
 }
+
+@test "sessions-server: conf.d-Volume filtert auf default.conf (T015167)" {
+  # Das nginx-conf-Volume mountet die ConfigMap nach /etc/nginx/conf.d — dem
+  # Include-Verzeichnis des Servers. Ohne items-Filter landet der nginx.conf-Key
+  # (Main-Konfiguration, worker_processes etc.) mit im Include und nginx bricht
+  # mit "[emerg] worker_processes directive is not allowed here" ab.
+  # Positiv-Anker: der items-Filter existiert.
+  grep -qE 'key:[[:space:]]*default\.conf' "$MANIFEST"
+  # Block des nginx-conf-Volumes (Volumes-Ebene = 8 Spaces) bis zum naechsten
+  # Volume-Eintrag; letztere Zeile wird per $d wieder entfernt.
+  vol_block="$(sed -n '/^        - name: nginx-conf$/,/^        - name: /p' "$MANIFEST" | sed '$d')"
+  echo "$vol_block" | grep -qE 'key:[[:space:]]*default\.conf'
+  leaked="$(echo "$vol_block" | grep -cE 'key:[[:space:]]*nginx\.conf' || true)"
+  [ "$leaked" -eq 0 ]
+}


### PR DESCRIPTION
Follow-up zu #5137 (T014553): der neue non-root sessions-server-Pod crashlooped in `workspace` + `workspace-staging` (alter Pod serviert weiter, kein Traffic-Ausfall).

## Root Causes + Fixes
1. **conf.d-Include-Leak:** Das Volume `nginx-conf` mountete die gesamte ConfigMap nach `/etc/nginx/conf.d` — seit dem neuen Key `nginx.conf` inkludierte nginx die Main-Konfiguration als Server-Block → `[emerg] "worker_processes" directive is not allowed here`. **Fix:** `items:`-Filter auf `default.conf`.
2. **Latenter /health-Bug (vor T014553 existent):** `return 404;` auf Server-Level feuert in der Rewrite-Phase vor dem Location-Matching — `/health` antwortete immer 404, unentdeckt weil beide Probes nur tcpSocket prüfen. **Fix:** `location = /health` + `location / { return 404; }`.

## Verifikation
- Runtime im Docker (exakte Manifest-Semantik: uid 101, read-only rootfs, tmpfs /tmp, beide Config-Mounts): Start sauber, `/health` → 200 `ok`, unbekannter Pfad → 404, Slug-Routing (`Host: session-demo.sessions.mentolder.de`) → 200 mit Content aus `/srv/sessions/demo/`
- Neuer Guard `sessions-server: conf.d-Volume filtert auf default.conf (T015167)` — RED gegen defekten Stand verifiziert
- sessions-server.bats 5/5 grün · test:spec:changed exit 0 · manifests.bats 50 ok · workspace:validate ✓

Closes T015167