### PR TITLE
chore: flux suspend docs T014541

### DIFF
--- a/docs/runbooks/flux-suspensions.md
+++ b/docs/runbooks/flux-suspensions.md
@@ -1,0 +1,34 @@
+# Flux- & CronJob-Suspensions — Registry bewusster Ausnahmen
+
+> **Zweck:** Das System-Audit (§1.1 flux-cluster, Checkliste in
+> `.agents/skills/system-audit/references/checklists.md`) meldet jede Ressource mit
+> `Suspended=True` als Warning — **außer** die Ausnahme ist bewusst dokumentiert.
+> Diese Datei ist der Dokumentations-Touchpoint dafür: Jede beabsichtigte Suspension
+> steht hier mit Grund, Beleg und Wiederprüf-Anlass. Eine Suspension ohne Zeile in
+> dieser Tabelle ist ein Audit-Befund (SA-FC-Familie).
+
+Stand: 2026-08-23 ([T014541])
+
+## Registry
+
+| Ressource | Namespace | Deklariert in | Suspended seit | Grund | Beleg | Reaktivieren bei |
+|---|---|---|---|---|---|---|
+| CronJob `knowledge-ingest-markdown` | `workspace`, `workspace-staging` | `k3d/knowledge-ingest-cronjob.yaml` (`suspend: true`) | 2026-08-09 | Markdown-Ingest läuft bewusst **lokal-only** (`task knowledge:reindex SOURCE=markdown`) — der Cluster hat kein Repo-Mount | [T002605] (Kommentar im Manifest) | nächstem Knowledge-Stack-Change |
+| CronJobs `systemtest-cleanup`, `systemtest-outbox`, `systemtest-purge-all` | `website-staging` | `k3d/cronjob-systemtest-cleanup.yaml` (`suspend: true`, seit [T014541]) | ~2026-06-26 (live), 2026-08-23 (git) | Staging-Systemtest-Pipeline ruht (LastSchedule 2026-06-26). Der ursprüngliche Live-Grund wurde nicht protokolliert — die Suspension geschah ungeplant per kubectl; mit [T014541] ins Manifest kodifiziert, um die stille Drift zu beenden | [T014541] | Reaktivierung der Systemtest-/Failure-Bridge-Pipeline |
+| Kustomizations `ks-korczewski`, `ks-jobs-korczewski`, `ks-website-korczewski`; OCIRepository `fleet-manifests-gitlab`; Deployment `ddns-updater` | `workspace-korczewski` u. a. | `flux/clusters/fleet/ks-*.yaml`, `flux/clusters/fleet/oci-source-gitlab.yaml`, `prod-korczewski/*` | 2026-08-23 (kodifiziert) | Bewusste **korczewski-Brand-Pause** | [T014537] | Reaktivierung der korczewski-Brand |
+
+## Regeln
+
+1. **Dokumentationspflicht:** Jede neue Suspension braucht sofort einen Eintrag in
+   dieser Tabelle (Grund + Ticket-Beleg). Der System-Audit-Sweep liest diese Datei
+   als Positivliste.
+2. **Keine stille Drift:** Lebt eine Suspension nur im Cluster (per `kubectl`/Flux-CLI
+   gesetzt, nicht im Git), ist sie zeitnah ins Manifest zu kodifizieren — sonst
+   überlebt sie den nächsten Reconcile nicht oder verschleiert den Zustand dauerhaft
+   (genau das passierte bei `systemtest-*`: 57 Tage live-only).
+3. **Aufheben nur mit Beleg:** Eine Suspension wird nur über ein Ticket aufgehoben;
+   dabei Zeile hier entfernen bzw. Datum aktualisieren.
+
+[T002605]: https://github.com/Paddione/Bachelorprojekt/tickets/T002605
+[T014537]: https://github.com/Paddione/Bachelorprojekt/tickets/T014537
+[T014541]: https://github.com/Paddione/Bachelorprojekt/tickets/T014541

--- a/k3d/cronjob-systemtest-cleanup.yaml
+++ b/k3d/cronjob-systemtest-cleanup.yaml
@@ -15,6 +15,10 @@
 # lives there, not in workspace). The kustomize top-level `namespace: workspace`
 # transformer would otherwise force these into the wrong ns, so this manifest is
 # applied separately by `task workspace:deploy` via envsubst (see Taskfile).
+#
+# [T014541] All three jobs are SUSPENDED on purpose (staging systemtest pipeline
+# dormant since ~2026-06-26). Registered exception — see
+# docs/runbooks/flux-suspensions.md before unsuspending.
 ---
 
 apiVersion: batch/v1
@@ -26,6 +30,8 @@ metadata:
     app: cronjobs
 spec:
   schedule: "0 * * * *"
+  # [T014541] Suspended on purpose — registry: docs/runbooks/flux-suspensions.md
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
@@ -82,6 +88,8 @@ metadata:
     app: cronjobs
 spec:
   schedule: "0 */6 * * *"
+  # [T014541] Suspended on purpose — registry: docs/runbooks/flux-suspensions.md
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
@@ -138,6 +146,8 @@ metadata:
     app: cronjobs
 spec:
   schedule: "*/5 * * * *"
+  # [T014541] Suspended on purpose — registry: docs/runbooks/flux-suspensions.md
+  suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3

--- a/k3d/knowledge-ingest-cronjob.yaml
+++ b/k3d/knowledge-ingest-cronjob.yaml
@@ -394,6 +394,7 @@ spec:
   schedule: "30 2 * * *"
   # [T002605] Suspended: Markdown-Ingest laeuft bewusst lokal-only —
   # task knowledge:reindex SOURCE=markdown (Repo-Mount noetig, Cluster hat keinen).
+  # [T014541] Registrierte Ausnahme: docs/runbooks/flux-suspensions.md
   suspend: true
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 1


### PR DESCRIPTION
## Was

Registriert die bewussten Flux-/CronJob-Suspensions als dokumentierte Ausnahmen (System-Audit SA-FC-05, Checkliste §1.1: `Suspended=True ⇒ Warning außer bewusst dokumentiert`).

- **Neu:** `docs/runbooks/flux-suspensions.md` — zentrale Registry (Ressource, Namespace, Deklarationsort, Grund, Beleg, Reaktivier-Anlass) für knowledge-ingest-markdown, website-staging systemtest-* und die korczewski-Pause-Familie.
- **Kodifiziert:** `suspend: true` + Verweis-Kommentare in `k3d/cronjob-systemtest-cleanup.yaml` — die drei systemtest-CronJobs waren seit ~2026-06-26 **live-only** suspendiert (57d Drift, kein Git-Feld); damit ist der Live-Zustand deklarativ.
- **Verweis:** Kommentar-Ergänzung am bestehenden T002605-Suspend in `k3d/knowledge-ingest-cronjob.yaml`.

Kein Verhaltenswechsel im Cluster — Live-State wird nur ins Git geholt (Klärungsrunde T014541: dokumentieren, nicht aufheben).

Closes [T014541]