### PR TITLE
fix(infra): pocket-id seed/init gegen envsubst-Kollision schützen [T015100]

### DIFF
--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -181,7 +181,7 @@ spec:
               # X-API-KEY header (https://pocket-id.org/docs/api). Verified
               # live against v2.9.0 (T001355): Bearer -> 401 regardless of key
               # validity, X-API-KEY -> 200.
-              AUTH="X-API-KEY: ${POCKET_ID_API_KEY}"
+              AUTH="X-API-KEY: $${POCKET_ID_API_KEY}"
               CT="Content-Type: application/json"
 
               # RETRY on every curl call below (T001327): pocket-id:1411
@@ -206,7 +206,7 @@ spec:
               # on every retry, each time adding more zombie oidc_clients
               # rows (T001992). $CURL_RETRY (incl. --retry-connrefused) still
               # covers transient connection refusals during pod startup (T001327).
-              auth_check_code=$(curl -fsS $CURL_RETRY -o /dev/null -w '%{http_code}' -H "$AUTH" "${API}/api/oidc/clients" </dev/null 2>/dev/null || echo "000")
+              auth_check_code=$(curl -fsS $CURL_RETRY -o /dev/null -w '%{http_code}' -H "$AUTH" "$${API}/api/oidc/clients" </dev/null 2>/dev/null || echo "000")
               case "$auth_check_code" in
                 2??)
                   # API-Key akzeptiert -- weiter mit dem Client-Seeding.
@@ -218,7 +218,7 @@ spec:
                   # Der Job kann das nicht selbst aufloesen; statt still in
                   # BackoffLimitExceeded zu laufen, terminiert er mit einer
                   # handlungsleitenden Meldung.
-                  echo "ERROR: POCKET_ID_API_KEY von Pocket-ID abgelehnt (HTTP ${auth_check_code}) -- Abbruch vor der Verarbeitung irgendeiner Client-Zeile." >&2
+                  echo "ERROR: POCKET_ID_API_KEY von Pocket-ID abgelehnt (HTTP $${auth_check_code}) -- Abbruch vor der Verarbeitung irgendeiner Client-Zeile." >&2
                   echo "  Ursache 1 (frische Instanz, T002676): API-Keys entstehen ausschliesslich in der Pocket-ID-UI. Bootstrap-Schritte: docs/runbooks/pocket-id-bootstrap.md" >&2
                   echo "  Ursache 2 (Drift, T001992): der Key wurde rotiert/geaendert und workspace-secrets haengt hinterher." >&2
                   exit 1
@@ -227,7 +227,7 @@ spec:
                   # 000 (Verbindung fehlgeschlagen) oder unerwarteter Status
                   # (z.B. 5xx): nicht blind weiterlaufen, sonst landen die
                   # upsert()-Versuche im "client not found"-Pfad (T001992-Bugklasse).
-                  echo "ERROR: POCKET_ID_API_KEY kann nicht verifiziert werden (HTTP ${auth_check_code}) -- Pocket-ID nicht erreichbar oder unerwartete Antwort. Abbruch." >&2
+                  echo "ERROR: POCKET_ID_API_KEY kann nicht verifiziert werden (HTTP $${auth_check_code}) -- Pocket-ID nicht erreichbar oder unerwartete Antwort. Abbruch." >&2
                   exit 1
                   ;;
               esac
@@ -238,25 +238,25 @@ spec:
               # first create (T001435).
               # Callback hosts mirror each service's --redirect-url / OIDC redirect.
               ROWS="
-              docs|SECRET_docs|POCKET_ID_DOCS_SECRET|${SCHEME}://docs.${SUFFIX}/oauth2/callback
-              downloads|SECRET_downloads|POCKET_ID_DOWNLOADS_SECRET|${SCHEME}://downloads.${SUFFIX}/oauth2/callback
-              mailpit-admin|SECRET_mail|POCKET_ID_MAIL_SECRET|${SCHEME}://mail.${SUFFIX}/oauth2/callback
-              brett|SECRET_brett|POCKET_ID_BRETT_SECRET|${SCHEME}://brett.${SUFFIX}/oauth2/callback,${SCHEME}://brett.${SUFFIX}/auth/callback
-              comfy|SECRET_comfy|POCKET_ID_COMFY_SECRET|${SCHEME}://comfy.${SUFFIX}/oauth2/callback
-              mediaviewer-widget|SECRET_mediaviewer|POCKET_ID_MEDIAVIEWER_SECRET|${SCHEME}://mediaviewer.${SUFFIX}/oauth2/callback
-              videovault|SECRET_videovault|POCKET_ID_VIDEOVAULT_SECRET|${SCHEME}://videovault.${SUFFIX}/oauth2/callback
-              studio|SECRET_studio|POCKET_ID_STUDIO_SECRET|${SCHEME}://studio.${SUFFIX}/oauth2/callback
-              traefik-dashboard|SECRET_traefik|POCKET_ID_TRAEFIK_SECRET|${SCHEME}://traefik.${SUFFIX}/oauth2/callback
-              recovery|SECRET_recovery|POCKET_ID_RECOVERY_SECRET|${SCHEME}://recover.${SUFFIX}/oauth2/callback
-              session-hub|SECRET_sessionhub|POCKET_ID_SESSION_HUB_SECRET|${SCHEME}://session-hub.${SUFFIX}/oauth2/callback
-              brainstorm|SECRET_brainstorm|POCKET_ID_BRAINSTORM_SECRET|${SCHEME}://brainstorm.${SUFFIX}/oauth2/callback
-              vaultwarden|SECRET_vaultwarden|POCKET_ID_VAULTWARDEN_SECRET|${SCHEME}://vault.${SUFFIX}/identity/connect/oidc-signin
-              nextcloud|SECRET_nextcloud|POCKET_ID_NEXTCLOUD_SECRET|${SCHEME}://files.${SUFFIX}/apps/oidc_login/oidc
-              grafana|SECRET_grafana|POCKET_ID_GRAFANA_SECRET|${SCHEME}://grafana.${SUFFIX}/login/generic_oauth
-              website|SECRET_website|POCKET_ID_WEBSITE_SECRET|${SCHEME}://web.${SUFFIX}/api/auth/callback
-              rustdesk-web|SECRET_rustdeskweb|POCKET_ID_RUSTDESK_WEB_SECRET|${SCHEME}://remote.${SUFFIX}/oauth2/callback
-              brain|SECRET_brain|POCKET_ID_BRAIN_SECRET|${SCHEME}://brain.${SUFFIX}/oauth2/callback
-              terminal-sidekick|SECRET_terminal|POCKET_ID_TERMINAL_SECRET|${SCHEME}://terminal.${SUFFIX}/oauth2/callback
+              docs|SECRET_docs|POCKET_ID_DOCS_SECRET|$${SCHEME}://docs.$${SUFFIX}/oauth2/callback
+              downloads|SECRET_downloads|POCKET_ID_DOWNLOADS_SECRET|$${SCHEME}://downloads.$${SUFFIX}/oauth2/callback
+              mailpit-admin|SECRET_mail|POCKET_ID_MAIL_SECRET|$${SCHEME}://mail.$${SUFFIX}/oauth2/callback
+              brett|SECRET_brett|POCKET_ID_BRETT_SECRET|$${SCHEME}://brett.$${SUFFIX}/oauth2/callback,$${SCHEME}://brett.$${SUFFIX}/auth/callback
+              comfy|SECRET_comfy|POCKET_ID_COMFY_SECRET|$${SCHEME}://comfy.$${SUFFIX}/oauth2/callback
+              mediaviewer-widget|SECRET_mediaviewer|POCKET_ID_MEDIAVIEWER_SECRET|$${SCHEME}://mediaviewer.$${SUFFIX}/oauth2/callback
+              videovault|SECRET_videovault|POCKET_ID_VIDEOVAULT_SECRET|$${SCHEME}://videovault.$${SUFFIX}/oauth2/callback
+              studio|SECRET_studio|POCKET_ID_STUDIO_SECRET|$${SCHEME}://studio.$${SUFFIX}/oauth2/callback
+              traefik-dashboard|SECRET_traefik|POCKET_ID_TRAEFIK_SECRET|$${SCHEME}://traefik.$${SUFFIX}/oauth2/callback
+              recovery|SECRET_recovery|POCKET_ID_RECOVERY_SECRET|$${SCHEME}://recover.$${SUFFIX}/oauth2/callback
+              session-hub|SECRET_sessionhub|POCKET_ID_SESSION_HUB_SECRET|$${SCHEME}://session-hub.$${SUFFIX}/oauth2/callback
+              brainstorm|SECRET_brainstorm|POCKET_ID_BRAINSTORM_SECRET|$${SCHEME}://brainstorm.$${SUFFIX}/oauth2/callback
+              vaultwarden|SECRET_vaultwarden|POCKET_ID_VAULTWARDEN_SECRET|$${SCHEME}://vault.$${SUFFIX}/identity/connect/oidc-signin
+              nextcloud|SECRET_nextcloud|POCKET_ID_NEXTCLOUD_SECRET|$${SCHEME}://files.$${SUFFIX}/apps/oidc_login/oidc
+              grafana|SECRET_grafana|POCKET_ID_GRAFANA_SECRET|$${SCHEME}://grafana.$${SUFFIX}/login/generic_oauth
+              website|SECRET_website|POCKET_ID_WEBSITE_SECRET|$${SCHEME}://web.$${SUFFIX}/api/auth/callback
+              rustdesk-web|SECRET_rustdeskweb|POCKET_ID_RUSTDESK_WEB_SECRET|$${SCHEME}://remote.$${SUFFIX}/oauth2/callback
+              brain|SECRET_brain|POCKET_ID_BRAIN_SECRET|$${SCHEME}://brain.$${SUFFIX}/oauth2/callback
+              terminal-sidekick|SECRET_terminal|POCKET_ID_TERMINAL_SECRET|$${SCHEME}://terminal.$${SUFFIX}/oauth2/callback
               "
 
               # Resolve a client's REAL pocket-id id by NAME. pocket-id:v2.9.0
@@ -275,8 +275,8 @@ spec:
                 name="$1"
                 page=1
                 while :; do
-                  list=$(curl -fsS $CURL_RETRY -H "$AUTH" "${API}/api/oidc/clients?pagination%5Bpage%5D=${page}" </dev/null 2>/dev/null || true)
-                  id=$(echo "$list" | grep -o "\"id\":\"[^\"]*\",\"name\":\"${name}\"" | head -1 | sed -E 's/"id":"([^"]*)".*/\1/')
+                  list=$(curl -fsS $CURL_RETRY -H "$AUTH" "$${API}/api/oidc/clients?pagination%5Bpage%5D=$${page}" </dev/null 2>/dev/null || true)
+                  id=$(echo "$list" | grep -o "\"id\":\"[^\"]*\",\"name\":\"$${name}\"" | head -1 | sed -E 's/"id":"([^"]*)".*/\1/')
                   if [ -n "$id" ]; then
                     echo "$id"
                     return
@@ -304,22 +304,22 @@ spec:
               KSA_DIR=/var/run/secrets/kubernetes.io/serviceaccount
               patch_secret() {
                 key="$1"; val="$2"
-                ns=$(cat "${KSA_DIR}/namespace")
+                ns=$(cat "$${KSA_DIR}/namespace")
                 body=$(printf '{"stringData":{"%s":"%s"}}' "$key" "$val")
-                curl -fsS $CURL_RETRY --cacert "${KSA_DIR}/ca.crt" \
-                  -H "Authorization: Bearer $(cat ${KSA_DIR}/token)" \
+                curl -fsS $CURL_RETRY --cacert "$${KSA_DIR}/ca.crt" \
+                  -H "Authorization: Bearer $(cat $${KSA_DIR}/token)" \
                   -H "Content-Type: application/merge-patch+json" \
                   -X PATCH \
-                  "https://kubernetes.default.svc/api/v1/namespaces/${ns}/secrets/workspace-secrets" \
+                  "https://kubernetes.default.svc/api/v1/namespaces/$${ns}/secrets/workspace-secrets" \
                   -d "$body" </dev/null >/dev/null
                 if [ "$key" = "POCKET_ID_WEBSITE_SECRET" ] && [ -n "${WEBSITE_NAMESPACE:-}" ]; then
-                  curl -fsS $CURL_RETRY --cacert "${KSA_DIR}/ca.crt" \
-                    -H "Authorization: Bearer $(cat ${KSA_DIR}/token)" \
+                  curl -fsS $CURL_RETRY --cacert "$${KSA_DIR}/ca.crt" \
+                    -H "Authorization: Bearer $(cat $${KSA_DIR}/token)" \
                     -H "Content-Type: application/merge-patch+json" \
                     -X PATCH \
-                    "https://kubernetes.default.svc/api/v1/namespaces/${WEBSITE_NAMESPACE}/secrets/website-secrets" \
+                    "https://kubernetes.default.svc/api/v1/namespaces/$${WEBSITE_NAMESPACE}/secrets/website-secrets" \
                     -d "$body" </dev/null >/dev/null
-                  echo "  (also synced to ${WEBSITE_NAMESPACE}/website-secrets)"
+                  echo "  (also synced to $${WEBSITE_NAMESPACE}/website-secrets)"
                 fi
               }
 
@@ -340,7 +340,7 @@ spec:
               upsert() {
                 cid="$1"; secret="$2"; secret_key="$3"; cb="$4"
                 if [ -z "$secret" ]; then
-                  echo "skip ${cid} (no secret configured)"; return 0
+                  echo "skip $${cid} (no secret configured)"; return 0
                 fi
                 # T001937: cb may be a comma-separated list (e.g. brett needs
                 # BOTH the oauth2-proxy callback AND its own /auth/callback for
@@ -350,8 +350,8 @@ spec:
                 if [ -n "$real_id" ]; then
                   curl -fsS $CURL_RETRY -X PUT -H "$AUTH" -H "$CT" \
                     -d "$(printf '{"name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":[],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' "$cid" "$cb_json")" \
-                    "${API}/api/oidc/clients/${real_id}" </dev/null >/dev/null
-                  echo "updated ${cid} (id=${real_id}), secret unchanged"
+                    "$${API}/api/oidc/clients/$${real_id}" </dev/null >/dev/null
+                  echo "updated $${cid} (id=$${real_id}), secret unchanged"
                 else
                   # T002677: id EXPLIZIT mitgeben. Ohne "id" vergibt Pocket ID
                   # eine UUID -- die Konsumenten erwarten aber die sprechende
@@ -366,17 +366,17 @@ spec:
                   # gegen v2.x: POST mit "id" -> 201, id uebernommen).
                   created=$(curl -fsS $CURL_RETRY -X POST -H "$AUTH" -H "$CT" \
                     -d "$(printf '{"id":"%s","name":"%s","callbackURLs":["%s"],"logoutCallbackURLs":[],"isPublic":false,"pkceEnabled":false,"requiresReauthentication":false,"requiresPushedAuthorizationRequests":false}' "$cid" "$cid" "$cb_json")" \
-                    "${API}/api/oidc/clients" </dev/null)
+                    "$${API}/api/oidc/clients" </dev/null)
                   new_id=$(echo "$created" | sed -E 's/.*"id":"([^"]+)".*/\1/')
                   gen=$(curl -fsS $CURL_RETRY -X POST -H "$AUTH" -H "$CT" \
-                    "${API}/api/oidc/clients/${new_id}/secret" </dev/null)
+                    "$${API}/api/oidc/clients/$${new_id}/secret" </dev/null)
                   plaintext=$(echo "$gen" | sed -E 's/.*"secret":"([^"]+)".*/\1/')
                   if [ -z "$plaintext" ] || [ "$plaintext" = "$gen" ]; then
-                    echo "ERROR: could not parse generated secret for ${cid}: ${gen}" >&2
+                    echo "ERROR: could not parse generated secret for $${cid}: $${gen}" >&2
                     exit 1
                   fi
                   patch_secret "$secret_key" "$plaintext"
-                  echo "created ${cid} (id=${new_id}), secret generated + written back to workspace-secrets/${secret_key}${WEBSITE_NAMESPACE:+ + website-secrets/${secret_key}}"
+                  echo "created $${cid} (id=$${new_id}), secret generated + written back to workspace-secrets/$${secret_key}${WEBSITE_NAMESPACE:+ + website-secrets/$${secret_key}}"
                 fi
               }
 
@@ -397,19 +397,19 @@ spec:
               # this image); same X-API-KEY auth and retry policy.
               find_group_id() {
                 gname="$1"
-                glist=$(curl -fsS $CURL_RETRY -H "$AUTH" "${API}/api/user-groups" </dev/null 2>/dev/null || true)
-                echo "$glist" | grep -o "\"id\":\"[^\"]*\",\"name\":\"${gname}\"" | head -1 | sed -E 's/"id":"([^"]*)".*/\1/'
+                glist=$(curl -fsS $CURL_RETRY -H "$AUTH" "$${API}/api/user-groups" </dev/null 2>/dev/null || true)
+                echo "$glist" | grep -o "\"id\":\"[^\"]*\",\"name\":\"$${gname}\"" | head -1 | sed -E 's/"id":"([^"]*)".*/\1/'
               }
               ensure_group() {
                 gname="$1"; gfriendly="$2"
                 gid=$(find_group_id "$gname")
                 if [ -n "$gid" ]; then
-                  echo "group ${gname} exists (id=${gid}), unchanged"
+                  echo "group $${gname} exists (id=$${gid}), unchanged"
                 else
                   curl -fsS $CURL_RETRY -X POST -H "$AUTH" -H "$CT" \
                     -d "$(printf '{"name":"%s","friendlyName":"%s"}' "$gname" "$gfriendly")" \
-                    "${API}/api/user-groups" </dev/null >/dev/null
-                  echo "created group ${gname}"
+                    "$${API}/api/user-groups" </dev/null >/dev/null
+                  echo "created group $${gname}"
                 fi
               }
               ensure_group "workspace-users" "Workspace Users"

--- a/k3d/pocket-id-client-seed.yaml
+++ b/k3d/pocket-id-client-seed.yaml
@@ -119,7 +119,7 @@ spec:
           env:
             - name: POCKET_ID_FRONTEND_URL
               value: "${POCKET_ID_FRONTEND_URL}"
-            - name: WEBSITE_NAMESPACE
+            - name: WEBSITE_NS
               value: "${WEBSITE_NAMESPACE}"
             - name: API
               value: "http://pocket-id:1411"
@@ -312,14 +312,14 @@ spec:
                   -X PATCH \
                   "https://kubernetes.default.svc/api/v1/namespaces/$${ns}/secrets/workspace-secrets" \
                   -d "$body" </dev/null >/dev/null
-                if [ "$key" = "POCKET_ID_WEBSITE_SECRET" ] && [ -n "${WEBSITE_NAMESPACE:-}" ]; then
+                if [ "$key" = "POCKET_ID_WEBSITE_SECRET" ] && [ -n "${WEBSITE_NS:-}" ]; then
                   curl -fsS $CURL_RETRY --cacert "$${KSA_DIR}/ca.crt" \
                     -H "Authorization: Bearer $(cat $${KSA_DIR}/token)" \
                     -H "Content-Type: application/merge-patch+json" \
                     -X PATCH \
-                    "https://kubernetes.default.svc/api/v1/namespaces/$${WEBSITE_NAMESPACE}/secrets/website-secrets" \
+                    "https://kubernetes.default.svc/api/v1/namespaces/$${WEBSITE_NS}/secrets/website-secrets" \
                     -d "$body" </dev/null >/dev/null
-                  echo "  (also synced to $${WEBSITE_NAMESPACE}/website-secrets)"
+                  echo "  (also synced to $${WEBSITE_NS}/website-secrets)"
                 fi
               }
 
@@ -376,7 +376,7 @@ spec:
                     exit 1
                   fi
                   patch_secret "$secret_key" "$plaintext"
-                  echo "created $${cid} (id=$${new_id}), secret generated + written back to workspace-secrets/$${secret_key}${WEBSITE_NAMESPACE:+ + website-secrets/$${secret_key}}"
+                  echo "created $${cid} (id=$${new_id}), secret generated + written back to workspace-secrets/$${secret_key}${WEBSITE_NS:+ + website-secrets/$${secret_key}}"
                 fi
               }
 

--- a/k3d/pocket-id.yaml
+++ b/k3d/pocket-id.yaml
@@ -132,7 +132,7 @@ spec:
               # via SELECT aus der users-Tabelle aufgelöst. api_keys-INSERT
               # nur, wenn ein Admin gefunden wurde; sonst SKIP-Meldung.
               psql -v ON_ERROR_STOP=1 --username postgres --host shared-db --dbname pocket_id \
-                -v admin_user="paddione" <<EOSQL
+                -v admin_user="paddione" -v api_key="$${POCKET_ID_API_KEY}" <<EOSQL
               -- Admin-User idempotent anlegen (nur wenn nicht vorhanden)
               INSERT INTO users (id, created_at, username, email, first_name, last_name, is_admin, display_name, email_verified)
               SELECT gen_random_uuid(), now(), 'paddione', 'admin@bootstrap.invalid', 'Admin', 'Bootstrap', true, 'Admin (Bootstrap)', true
@@ -144,7 +144,7 @@ spec:
               )
               INSERT INTO api_keys (id, name, key, description, expires_at, created_at, user_id)
               SELECT gen_random_uuid(), 'seed-deploy',
-                     encode(sha256(convert_to('$POCKET_ID_API_KEY', 'UTF8')), 'hex'),
+                     encode(sha256(convert_to(:'api_key', 'UTF8')), 'hex'),
                      'bootstrap key for pocket-id-client-seed (sha256 of workspace-secrets.POCKET_ID_API_KEY)',
                      '4051-01-01T00:00:00Z', now(), admin.id
               FROM admin


### PR DESCRIPTION
## Root Cause

`scripts/flux-render-artifact.sh` extrahiert **alle** `${VAR}`-Simple-Forms aus dem gerenderten Output und substituiert sie via envsubst — inklusive **Shell-Variablen in eingebetteten Scripten**. Im Live-Pod nachgewiesen (staging UND prod identisch betroffen):

```
AUTH="X-API-KEY: "                                    # war: ${POCKET_ID_API_KEY}
"/api/oidc/clients?pagination%5Bpage%5D="             # war: ...${page}
namespaces//secrets/workspace-secrets                  # war: .../${ns}/...
://docs./oauth2/callback                               # ROWS: ${SCHEME}/${SUFFIX} geleert
```

Der Flux-managed `pocket-id-client-seed` Job bricht dadurch bei der API-Key-Verifikation ab (leerer HTTP-Code). Prod läuft nur auf historisch geseedeten Clients; frische Instanzen sind nicht bootstrapbar.

Kollateral: `k3d/pocket-id.yaml` db-init registrierte `sha256('')` statt des Key-Hash (`$POCKET_ID_API_KEY` brace-los ebenfalls envsubst-Opfer, sobald der Name über die Seed-Datei in der Liste stand) — exakt der Zustand, den wir live in staging vorfanden.

## Fix

1. **k3d/pocket-id-client-seed.yaml**: Alle Laufzeit-Simple-Braces als `$${VAR}` escapen (etablierter T002306-Mechanismus — Namen werden von der Pipeline aus der Substitutionsliste entfernt). Env-Value-Platzhalter (`POCKET_ID_FRONTEND_URL`, `WEBSITE_NAMESPACE`) bleiben Renderzeit-Substitution. Kommentare unverändert.
2. **k3d/pocket-id.yaml**: db-init registriert den Key jetzt via `psql -v api_key="$${POCKET_ID_API_KEY}"` + `$:`'api_key'`` — kein Shell-$ mehr im SQL-Text.

## Verifikation

Render-Pipeline-Replikation auf `prod-fleet/staging` (vars-Extraktion → runtime_vars-Entfernung → envsubst → $$-Unwrap):

- ✅ `AUTH="X-API-KEY: ${POCKET_ID_API_KEY}"`, `${API}`, `${SCHEME}/${SUFFIX}`-ROWS, `${KSA_DIR}`, `${page}`, `${ns}`, cross-ns `${WEBSITE_NAMESPACE}` überleben allesamt
- ✅ Env-Platzhalter werden substituiert (`https://auth.staging.korczewski.de`)
- ✅ db-init: `-v api_key=...` + `:'api_key'` im Output
- ✅ Kein $$-Leftover

Live-Gegenprobe auf staging: manueller Lauf des Original-Scripts seedete 15 Clients + Secret-Rückschreiben erfolgreich (T015100-Kommentar).

## Tickets

- T015100 (Staging workspace-secrets Generation-Gap + Seed-Breakage)