### PR TITLE
fix(factory): post-merge closure verifiziert Ticket-Identitaet per UUID-Ankern [T015010]

### DIFF
--- a/components/website/src/data/test-inventory.json
+++ b/components/website/src/data/test-inventory.json
@@ -5184,6 +5184,12 @@
     "kind": "shell"
   },
   {
+    "id": "software-factory/auto-close-uuid-guard",
+    "file": "tests/spec/software-factory/auto-close-uuid-guard.bats",
+    "category": "software-factory",
+    "kind": "shell"
+  },
+  {
     "id": "software-factory/auto-triage-type-vocab",
     "file": "tests/spec/software-factory/auto-triage-type-vocab.bats",
     "category": "software-factory",

--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1191,
+      "file_count": 1192,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -927,6 +927,7 @@
         "tests/spec/sidekick-assistant.bats",
         "tests/spec/software-factory/_sf_common.bash",
         "tests/spec/software-factory/agent-lock-scope-argument.bats",
+        "tests/spec/software-factory/auto-close-uuid-guard.bats",
         "tests/spec/software-factory/auto-triage-type-vocab.bats",
         "tests/spec/software-factory/babysit-prs-ci-never-ran.bats",
         "tests/spec/software-factory/babysit-prs-conflict-guard-T012500.bats",

--- a/scripts/factory/auto-close-merged.sh
+++ b/scripts/factory/auto-close-merged.sh
@@ -4,6 +4,15 @@
 # not yet advanced to done. Closes the auto-close gap observed in T001415
 # (T001371, T001412, T414 all merged without their tickets transitioning).
 #
+# [T015010] Identity-Guard: Der Titel-Tag wird NICHT blind per external_id
+# geschlossen. Vor dem Closure-Schreibzugriff prüft eine gemeinsame Query,
+# ob Pre-Merge-Anker (ticket_links kind='pr' für die PR-Nummer,
+# ticket_plans für Branch/PR) auf dieselbe Ticket-UUID zeigen. Existieren
+# Anker und keiner passt zur gefundenen Zeile, liegt ein ID-Reuse vor
+# (Vorfall T014936 / Incident T015005: gelöschte external_id wurde neu
+# herausgegeben, die Automation schloss das FALSCHE Ticket) — dann wird
+# laut geskippt statt falsch zu schließen.
+#
 # USAGE: BRAND=<brand> bash scripts/factory/auto-close-merged.sh [--dry-run]
 #
 # ENV:
@@ -37,6 +46,22 @@ extract_ticket_ids_from_title() {
   fi
 }
 
+# identity_guard_blocks <anchor_count> <anchor_match> — [T015010] reine
+# Entscheidungsfunktion (ohne DB-Zugriff, von den Bats-Tests sourcbar).
+#   anchor_count — Anzahl gefundener Pre-Merge-Anker (ticket_links/ticket_plans)
+#   anchor_match — 't' wenn mindestens ein Anker auf die Kandidaten-UUID zeigt,
+#                  sonst 'f' (psql-Boolean-Darstellung)
+# Rückkehr 0 = blockieren (Anker existieren, aber keiner passt → ID-Reuse-
+# Verdacht, Closure skippen). Rückkehr 1 = weitermachen: entweder keine Anker
+# vorhanden (Legacy-Pfad, z.B. manuelle Chores ohne Plan/Link) oder mindestens
+# ein Anker bestätigt die Identität. Ein LEERER anchor_count (unparseierbare
+# Query-Antwort) blockiert ebenfalls — fail-closed [T015010].
+identity_guard_blocks() {
+  local anchor_count="${1-}" anchor_match="${2:-f}"
+  if [[ -z "$anchor_count" ]]; then return 0; fi
+  [[ "$anchor_count" != "0" && "$anchor_match" != "t" ]]
+}
+
 # Direct execution only; sourcing this file (tests) must not run the poller.
 main() {
 DRY_RUN=false
@@ -46,6 +71,7 @@ while [[ $# -gt 0 ]]; do case "$1" in
     echo "Usage: BRAND=<brand> bash $(basename "${BASH_SOURCE[0]}") [--dry-run]"
     echo "  auto-close-merged: merged PRs with [T-NNNNNN] → ticket.sh update-status done"
     # T001580: Skips plan-only/archive branches to avoid premature closure
+    echo "  [T015010] Identity-Guard: Closure nur bei UUID-Konsens mit Pre-Merge-Ankern (PR-Link/Plan)"
     exit 0 ;;
   *) echo "Unknown option: $1" >&2; exit 2 ;;
 esac; done
@@ -162,18 +188,51 @@ echo "$PRS" | while IFS=$'\t' read -r pr_num title branch; do
   # DB-/Cluster-Ausfaelle: unter `set -euo pipefail` wuerde ein fehlgeschlagener
   # Lookup den gesamten Batch-Lauf abbrechen und die restlichen Kinder (und PRs)
   # offen lassen. Leere row → "existiert nicht"-Skip, wie bei unbekannten IDs.
+  #
+  # [T015010] Identity-Guard: Kandidaten-Zeile und Pre-Merge-Anker werden in
+  # EINER Query aufgeloest. Anker sind (a) ticket_links-Zeilen kind='pr' zur
+  # PR-Nummer (from_id = Ticket-UUID, self-linked) und (b) ticket_plans-Zeilen
+  # zum PR-Branch bzw. zur PR-Nummer (ticket_id = Ticket-UUID). Beide Anker
+  # entstehen VOR dem Merge und ueberleben Loesch/Reuse der external_id.
+  # anchor_count = Anzahl Anker, anchor_match = 't', wenn mindestens ein Anker
+  # auf die UUID der Kandidaten-Zeile zeigt.
   row=$(cat <<SQL | factory_psql 2>/dev/null || true
-SELECT status, type, title FROM tickets.tickets WHERE external_id = '$ticket' LIMIT 1;
+WITH cand AS (
+  SELECT id, status, type, title FROM tickets.tickets WHERE external_id = '$ticket' LIMIT 1
+), anchors AS (
+  SELECT from_id AS ticket_uuid FROM tickets.ticket_links
+    WHERE kind = 'pr' AND pr_number = $pr_num
+  UNION
+  SELECT p.ticket_id FROM tickets.ticket_plans p
+    WHERE p.branch = '$branch' OR p.pr_number = $pr_num
+)
+SELECT c.status, c.type, c.title,
+       (SELECT count(*) FROM anchors)::text AS anchor_count,
+       EXISTS (SELECT 1 FROM anchors a WHERE a.ticket_uuid = c.id)::text AS anchor_match
+FROM cand c LIMIT 1;
 SQL
 )
   [[ -z "$row" ]] && { echo "auto-close-merged: $ticket (PR #$pr_num) existiert nicht in ${BRAND} — skip [T001580]" >&2; continue; }
   status=$(printf '%s' "$row" | awk -F'|' '{print $1}' | tr -d ' ')
   ttype=$(printf '%s' "$row" | awk -F'|' '{print $2}' | tr -d ' ')
   title=$(printf '%s' "$row" | awk -F'|' '{print $3}' | tr -d ' ')
+  anchor_count=$(printf '%s' "$row" | awk -F'|' '{print $4}' | tr -d ' ')
+  anchor_match=$(printf '%s' "$row" | awk -F'|' '{print $5}' | tr -d ' ')
 
   case "$status" in
     done|archived) echo "auto-close-merged: $ticket (PR #$pr_num) bereits $status — skip [T001580]" >&2; continue ;;
   esac
+
+  # [T015010] Identity-Guard: Anker existieren, aber keiner zeigt auf diese
+  # Ticket-UUID → die external_id wurde seit dem Merge-Tag neu herausgegeben
+  # (ID-Reuse, Vorfall T014936). Das hier gefundene Ticket ist NICHT das
+  # gemeinte — laut skippen statt es falsch zu schließen. Bewusst NACH dem
+  # Terminal-Status-Check: bei done/archived findet kein Schreibzugriff statt,
+  # dort wäre die Guard-Meldung nur Lärm.
+  if identity_guard_blocks "$anchor_count" "$anchor_match"; then
+    echo "auto-close-merged [T015010]: $ticket (PR #$pr_num) NICHT geschlossen — Identity-Guard: Pre-Merge-Anker (PR-Link/Plan) zeigen auf ein anderes Ticket (ID-Reuse-Verdacht, Incident T015005). Manuell pruefen." >&2
+    continue
+  fi
 
   resolution="shipped"
   # Dual-Vokabular [T002329]: 'bug' bleibt gueltig, bis Teil D (T002331) es aus dem

--- a/tests/spec/software-factory/auto-close-uuid-guard.bats
+++ b/tests/spec/software-factory/auto-close-uuid-guard.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# tests/spec/software-factory/auto-close-uuid-guard.bats — T015010
+#
+# Die Post-Merge-Closure (scripts/factory/auto-close-merged.sh) loeste den
+# [T-NNNNNN]-Tag im PR-Titel blind per external_id auf. Nach dem Loesch-/
+# Reuse-Vorfall T014936 (Incident T015005) schloss sie dadurch das FALSCHE
+# (neu herausgegebene) Ticket. Diese Tests sichern den Identity-Guard:
+# Pre-Merge-Anker (ticket_links kind='pr', ticket_plans branch/pr_number)
+# muessen die UUID der Kandidaten-Zeile bestaetigen, sonst wird geskippt.
+
+load '_sf_common'
+
+setup() {
+  _sf_setup
+  SCRIPT="$REPO_ROOT/scripts/factory/auto-close-merged.sh"
+}
+
+@test "T015010: Closure-Lookup joint Pre-Merge-Anker (ticket_links kind='pr' + ticket_plans)" {
+  [ -f "$SCRIPT" ]
+  grep -q "tickets.ticket_links" "$SCRIPT"
+  grep -q "kind = 'pr' AND pr_number" "$SCRIPT"
+  grep -q "tickets.ticket_plans" "$SCRIPT"
+  grep -q "p.branch = '\$branch' OR p.pr_number" "$SCRIPT"
+}
+
+@test "T015010: Anker werden per UUID gegen die Kandidaten-Zeile geprueft (nicht per external_id)" {
+  [ -f "$SCRIPT" ]
+  # Der EXISTS-Vergleich läuft über die Ticket-UUID (c.id), nicht die external_id
+  grep -q "a.ticket_uuid = c.id" "$SCRIPT"
+}
+
+@test "T015010: Identity-Guard blockiert bei Anker-Mismatch (reine Entscheidungsfunktion)" {
+  run bash -c 'source "'"$SCRIPT"'"; identity_guard_blocks 2 f'
+  [ "$status" -eq 0 ]  # blockieren
+  run bash -c 'source "'"$SCRIPT"'"; identity_guard_blocks 1 f'
+  [ "$status" -eq 0 ]  # blockieren
+  run bash -c 'source "'"$SCRIPT"'"; identity_guard_blocks "" f'
+  [ "$status" -eq 0 ]  # blockieren (leerer Count ist nicht "keine Anker geprueft")
+}
+
+@test "T015010: Identity-Guard erlaubt Closure bei UUID-Konsens oder fehlenden Ankern" {
+  run bash -c 'source "'"$SCRIPT"'"; identity_guard_blocks 3 t'
+  [ "$status" -eq 1 ]  # Anker bestaetigt → weiter
+  run bash -c 'source "'"$SCRIPT"'"; identity_guard_blocks 0 f'
+  [ "$status" -eq 1 ]  # keine Anker (Legacy-Pfad, z.B. manueller Chore) → weiter
+}
+
+@test "T015010: Guard sitzt VOR dem Closure-Schreibzugriff (update-status)" {
+  [ -f "$SCRIPT" ]
+  local guard_line close_line
+  guard_line=$(grep -n 'identity_guard_blocks "\$anchor_count"' "$SCRIPT" | head -1 | cut -d: -f1)
+  close_line=$(grep -n 'update-status.*--status.*done' "$SCRIPT" | head -1 | cut -d: -f1)
+  [ -n "$guard_line" ] || { echo "FAIL: Identity-Guard-Aufruf fehlt"; false; }
+  [ -n "$close_line" ] || { echo "FAIL: update-status-Aufruf fehlt"; false; }
+  [ "$guard_line" -lt "$close_line" ] || { echo "FAIL: Guard muss VOR dem Closure-Schreibzugriff liegen"; false; }
+}
+
+@test "T015010: Mismatch-Skip meldet ID-Reuse-Verdacht mit Incident-Referenz" {
+  [ -f "$SCRIPT" ]
+  grep -q 'NICHT geschlossen — Identity-Guard' "$SCRIPT"
+  grep -q 'T015005' "$SCRIPT"
+}


### PR DESCRIPTION
## Summary
Fix für **T015010** (Follow-up (b) aus Incident T015005 / Vorfall T014936): Die Post-Merge-Closure in `scripts/factory/auto-close-merged.sh` löste den `[T-NNNNNN]`-Tag im PR-Titel blind per `external_id` auf. Nach einem ID-Reuse (gelöschte external_id wird von der Sequenz neu herausgegeben) schloss die Automation das **falsche** Ticket.

**Fix — Identity-Guard:**
- Kandidaten-Zeile und Pre-Merge-Anker werden in **einer** read-only Query aufgelöst: `ticket_links kind='pr'` (from_id = Ticket-UUID) zur PR-Nummer sowie `ticket_plans` (ticket_id) zu Branch/PR-Nummer
- Existieren Anker und keiner zeigt auf die UUID der Kandidaten-Zeile → **lauter Skip** mit Incident-Referenz statt Falsch-Closure
- Keine Anker (z.B. manueller Chore ohne Plan/Link) → Legacy-Verhalten unverändert
- Guard läuft bewusst **nach** dem Terminal-Status-Check (done/archived skippt ohnehin ohne Schreibzugriff — dort wäre die Meldung nur Lärm)
- Entscheidung als reine Funktion `identity_guard_blocks` (fail-closed bei unparseierbarem Anker-Count), von den Bats-Tests sourcbar

Ref: T015010

## Test Plan
- [x] Neu: `tests/spec/software-factory/auto-close-uuid-guard.bats` — 6/6 grün (Anker-Join, UUID-Vergleich, Block/Pass-Entscheidungen, Guard vor Schreibzugriff, Incident-Referenz)
- [x] Bestand: ticket-lifecycle.bats + wakeup-auto-close-timeout.bats + t001415-mishap-bundle.bats — 0 Failures
- [x] Live-Smoke: CTE gegen Produktiv-DB validiert; `--dry-run` über die letzten 30 gemergten PRs — alle Terminal-Tickets skippen konventionell, keine falschen Guard-Alarme, Anker-Matches verifiziert (T014553/PR #5137: Link+Plan → dieselbe UUID)
- [x] `task freshness:check` grün, `preflight-pr-scope.sh` scope 'factory' ✓