### PR TITLE
chore: auto-regenerate freshness artifacts

### DIFF
--- a/docs/code-quality/repo-index.json
+++ b/docs/code-quality/repo-index.json
@@ -5,7 +5,7 @@
       "id": "tests",
       "name": "Test suites (BATS + Playwright + vitest)",
       "owner_agent": "bachelorprojekt-test",
-      "file_count": 1192,
+      "file_count": 1193,
       "files": [
         "components/website/test/fixtures/einvoice/kleinunternehmer.cii.xml",
         "components/website/test/fixtures/einvoice/mixed-rate.cii.xml",
@@ -1178,6 +1178,7 @@
         "tests/unit/ticket-grill.bats",
         "tests/unit/ticket-lastenheft.bats",
         "tests/unit/ticket-triage.bats",
+        "tests/unit/tickets-delete-guard.bats",
         "tests/unit/tickets-migration.bats",
         "tests/unit/tickets-plan-staged-migration.bats",
         "tests/unit/tickets-pr-events.bats",
@@ -1205,7 +1206,7 @@
       "id": "scripts-db",
       "name": "Database scripts (migrations + datamodel)",
       "owner_agent": "bachelorprojekt-db",
-      "file_count": 67,
+      "file_count": 68,
       "files": [
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-korczewski.sql",
         "scripts/datamodel/2026-05-23-audit-phase5-add-fk-indexes-mentolder.sql",
@@ -1273,7 +1274,8 @@
         "scripts/migrations/2026-08-19-llm-proxy-parallel-slots.sql",
         "scripts/migrations/2026-08-21-disable-dead-llm-proxy-backends.sql",
         "scripts/migrations/2026-08-22-factory-model-qwen38.sql",
-        "scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql"
+        "scripts/migrations/2026-08-22-llm-proxy-qwen38-backend.sql",
+        "scripts/migrations/2026-08-23-tickets-delete-guard-audit.sql"
       ]
     },
     {


### PR DESCRIPTION
Automatisch erzeugt von `freshness-regen.yml` (run 32657672060).

Regenerierte Freshness-Artefakte, die auf `main` veraltet waren.
Ersetzt den früheren Direkt-Push auf `main` (T002889).
