### PR TITLE
chore(scripts): FreeToken-Prefill-Bench und ft-serve-Restart-Werkzeug aufnehmen [T015171]

### DIFF
--- a/scripts/llm/bench-freetoken-prefill.sh
+++ b/scripts/llm/bench-freetoken-prefill.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# scripts/llm/bench-freetoken-prefill.sh — Prefill- und Decode-Durchsatz eines
+# FreeToken-Servers (ft serve) messen, getrennt nach kalt/Radix-Cache-Treffer.
+#
+# WARUM ES DAS GIBT: Bei Qwen3.6-35B-A3B-NVFP4 auf einer RTX 5070 Ti (16 GB,
+# MoE-Offload) ist Decode gesund, Prefill aber um Groessenordnungen langsamer als
+# der Wert, den der Server selbst unter /v1/stats als `prefill_tps` meldet.
+# Gemessen 2026-08-23 gegen ft 0.1.1+g30aa89115, Default-Flags
+# (`ft serve --model … --host 0.0.0.0 --num-tokens 32768`):
+#
+#     7.490 Tok ->  53,4 s   (7,13 ms/Tok)
+#     9.576 Tok ->  67,9 s   (7,09 ms/Tok)
+#    20.341 Tok -> 162,4 s   (7,98 ms/Tok)
+#    26.011 Tok -> 226,1 s   (8,69 ms/Tok)
+#    identischer Prompt erneut: 2,44 s  (Radix-Prefix-Cache, funktioniert)
+#
+# `prefill_tps` aus /v1/stats ist eine Kernel-Kennzahl und NICHT die Wanduhr —
+# es meldete 10.806 Tok/s, waehrend die Wanduhr 115 Tok/s ergab. Deshalb misst
+# dieses Skript ausschliesslich end-to-end und gibt die Serverzahl nur zum
+# Vergleich mit aus.
+#
+# Vergleichbarkeit:
+#   - Fester Seed -> zwei Laeufe erzeugen denselben Prompt.
+#   - --tag haengt an jede Zeile, welche Servervariante lief (Flags/Env), damit
+#     eine Zahl ohne ihre Konfiguration nicht in die Ablage wandert.
+#   - Der kalte Lauf variiert den Prompt je --tag, sonst misst man den
+#     Radix-Cache statt des Prefills.
+#
+# Usage:
+#   bash scripts/llm/bench-freetoken-prefill.sh --tag baseline
+#   bash scripts/llm/bench-freetoken-prefill.sh --tag hit-d2d --tokens 4000,8000,16000
+#   bash scripts/llm/bench-freetoken-prefill.sh --help
+set -euo pipefail
+
+BASE_URL="${FT_BASE_URL:-http://127.0.0.1:1919}"
+TOKENS="4000,8000,16000"
+TAG="untagged"
+DECODE_TOKENS=200
+
+usage() { sed -n '2,40p' "$0" | sed 's|^# \{0,1\}||'; exit 0; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h) usage ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --tokens) TOKENS="$2"; shift 2 ;;
+    --base-url) BASE_URL="$2"; shift 2 ;;
+    --decode-tokens) DECODE_TOKENS="$2"; shift 2 ;;
+    *) echo "unbekanntes Argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v curl >/dev/null || { echo "curl fehlt" >&2; exit 1; }
+command -v python3 >/dev/null || { echo "python3 fehlt" >&2; exit 1; }
+
+health="$(curl -sS --max-time 10 "$BASE_URL/health")" || { echo "Server auf $BASE_URL nicht erreichbar" >&2; exit 1; }
+MODEL="$(printf '%s' "$health" | python3 -c 'import json,sys;print(json.load(sys.stdin)["model"])')"
+FTVER="$(printf '%s' "$health" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("version","?"))')"
+
+echo "# Messbasis"
+echo "#   base_url = $BASE_URL"
+echo "#   model    = $MODEL"
+echo "#   version  = $FTVER"
+echo "#   tag      = $TAG"
+cat > /tmp/ftbench_geo.py <<'PY'
+import json,sys
+g=json.load(sys.stdin)["geometry"]
+u=g["unit_bytes"]
+tot=g["num_experts"]*g["num_moe_layers"]
+mc=g["moe_cache_size"]
+print("#   experten = %d/%d Slots (%.1f%% resident, %.2f GiB)" % (mc,tot,100*mc/tot,mc*u["moe_per_expert"]/2**30))
+print("#   kv       = %d Tokens (%.2f GiB)" % (g["num_pages"],g["num_pages"]*u["kv_per_token"]/2**30))
+print("#   mamba    = %d Slots (%.2f GiB)" % (g["num_mamba_slots"],g["num_mamba_slots"]*u["mamba_per_slot"]/2**30))
+print("#   budget   = %.2f GiB" % (g["cache_budget_bytes"]/2**30))
+PY
+curl -sS --max-time 10 "$BASE_URL/v1/cache/status" | python3 /tmp/ftbench_geo.py
+echo
+printf '%-10s %-8s %10s %10s %10s %12s\n' TAG PHASE TOKENS WALL_S TOK_PER_S MS_PER_TOK
+
+mkreq() { # $1=zieltokens $2=salt $3=max_tokens $4=prompt-praefix-modus
+  cat > /tmp/ftbench_mk.py <<'PY'
+import json,random,sys
+target,salt,maxtok,model=int(sys.argv[1]),sys.argv[2],int(sys.argv[3]),sys.argv[4]
+random.seed(hash(salt) & 0xffffffff)
+w=['Ableitung','Kennwert','Vorgabe','Strecke','Beitrag','Rahmen','Vorlauf','Gewicht',
+   'Schnitt','Anlage','Reaktor','Zeitplan','Messwert','Deckung','Streuung','Ertrag']
+# ~1,35 Tokens je Wort bei deutschem Fuelltext -> Wortzahl daraus ableiten
+words=int(target/1.35)
+per=28
+lines=[f"Satz {i}: "+" ".join(random.choice(w) for _ in range(per)) for i in range(words//per+1)]
+body="\n".join(lines)+"\n\nAntworte nur mit OK."
+json.dump({"model":model,"messages":[{"role":"user","content":body}],
+           "max_tokens":maxtok,"temperature":0.0,
+           "chat_template_kwargs":{"enable_thinking":False}},sys.stdout)
+PY
+  python3 /tmp/ftbench_mk.py "$1" "$2" "$3" "$MODEL"
+}
+
+run() { # $1=label $2=payloadfile -> setzt WALL, PTOK
+  local t0 t1
+  t0=$(date +%s.%N)
+  curl -sS --max-time 900 "$BASE_URL/v1/chat/completions" \
+    -H 'Content-Type: application/json' -d @"$2" -o /tmp/ftbench.out
+  t1=$(date +%s.%N)
+  WALL=$(python3 -c "print(f'{$t1-$t0:.2f}')")
+  PTOK=$(python3 -c 'import json;print(json.load(open("/tmp/ftbench.out"))["usage"]["prompt_tokens"])')
+  CTOK=$(python3 -c 'import json;print(json.load(open("/tmp/ftbench.out"))["usage"]["completion_tokens"])')
+}
+
+row() { printf '%-10s %-8s %10s %10s %10s %12s\n' "$TAG" "$1" "$2" "$3" \
+        "$(python3 -c "print(f'{$2/$3:.1f}')")" "$(python3 -c "print(f'{1000*$3/$2:.2f}')")"; }
+
+# Decode: kurzer Prompt, viele Ausgabetoken. Eigener Payload — der Prefill-Fuelltext
+# endet auf "Antworte nur mit OK" und wuerde hier 2 statt DECODE_TOKENS Tokens erzeugen.
+cat > /tmp/ftbench_dec.py <<'PY'
+import json,sys
+model,maxtok=sys.argv[1],int(sys.argv[2])
+json.dump({"model":model,
+           "messages":[{"role":"user","content":"Zaehle von 1 bis 400, nur die Zahlen, kommagetrennt, ohne weiteren Text."}],
+           "max_tokens":maxtok,"temperature":0.0,"ignore_eos":True,
+           "chat_template_kwargs":{"enable_thinking":False}},sys.stdout)
+PY
+python3 /tmp/ftbench_dec.py "$MODEL" "$DECODE_TOKENS" > /tmp/ftbench.decode.json
+run decode /tmp/ftbench.decode.json
+row decode "$CTOK" "$WALL"
+
+IFS=',' read -ra SIZES <<< "$TOKENS"
+for n in "${SIZES[@]}"; do
+  mkreq "$n" "cold-$TAG-$n" 4 > /tmp/ftbench.p.json
+  run "prefill-$n" /tmp/ftbench.p.json
+  row prefill "$PTOK" "$WALL"
+  # Zweiter Lauf mit identischem Prompt: muss den Radix-Cache treffen
+  run "cached-$n" /tmp/ftbench.p.json
+  row cached "$PTOK" "$WALL"
+done
+
+echo
+echo "# Serverzahlen zum Vergleich (NICHT die Wanduhr):"
+cat > /tmp/ftbench_st.py <<'PY'
+import json,sys
+d=json.load(sys.stdin)
+print("#   throughput =",d["throughput"])
+print("#   vram_bytes = %.2f GiB" % (d["vram_bytes"]/2**30))
+PY
+curl -sS --max-time 10 "$BASE_URL/v1/stats" | python3 /tmp/ftbench_st.py

--- a/scripts/llm/restart-freetoken.ps1
+++ b/scripts/llm/restart-freetoken.ps1
@@ -1,0 +1,94 @@
+# scripts/llm/restart-freetoken.ps1 -- FreeToken-Server (ft serve) mit definierten
+# Zusatzflags neu starten, damit Prefill-Varianten reproduzierbar A/B-getestet werden koennen.
+#
+# WARUM ES DAS GIBT: Prefill von Qwen3.6-35B-A3B-NVFP4 lief mit Default-Flags bei
+# ~149 Tok/s (6,69 ms/Tok) gegen 45 Tok/s Decode -- Faktor 3,3 statt der ueblichen
+# 50-200. Die Kandidatenflags (--moe-prefill-hit-d2d, --max-prefill-length,
+# --max-running-requests/--graph, --moe-backend) lassen sich nur durch Neustart
+# vergleichen. Ohne Skript ist jeder Lauf eine Handmessung mit anderem Kommando.
+#
+# Der Basisaufruf ist der, der am 2026-08-23 lief:
+#   ft serve --model C:\Users\<user>\models\Qwen3.6-35B-A3B-NVFP4 --host 0.0.0.0 --num-tokens 32768
+#
+# Usage (aus WSL):
+#   powershell.exe -NoProfile -File restart-freetoken.ps1 -Tag hit-d2d -ExtraArgs "--moe-prefill-hit-d2d"
+#   powershell.exe -NoProfile -File restart-freetoken.ps1 -Tag solo -ExtraArgs "--moe-prefill-hit-d2d --max-running-requests 1 --graph 1"
+#   powershell.exe -NoProfile -File restart-freetoken.ps1 -Tag ssm-bf16 -ExtraArgs "--moe-prefill-hit-d2d" -EnvVars "FREETOKEN_MAMBA_SSM_DTYPE=bfloat16"
+#   powershell.exe -NoProfile -File restart-freetoken.ps1 -Stop
+
+param(
+    [string]$Tag = "run",
+    [string]$ExtraArgs = "",
+    [string]$EnvVars = "",
+    [string]$Model = "$env:USERPROFILE\models\Qwen3.6-35B-A3B-NVFP4",
+    [int]$NumTokens = 32768,
+    [int]$ReadyTimeoutSec = 900,
+    [switch]$Stop
+)
+
+$ErrorActionPreference = "Stop"
+$FtExe   = "$env:LOCALAPPDATA\FreeToken\venv\Scripts\ft.exe"
+$LogDir  = "$env:LOCALAPPDATA\FreeToken\logs"
+$BaseUrl = "http://127.0.0.1:1919"
+
+function Stop-FreeToken {
+    $procs = Get-CimInstance Win32_Process -Filter "Name='ft.exe'" |
+             Where-Object { $_.CommandLine -like "*serve*" }
+    foreach ($p in $procs) {
+        Write-Host "stoppe ft.exe PID $($p.ProcessId) (Prozessbaum)"
+        & taskkill.exe /PID $p.ProcessId /T /F 2>&1 | Out-Null
+    }
+    # Warten, bis der Port wirklich frei ist -- sonst scheitert der Neustart am Bind.
+    for ($i = 0; $i -lt 60; $i++) {
+        $listening = Get-NetTCPConnection -LocalPort 1919 -State Listen -ErrorAction SilentlyContinue
+        if (-not $listening) { return }
+        Start-Sleep -Seconds 1
+    }
+    Write-Warning "Port 1919 ist nach 60 s noch belegt."
+}
+
+if ($Stop) { Stop-FreeToken; Write-Host "gestoppt."; exit 0 }
+
+if (-not (Test-Path $FtExe))  { throw "ft.exe nicht gefunden: $FtExe" }
+if (-not (Test-Path $Model))  { throw "Modellverzeichnis nicht gefunden: $Model" }
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+Stop-FreeToken
+
+foreach ($kv in ($EnvVars -split '\s+' | Where-Object { $_ })) {
+    $name, $value = $kv -split '=', 2
+    Write-Host "env $name=$value"
+    [Environment]::SetEnvironmentVariable($name, $value, "Process")
+}
+
+$argList = @("serve", "--model", $Model, "--host", "0.0.0.0", "--num-tokens", "$NumTokens")
+$argList += ($ExtraArgs -split '\s+' | Where-Object { $_ })
+
+$stamp  = Get-Date -Format "yyyyMMdd-HHmmss"
+$outLog = Join-Path $LogDir "$Tag-$stamp.out.log"
+$errLog = Join-Path $LogDir "$Tag-$stamp.err.log"
+
+Write-Host "starte: ft $($argList -join ' ')"
+Write-Host "log:    $outLog"
+Start-Process -FilePath $FtExe -ArgumentList $argList `
+    -RedirectStandardOutput $outLog -RedirectStandardError $errLog `
+    -WindowStyle Hidden | Out-Null
+
+# Bereitschaft aktiv pruefen. Abwesenheit eines Fehlers ist kein Bereitschaftsnachweis --
+# es wird auf ein positives Signal gewartet (status=ok UND maintenance=serving).
+$deadline = (Get-Date).AddSeconds($ReadyTimeoutSec)
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 5
+    $alive = Get-CimInstance Win32_Process -Filter "Name='ft.exe'" |
+             Where-Object { $_.CommandLine -like "*serve*" }
+    if (-not $alive) { throw "ft.exe ist beendet. Siehe $errLog" }
+    try {
+        $h = Invoke-RestMethod -Uri "$BaseUrl/health" -TimeoutSec 5
+        if ($h.status -eq "ok" -and $h.maintenance -eq "serving") {
+            Write-Host "bereit nach $([int]((Get-Date) - (Get-Item $outLog).CreationTime).TotalSeconds) s -- model=$($h.model) version=$($h.version)"
+            exit 0
+        }
+        Write-Host "  ... status=$($h.status) maintenance=$($h.maintenance)"
+    } catch { Write-Host "  ... noch kein /health" }
+}
+throw "Server wurde in $ReadyTimeoutSec s nicht bereit. Siehe $outLog / $errLog"


### PR DESCRIPTION
## Was

Nimmt zwei Werkzeuge aus der FreeToken-Prefill-Messreihe vom 2026-08-23 ins Repo auf (waren untracked im Hauptcheckout — Hygiene-Befund):

- `scripts/llm/bench-freetoken-prefill.sh` — misst Prefill-/Decode-Durchsatz end-to-end gegen `ft serve` (fester Seed, `--tag` pro Zeile, kalt vs. Radix-Cache-Treffer). Anlass: `prefill_tps` aus `/v1/stats` ist eine Kernel-Kennzahl (~10.806 Tok/s) und keine Wanduhr (~115 Tok/s gemessen).
- `scripts/llm/restart-freetoken.ps1` — startet FreeToken auf Windows mit definierten Zusatzflags/Env (`-Tag/-ExtraArgs/-EnvVars/-Stop`) für reproduzierbare Flag-A/B-Tests (`--moe-prefill-hit-d2d`, `--max-prefill-length`, …).

## Warum kein Verhaltenswechsel

Reine Tooling-Aufnahme; es wird nichts am Cluster/Stack geändert.

Closes [T015171]